### PR TITLE
Add Custom Virtual Directory Support

### DIFF
--- a/Functions/AccountACL/Add-PASAccountACL.ps1
+++ b/Functions/AccountACL/Add-PASAccountACL.ps1
@@ -40,6 +40,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -133,7 +137,13 @@ To force all output to be shown, pipe to Select-Object *
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
 
     )
 
@@ -142,7 +152,7 @@ To force all output to be shown, pipe to Select-Object *
     PROCESS{
 
         #URL for request
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Account/$($AccountAddress | 
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Account/$($AccountAddress | 
         
             Get-EscapedString)|$($AccountUserName | 
             
@@ -173,6 +183,7 @@ To force all output to be shown, pipe to Select-Object *
                     "sessionToken" = $sessionToken
                     "WebSession" = $WebSession
                     "BaseURI" = $BaseURI
+					"PVWAAppName" = $PVWAAppName
 
             }
 

--- a/Functions/AccountACL/Get-PASAccountACL.ps1
+++ b/Functions/AccountACL/Get-PASAccountACL.ps1
@@ -25,6 +25,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -85,7 +89,13 @@ To force all output to be shown, pipe to Select-Object *
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
 
     )
 
@@ -94,7 +104,7 @@ To force all output to be shown, pipe to Select-Object *
     PROCESS{
         
         #Create URL for request
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Account/$($AccountAddress | 
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Account/$($AccountAddress | 
         
             Get-EscapedString)|$($AccountUserName | 
             
@@ -118,6 +128,7 @@ To force all output to be shown, pipe to Select-Object *
                     "sessionToken" = $sessionToken
                     "WebSession" = $WebSession
                     "BaseURI" = $BaseURI
+					"PVWAAppName" = $PVWAAppName
 
             }
 

--- a/Functions/AccountACL/Remove-PASAccountACL.ps1
+++ b/Functions/AccountACL/Remove-PASAccountACL.ps1
@@ -25,6 +25,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -85,7 +89,13 @@ None
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
@@ -93,7 +103,7 @@ None
     PROCESS{
 
         #URL for request
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Account/$($AccountAddress | 
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Account/$($AccountAddress | 
         
             Get-EscapedString)|$($AccountUserName | 
             

--- a/Functions/AccountGroups/Add-PASAccountGroupMember.ps1
+++ b/Functions/AccountGroups/Add-PASAccountGroupMember.ps1
@@ -28,6 +28,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -78,7 +82,13 @@ To force all output to be shown, pipe to Select-Object *
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI<#,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"#>
     )
 
     BEGIN{}#begin
@@ -111,6 +121,7 @@ To force all output to be shown, pipe to Select-Object *
                             "sessionToken" = $sessionToken
                             "WebSession" = $WebSession
                             "BaseURI" = $BaseURI
+					        #"PVWAAppName" = $PVWAAppName
 
             }
 

--- a/Functions/AccountGroups/New-PASAccountGroup.ps1
+++ b/Functions/AccountGroups/New-PASAccountGroup.ps1
@@ -31,6 +31,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -87,7 +91,13 @@ To force all output to be shown, pipe to Select-Object *
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI<#,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"#>
     )
 
     BEGIN{}#begin
@@ -114,6 +124,7 @@ To force all output to be shown, pipe to Select-Object *
                             "sessionToken" = $sessionToken
                             "WebSession" = $WebSession
                             "BaseURI" = $BaseURI
+					        #"PVWAAppName" = $PVWAAppName
 
             }
 

--- a/Functions/Accounts/Add-PASAccount.ps1
+++ b/Functions/Accounts/Add-PASAccount.ps1
@@ -71,6 +71,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -218,7 +222,13 @@ None
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{
@@ -242,7 +252,7 @@ None
     PROCESS{
 
         #Create URL for Request
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Account"
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Account"
 
         #Get all parameters that will be sent in the request
         $boundParameters = $PSBoundParameters | Get-PASParameters

--- a/Functions/Accounts/Add-PASPendingAccount.ps1
+++ b/Functions/Accounts/Add-PASPendingAccount.ps1
@@ -91,6 +91,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -256,7 +260,13 @@ None
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
@@ -264,7 +274,7 @@ None
     PROCESS{
 
         #Create URL for Request
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/PendingAccounts"
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/PendingAccounts"
 
         #Get all parameters that will be sent in the request
         $boundParameters = $PSBoundParameters | Get-PASParameters

--- a/Functions/Accounts/Get-PASAccount.ps1
+++ b/Functions/Accounts/Get-PASAccount.ps1
@@ -34,6 +34,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -86,7 +90,13 @@ To force all output to be shown, pipe to Select-Object *
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
 
     )
 
@@ -105,7 +115,7 @@ To force all output to be shown, pipe to Select-Object *
         }) -join '&'
         
         #Create request URL
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Accounts?$query"
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Accounts?$query"
 
         #Send request to web service
         $result = Invoke-PASRestMethod -Uri $URI -Method GET -Headers $sessionToken -WebSession $WebSession
@@ -167,6 +177,7 @@ To force all output to be shown, pipe to Select-Object *
                     "sessionToken" = $sessionToken
                     "WebSession" = $WebSession
                     "BaseURI" = $BaseURI
+					"PVWAAppName" = $PVWAAppName
 
             }
 

--- a/Functions/Accounts/Get-PASAccountActivity.ps1
+++ b/Functions/Accounts/Get-PASAccountActivity.ps1
@@ -19,6 +19,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -59,7 +63,13 @@ To force all output to be shown, pipe to Select-Object *
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
 
     )
 
