### PR TITLE
Ver 10 1

### DIFF
--- a/Functions/Accounts/Get-PASAccountPassword.ps1
+++ b/Functions/Accounts/Get-PASAccountPassword.ps1
@@ -5,11 +5,49 @@ Returns password for an account.
 
 .DESCRIPTION
 Returns password for an account identified by its AccountID.
-Will not return SSH Keys.
-Cannot be used if a reason for password access must be specified.
+
+If using version 9.7+ of the API:
+ - Will not return SSH Keys.
+ - Cannot be used if a reason for password access must be specified.
+
+If using version 10.1+ of the API:
+ - Will return SSH key of an existing account
+ - Can be used if a reason and/or ticket ID must be specified.
 
 .PARAMETER AccountID
 The ID of the account whose password will be retrieved.
+
+.PARAMETER UseV10API
+Specify switch to explicitly use the version 10 api when only providing AccountID.
+
+.PARAMETER Reason
+The reason that is required to be specified to retrieve the password/SSH key.
+Use of parameter requires version 10.1 at a minimum.
+
+.PARAMETER TicketingSystemName
+The name of the Ticketing System.
+Use of parameter requires version 10.1 at a minimum.
+
+.PARAMETER TicketId
+The ticket ID of the ticketing system.
+Use of parameter requires version 10.1 at a minimum.
+
+.PARAMETER Version
+The version number of the required password.
+If there are no previous versions, the current password/key version is returned.
+Use of parameter requires version 10.1 at a minimum.
+
+.PARAMETER ActionType
+The action this password will be used for.
+Use of parameter requires version 10.1 at a minimum.
+
+.PARAMETER isUse
+Internal parameter (for PSMP only).
+Use of parameter requires version 10.1 at a minimum.
+
+.PARAMETER Machine
+The address of the remote machine to connect to.
+Use of parameter requires version 10.1 at a minimum.
 
 .PARAMETER sessionToken
 Hashtable containing the session token returned from New-PASSession
@@ -28,7 +66,25 @@ Defaults to PasswordVault
 .EXAMPLE
 $token | Get-PASAccount -Keywords root -Safe Prod_Safe | Get-PASAccountPassword
 
-Will return the password value of the account fond by Get-PASAccount:
+Will return the password value of the account found by Get-PASAccount:
+
+Password
+--------
+Ra^D0MwM666*&U
+
+.EXAMPLE
+$token | Get-PASAccount -Keywords root -Safe Prod_Safe | Get-PASAccountPassword -UseV10API
+
+Will retrieve the password value of the account found by Get-PASAccount using the v10 API:
+
+Password
+--------
+Ra^D0MwM666*&U
+
+.EXAMPLE
+$token | Get-PASAccount -Keywords root -Safe Prod_Safe | Get-PASAccountPassword -Reason "Incident Investigation"
+
+Will retrieve the password value of the account found by Get-PASAccount using the v10 API, and specify a reason for access.
 
 Password
 --------
@@ -46,7 +102,10 @@ pipeline operations.
 
 Output format is defined via psPAS.Format.ps1xml.
 To force all output to be shown, pipe to Select-Object *
+
 .NOTES
+Minimum API version is 9.7 for password retrieval only.
+From version 10.1 onwards both passwords and ssh keys can be retrieved.
 
 .LINK
 #>