@@ -68,7 +78,7 @@ To force all output to be shown, pipe to Select-Object *
     PROCESS{
 
         #Create request URL
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Accounts/$($AccountID | 
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Accounts/$($AccountID | 
         
             Get-EscapedString)/Activities"
 
@@ -89,6 +99,7 @@ To force all output to be shown, pipe to Select-Object *
                         "sessionToken" = $sessionToken
                         "WebSession" = $WebSession
                         "BaseURI" = $BaseURI
+					    "PVWAAppName" = $PVWAAppName
 
                 }
         

--- a/Functions/Accounts/Get-PASAccountCredentials.ps1
+++ b/Functions/Accounts/Get-PASAccountCredentials.ps1
@@ -21,6 +21,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -63,7 +67,13 @@ To force all output to be shown, pipe to Select-Object *
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
 
     )
 
@@ -72,7 +82,7 @@ To force all output to be shown, pipe to Select-Object *
     PROCESS{
 
         #Create request URL
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Accounts/$($AccountID | 
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Accounts/$($AccountID | 
         
             Get-EscapedString)/Credentials"
 
@@ -92,6 +102,7 @@ To force all output to be shown, pipe to Select-Object *
                     "sessionToken" = $sessionToken
                     "WebSession" = $WebSession
                     "BaseURI" = $BaseURI
+					"PVWAAppName" = $PVWAAppName
 
                 }
 

--- a/Functions/Accounts/Remove-PASAccount.ps1
+++ b/Functions/Accounts/Remove-PASAccount.ps1
@@ -21,6 +21,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -59,7 +63,13 @@ None
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
 
     )
 