@@ -58,6 +117,63 @@ To force all output to be shown, pipe to Select-Object *
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[string]$AccountID,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $false,
+			ParameterSetName = "v10"
+		)]
+		[switch]$UseV10API,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $false,
+			ParameterSetName = "v10"
+		)]
+		[string]$Reason,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $false,
+			ParameterSetName = "v10"
+		)]
+		[string]$TicketingSystemName,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $false,
+			ParameterSetName = "v10"
+		)]
+		[string]$TicketId,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $false,
+			ParameterSetName = "v10"
+		)]
+		[int]$Version,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $false,
+			ParameterSetName = "v10"
+		)]
+		[ValidateSet("show", "copy", "connect")]
+		[string]$ActionType,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $false,
+			ParameterSetName = "v10"
+		)]
+		[boolean]$isUse,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $false,
+			ParameterSetName = "v10"
+		)]
+		[switch]$Machine,
 
 		[parameter(
 			Mandatory = $true,
@@ -89,13 +205,46 @@ To force all output to be shown, pipe to Select-Object *
 
 	PROCESS {
 
-		#Create request URL
-		$URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Accounts/$($AccountID |
+		#Build Request
+		if($($PSCmdlet.ParameterSetName) -eq "v10") {
 
-            Get-EscapedString)/Credentials"
+			#For Version 10.1+
+			$Request = @{
 
-		#Send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -Headers $sessionToken -WebSession $WebSession
+				"URI"    = "$baseURI/$PVWAAppName/api/Accounts/$($AccountID |
+
+            	Get-EscapedString)/Password/Retrieve"
+
+				"Method" = "POST"
+
+				#Get all parameters that will be sent in the request
+				"Body"   = $PSBoundParameters | Get-PASParameter -ParametersToRemove AccountID, UseV10API | ConvertTo-Json
+
+			}
+
+		}
+
+		Else {
+
+			#For Version 9.7+
+			$Request = @{
+
+				"URI"    = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Accounts/$($AccountID |
+
+				Get-EscapedString)/Credentials"
+
+				"Method" = "GET"
+
+			}
+
+		}
+
+		#Add default Request parameters
+		$Request.Add("Headers", $sessionToken)
+		$Request.Add("WebSession", $WebSession)
+
+		#splat request to web service
+		$result = Invoke-PASRestMethod @Request
 
 		If($result) {
 

--- a/Functions/Accounts/Invoke-PASCredChange.ps1
+++ b/Functions/Accounts/Invoke-PASCredChange.ps1
@@ -1,21 +1,51 @@
 function Invoke-PASCredChange {
 	<#
 	.SYNOPSIS
-	Initiates an immediate password change by the CPM to a new random password.
+	Either initiates an immediate password change by the CPM to a new random password or a specified password value,
+	or updates an accounts password only in the vault.
 
 	.DESCRIPTION
+	This function has 3 modes of operation, either:
+
 	Flags a managed account credentials for an immediate CPM password change.
-	The "Initiate CPM password management operations" permission is required.
+	 - The "Initiate CPM password management operations" permission is required.
+
+	Sets a password to use for an account's next CPM change.
+	 - The "Initiate CPM password management operations" & "Specify next password value" permission is required.
+
+	Updates the account's password only in the Vault (without affecting the credentials on the target device).
+	 - The "Update password value" permission is required.
 
 	.PARAMETER AccountID
 	The unique ID  of the account.
 	This is retrieved by the Get-PASAccount function.
 
-	.PARAMETER ChangeEntireGroup
+	.PARAMETER ChangeCredsForGroup
 	Boolean value, dictating if all accounts that belong to the same group should
 	have their passwords changed.
 	This is only relevant for accounts that belong to an account group.
 	Parameter will be ignored if account does not belong to a group.
+	Applicable to immediate change via CPM, and password change in the vault only.
+
+	.PARAMETER UpdateVaultOnly
+	Specify this switch to only update the password in the vault
+
+	.PARAMETER SetNextPassword
+	Specify this switch to provide a value for the next password to be set by the CPM
+
+	.PARAMETER AutoGenerate
+	Whether or not the password will be generated according to the password policy rules.
+	If the CPM is not configured to enforce a password policy rule, this parameter is irrelevant.
+	If the NewCredentials parameter contains a value, this parameter will be ignored.
+	Only relevant when updating password in vault only.
+
+	.PARAMETER ChangeImmediately
+	Whether or not the password will be changed immediately in the Vault.
+	Only relevant when specifying a password value for the next CPM change.
+
+	.PARAMETER NewCredentials
+	Secure String value of the new account password that will be allocated to the account in the Vault.
+	Only relevant when specifying a password value for the next CPM change, or updating the password only in the vault.
 
 	.PARAMETER sessionToken
 	Hashtable containing the session token returned from New-PASSession
@@ -41,17 +71,34 @@ function Invoke-PASCredChange {
 
 	Will mark xAccount for immediate password change by CPM
 
+	.EXAMPLE
+	$token | Invoke-PASCredChange -AccountID 24_3 -UpdateVaultOnly -NewCredentials (Read-Host -AsSecureString)
+
+	Updates the password int he vault to the specified value
+
+	.EXAMPLE
+	$token | Invoke-PASCredChange -AccountID 24_3 -SetNextPassword -ChangeImmediately $true -NewCredentials $PassWD
+
+	Immediately changes, via CPM, the password to the value contained in the $PassWD variable
+
+	.EXAMPLE
+	$token | Invoke-PASCredChange -AccountID 24_3 -SetNextPassword -NewCredentials $PassWD
+
+	Changes, via CPM, the password to the value contained in the $PassWD variable
+
 	.INPUTS
-	SessionToken, AccountID, WebSession & BaseURI can be piped by  property name
+	SessionToken, AccountID, NewCredentials, WebSession & BaseURI can be piped by  property name
 
 	.OUTPUTS
 	None
 
 	.NOTES
-	Minimum CyberArk version 9.10
+	Minimum CyberArk version 9.10 for immediate change by CPM
+	Minimum CyberArk version 10.1 for specify next password value, and update password only in the Vault
 
 	#>
-	[CmdletBinding(SupportsShouldProcess)]
+
+	[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = "Change")]
 	param(
 		[parameter(
 			Mandatory = $true,
@@ -62,9 +109,57 @@ function Invoke-PASCredChange {
 
 		[parameter(
 			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $false
+			ValueFromPipelinebyPropertyName = $false,
+			ParameterSetName = "Change"
 		)]
-		[boolean]$ChangeEntireGroup,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $false,
+			ParameterSetName = "Password/Update"
+		)]
+		[boolean]$ChangeCredsForGroup,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $false,
+			ParameterSetName = "Password/Update"
+		)]
+		[switch]$UpdateVaultOnly,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $false,
+			ParameterSetName = "SetNextPassword"
+		)]
+		[switch]$SetNextPassword,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $false,
+			ParameterSetName = "Password/Update"
+		)]
+		[boolean]$AutoGenerate,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $false,
+			ParameterSetName = "SetNextPassword"
+		)]
+		[boolean]$ChangeImmediately,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "Password/Update"
+		)]
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "SetNextPassword"
+		)]
+		[securestring]$NewCredentials,
 
 		[parameter(
 			Mandatory = $true,
@@ -95,13 +190,32 @@ function Invoke-PASCredChange {
 
 	PROCESS {
 
+		Write-Debug "ParameterSet $($PSCmdlet.ParameterSetName)"
+
 		#Create URL for request
-		$URI = "$baseURI/$PVWAAppName/API/Accounts/$AccountID/Change"
+		$URI = "$baseURI/$PVWAAppName/API/Accounts/$AccountID/$($PSCmdlet.ParameterSetName)"
+
+		#Get all parameters that will be sent in the request
+		$boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove UpdateVaultOnly, SetNextPassword
+
+		#deal with NewCredentials SecureString
+		If($PSBoundParameters.ContainsKey("NewCredentials")) {
+
+			#Create New Credential object
+			$Pwd = New-Object -TypeName "System.Management.Automation.PSCredential" -ArgumentList $(
+
+				#Assign password and dummy username
+				$AccountID), $NewCredentials
+
+			#Include decoded password in request
+			$boundParameters["NewCredentials"] = $($Pwd.GetNetworkCredential().Password)
+
+		}
 
 		#create request body
-		$body = $PSBoundParameters | Get-PASParameter | ConvertTo-Json
+		$body = $boundParameters | ConvertTo-Json
 
-		if($PSCmdlet.ShouldProcess($AccountID, "Mark for Immediate Change by CPM")) {
+		if($PSCmdlet.ShouldProcess($AccountID, "Password: $($PSCmdlet.ParameterSetName) Value")) {
 
 			#send request to web service
 			Invoke-PASRestMethod -Uri $URI -Method POST -body $body -Headers $SessionToken -WebSession $WebSession

--- a/Functions/Monitoring/Stop-PASPSMSession.ps1
+++ b/Functions/Monitoring/Stop-PASPSMSession.ps1
@@ -1,0 +1,92 @@
+function Stop-PASPSMSession {
+	<#
+.SYNOPSIS
+Terminates a Live PSM Session.
+
+.DESCRIPTION
+Terminates a Live PSM Session identified by the unique ID of the PSM Session.
+
+.PARAMETER LiveSessionId
+The unique ID/SessionGuid of a Live PSM Session.
+
+.PARAMETER sessionToken
+Hashtable containing the session token returned from New-PASSession
+
+.PARAMETER WebSession
+WebRequestSession object returned from New-PASSession
+
+.PARAMETER BaseURI
+PVWA Web Address
+Do not include "/PasswordVault/"
+
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
+.EXAMPLE
+$token | Stop-PASPSMSession -LiveSessionId <Session UUID>
+
+Terminates Live PSM Session identified by the session UUID.
+
+.INPUTS
+All parameters can be piped by property name
+
+.OUTPUTS
+None
+
+.NOTES
+Minimum CyberArk Version 10.1
+
+.LINK
+
+#>
+	[CmdletBinding()]
+	param(
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[Alias("SessionGuid")]
+		[string]$LiveSessionId,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[hashtable]$sessionToken,
+
+		[parameter(
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[Microsoft.PowerShell.Commands.WebRequestSession]$WebSession,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$BaseURI,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
+	)
+
+	BEGIN {}#begin
+
+	PROCESS {
+
+		#Create URL for Request
+		$URI = "$baseURI/$PVWAAppName/api/LiveSessions/$($LiveSessionId | Get-EscapedString)/Terminate"
+
+		#send request to PAS web service
+		Invoke-PASRestMethod -Uri $URI -Method POST -Headers $sessionToken -WebSession $WebSession
+
+	} #process
+
+	END {}#end
+
+}

--- a/Functions/Monitoring/Stop-PASPSMSession.ps1
+++ b/Functions/Monitoring/Stop-PASPSMSession.ps1
@@ -40,7 +40,7 @@ Minimum CyberArk Version 10.1
 .LINK
 
 #>
-	[CmdletBinding()]
+	[CmdletBinding(SupportsShouldProcess)]
 	param(
 		[parameter(
 			Mandatory = $true,
@@ -82,8 +82,12 @@ Minimum CyberArk Version 10.1
 		#Create URL for Request
 		$URI = "$baseURI/$PVWAAppName/api/LiveSessions/$($LiveSessionId | Get-EscapedString)/Terminate"
 
-		#send request to PAS web service
-		Invoke-PASRestMethod -Uri $URI -Method POST -Headers $sessionToken -WebSession $WebSession
+		if($PSCmdlet.ShouldProcess($LiveSessionId, "Terminate PSM Session")) {
+
+			#send request to PAS web service
+			Invoke-PASRestMethod -Uri $URI -Method POST -Headers $sessionToken -WebSession $WebSession
+
+		}
 
 	} #process
 

--- a/Functions/SystemHealth/Get-PASComponentDetail.ps1
+++ b/Functions/SystemHealth/Get-PASComponentDetail.ps1
@@ -1,4 +1,4 @@
-Function Get-PASComponentDetails {
+Function Get-PASComponentDetail {
 	<#
 .SYNOPSIS
 Returns details & health information about CyberArk component instances.
@@ -25,17 +25,17 @@ The name of the CyberArk PVWA Virtual Directory.
 Defaults to PasswordVault
 
 .EXAMPLE
-$token | Get-PASComponentDetails -ComponentID CPM
+$token | Get-PASComponentDetail -ComponentID CPM
 
 Displays CPM Component information
 
 .EXAMPLE
-$token | Get-PASComponentDetails -ComponentID PVWA
+$token | Get-PASComponentDetail -ComponentID PVWA
 
 Displays PVWA Component information
 
 .EXAMPLE
-$token | Get-PASComponentDetails -ComponentID SessionManagement
+$token | Get-PASComponentDetail -ComponentID SessionManagement
 
 Displays PSM Component information
 

--- a/Functions/SystemHealth/Get-PASComponentDetails.ps1
+++ b/Functions/SystemHealth/Get-PASComponentDetails.ps1
@@ -1,0 +1,105 @@
+Function Get-PASComponentDetails {
+	<#
+.SYNOPSIS
+Returns details & health information about CyberArk component instances.
+
+.DESCRIPTION
+Returns details about specific components and all their installed instances,
+as well as system health information for each one.
+
+.PARAMETER ComponentID
+Specify component type to return information on (PVWA, SessionManagement, CPM or AIM)
+
+.PARAMETER sessionToken
+Hashtable containing the session token returned from New-PASSession
+
+.PARAMETER WebSession
+WebRequestSession object returned from New-PASSession
+
+.PARAMETER BaseURI
+PVWA Web Address
+Do not include "/PasswordVault/"
+
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
+.EXAMPLE
+$token | Get-PASComponentDetails -ComponentID CPM
+
+Displays CPM Component information
+
+.EXAMPLE
+$token | Get-PASComponentDetails -ComponentID PVWA
+
+Displays PVWA Component information
+
+.EXAMPLE
+$token | Get-PASComponentDetails -ComponentID SessionManagement
+
+Displays PSM Component information
+
+.INPUTS
+All parameters can be piped to the function by propertyname
+
+.OUTPUTS
+
+.NOTES
+Requires minimum version of CyberArk 10.1.
+
+.LINK
+
+#>
+	[CmdletBinding()]
+	param(
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[ValidateSet("PVWA", "SessionManagement", "CPM", "AIM")]
+		[string]$ComponentID,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[hashtable]$sessionToken,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[Microsoft.PowerShell.Commands.WebRequestSession]$WebSession,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$BaseURI,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
+	)
+
+	BEGIN {}#begin
+
+	PROCESS {
+
+		#Create URL for request
+		$URI = "$baseURI/$PVWAAppName/api/ComponentsMonitoringDetails/$ComponentID"
+
+		#send request to web service
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET -Headers $sessionToken -WebSession $WebSession
+
+		#output returned data
+		$result | Select-Object -ExpandProperty ComponentsDetails
+
+	}#process
+
+	END {}#end
+}

--- a/Functions/SystemHealth/Get-PASComponentSummary.ps1
+++ b/Functions/SystemHealth/Get-PASComponentSummary.ps1
@@ -1,0 +1,88 @@
+Function Get-PASComponentSummary {
+	<#
+.SYNOPSIS
+Returns consolidated information about CyberArk Components.
+
+.DESCRIPTION
+Returns consolidated information about the Vault, PVWA, CPM, PSM/PSMP and AIM.
+Includes all clients that are relevant to each specific component.
+
+.PARAMETER sessionToken
+Hashtable containing the session token returned from New-PASSession
+
+.PARAMETER WebSession
+WebRequestSession object returned from New-PASSession
+
+.PARAMETER BaseURI
+PVWA Web Address
+Do not include "/PasswordVault/"
+
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
+.EXAMPLE
+$token | Get-PASComponentSummary
+
+Displays CyberArk Component information
+
+.INPUTS
+All parameters can be piped to the function by propertyname
+
+.OUTPUTS
+
+.NOTES
+Requires minimum version of CyberArk 10.1.
+
+.LINK
+
+#>
+	[CmdletBinding()]
+	param(
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[hashtable]$sessionToken,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[Microsoft.PowerShell.Commands.WebRequestSession]$WebSession,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$BaseURI,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
+	)
+
+	BEGIN {}#begin
+
+	PROCESS {
+
+		#Create URL for request
+		$URI = "$baseURI/$PVWAAppName/api/ComponentsMonitoringSummary"
+
+		#send request to web service
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET -Headers $sessionToken -WebSession $WebSession
+
+		$result | Select-Object -ExpandProperty Components
+
+		$result | Select-Object -ExpandProperty Vaults | Add-ObjectDetail -PropertyToAdd @{
+			"ComponentID"   = "EPV"
+			"ComponentName" = "EPV"
+		} | Select-Object ComponentID, ComponentName, Role, IP, IsLoggedOn
+
+	}#process
+
+	END {}#end
+}

--- a/Private/Invoke-PASRestMethod.ps1
+++ b/Private/Invoke-PASRestMethod.ps1
@@ -187,6 +187,13 @@ to ensure session persistence.
 
 						}
 
+						elseif(($webResponse.headers)["Content-Type"] -match "text/html") {
+
+							#Return only the text between opening and closing quotes
+							[regex]::matches($($webResponse.content), '^"(.*)"$').Groups[1].Value
+
+						}
+
 						Elseif(($webResponse.headers)["Content-Type"] -match "application/json") {
 
 							#Create Return Object from Returned JSON

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Exposes the available methods of the web service for CyberArk PAS up to v10.1.
   - `Get-PASAccountPassword` (_Updated_)
   - `Stop-PASPSMSession`
   - `Get-PASComponentSummary`
-  - `Get-PASComponentDetails`
+  - `Get-PASComponentDetail`
 
 For the functions which have been updated, new features present in the REST API specific to version 10.1 have now been included where applicable.
 
@@ -233,4 +233,4 @@ Chapeau!
 |9.9|All Previous Functions|
 |9.9.5|All Previous Functions, and:<br/>`New-PASAccountGroup`<br/>`Add-PASAccountGroupMember`<br/><br/>|
 |9.10|All Previous Functions, and:<br/>`Invoke-PASCredChange` (_Limited Functionality_)<br/>`Invoke-PASCredVerify`<br/>`Invoke-PASCredReconcile`<br/>`Unlock-PASAccount`<br/>`Get-PASAccountGroup`<br/>`Get-PASAccountGroupMember`<br/>`Remove-PASAccountGroupMember`<br/>`New-PASRequest`<br/>`Get-PASRequest`<br/>`Get-PASRequestDetail`<br/>`Remove-PASRequest`<br/>`Approve-PASRequest`<br/>`Deny-PASRequest`<br/>`Get-PASPlatform`<br/>`Get-PASRecording`<br/>`Get-PASLiveSession`<br/>`Get-PASPSMConnectionParameter`<br/><br/>|
-|10.1|All Previous Functions, and:<br/>`Invoke-PASCredChange` (_Updated for 10.1_)<br/>`Get-PASAccountPassword` (_Updated for 10.1_)<br/>`Stop-PASPSMSession`<br/>`Get-PASComponentSummary`<br/>`Get-PASComponentDetails`<br/><br/>|
+|10.1|All Previous Functions, and:<br/>`Invoke-PASCredChange` (_Updated for 10.1_)<br/>`Get-PASAccountPassword` (_Updated for 10.1_)<br/>`Stop-PASPSMSession`<br/>`Get-PASComponentSummary`<br/>`Get-PASComponentDetail`<br/><br/>|

--- a/README.md
+++ b/README.md
@@ -19,30 +19,22 @@
 
 PowerShell module for CyberArk Privileged Account Security Web Services REST API.
 
-Exposes the available methods of the web service for CyberArk PAS up to v9.10.
+Exposes the available methods of the web service for CyberArk PAS up to v10.1.
 
 ----------
 
 ## Latest Update
 
-- Released functions for the new functionality in the CyberArk 9.10 API:
-  - `Invoke-PASCredChange`
-  - `Invoke-PASCredVerify`
-  - `Invoke-PASCredReconcile`
-  - `Unlock-PASAccount`
-  - `Get-PASAccountGroup`
-  - `Get-PASAccountGroupMember`
-  - `Remove-PASAccountGroupMember`
-  - `New-PASRequest`
-  - `Get-PASRequest`
-  - `Get-PASRequestDetail`
-  - `Remove-PASRequest`
-  - `Approve-PASRequest`
-  - `Deny-PASRequest`
-  - `Get-PASPlatform`
-  - `Get-PASPSMRecording`
-  - `Get-PASPSMLiveSession`
-  - `Get-PASPSMConnectionParameter`
+- Released new or updated functions for the new functionality in the CyberArk 10.1 API:
+  - `Invoke-PASCredChange` (_Updated_)
+  - `Get-PASAccountPassword` (_Updated_)
+  - `Stop-PASPSMSession`
+  - `Get-PASComponentSummary`
+  - `Get-PASComponentDetails`
+
+For the functions which have been updated, new features present in the REST API specific to version 10.1 have now been included where applicable.
+
+The functions can still be used on appropriate earlier CyberArk versions, but not all features/parameters of the functions will be available to you. If in doubt, check the comment based help & [compatibility table](#CyberArk_Version_Compatibility).
 
 ## Getting Started
 
@@ -236,8 +228,9 @@ Chapeau!
 |9.4|All Previous Functions<br/><br/>|
 |9.5|All Previous Functions, and:<br/>`Set-PASAccount`<br/><br/>|
 |9.6|All Previous Functions, and:<br/>`Add-PASPublicSSHKey`<br/>`Get-PASPublicSSHKey`<br/>`Remove-PASPublicSSHKey`<br/><br/>|
-|9.7|All Previous Functions, and:<br/>`New-PASSession` (CyberArk, LDAP, RADIUS Authentication)<br/>`New-PASSAMLSession` (*In Development)<br/>`Close-PASSAMLSession` (*In Development)<br/>`New-PASSharedSession`<br/>`Close-PASSharedSession`<br/>`Get-PASServerWebService`<br/>`Get-PASSafeShareLogo`<br/>`Get-PASServer`<br/>`New-PASUser`<br/>`Set-PASUser`<br/>`Remove-PASUser`<br/>`Get-PASLoggedOnUser`<br/>`Get-PASUser`<br/>`Unblock-PASUser`<br/>`Add-PASGroupMember`<br/>`Add-PASPendingAccount`<br/>`Get-PASAccountPassword`<br/>`Start-PASCredVerify`<br/>`Get-PASAccountActivity`<br/>`Get-PASSafe`<br/>`Get-PASSafeMember`<br/><br/>|
+|9.7|All Previous Functions, and:<br/>`New-PASSession` (CyberArk, LDAP, RADIUS Authentication)<br/>`New-PASSAMLSession` (*In Development)<br/>`Close-PASSAMLSession` (*In Development)<br/>`New-PASSharedSession`<br/>`Close-PASSharedSession`<br/>`Get-PASServerWebService`<br/>`Get-PASSafeShareLogo`<br/>`Get-PASServer`<br/>`New-PASUser`<br/>`Set-PASUser`<br/>`Remove-PASUser`<br/>`Get-PASLoggedOnUser`<br/>`Get-PASUser`<br/>`Unblock-PASUser`<br/>`Add-PASGroupMember`<br/>`Add-PASPendingAccount`<br/>`Get-PASAccountPassword` (_Limited Functionality_)<br/>`Start-PASCredVerify`<br/>`Get-PASAccountActivity`<br/>`Get-PASSafe`<br/>`Get-PASSafeMember`<br/><br/>|
 |9.8|All Previous Functions, and:<br/>`New-PASOnboardingRule`<br/>`Remove-PASOnboardingRule`<br/>`Get-PASOnboardingRule`<br/><br/>|
 |9.9|All Previous Functions|
 |9.9.5|All Previous Functions, and:<br/>`New-PASAccountGroup`<br/>`Add-PASAccountGroupMember`<br/><br/>|
-|9.10|All Previous Functions, and:<br/>`Invoke-PASCredChange`<br/>`Invoke-PASCredVerify`<br/>`Invoke-PASCredReconcile`<br/>`Unlock-PASAccount`<br/>`Get-PASAccountGroup`<br/>`Get-PASAccountGroupMember`<br/>`Remove-PASAccountGroupMember`<br/>`New-PASRequest`<br/>`Get-PASRequest`<br/>`Get-PASRequestDetail`<br/>`Remove-PASRequest`<br/>`Approve-PASRequest`<br/>`Deny-PASRequest`<br/>`Get-PASPlatform`<br/>`Get-PASRecording`<br/>`Get-PASLiveSession`<br/>`Get-PASPSMConnectionParameter`<br/><br/>|
+|9.10|All Previous Functions, and:<br/>`Invoke-PASCredChange` (_Limited Functionality_)<br/>`Invoke-PASCredVerify`<br/>`Invoke-PASCredReconcile`<br/>`Unlock-PASAccount`<br/>`Get-PASAccountGroup`<br/>`Get-PASAccountGroupMember`<br/>`Remove-PASAccountGroupMember`<br/>`New-PASRequest`<br/>`Get-PASRequest`<br/>`Get-PASRequestDetail`<br/>`Remove-PASRequest`<br/>`Approve-PASRequest`<br/>`Deny-PASRequest`<br/>`Get-PASPlatform`<br/>`Get-PASRecording`<br/>`Get-PASLiveSession`<br/>`Get-PASPSMConnectionParameter`<br/><br/>|
+|10.1|All Previous Functions, and:<br/>`Invoke-PASCredChange` (_Updated for 10.1_)<br/>`Get-PASAccountPassword` (_Updated for 10.1_)<br/>`Stop-PASPSMSession`<br/>`Get-PASComponentSummary`<br/>`Get-PASComponentDetails`<br/><br/>|

--- a/psPAS.psd1
+++ b/psPAS.psd1
@@ -4,7 +4,7 @@
 	RootModule        = 'psPAS.psm1'
 
 	# Version number of this module.
-	ModuleVersion     = '0.9.5'
+	ModuleVersion     = '0.9.6'
 
 	# ID used to uniquely identify this module
 	GUID              = '11c880d2-1430-4bd2-b6e8-f324741b460b'
@@ -133,7 +133,7 @@
 		'Get-PASPSMSession',
 		'Stop-PASPSMSession',
 		'Get-PASComponentSummary',
-		'Get-PASComponentDetails'
+		'Get-PASComponentDetail'
 	)
 
 	# Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.

--- a/psPAS.psd1
+++ b/psPAS.psd1
@@ -4,7 +4,7 @@
 	RootModule        = 'psPAS.psm1'
 
 	# Version number of this module.
-	ModuleVersion     = '0.8.7'
+	ModuleVersion     = '0.9.0'
 
 	# ID used to uniquely identify this module
 	GUID              = '11c880d2-1430-4bd2-b6e8-f324741b460b'
@@ -16,7 +16,7 @@
 	# CompanyName = ''
 
 	# Copyright statement for this module
-	Copyright         = '(c) 2017 Pete Maan. All rights reserved.'
+	Copyright         = '(c) 2018 Pete Maan. All rights reserved.'
 
 	# Description of the functionality provided by this module
 	Description       = 'Module to expose CyberArk REST API/Web Service functions'

--- a/psPAS.psd1
+++ b/psPAS.psd1
@@ -4,7 +4,7 @@
 	RootModule        = 'psPAS.psm1'
 
 	# Version number of this module.
-	ModuleVersion     = '0.9.2'
+	ModuleVersion     = '0.9.3'
 
 	# ID used to uniquely identify this module
 	GUID              = '11c880d2-1430-4bd2-b6e8-f324741b460b'
@@ -131,7 +131,8 @@
 		'Get-PASPSMConnectionParameter',
 		'Get-PASPSMRecording',
 		'Get-PASPSMSession',
-		'Stop-PASPSMSession'
+		'Stop-PASPSMSession',
+		'Get-PASComponentSummary'
 	)
 
 	# Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.

--- a/psPAS.psd1
+++ b/psPAS.psd1
@@ -4,7 +4,7 @@
 	RootModule        = 'psPAS.psm1'
 
 	# Version number of this module.
-	ModuleVersion     = '0.9.0'
+	ModuleVersion     = '0.9.1'
 
 	# ID used to uniquely identify this module
 	GUID              = '11c880d2-1430-4bd2-b6e8-f324741b460b'

--- a/psPAS.psd1
+++ b/psPAS.psd1
@@ -4,7 +4,7 @@
 	RootModule        = 'psPAS.psm1'
 
 	# Version number of this module.
-	ModuleVersion     = '0.9.6'
+	ModuleVersion     = '0.9.7'
 
 	# ID used to uniquely identify this module
 	GUID              = '11c880d2-1430-4bd2-b6e8-f324741b460b'

--- a/psPAS.psd1
+++ b/psPAS.psd1
@@ -4,7 +4,7 @@
 	RootModule        = 'psPAS.psm1'
 
 	# Version number of this module.
-	ModuleVersion     = '0.9.4'
+	ModuleVersion     = '0.9.5'
 
 	# ID used to uniquely identify this module
 	GUID              = '11c880d2-1430-4bd2-b6e8-f324741b460b'

--- a/psPAS.psd1
+++ b/psPAS.psd1
@@ -4,7 +4,7 @@
 	RootModule        = 'psPAS.psm1'
 
 	# Version number of this module.
-	ModuleVersion     = '0.9.1'
+	ModuleVersion     = '0.9.2'
 
 	# ID used to uniquely identify this module
 	GUID              = '11c880d2-1430-4bd2-b6e8-f324741b460b'
@@ -130,7 +130,8 @@
 		'Get-PASRequestDetail',
 		'Get-PASPSMConnectionParameter',
 		'Get-PASPSMRecording',
-		'Get-PASPSMSession'
+		'Get-PASPSMSession',
+		'Stop-PASPSMSession'
 	)
 
 	# Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.

--- a/psPAS.psd1
+++ b/psPAS.psd1
@@ -4,7 +4,7 @@
 	RootModule        = 'psPAS.psm1'
 
 	# Version number of this module.
-	ModuleVersion     = '0.9.3'
+	ModuleVersion     = '0.9.4'
 
 	# ID used to uniquely identify this module
 	GUID              = '11c880d2-1430-4bd2-b6e8-f324741b460b'
@@ -132,7 +132,8 @@
 		'Get-PASPSMRecording',
 		'Get-PASPSMSession',
 		'Stop-PASPSMSession',
-		'Get-PASComponentSummary'
+		'Get-PASComponentSummary',
+		'Get-PASComponentDetails'
 	)
 
 	# Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.


### PR DESCRIPTION
## Summary

Module update for CyberArk 10.1 API features

This PR implements the following **features**:

Update to Invoke-PASCredChange (specify password for next CPM Change, Change password in vault only )
Update to Get-PASAccountPassword (supports specifying reason/ticket info)
Added Stop-PASPSMSession (Terminates Live PSM Session)
Added Get-PASComponentSummary (CyberArk Summary Information)
Added Get-PASComponentDetail (Component health information)

## Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes. -->
Fixes #
Closes #49 