@@ -68,7 +78,7 @@ None
     PROCESS{
         
         #Create URL for request
-        $URI = "$BaseURI/PasswordVault/WebServices/PIMServices.svc/Accounts/$AccountID"
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Accounts/$AccountID"
         
         #Send request to webservice
         Invoke-PASRestMethod -Uri $URI -Method DELETE -Headers $sessionToken -WebSession $WebSession

--- a/Functions/Accounts/Set-PASAccount.ps1
+++ b/Functions/Accounts/Set-PASAccount.ps1
@@ -67,6 +67,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -185,7 +189,13 @@ To move accounts to a different folder, Move accounts/folders permission is requ
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
@@ -193,7 +203,7 @@ To move accounts to a different folder, Move accounts/folders permission is requ
     PROCESS{
 
         #Create URL for Request
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Accounts/$AccountID"
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Accounts/$AccountID"
 
         #Get all parameters that will be sent in the request
         $boundParameters = $PSBoundParameters | Get-PASParameters -ParametersToRemove InputObject
@@ -266,6 +276,7 @@ To move accounts to a different folder, Move accounts/folders permission is requ
                         "sessionToken" = $sessionToken
                         "WebSession" = $WebSession
                         "BaseURI" = $BaseURI
+					    "PVWAAppName" = $PVWAAppName
 
             }
 

--- a/Functions/Accounts/Start-PASCredChange.ps1
+++ b/Functions/Accounts/Start-PASCredChange.ps1
@@ -31,6 +31,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -83,7 +87,13 @@ None
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{
@@ -97,7 +107,7 @@ None
     PROCESS{
         
         #Create URL for request
-        $URI = "$BaseURI/PasswordVault/WebServices/PIMServices.svc/Accounts/$AccountID/ChangeCredentials"
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Accounts/$AccountID/ChangeCredentials"
 
         #Header is normally just session token
         $header = $SessionToken

--- a/Functions/Accounts/Start-PASCredVerify.ps1
+++ b/Functions/Accounts/Start-PASCredVerify.ps1
@@ -21,6 +21,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -59,7 +63,13 @@ None
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
@@ -67,7 +77,7 @@ None
     PROCESS{
         
         #Create URL for request
-        $URI = "$BaseURI/PasswordVault/WebServices/PIMServices.svc/Accounts/$AccountID/VerifyCredentials"
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Accounts/$AccountID/VerifyCredentials"
 
         $body = @{} | ConvertTo-Json
 

--- a/Functions/Applications/Add-PASApplication.ps1
+++ b/Functions/Applications/Add-PASApplication.ps1
@@ -59,6 +59,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -165,7 +169,13 @@ None
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
 
     )
 
@@ -174,7 +184,7 @@ None
     PROCESS{
 
         #WebService URL
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Applications"
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Applications"
 
         #Create Request Body
         $body = @{

--- a/Functions/Applications/Add-PASApplicationAuthenticationMethod.ps1
+++ b/Functions/Applications/Add-PASApplicationAuthenticationMethod.ps1
@@ -39,6 +39,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -94,7 +98,13 @@ not accept input from the pipeline.
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     DynamicParam{
@@ -127,7 +137,7 @@ not accept input from the pipeline.
 
     PROCESS{
 
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Applications/$($AppID | 
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Applications/$($AppID | 
         
             Get-EscapedString)/Authentications"
         

--- a/Functions/Applications/Get-PASApplication.ps1
+++ b/Functions/Applications/Get-PASApplication.ps1
@@ -20,6 +20,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -63,7 +67,13 @@ To force all output to be shown, pipe to Select-Object *
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
@@ -71,7 +81,7 @@ To force all output to be shown, pipe to Select-Object *
     PROCESS{
 
         #URL for Request
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Applications/$($AppID | 
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Applications/$($AppID | 
         
             Get-EscapedString)"
     
@@ -89,6 +99,7 @@ To force all output to be shown, pipe to Select-Object *
                     "sessionToken" = $sessionToken
                     "WebSession" = $WebSession
                     "BaseURI" = $BaseURI
+					"PVWAAppName" = $PVWAAppName
 
             }
 

--- a/Functions/Applications/Get-PASApplicationAuthenticationMethods.ps1
+++ b/Functions/Applications/Get-PASApplicationAuthenticationMethods.ps1
@@ -20,6 +20,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -64,14 +68,20 @@ To force all output to be shown, pipe to Select-Object *
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
 
     PROCESS{
 
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Applications/$($AppID | 
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Applications/$($AppID | 
         
             Get-EscapedString)/Authentications"
         
@@ -88,6 +98,7 @@ To force all output to be shown, pipe to Select-Object *
                     "sessionToken" = $sessionToken
                     "WebSession" = $WebSession
                     "BaseURI" = $BaseURI
+					"PVWAAppName" = $PVWAAppName
 
             }
                 

--- a/Functions/Applications/Get-PASApplications.ps1
+++ b/Functions/Applications/Get-PASApplications.ps1
@@ -29,6 +29,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -87,7 +91,13 @@ To force all output to be shown, pipe to Select-Object *
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
@@ -105,7 +115,7 @@ To force all output to be shown, pipe to Select-Object *
         }) -join '&'
 
         #Create URL for request
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Applications?$query"
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Applications?$query"
 
         #Send request to web service
         $result = Invoke-PASRestMethod -Uri $URI -Method GET -Headers $sessionToken -WebSession $WebSession
@@ -124,6 +134,7 @@ To force all output to be shown, pipe to Select-Object *
                     "sessionToken" = $sessionToken
                     "WebSession" = $WebSession
                     "BaseURI" = $BaseURI
+					"PVWAAppName" = $PVWAAppName
 
             }
                 

--- a/Functions/Applications/Remove-PASApplication.ps1
+++ b/Functions/Applications/Remove-PASApplication.ps1
@@ -20,6 +20,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -58,7 +62,13 @@ None
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
@@ -66,7 +76,7 @@ None
     PROCESS{
 
         #Request URL
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Applications/$($AppID | 
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Applications/$($AppID | 
         
             Get-EscapedString)/"
         

--- a/Functions/Applications/Remove-PASApplicationAuthenticationMethod.ps1
+++ b/Functions/Applications/Remove-PASApplicationAuthenticationMethod.ps1
@@ -23,6 +23,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -68,7 +72,13 @@ None
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
@@ -76,7 +86,7 @@ None
     PROCESS{
 
         #request URL
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Applications/$($AppID | 
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Applications/$($AppID | 
         
             Get-EscapedString)/Authentications/$($AuthID | 
             

--- a/Functions/Authentication/Add-PASPublicSSHKey.ps1
+++ b/Functions/Authentication/Add-PASPublicSSHKey.ps1
@@ -33,6 +33,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -83,7 +87,13 @@ To force all output to be shown, pipe to Select-Object *
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
@@ -91,7 +101,7 @@ To force all output to be shown, pipe to Select-Object *
     PROCESS{
 
         #Create URL to endpoint for request
-        $URI = "$BaseURI/PasswordVault/WebServices/PIMServices.svc/Users/$($UserName | 
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Users/$($UserName | 
             
             Get-EscapedString)/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys"
         
@@ -118,6 +128,7 @@ To force all output to be shown, pipe to Select-Object *
                     "sessionToken" = $sessionToken
                     "WebSession" = $WebSession
                     "BaseURI" = $BaseURI
+					"PVWAAppName" = $PVWAAppName
 
                 }
 

--- a/Functions/Authentication/Close-PASSAMLSession.ps1
+++ b/Functions/Authentication/Close-PASSAMLSession.ps1
@@ -17,6 +17,10 @@ A string containing the base web address to send te request to.
 Pass the portion the PVWA HTTP address. 
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -47,7 +51,13 @@ New-PASSAMLSession function needs to be fixed first.
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{
@@ -57,7 +67,7 @@ New-PASSAMLSession function needs to be fixed first.
     PROCESS{
 
         #Construct URL for request
-        $URI = "$baseURI/PasswordVault/WebServices/auth/SAML/SAMLAuthenticationService.svc/Logoff"
+        $URI = "$baseURI/$PVWAAppName/WebServices/auth/SAML/SAMLAuthenticationService.svc/Logoff"
 
         $Body = @{} | ConvertTo-Json
 

--- a/Functions/Authentication/Close-PASSession.ps1
+++ b/Functions/Authentication/Close-PASSession.ps1
@@ -16,6 +16,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -46,7 +50,13 @@ None
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
 
     )
 
@@ -55,7 +65,7 @@ None
     PROCESS{
 
         #Construct URL for request
-        $URI = "$BaseURI/PasswordVault/WebServices/auth/Cyberark/CyberArkAuthenticationService.svc/Logoff"
+        $URI = "$baseURI/$PVWAAppName/WebServices/auth/Cyberark/CyberArkAuthenticationService.svc/Logoff"
 
         #Send Logoff Request
         Invoke-PASRestMethod -Uri $URI -Method POST -Headers $sessionToken -WebSession $WebSession

--- a/Functions/Authentication/Close-PASSharedSession.ps1
+++ b/Functions/Authentication/Close-PASSharedSession.ps1
@@ -17,6 +17,10 @@ A string containing the base web address to send te request to.
 Pass the portion the PVWA HTTP address. 
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -50,7 +54,13 @@ None
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{
@@ -60,7 +70,7 @@ None
     PROCESS{
 
         #Construct URL for request
-        $URI = "$baseURI/PasswordVault/WebServices/auth/Shared/RestfulAuthenticationService.svc/Logoff"
+        $URI = "$baseURI/$PVWAAppName/WebServices/auth/Shared/RestfulAuthenticationService.svc/Logoff"
 
         #Send Logon Request
         Invoke-PASRestMethod -Uri $URI -Method POST -Header $sessionToken -WebSession $WebSession

--- a/Functions/Authentication/Get-PASPublicSSHKey.ps1
+++ b/Functions/Authentication/Get-PASPublicSSHKey.ps1
@@ -24,6 +24,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -65,7 +69,13 @@ To force all output to be shown, pipe to Select-Object *
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
 
     )
 
@@ -74,7 +84,7 @@ To force all output to be shown, pipe to Select-Object *
     PROCESS{
 
         #Create URL for request
-        $URI = "$BaseURI/PasswordVault/WebServices/PIMServices.svc/Users/$($UserName | 
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Users/$($UserName | 
             
             Get-EscapedString)/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys"
 
@@ -95,6 +105,7 @@ To force all output to be shown, pipe to Select-Object *
                     "sessionToken" = $sessionToken
                     "WebSession" = $WebSession
                     "BaseURI" = $BaseURI
+					"PVWAAppName" = $PVWAAppName
 
                 }
 

--- a/Functions/Authentication/New-PASSAMLSession.ps1
+++ b/Functions/Authentication/New-PASSAMLSession.ps1
@@ -24,6 +24,10 @@ A string containing the base web address to send te request to.
 Pass the portion the PVWA HTTP address. 
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -45,7 +49,7 @@ other functions from this return object.
     param(
         [parameter(
             Mandatory=$true,
-            ValueFromPipeline=$true
+            ValueFromPipelinebyPropertyName=$true
         )]
         [ValidateNotNullOrEmpty()]
         [PSCredential]$Credential,
@@ -56,15 +60,22 @@ other functions from this return object.
         [string]$SessionVariable = "PASSession",
 
         [parameter(
-            Mandatory=$true
+            Mandatory=$true,
+			ValueFromPipeline=$false
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipeline=$false
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{
         
         #Construct URL for request
-        $URI = "$baseURI/PasswordVault/WebServices/auth/SAML/SAMLAuthenticationService.svc/Logon"
+        $URI = "$baseURI/$PVWAAppName/WebServices/auth/SAML/SAMLAuthenticationService.svc/Logon"
 
     }#begin
 
@@ -99,6 +110,9 @@ other functions from this return object.
 
             #The Web Service URL the request was sent to
             "BaseURI" = $BaseURI
+
+            #The PVWA App Name/Virtual Directory
+			"PVWAAppName" = $PVWAAppName
 
             #Set default properties to display in output
         } | Add-ObjectDetail -DefaultProperties sessionToken, BaseURI

--- a/Functions/Authentication/New-PASSession.ps1
+++ b/Functions/Authentication/New-PASSession.ps1
@@ -41,6 +41,10 @@ A string containing the base web address to send te request to.
 Pass the portion the PVWA HTTP address. 
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -66,7 +70,7 @@ To force all output to be shown, pipe to Select-Object *
     param(  
         [parameter(
             Mandatory=$true,
-            ValueFromPipeline=$true
+            ValueFromPipelinebyPropertyName=$true
         )]
         [ValidateNotNullOrEmpty()]
         [PSCredential]$Credential,
@@ -100,13 +104,19 @@ To force all output to be shown, pipe to Select-Object *
             Mandatory=$true,
             ValueFromPipeline=$false
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+        [parameter(
+            Mandatory=$false,
+            ValueFromPipeline=$false
+        )]
+        [string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{
         
         #Construct URL for request
-        $URI = "$baseURI/PasswordVault/WebServices/auth/Cyberark/CyberArkAuthenticationService.svc/Logon"
+        $URI = "$baseURI/$PVWAAppName/WebServices/auth/Cyberark/CyberArkAuthenticationService.svc/Logon"
 
 
     }#begin
@@ -157,6 +167,9 @@ To force all output to be shown, pipe to Select-Object *
 
             #The Web Service URL the request was sent to
             "BaseURI" = $BaseURI
+
+            #PVWA Application Name/Virtual Directory
+            "PVWAAppName" = $PVWAAppName
 
             #The Connection Number
             "ConnectionNumber" = $connectionNumber

--- a/Functions/Authentication/New-PASSharedSession.ps1
+++ b/Functions/Authentication/New-PASSharedSession.ps1
@@ -18,6 +18,10 @@ A string containing the base web address to send te request to.
 Pass the portion the PVWA HTTP address. 
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -44,15 +48,22 @@ ConnectionNumber; the connectionNumber provided to this function.
         [string]$SessionVariable = "PASSession",
 
         [parameter(
-            Mandatory=$true
+            Mandatory=$true,
+			ValueFromPipeline=$false
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{
         
         #Construct URL for request
-        $URI = "$baseURI/PasswordVault/WebServices/auth/Shared/RestfulAuthenticationService.svc/Logon"
+        $URI = "$baseURI/$PVWAAppName/WebServices/auth/Shared/RestfulAuthenticationService.svc/Logon"
 
     }#begin
 
@@ -79,6 +90,9 @@ ConnectionNumber; the connectionNumber provided to this function.
 
             #The Web Service URL the request was sent to
             "BaseURI" = $BaseURI
+
+            #PVWA App Name/Virtual Directory
+			"PVWAAppName" = $PVWAAppName
 
             #Set default properties to display in output
         } | Add-ObjectDetail -DefaultProperties sessionToken, BaseURI

--- a/Functions/Authentication/Remove-PASPublicSSHKey.ps1
+++ b/Functions/Authentication/Remove-PASPublicSSHKey.ps1
@@ -29,6 +29,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -70,7 +74,13 @@ TODO
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
@@ -78,7 +88,7 @@ TODO
     PROCESS{
 
         #Create URL string for request
-        $URI = "$BaseURI/PasswordVault/WebServices/PIMServices.svc/Users/$($UserName | 
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Users/$($UserName | 
             
             Get-EscapedString)/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys/$KeyID"
 

--- a/Functions/OnboardingRules/Get-PASOnboardingRule.ps1
+++ b/Functions/OnboardingRules/Get-PASOnboardingRule.ps1
@@ -17,6 +17,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -62,7 +66,13 @@ Not Tested
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
@@ -70,7 +80,7 @@ Not Tested
     PROCESS{
 
         #Create URL for request
-        $URI = "$baseURI/PasswordVault/api/AutomaticOnboardingRules/"
+        $URI = "$baseURI/$PVWAAppName/api/AutomaticOnboardingRules/"
         
         #send request to web service
         $result = Invoke-PASRestMethod -Uri $URI -Method GET -Headers $sessionToken -WebSession $WebSession
@@ -88,6 +98,7 @@ Not Tested
                     "sessionToken" = $sessionToken
                     "WebSession" = $WebSession
                     "BaseURI" = $BaseURI
+					"PVWAAppName" = $PVWAAppName
 
             }
     

--- a/Functions/OnboardingRules/New-PASOnboardingRule.ps1
+++ b/Functions/OnboardingRules/New-PASOnboardingRule.ps1
@@ -40,6 +40,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -120,7 +124,13 @@ Not Tested
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
@@ -128,7 +138,7 @@ Not Tested
     PROCESS{
 
         #Create URL for request
-        $URI = "$baseURI/PasswordVault/api/AutomaticOnboardingRules"
+        $URI = "$baseURI/$PVWAAppName/api/AutomaticOnboardingRules"
 
         #create request body
         $body = $PSBoundParameters | Get-PASParameters | ConvertTo-Json
@@ -145,6 +155,7 @@ Not Tested
                     "sessionToken" = $sessionToken
                     "WebSession" = $WebSession
                     "BaseURI" = $BaseURI
+					"PVWAAppName" = $PVWAAppName
 
             }
     

--- a/Functions/OnboardingRules/Remove-PASOnboardingRule.ps1
+++ b/Functions/OnboardingRules/Remove-PASOnboardingRule.ps1
@@ -21,6 +21,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -58,7 +62,13 @@ None
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
     
     BEGIN{}#begin
@@ -66,7 +76,7 @@ None
     PROCESS{
         
         #Create URL for request
-        $URI = "$baseURI/PasswordVault/api/AutomaticOnboardingRules/$($RuleID | 
+        $URI = "$baseURI/$PVWAAppName/api/AutomaticOnboardingRules/$($RuleID | 
         
             Get-EscapedString)"
         

--- a/Functions/PolicyACL/Add-PASPolicyACL.ps1
+++ b/Functions/PolicyACL/Add-PASPolicyACL.ps1
@@ -35,6 +35,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -113,7 +117,13 @@ To force all output to be shown, pipe to Select-Object *
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
@@ -121,7 +131,7 @@ To force all output to be shown, pipe to Select-Object *
     PROCESS{
 
         #Create URL for request
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Policy/$($PolicyID | 
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Policy/$($PolicyID | 
         
             Get-EscapedString)/PrivilegedCommands"
         
@@ -148,6 +158,7 @@ To force all output to be shown, pipe to Select-Object *
                     "sessionToken" = $sessionToken
                     "WebSession" = $WebSession
                     "BaseURI" = $BaseURI
+					"PVWAAppName" = $PVWAAppName
 
             }
 

--- a/Functions/PolicyACL/Get-PASPolicyACL.ps1
+++ b/Functions/PolicyACL/Get-PASPolicyACL.ps1
@@ -20,6 +20,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -63,7 +67,13 @@ To force all output to be shown, pipe to Select-Object *
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
         
     )
 
@@ -72,7 +82,7 @@ To force all output to be shown, pipe to Select-Object *
     PROCESS{
 
         #Create URL for reuest
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Policy/$($PolicyID | 
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Policy/$($PolicyID | 
         
             Get-EscapedString)/PrivilegedCommands"
         
@@ -92,6 +102,7 @@ To force all output to be shown, pipe to Select-Object *
                     "sessionToken" = $sessionToken
                     "WebSession" = $WebSession
                     "BaseURI" = $BaseURI
+					"PVWAAppName" = $PVWAAppName
 
             }
 

--- a/Functions/PolicyACL/Remove-PASPolicyACL.ps1
+++ b/Functions/PolicyACL/Remove-PASPolicyACL.ps1
@@ -22,6 +22,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -66,7 +70,13 @@ None
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
 
     )
 
@@ -75,7 +85,7 @@ None
     PROCESS{
 
         #Create base URL for request
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Policy/$($PolicyID | 
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Policy/$($PolicyID | 
         
             Get-EscapedString)/PrivilegedCommands/$($Id | 
                 

--- a/Functions/SafeMembers/Add-PASSafeMember.ps1
+++ b/Functions/SafeMembers/Add-PASSafeMember.ps1
@@ -14,6 +14,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .PARAMETER SafeName
 The name of the safe to add the member to
 
@@ -123,6 +127,10 @@ WebRequestSession object returned from New-PASSession
 .PARAMETER BaseURI
 PVWA Web Address
 Do not include "/PasswordVault/"
+
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
 
 .EXAMPLE
 
@@ -313,7 +321,13 @@ To force all output to be shown, pipe to Select-Object *
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{
@@ -332,7 +346,7 @@ To force all output to be shown, pipe to Select-Object *
     PROCESS{
 
         #Create URL for request
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Safes/$($SafeName | 
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Safes/$($SafeName | 
         
             Get-EscapedString)/Members"
         
@@ -382,6 +396,7 @@ To force all output to be shown, pipe to Select-Object *
                     "sessionToken" = $sessionToken
                     "WebSession" = $WebSession
                     "BaseURI" = $BaseURI
+					"PVWAAppName" = $PVWAAppName
 
                 }
         

--- a/Functions/SafeMembers/Get-PASSafeMembers.ps1
+++ b/Functions/SafeMembers/Get-PASSafeMembers.ps1
@@ -20,6 +20,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -65,7 +69,13 @@ To force all output to be shown, pipe to Select-Object *
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
@@ -73,7 +83,7 @@ To force all output to be shown, pipe to Select-Object *
     PROCESS{
 
         #Create URL for request
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Safes/$($SafeName | 
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Safes/$($SafeName | 
         
             Get-EscapedString)/Members"
         
@@ -93,6 +103,7 @@ To force all output to be shown, pipe to Select-Object *
                 "sessionToken" = $sessionToken
                 "WebSession" = $WebSession
                 "BaseURI" = $BaseURI
+				"PVWAAppName" = $PVWAAppName
 
             }
         

--- a/Functions/SafeMembers/Remove-PASSafeMember.ps1
+++ b/Functions/SafeMembers/Remove-PASSafeMember.ps1
@@ -24,6 +24,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -70,7 +74,13 @@ None
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
@@ -78,7 +88,7 @@ None
     PROCESS{
 
         #Create URL for request
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Safes/$($SafeName | 
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Safes/$($SafeName | 
         
             Get-EscapedString)/Members/$($MemberName | 
                 

--- a/Functions/SafeMembers/Set-PASSafeMember.ps1
+++ b/Functions/SafeMembers/Set-PASSafeMember.ps1
@@ -113,6 +113,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -296,7 +300,13 @@ To force all output to be shown, pipe to Select-Object *
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{
@@ -315,7 +325,7 @@ To force all output to be shown, pipe to Select-Object *
     PROCESS{
 
         #Create URL for request
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Safes/$($SafeName | 
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Safes/$($SafeName | 
         
             Get-EscapedString)/Members/$($MemberName | 
                 
@@ -364,6 +374,7 @@ To force all output to be shown, pipe to Select-Object *
                     "sessionToken" = $sessionToken
                     "WebSession" = $WebSession
                     "BaseURI" = $BaseURI
+					"PVWAAppName" = $PVWAAppName
 
                 }
 

--- a/Functions/Safes/Add-PASSafe.ps1
+++ b/Functions/Safes/Add-PASSafe.ps1
@@ -45,6 +45,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -126,7 +130,13 @@ To force all output to be shown, pipe to Select-Object *
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
@@ -134,7 +144,7 @@ To force all output to be shown, pipe to Select-Object *
     PROCESS{
 
         #Create URL for request
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Safes"
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Safes"
 
         #create request body
         $body = @{
@@ -156,6 +166,7 @@ To force all output to be shown, pipe to Select-Object *
             "sessionToken" = $sessionToken
             "WebSession" = $WebSession
             "BaseURI" = $BaseURI
+			"PVWAAppName" = $PVWAAppName
 
         }
     

--- a/Functions/Safes/Get-PASSafe.ps1
+++ b/Functions/Safes/Get-PASSafe.ps1
@@ -26,6 +26,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -85,7 +89,13 @@ To force all output to be shown, pipe to Select-Object *
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
@@ -93,7 +103,7 @@ To force all output to be shown, pipe to Select-Object *
     PROCESS{
 
         #Create base URL for request
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Safes"
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Safes"
 
         #If SafeName specified
         If($($PSCmdlet.ParameterSetName) -eq "byName"){
@@ -145,6 +155,7 @@ To force all output to be shown, pipe to Select-Object *
                 "sessionToken" = $sessionToken
                 "WebSession" = $WebSession
                 "BaseURI" = $BaseURI
+				"PVWAAppName" = $PVWAAppName
 
             }
 

--- a/Functions/Safes/Remove-PASSafe.ps1
+++ b/Functions/Safes/Remove-PASSafe.ps1
@@ -21,6 +21,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -60,7 +64,13 @@ None
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
     
     BEGIN{}#begin
@@ -68,7 +78,7 @@ None
     PROCESS{
         
         #Create URL for request
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Safes/$($SafeName | 
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Safes/$($SafeName | 
         
             Get-EscapedString)"
         

--- a/Functions/Safes/Set-PASSafe.ps1
+++ b/Functions/Safes/Set-PASSafe.ps1
@@ -45,6 +45,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -136,7 +140,13 @@ To force all output to be shown, pipe to Select-Object *
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
@@ -144,7 +154,7 @@ To force all output to be shown, pipe to Select-Object *
     PROCESS{
         
         #Create URL for Request
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Safes/$($SafeName | 
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Safes/$($SafeName | 
         
             Get-EscapedString)"
         
@@ -164,6 +174,7 @@ To force all output to be shown, pipe to Select-Object *
                 "sessionToken" = $sessionToken
                 "WebSession" = $WebSession
                 "BaseURI" = $BaseURI
+				"PVWAAppName" = $PVWAAppName
 
             }
 

--- a/Functions/ServerWebServices/Get-PASSafeShareLogo.ps1
+++ b/Functions/ServerWebServices/Get-PASSafeShareLogo.ps1
@@ -16,6 +16,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -47,7 +51,13 @@ SafeShare no longer available from CyberArk
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
@@ -55,7 +65,7 @@ SafeShare no longer available from CyberArk
     PROCESS{
 
         #Create URL for request
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Logo?type=$ImageType"
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Logo?type=$ImageType"
         
         #send request to web service
         $result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $WebSession

--- a/Functions/ServerWebServices/Get-PASServer.ps1
+++ b/Functions/ServerWebServices/Get-PASServer.ps1
@@ -18,6 +18,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -51,7 +55,13 @@ ServerName, ExternalVersion, InternalVersion
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
@@ -59,7 +69,7 @@ ServerName, ExternalVersion, InternalVersion
     PROCESS{
 
         #Create URL for request
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Server"
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Server"
 
         #send request to web service
         $result = Invoke-PASRestMethod -Uri $URI -Method GET -Headers $sessionToken -WebSession $WebSession

--- a/Functions/ServerWebServices/Get-PASServerWebService.ps1
+++ b/Functions/ServerWebServices/Get-PASServerWebService.ps1
@@ -14,6 +14,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -40,7 +44,13 @@ ServerName, ServerID, ApplicationName & Available Authentication Methods
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
@@ -48,7 +58,7 @@ ServerName, ServerID, ApplicationName & Available Authentication Methods
     PROCESS{
 
         #Create URL for request
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Verify"
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Verify"
 
         #send request to web service
         $result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $WebSession

--- a/Functions/User/Add-PASGroupMember.ps1
+++ b/Functions/User/Add-PASGroupMember.ps1
@@ -22,6 +22,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -65,7 +69,13 @@ None
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
@@ -73,7 +83,7 @@ None
     PROCESS{
 
         #Create URL for request
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Groups/$($GroupName | 
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Groups/$($GroupName | 
         
             Get-EscapedString)/Users"
 

--- a/Functions/User/Get-PASLoggedOnUser.ps1
+++ b/Functions/User/Get-PASLoggedOnUser.ps1
@@ -16,6 +16,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -53,7 +57,13 @@ To force all output to be shown, pipe to Select-Object *
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
@@ -61,7 +71,7 @@ To force all output to be shown, pipe to Select-Object *
     PROCESS{
 
         #Create URL for request
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/User"
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/User"
 
         #send request to web service
         $result = Invoke-PASRestMethod -Uri $URI -Method GET -Headers $sessionToken -WebSession $WebSession
@@ -75,6 +85,7 @@ To force all output to be shown, pipe to Select-Object *
             "sessionToken" = $sessionToken
             "WebSession" = $WebSession
             "BaseURI" = $BaseURI
+			"PVWAAppName" = $PVWAAppName
             
         }
     

--- a/Functions/User/Get-PASUser.ps1
+++ b/Functions/User/Get-PASUser.ps1
@@ -19,6 +19,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -62,7 +66,13 @@ To force all output to be shown, pipe to Select-Object *
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
@@ -70,7 +80,7 @@ To force all output to be shown, pipe to Select-Object *
     PROCESS{
 
         #Create URL for request
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Users/$($UserName | 
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Users/$($UserName | 
         
             Get-EscapedString)"
 
@@ -86,6 +96,7 @@ To force all output to be shown, pipe to Select-Object *
             "sessionToken" = $sessionToken
             "WebSession" = $WebSession
             "BaseURI" = $BaseURI
+			"PVWAAppName" = $PVWAAppName
             
         }
     

--- a/Functions/User/New-PASUser.ps1
+++ b/Functions/User/New-PASUser.ps1
@@ -52,6 +52,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -154,7 +158,13 @@ To force all output to be shown, pipe to Select-Object *
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
@@ -178,7 +188,7 @@ To force all output to be shown, pipe to Select-Object *
         $body = $boundParameters | ConvertTo-Json
 
         #Create URL for request
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Users"
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Users"
         
         #send request to web service
         $result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -Headers $sessionToken -WebSession $WebSession
@@ -192,6 +202,7 @@ To force all output to be shown, pipe to Select-Object *
             "sessionToken" = $sessionToken
             "WebSession" = $WebSession
             "BaseURI" = $BaseURI
+            "PVWAAppName" = $PVWAAppName
 
         }
     

--- a/Functions/User/Remove-PASUser.ps1
+++ b/Functions/User/Remove-PASUser.ps1
@@ -19,6 +19,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -56,7 +60,13 @@ None
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
@@ -64,7 +74,7 @@ None
     PROCESS{
 
         #Create URL for request
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Users/$($UserName | 
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Users/$($UserName | 
         
             Get-EscapedString)"
 

--- a/Functions/User/Set-PASUser.ps1
+++ b/Functions/User/Set-PASUser.ps1
@@ -48,6 +48,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -150,7 +154,13 @@ To force all output to be shown, pipe to Select-Object *
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
@@ -175,7 +185,7 @@ To force all output to be shown, pipe to Select-Object *
         }
 
         #Create URL for request
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Users/$($UserName | 
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Users/$($UserName | 
         
             Get-EscapedString)"
 
@@ -194,6 +204,7 @@ To force all output to be shown, pipe to Select-Object *
             "sessionToken" = $sessionToken
             "WebSession" = $WebSession
             "BaseURI" = $BaseURI
+			"PVWAAppName" = $PVWAAppName
 
         }
     

--- a/Functions/User/Unblock-PASUser.ps1
+++ b/Functions/User/Unblock-PASUser.ps1
@@ -23,6 +23,10 @@ WebRequestSession object returned from New-PASSession
 PVWA Web Address
 Do not include "/PasswordVault/"
 
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
 .EXAMPLE
 
 .INPUTS
@@ -73,7 +77,13 @@ To force all output to be shown, pipe to Select-Object *
             Mandatory=$true,
             ValueFromPipelinebyPropertyName=$true
         )]
-        [string]$BaseURI
+        [string]$BaseURI,
+
+		[parameter(
+			Mandatory=$false,
+			ValueFromPipelinebyPropertyName=$true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
     )
 
     BEGIN{}#begin
@@ -81,7 +91,7 @@ To force all output to be shown, pipe to Select-Object *
     PROCESS{
 
         #Create URL for request
-        $URI = "$baseURI/PasswordVault/WebServices/PIMServices.svc/Users/$($UserName | 
+        $URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Users/$($UserName | 
         
             Get-EscapedString)"
 
@@ -104,6 +114,7 @@ To force all output to be shown, pipe to Select-Object *
             "sessionToken" = $sessionToken
             "WebSession" = $WebSession
             "BaseURI" = $BaseURI
+			"PVWAAppName" = $PVWAAppName
 
         }
     

--- a/Private/Get-PASParameters.ps1
+++ b/Private/Get-PASParameters.ps1
@@ -70,7 +70,8 @@ Hashtable/$PSBoundParameters object, with defined parameters removed.
                                     "BaseURI"
                                     "AccountID",
                                     "SessionVariable",
-                                    "WebSession")
+                                    "WebSession",
+                                    "PVWAAppName")
     )
 
     BEGIN{

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ Exposes the available methods of the web service for CyberArk PAS up to v9.9.
 
 ----------
 ## Latest Update
- - [Pipeline Support](#Pipeline_Support), where possible, across all functions
+ - Hardcoded value for PVWA Virtual Directory removed:
+	- You can now specify your own value if the PVWA is published under a Virtual Directory named something other than "PasswordVault".
+ - Use of TLS 1.2 Security Protocol enforced for Web Requests.
+ - [Pipeline Support](#Pipeline_Support), where possible, across all functions:
 	- All output objects now also contain the URL value, Session Token & WebSession information to pass to subsequent functions on the pipeline.
 	- Wherever possible ValueFromPipelinebyPropertyName is set to $true, allowing chained commands like Get-Credential | New-PASSession | Get-PASUser | Set-PASUser 
  - Secure Strings now required for Initial or Updated password values provided to the following functions:
@@ -16,7 +19,7 @@ Exposes the available methods of the web service for CyberArk PAS up to v9.9.
 	- New-PASUser
 	- Set-PASUser
 	- New-PASSession
- - [psPAS.Format.ps1xml](psPAS.Format.ps1xml) now included
+ - [psPAS.Format.ps1xml](psPAS.Format.ps1xml) now included:
 	- Defines views and default properties for psPAS output objects
 	- Use "Select-Object *" to see all properties of output objects if you are not seeing a property you expect.
 
@@ -79,7 +82,7 @@ $token | Add-PASSafe -SafeName psPAS -ManagingCPM PasswordManager -NumberOfVersi
 ```
 A CyberArk authentication token, and the URL of the Web Service, MUST be provided to each function (with the exception of Logon via New-PASSession).
 ```
-Get-PASUser -UserName psPASUser -sessionToken $token.sessionToken -baseURI "http://PVWA"
+Get-PASUser -UserName psPASUser -sessionToken $token.sessionToken -baseURI "https://PVWA"
 ```
 ### <a id="Pipeline_Support"></a>Working with the Pipeline
 
@@ -93,11 +96,11 @@ Examples below:
 
  - Logon, find and update a user, then logoff: 
 ```
-Get-Credential | New-PASSession -BaseURI http://PVWA_URL | Get-PASAccount pete | Set-PASAccount -Address 10.10.10.10 -Name Pete-psPAS-Test -UserName pspete | Close-PASSession
+Get-Credential | New-PASSession -BaseURI https://PVWA_URL | Get-PASAccount pete | Set-PASAccount -Address 10.10.10.10 -Name Pete-psPAS-Test -UserName pspete | Close-PASSession
 ```
  - Activate a Suspended CyberArk User:
 ```
-$cred | New-PASSession -BaseURI http://cyberark | Get-PASUser PebKac | Unblock-PASUser -Suspended $false
+$cred | New-PASSession -BaseURI https://cyberark | Get-PASUser PebKac | Unblock-PASUser -Suspended $false
 ```
  - Add a User to a group
  ```


### PR DESCRIPTION
Add PVWAAppName Parameter to all applicable functions, allows specifying
PVWA virtual directory other than the default PasswordVault.
Remove Hardcoded "PasswordVault" value from URLs.
Add PVWAAppName to pipeline output.
Closes #12