### PR TITLE
Add Pester Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,24 +27,11 @@ Exposes the available methods of the web service for CyberArk PAS up to v10.1.
 
 ## Latest Update
 
-- Module now available via the [PowerShell Gallery](https://www.powershellgallery.com/packages/psPAS/).
-- Updated Repository Structure
-  - All module files now contained under the `psPAS` directory.
-  - Files not needed for module operations remain at the root level.
-  - A directory for Pester tests has been created, and contains initial tests for ensuring module consistency.
-    - Some module files have been updated based on the output of Pester (mainly missing help descriptions for parameters, or functions without examples).
-  - Project now integrated with [Appveyor](https://ci.appveyor.com/project/pspete/pspas).
-
-- Released new or updated functions for the new functionality in the CyberArk 10.1 API:
-  - `Invoke-PASCredChange` (_Updated_)
-  - `Get-PASAccountPassword` (_Updated_)
-  - `Stop-PASPSMSession`
-  - `Get-PASComponentSummary`
-  - `Get-PASComponentDetail`
-
-For the functions which have been updated, new features present in the REST API specific to version 10.1 have now been included where applicable.
-
-The functions can still be used on appropriate earlier CyberArk versions, but not all features/parameters of the functions will be available to you. If in doubt, check the comment based help & [compatibility table](#CyberArk_Version_Compatibility).
+- Added initial Pester tests for all functions.
+- Bug Fixes:
+  - ```Add-PASAccountGroupMember``` was not sending AccountID with request, now fixed.
+  - ```New-PASSAMLSession``` - authentication token was not being sent in request header, now fixed.
+  - ```Get-PASOnboardingRule```, ```New-PASOnboardingRule``` & ```Remove-PASOnboardingRule```, parameters updated to allow specification of alternate PVWA application name (in-line with the rest of the module's functions).
 
 ## Getting Started
 
@@ -57,8 +44,8 @@ The functions can still be used on appropriate earlier CyberArk versions, but no
 - A user with which to authenticate, with appropriate Vault/Safe permissions.
   - LDAP, CyberArk, RADIUS & Shared authentication can be used from CyberArk version 9.7 onwards.
   - For CyberArk 9.6 and below, only CyberArk authentication is supported.
-  - SAML authentication is supported from version 9.7, but the psPAS functions to support this are still in development (i.e. not working & not tested).
-    - The work in progress functions are included in the module - if you are using SAML authentication, have the insight, and are interested in helping getting this to work, let me know.
+  - SAML authentication is supported from version 9.7; the psPAS functions to support this are untested.
+    - The functions are included in the module - if you are using SAML authentication, and can feedback whether the functions work it would be appreciated.
 
 ### Install and Use
 
@@ -239,7 +226,7 @@ This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md
 
 Any and all contributions to this project are appreciated.
 
-The SAML authentication capability needs some attention.
+The SAML authentication capability needs testing, no federation service is available to me to confirm that the functionality works as required...
 
 See the [CONTRIBUTING.md](CONTRIBUTING.md) for a few more details.
 
@@ -264,7 +251,7 @@ Chapeau!
 |9.4|All Previous Functions<br/><br/>|
 |9.5|All Previous Functions, and:<br/>`Set-PASAccount`<br/><br/>|
 |9.6|All Previous Functions, and:<br/>`Add-PASPublicSSHKey`<br/>`Get-PASPublicSSHKey`<br/>`Remove-PASPublicSSHKey`<br/><br/>|
-|9.7|All Previous Functions, and:<br/>`New-PASSession` (CyberArk, LDAP, RADIUS Authentication)<br/>`New-PASSAMLSession` (*In Development)<br/>`Close-PASSAMLSession` (*In Development)<br/>`New-PASSharedSession`<br/>`Close-PASSharedSession`<br/>`Get-PASServerWebService`<br/>`Get-PASSafeShareLogo`<br/>`Get-PASServer`<br/>`New-PASUser`<br/>`Set-PASUser`<br/>`Remove-PASUser`<br/>`Get-PASLoggedOnUser`<br/>`Get-PASUser`<br/>`Unblock-PASUser`<br/>`Add-PASGroupMember`<br/>`Add-PASPendingAccount`<br/>`Get-PASAccountPassword` (_Limited Functionality_)<br/>`Start-PASCredVerify`<br/>`Get-PASAccountActivity`<br/>`Get-PASSafe`<br/>`Get-PASSafeMember`<br/><br/>|
+|9.7|All Previous Functions, and:<br/>`New-PASSession` (CyberArk, LDAP, RADIUS Authentication)<br/>`New-PASSAMLSession`<br/>`Close-PASSAMLSession` <br/>`New-PASSharedSession`<br/>`Close-PASSharedSession`<br/>`Get-PASServerWebService`<br/>`Get-PASSafeShareLogo`<br/>`Get-PASServer`<br/>`New-PASUser`<br/>`Set-PASUser`<br/>`Remove-PASUser`<br/>`Get-PASLoggedOnUser`<br/>`Get-PASUser`<br/>`Unblock-PASUser`<br/>`Add-PASGroupMember`<br/>`Add-PASPendingAccount`<br/>`Get-PASAccountPassword` (_Limited Functionality_)<br/>`Start-PASCredVerify`<br/>`Get-PASAccountActivity`<br/>`Get-PASSafe`<br/>`Get-PASSafeMember`<br/><br/>|
 |9.8|All Previous Functions, and:<br/>`New-PASOnboardingRule`<br/>`Remove-PASOnboardingRule`<br/>`Get-PASOnboardingRule`<br/><br/>|
 |9.9|All Previous Functions|
 |9.9.5|All Previous Functions, and:<br/>`New-PASAccountGroup`<br/>`Add-PASAccountGroupMember`<br/><br/>|

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # psPAS
 
-[![Build status](https://ci.appveyor.com/api/projects/status/j45hbplm4dq4vfye/branch/master?svg=true)](https://ci.appveyor.com/project/pspete/pspas/branch/master)
+[![Build status](https://ci.appveyor.com/api/projects/status/j45hbplm4dq4vfye/branch/master?svg=true)](https://ci.appveyor.com/project/pspete/pspas/branch/master) [![Coverage Status](https://coveralls.io/repos/github/pspete/psPAS/badge.svg)](https://coveralls.io/github/pspete/psPAS)
 
 ## **Table of Contents**
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Exposes the available methods of the web service for CyberArk PAS up to v10.1.
 - Added initial Pester tests for all functions.
 - Bug Fixes:
   - ```Add-PASAccountGroupMember``` was not sending AccountID with request, now fixed.
+  - ```New-PASAccountGroup``` fixed an incorrect parameter name (_GroupPlatformID_).
   - ```New-PASSAMLSession``` - authentication token was not being sent in request header, now fixed.
   - ```Get-PASOnboardingRule```, ```New-PASOnboardingRule``` & ```Remove-PASOnboardingRule```, parameters updated to allow specification of alternate PVWA application name (in-line with the rest of the module's functions).
 

--- a/Tests/Add-PASAccount.Tests.ps1
+++ b/Tests/Add-PASAccount.Tests.ps1
@@ -77,8 +77,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				{((Get-Command $FunctionName).Parameters["$Parameter"].Attributes).Mandatory} |
-					Should Be $true
+				(Get-Command Add-PASAccount).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
 
 			}
 

--- a/Tests/Add-PASAccount.Tests.ps1
+++ b/Tests/Add-PASAccount.Tests.ps1
@@ -1,0 +1,151 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			Write-Output @{}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"Safe"                  = "P_Safe"
+			"platformID"            = "P_Platform"
+			"password"              = $("P_Password" | ConvertTo-SecureString -AsPlainText -Force)
+			"username"              = "P_UserName"
+			"sessionToken"          = @{"Authorization" = "P_AuthValue"}
+			"WebSession"            = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"               = "https://P_URI"
+			"PVWAAppName"           = "P_App"
+			"Port"                  = 1234
+			"ExtraPass1Name"        = "P_ExtP1"
+			"DynamicProperties"     = @{"TestKey" = "TestVal"; "TestKey1" = "TestVal"; "TestKey2" = "TestVal"}
+			"address"               = "10.10.10.10"
+			"accountName"           = "SomeName"
+			"disableAutoMgmt"       = $true
+			"disableAutoMgmtReason" = "SomeReason"
+			"groupName"             = "SomeGroup"
+			"groupPlatformID"       = "GPlatform"
+			"ExtraPass1Folder"      = "Root"
+			"ExtraPass1Safe"        = "Safe1"
+			"ExtraPass3Name"        = "SomeName"
+			"ExtraPass3Folder"      = "Root"
+			"ExtraPass3Safe"        = "SomeSafe"
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'safe'},
+			@{Parameter = 'platformID'},
+			@{Parameter = 'password'},
+			@{Parameter = 'username'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				{((Get-Command $FunctionName).Parameters["$Parameter"].Attributes).Mandatory} |
+					Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Add-PASAccount -verbose
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Account"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody.Account) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody.Account | Get-Member -MemberType NoteProperty).length | Should Be 11
+
+			}
+
+			It "has expected number of nested properties" {
+
+				($Script:RequestBody.Account.Properties).count | Should Be 10
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Add-PASAccountACL.Tests.ps1
+++ b/Tests/Add-PASAccountACL.Tests.ps1
@@ -1,0 +1,157 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[pscustomobject]@{"AddAccountPrivilegedCommandResult" = [pscustomobject]@{"some" = "thing"}}
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken"    = @{"Authorization" = "P_AuthValue"}
+			"WebSession"      = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"         = "https://P_URI"
+			"PVWAAppName"     = "P_App"
+			"AccountPolicyID" = "UNIXSSH"
+			"AccountAddress"  = "ServerA.domain.com"
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'AccountPolicyId'},
+			@{Parameter = 'AccountAddress'},
+			@{Parameter = 'AccountUserName'},
+			@{Parameter = 'Command'},
+			@{Parameter = 'CommandGroup'},
+			@{Parameter = 'PermissionType'},
+			@{Parameter = 'UserName'}
+
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Add-PASAccountACL).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Add-PASAccountACL -AccountUserName "root" -Command 'some command' -CommandGroup $false -PermissionType Deny -UserName "TestUser"
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Account/ServerA.domain.com|root|UNIXSSH/PrivilegedCommands"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'PUT' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 5
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 5
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.ACL.Account
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Add-PASAccountGroupMember.Tests.ps1
+++ b/Tests/Add-PASAccountGroupMember.Tests.ps1
@@ -1,0 +1,127 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"AccountID"    = "99_9"
+			"GroupID"      = "88_8"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'AccountID'},
+			@{Parameter = 'GroupID'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Add-PASAccountGroupMember).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Add-PASAccountGroupMember
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/AccountGroups/88_8/Members"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 1
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Add-PASApplication.Tests.ps1
+++ b/Tests/Add-PASApplication.Tests.ps1
@@ -1,0 +1,133 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"AppID"        = "SomeApplication"
+			"Location"     = "\SomeLocation\"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'AppID'},
+			@{Parameter = 'Location'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Add-PASApplication).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Add-PASApplication -ExpirationDate 04-20-2019
+
+		Context "Input" {
+
+			It "validates expiration date pattern" {
+
+				{$InputObj | Add-PASApplication -ExpirationDate 20-04-2019} | Should throw
+
+			}
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Applications"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody.application) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody.application | Get-Member -MemberType NoteProperty).length | Should Be 3
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Add-PASApplicationAuthenticationMethod.Tests.ps1
+++ b/Tests/Add-PASApplicationAuthenticationMethod.Tests.ps1
@@ -1,0 +1,180 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"AppID"        = "SomeApplication"
+			"AuthValue"    = "SomePath"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'AppID'},
+			@{Parameter = 'AuthType'},
+			@{Parameter = 'AuthValue'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Add-PASApplicationAuthenticationMethod).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Add-PASApplicationAuthenticationMethod -AuthType path -IsFolder $true -AllowInternalScripts $true
+
+		Context "Input" {
+
+			It "validates authType parameter" {
+
+				{$InputObj | Add-PASApplicationAuthenticationMethod -AuthType InvalidAuthType} | Should throw
+
+			}
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Applications/SomeApplication/Authentications"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody.authentication) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has dynamic parameter 'IsFolder' when authtype path is specified" {
+
+				$Script:RequestBody.authentication.IsFolder | Should Be $true
+
+			}
+
+			It "has dynamic parameter 'AllowInternalScripts' when authtype path is specified" {
+
+				$Script:RequestBody.authentication.AllowInternalScripts | Should Be $true
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody.authentication | Get-Member -MemberType NoteProperty).length | Should Be 5
+
+			}
+
+			It "has dynamic parameter 'Comment' when authtype 'hash' is specified" {
+
+				$InputObj | Add-PASApplicationAuthenticationMethod -AuthType hash -Comment "Some Comment"
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$RequestBody = $Body | ConvertFrom-Json
+
+					($RequestBody.authentication.Comment) -eq "Some Comment"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "has dynamic parameter 'comment' when authtype 'certificateserialnumber' is specified" {
+
+				$InputObj | Add-PASApplicationAuthenticationMethod -AuthType certificateserialnumber -Comment "Some Other Comment"
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$RequestBody = $Body | ConvertFrom-Json
+
+					($RequestBody.authentication.Comment) -eq "Some Other Comment"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "throws if dynamic parameter 'comment' is specified with incorrect authtype" {
+
+				{$InputObj | Add-PASApplicationAuthenticationMethod -AuthType path -Comment "Some Random Comment"} | Should Throw
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Add-PASGroupMember.Tests.ps1
+++ b/Tests/Add-PASGroupMember.Tests.ps1
@@ -1,0 +1,127 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			Write-Output "Added"
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"GroupName"    = "SomeGroup"
+			"UserName"     = "SomeUser"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'GroupName'},
+			@{Parameter = 'UserName'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Add-PASGroupMember).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Add-PASGroupMember
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Groups/SomeGroup/Users"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 1
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Add-PASPendingAccount.Tests.ps1
+++ b/Tests/Add-PASPendingAccount.Tests.ps1
@@ -1,0 +1,147 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repo Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			Write-Output @{}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken"            = @{"Authorization" = "P_AuthValue"}
+			"WebSession"              = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"                 = "https://P_URI"
+			"PVWAAppName"             = "P_App"
+			"UserName"                = "SomeUser"
+			"Address"                 = "SomeAddress"
+			"AccountDiscoveryDate"    = "2018-02-22T22:22:22Z"
+			"OSType"                  = "Windows"
+			"AccountEnabled"          = "enabled"
+			"AccountOSGroups"         = "SomeGroup"
+			"AccountType"             = "local"
+			"DiscoveryPlatformType"   = "SomePlatform"
+			"Domain"                  = "SomeDomain"
+			"LastLogonDate"           = "2017-12-31T23:59:59Z"
+			"LastPasswordSet"         = "1995-05-06T20:20:00Z"
+			"PasswordNeverExpires"    = $true
+			"OSVersion"               = "SomeValue"
+			"OU"                      = "SomeOU"
+			"AccountCategory"         = "privileged"
+			"AccountCategoryCriteria" = "some;category"
+			"UserDisplayName"         = "DisplayThis"
+			"AccountDescription"      = "SomeDescription"
+			"AccountExpirationDate"   = "2020-01-01T00:00:00Z"
+			"UID"                     = "0"
+			"GID"                     = "0"
+			"MachineOSFamily"         = "Workstation"
+		}
+
+		Context "Mandatory Parameters" {
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'UserName'},
+			@{Parameter = 'Address'},
+			@{Parameter = 'AccountDiscoveryDate'},
+			@{Parameter = 'AccountEnabled'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+				param($Parameter)
+
+				{((Get-Command $FunctionName).Parameters["$Parameter"].Attributes).Mandatory} |
+					Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Add-PASPendingAccount -verbose
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled 'Invoke-PASRestMethod' -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/PendingAccounts"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request using expected method" {
+
+				Assert-MockCalled 'Invoke-PASRestMethod' -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody.pendingAccount) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody.pendingAccount | Get-Member -MemberType NoteProperty).length | Should Be 21
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Add-PASPendingAccount.Tests.ps1
+++ b/Tests/Add-PASPendingAccount.Tests.ps1
@@ -79,8 +79,7 @@ Describe $FunctionName {
 			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
 				param($Parameter)
 
-				{((Get-Command $FunctionName).Parameters["$Parameter"].Attributes).Mandatory} |
-					Should Be $true
+				(Get-Command Add-PASPendingAccount).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
 
 			}
 

--- a/Tests/Add-PASPolicyACL.Tests.ps1
+++ b/Tests/Add-PASPolicyACL.Tests.ps1
@@ -1,0 +1,154 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[pscustomobject]@{"AddPolicyPrivilegedCommandResult" = [pscustomobject]@{"some" = "thing"}}
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"PolicyID"     = "UNIXSSH"
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'Command'},
+			@{Parameter = 'CommandGroup'},
+			@{Parameter = 'PermissionType'},
+			@{Parameter = 'PolicyID'},
+			@{Parameter = 'UserName'}
+
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Add-PASPolicyACL).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Add-PASPolicyACL -UserName "root" -Command 'some command' -CommandGroup $false -PermissionType Deny
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Policy/UNIXSSH/PrivilegedCommands"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'PUT' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 4
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 5
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.ACL.Policy
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Add-PASPublicSSHKey.Tests.ps1
+++ b/Tests/Add-PASPublicSSHKey.Tests.ps1
@@ -1,0 +1,155 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{"AddUserAuthorizedKeyResult" = [PSCustomObject]@{"PublicSSHKey" = "SomeSSHKey"}}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"UserName"     = "SomeUser"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'UserName'},
+			@{Parameter = 'PublicSSHKey'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Add-PASPublicSSHKey).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Add-PASPublicSSHKey -PublicSSHKey "SomeSSHKey"
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Users/SomeUser/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody.PublicSSHKey) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody.PublicSSHKey).count | Should Be 1
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 6
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.PublicSSHKey
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+			It "returns expected UserName property in response" {
+
+				$response.UserName | Should Be "SomeUser"
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Add-PASSafe.Tests.ps1
+++ b/Tests/Add-PASSafe.Tests.ps1
@@ -1,0 +1,161 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{"addsaferesult" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2"}}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"SafeName"     = "SomeName"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'SafeName'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Add-PASSafe).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+			It "specifies parameter NumberOfVersionsRetention as mandatory for ParameterSet Versions" {
+
+				(Get-Command Add-PASSafe).Parameters["NumberOfVersionsRetention"].ParameterSets["Versions"].IsMandatory | Should be $true
+
+			}
+
+			It "specifies parameter NumberOfDaysRetention as mandatory for ParameterSet Days" {
+
+				(Get-Command Add-PASSafe).Parameters["NumberOfDaysRetention"].ParameterSets["Days"].IsMandatory | Should be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Add-PASSafe -NumberOfDaysRetention 1
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Safes"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody.safe) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody.safe | Get-Member -MemberType NoteProperty).length | Should Be 2
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 6
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Safe
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Add-PASSafeMember.Tests.ps1
+++ b/Tests/Add-PASSafeMember.Tests.ps1
@@ -1,0 +1,227 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{
+				"member" = [PSCustomObject]@{
+					"MemberName"               = "SomeMember"
+					"MembershipExpirationDate" = "1/1/1970"
+					"SearchIn"                 = "SomePlace"
+					"Permissions"              = @(
+						[pscustomobject]@{
+							"Key"   = "Key1"
+							"Value" = "Value1"
+						},
+						[pscustomobject]@{
+							"Key"   = "Key2"
+							"Value" = "Value2"
+						},
+						[pscustomobject]@{
+							"Key"   = "TrueKey"
+							"Value" = "true"
+						},
+						[pscustomobject]@{
+							"Key"   = "FalseKey"
+							"Value" = $false
+						},
+						[pscustomobject]@{
+							"Key"   = "AnotherKey"
+							"Value" = "AnotherValue"
+						},
+						[pscustomobject]@{
+							"Key"   = "AnotherFalseKey"
+							"Value" = $false
+						}
+
+
+					)
+				}
+			}
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken"                           = @{"Authorization" = "P_AuthValue"}
+			"WebSession"                             = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"                                = "https://P_URI"
+			"PVWAAppName"                            = "P_App"
+			"SafeName"                               = "SomeSafe"
+			"MemberName"                             = "SomeUser"
+			"SearchIn"                               = "SomePlace"
+			"UseAccounts"                            = $true
+			"RetrieveAccounts"                       = $true
+			"ListAccounts"                           = $true
+			"AddAccounts"                            = $false
+			"UpdateAccountContent"                   = $false
+			"UpdateAccountProperties"                = $false
+			"InitiateCPMAccountManagementOperations" = $true
+			"SpecifyNextAccountContent"              = $false
+			"RenameAccounts"                         = $false
+			"DeleteAccounts"                         = $false
+			"UnlockAccounts"                         = $true
+			"ManageSafe"                             = $false
+			"ManageSafeMembers"                      = $false
+			"BackupSafe"                             = $false
+			"ViewAuditLog"                           = $true
+			"ViewSafeMembers"                        = $true
+			"RequestsAuthorizationLevel"             = 0
+			"AccessWithoutConfirmation"              = $false
+			"CreateFolders"                          = $false
+			"DeleteFolders"                          = $false
+			"MoveAccountsAndFolders"                 = $false
+
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'SafeName'},
+			@{Parameter = 'MemberName'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Add-PASSafeMember).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Add-PASSafeMember -MembershipExpirationDate "12/31/18"
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Safes/SomeSafe/Members"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody.member) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody.member | Get-Member -MemberType NoteProperty).length | Should Be 4
+
+			}
+
+			It "has expected number of nested properties" {
+
+				($Script:RequestBody.member.permissions).Count | Should Be 21
+
+			}
+
+			It "throws if invalid date pattern specified" {
+
+				{$InputObj | Add-PASSafeMember -MembershipExpirationDate "31/12/18"} | Should throw
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 9
+
+			}
+
+			It "has expected number of nested properties" {
+
+				($response.permissions).count | Should Be 4
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.SafeMemberExtended
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Approve-PASRequest.Tests.ps1
+++ b/Tests/Approve-PASRequest.Tests.ps1
@@ -1,0 +1,126 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"RequestID"    = "24_68"
+			"Reason"       = "Some Reason"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'RequestID'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Approve-PASRequest).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Approve-PASRequest
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/IncomingRequests/24_68/Confirm"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 1
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Close-PASSAMLSession.Tests.ps1
+++ b/Tests/Close-PASSAMLSession.Tests.ps1
@@ -1,0 +1,123 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Close-PASSAMLSession).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Close-PASSAMLSession -verbose
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/auth/SAML/SAMLAuthenticationService.svc/Logoff"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 0
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Close-PASSession.Tests.ps1
+++ b/Tests/Close-PASSession.Tests.ps1
@@ -1,0 +1,111 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Close-PASSession).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Close-PASSession -verbose
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/auth/Cyberark/CyberArkAuthenticationService.svc/Logoff"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Close-PASSharedSession.Tests.ps1
+++ b/Tests/Close-PASSharedSession.Tests.ps1
@@ -1,0 +1,111 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Close-PASSharedSession).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Close-PASSharedSession
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/auth/Shared/RestfulAuthenticationService.svc/Logoff"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Deny-PASRequest.Tests.ps1
+++ b/Tests/Deny-PASRequest.Tests.ps1
@@ -1,0 +1,126 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"RequestID"    = "24_68"
+			"Reason"       = "Some Reason"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'RequestID'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Deny-PASRequest).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Deny-PASRequest
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/IncomingRequests/24_68/Reject"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 1
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-EscapedString.Tests.ps1
+++ b/Tests/Get-EscapedString.Tests.ps1
@@ -1,0 +1,40 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repo Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		It 'outputs a string' {
+
+			"+ & %" | Get-EscapedString | Should BeOfType System.String
+
+		}
+
+		It 'outputs an escaped string' {
+
+			"+ & %" | Get-EscapedString | Should BeExactly "%2B%20%26%20%25"
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASAccount.Tests.ps1
+++ b/Tests/Get-PASAccount.Tests.ps1
@@ -127,8 +127,7 @@ Describe $FunctionName {
 			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
 				param($Parameter)
 
-				{((Get-Command $FunctionName).Parameters["$Parameter"].Attributes).Mandatory} |
-					Should Be $true
+				(Get-Command Get-PASAccount).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
 
 			}
 

--- a/Tests/Get-PASAccount.Tests.ps1
+++ b/Tests/Get-PASAccount.Tests.ps1
@@ -1,0 +1,213 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repo Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+
+			$result = [pscustomobject]@{
+				"Count"    = 30
+				"Accounts" = [pscustomobject]@{
+					"AccountID"          = "66_6"
+					"Properties"         = @(
+						[pscustomobject]@{
+							"Key"   = "Safe"
+							"Value" = "zzTestSafe1"
+						},
+						[pscustomobject]@{
+							"Key"   = "Folder"
+							"Value" = "Root"
+						},
+						[pscustomobject]@{
+							"Key"   = "Name"
+							"Value" = "Operating System-_Test_WinDomain-VIRTUALREAL.IT-user01"
+						},
+						[pscustomobject]@{
+							"Key"   = "UserName"
+							"Value" = "user01"
+						},
+						[pscustomobject]@{
+							"Key"   = "PolicyID"
+							"Value" = "_Test_WinDomain"
+						},
+						[pscustomobject]@{
+							"Key"   = "LogonDomain"
+							"Value" = "VIRTUALREAL"
+						},
+						[pscustomobject]@{
+							"Key"   = "LastSuccessVerification"
+							"Value" = "1511973510"
+						},
+						[pscustomobject]@{
+							"Key"   = "Address"
+							"Value" = "VIRTUALREAL.IT"
+						},
+						[pscustomobject]@{
+							"Key"   = "DeviceType"
+							"Value" = "Operating System"
+						}
+					)
+					"InternalProperties" = @(
+						[pscustomobject]@{
+							"Key"   = "CPMStatus"
+							"Value" = "success"
+						},
+						[pscustomobject]@{
+							"Key"   = "SequenceID"
+							"Value" = "1"
+						},
+						[pscustomobject]@{
+							"Key"   = "CreationMethod"
+							"Value" = "PVWA"
+						},
+						[pscustomobject]@{
+							"Key"   = "RetriesCount"
+							"Value" = "-1"
+						},
+						[pscustomobject]@{
+							"Key"   = "LastSuccessChange"
+							"Value" = "1516127648"
+						},
+						[pscustomobject]@{
+							"Key"   = "LastTask"
+							"Value" = "ChangeTask"
+						}
+					)
+				}
+			}
+			return $result
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"Keywords"     = "SomeValue"
+			"Safe"         = "SomeSafe"
+		}
+
+		Context "Mandatory Parameters" {
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+				param($Parameter)
+
+				{((Get-Command $FunctionName).Parameters["$Parameter"].Attributes).Mandatory} |
+					Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Get-PASAccount -WarningVariable warning -WarningAction SilentlyContinue
+
+		Context "Request Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Accounts?Keywords=SomeValue&Safe=SomeSafe"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request using expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Response Output" {
+
+			it "provides output" {
+
+				$response | Should not be null
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 14
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Account
+
+			}
+
+			it "writes warning that more than 1 account returned from the search" {
+
+				$warning | Should be "30 matching accounts found. Only the first result will be returned"
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not Be Null
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASAccount.Tests.ps1
+++ b/Tests/Get-PASAccount.Tests.ps1
@@ -202,7 +202,7 @@ Describe $FunctionName {
 			It "returns default property <Property> in response" -TestCases $DefaultProps {
 				param($Property)
 
-				$response.$Property | Should Not Be Null
+				$response.$Property | Should Not BeNullOrEmpty
 
 			}
 

--- a/Tests/Get-PASAccountACL.Tests.ps1
+++ b/Tests/Get-PASAccountACL.Tests.ps1
@@ -1,0 +1,142 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[pscustomobject]@{"ListAccountPrivilegedCommandsResult" = [pscustomobject]@{"some" = "thing"; "other" = "thing"}}
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken"    = @{"Authorization" = "P_AuthValue"}
+			"WebSession"      = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"         = "https://P_URI"
+			"PVWAAppName"     = "P_App"
+			"AccountPolicyID" = "UNIXSSH"
+			"AccountAddress"  = "ServerA.domain.com"
+			"AccountUserName" = "root"
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'AccountPolicyId'},
+			@{Parameter = 'AccountAddress'},
+			@{Parameter = 'AccountUserName'}
+
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Get-PASAccountACL).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Get-PASAccountACL
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Account/ServerA.domain.com|root|UNIXSSH/PrivilegedCommands"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 6
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.ACL.Account
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASAccountActivity.Tests.ps1
+++ b/Tests/Get-PASAccountActivity.Tests.ps1
@@ -63,8 +63,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				{((Get-Command $FunctionName).Parameters["$Parameter"].Attributes).Mandatory} |
-					Should Be $true
+				(Get-Command Get-PASAccountActivity).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
 
 			}
 

--- a/Tests/Get-PASAccountActivity.Tests.ps1
+++ b/Tests/Get-PASAccountActivity.Tests.ps1
@@ -1,0 +1,143 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[pscustomobject]@{"GetAccountActivitiesResult" = [pscustomobject]@{
+					"prop1" = "val1"
+					"prop2" = "val2"
+					"prop3" = "val3"
+				}
+			}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"AccountID"    = "66_6"
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'AccountID'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				{((Get-Command $FunctionName).Parameters["$Parameter"].Attributes).Mandatory} |
+					Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Get-PASAccountActivity -verbose
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Accounts/66_6/Activities"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not be null
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 7
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.AccountActivity
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not Be Null
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASAccountActivity.Tests.ps1
+++ b/Tests/Get-PASAccountActivity.Tests.ps1
@@ -132,7 +132,7 @@ Describe $FunctionName {
 			It "returns default property <Property> in response" -TestCases $DefaultProps {
 				param($Property)
 
-				$response.$Property | Should Not Be Null
+				$response.$Property | Should Not BeNullOrEmpty
 
 			}
 

--- a/Tests/Get-PASAccountGroup.Tests.ps1
+++ b/Tests/Get-PASAccountGroup.Tests.ps1
@@ -1,0 +1,137 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[pscustomobject]@{"Prop1" = "Val1"}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"Safe"         = "SomeSafe"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'Safe'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Get-PASAccountGroup).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Get-PASAccountGroup -verbose
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/AccountGroups?Safe=SomeSafe"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 5
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.AccountGroup
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASAccountGroupMember.Tests.ps1
+++ b/Tests/Get-PASAccountGroupMember.Tests.ps1
@@ -1,0 +1,137 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[pscustomobject]@{"Prop1" = "Val1"}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"GroupID"      = "32_1"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'GroupID'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Get-PASAccountGroupMember).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Get-PASAccountGroupMember -verbose
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/AccountGroups/32_1/Members"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 5
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.AccountGroup.Member
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASAccountPassword.Tests.ps1
+++ b/Tests/Get-PASAccountPassword.Tests.ps1
@@ -174,7 +174,7 @@ Describe $FunctionName {
 			It "returns default property <Property> in response" -TestCases $DefaultProps {
 				param($Property)
 
-				$response.$Property | Should Not Be Null
+				$response.$Property | Should Not BeNullOrEmpty
 
 			}
 

--- a/Tests/Get-PASAccountPassword.Tests.ps1
+++ b/Tests/Get-PASAccountPassword.Tests.ps1
@@ -58,8 +58,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				{((Get-Command $FunctionName).Parameters["$Parameter"].Attributes).Mandatory} |
-					Should Be $true
+				(Get-Command Get-PASAccountPassword).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
 
 			}
 

--- a/Tests/Get-PASAccountPassword.Tests.ps1
+++ b/Tests/Get-PASAccountPassword.Tests.ps1
@@ -1,0 +1,185 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			Write-Output "String"
+		}
+
+		$InputObj = [pscustomobject]@{
+			"AccountID"    = "77_7"
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'AccountID'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				{((Get-Command $FunctionName).Parameters["$Parameter"].Attributes).Mandatory} |
+					Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Get-PASAccountPassword -verbose
+
+		Context "Input - legacy API parameterset" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Accounts/77_7/Credentials"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Input - v10 API parameterset" {
+
+			$InputObj | Get-PASAccountPassword -UseV10API -Reason "SomeReason" -TicketingSystemName "someSystem" -TicketId 12345
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/api/Accounts/77_7/Password/Retrieve"
+
+				} -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody) -ne $null
+
+				} -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 3
+
+			}
+
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not be null
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 5
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Credential
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not Be Null
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASApplication.Tests.ps1
+++ b/Tests/Get-PASApplication.Tests.ps1
@@ -1,0 +1,152 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{"application" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2"}}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"AppID"        = "SomeApplication"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Get-PASApplication).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+			It "specifies parameter AppID as mandatory for ParameterSet byAppID" {
+
+				(Get-Command Get-PASApplication).Parameters["AppID"].ParameterSets["byAppID"].IsMandatory | Should be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Get-PASApplication -ExactMatch
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint (byAppID ParameterSet)" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Applications/SomeApplication"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint (byQuery ParameterSet)" {
+				$InputObj | Get-PASApplication
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Applications?AppID=SomeApplication"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 6
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Application
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASApplicationAuthenticationMethod.Tests.ps1
+++ b/Tests/Get-PASApplicationAuthenticationMethod.Tests.ps1
@@ -1,0 +1,137 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{"authentication" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2"}}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"AppID"        = "SomeApplication"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'AppID'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Get-PASApplicationAuthenticationMethod).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Get-PASApplicationAuthenticationMethod
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint (byAppID ParameterSet)" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Applications/SomeApplication/Authentications"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 6
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.ApplicationAuth
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASComponentDetail.Tests.ps1
+++ b/Tests/Get-PASComponentDetail.Tests.ps1
@@ -1,0 +1,118 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{"ComponentsDetails" = [PSCustomObject]@{"SomeProp" = "SomValue"; "OtherProp" = "OtherValue"}}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'ComponentID'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Get-PASComponentDetail).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Get-PASComponentDetail -ComponentID PVWA
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/api/ComponentsMonitoringDetails/PVWA"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 2
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASComponentSummary.Tests.ps1
+++ b/Tests/Get-PASComponentSummary.Tests.ps1
@@ -1,0 +1,120 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{
+				"Components" = [PSCustomObject]@{"ComponentID" = "SomValue"; "ComponentName" = "OtherValue"; "Role" = "SomValue"; "IP" = "OtherValue"; "IsLoggedOn" = "OtherValue"}
+				"Vaults"     = [PSCustomObject]@{"Role" = "SomValue"; "IP" = "OtherValue"; "IsLoggedOn" = "OtherValue"}
+			}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Get-PASComponentSummary).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Get-PASComponentSummary
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/api/ComponentsMonitoringSummary"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 5
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASLoggedOnUser.Tests.ps1
+++ b/Tests/Get-PASLoggedOnUser.Tests.ps1
@@ -1,0 +1,135 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{"Detail1" = "Detail"; "Detail2" = "Detail"}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Get-PASLoggedOnUser).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Get-PASLoggedOnUser
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/User"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 6
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.User
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASOnboardingRule.Tests.ps1
+++ b/Tests/Get-PASOnboardingRule.Tests.ps1
@@ -1,0 +1,136 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{"AutomaticOnboardingRules" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2"}}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"AccountID"    = "99_9"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Get-PASOnboardingRule).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Get-PASOnboardingRule
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/api/AutomaticOnboardingRules/"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 6
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.OnboardingRule
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASPSMConnectionParameter.Tests.ps1
+++ b/Tests/Get-PASPSMConnectionParameter.Tests.ps1
@@ -1,0 +1,151 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{"Prop1" = "VAL1"; "Prop2" = "Val2"; "Prop3" = "Val3"}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken"        = @{"Authorization" = "P_AuthValue"}
+			"WebSession"          = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"             = "https://P_URI"
+			"PVWAAppName"         = "P_App"
+			"AccountID"           = "99_9"
+			"ConnectionComponent" = "SomeConnectionComponent"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'AccountID'},
+			@{Parameter = 'ConnectionComponent'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Get-PASPSMConnectionParameter).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Get-PASPSMConnectionParameter
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/Accounts/99_9/PSMConnect"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 1
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 3
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be System.Management.Automation.PSCustomObject
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "does not return default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Be $null
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASPSMRecording.Tests.ps1
+++ b/Tests/Get-PASPSMRecording.Tests.ps1
@@ -1,0 +1,136 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{"Recordings" = [PSCustomObject]@{"Prop1" = "VAL1"; "Prop2" = "Val2"; "Prop3" = "Val3"}}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"Limit"        = 9
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Get-PASPSMRecording).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Get-PASPSMRecording
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/Recordings?Limit=9"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 7
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.PSM.Recording
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASPSMSession.Tests.ps1
+++ b/Tests/Get-PASPSMSession.Tests.ps1
@@ -1,0 +1,136 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{"LiveSessions" = [PSCustomObject]@{"Prop1" = "VAL1"; "Prop2" = "Val2"; "Prop3" = "Val3"}}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"Limit"        = 9
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Get-PASPSMSession).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Get-PASPSMSession
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/LiveSessions?Limit=9"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 7
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.PSM.Session
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASParameter.Tests.ps1
+++ b/Tests/Get-PASParameter.Tests.ps1
@@ -1,0 +1,60 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		[array]$CommonParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+		[array]$CommonParameters += [System.Management.Automation.PSCmdlet]::OptionalCommonParameters
+		[hashtable]$InputParams = @{"KeepThis" = "Kept"; "RemoveThis" = "Removed"}
+
+		$CommonParameters | ForEach-Object {$InputParams.Add($_, "something")}
+
+		$ReturnData = $InputParams | Get-PASParameter -ParametersToRemove RemoveThis
+
+		It 'returns a hashtable' {
+
+			$ReturnData | Should BeOfType System.Collections.Hashtable
+
+		}
+
+		$CommonParameters | ForEach-Object {
+
+			It "does not include $_ in return data" {
+
+				$ReturnData[$_] | Should BeNullOrEmpty
+
+			}
+
+		}
+
+		It 'does not return additional specified parameters' {
+			$ReturnData["RemoveThis"] | Should BeNullOrEmpty
+		}
+
+		It 'returns expected value' {
+			$ReturnData["KeepThis"] | Should Be "Kept"
+		}
+
+	}
+
+}

--- a/Tests/Get-PASPlatform.Tests.ps1
+++ b/Tests/Get-PASPlatform.Tests.ps1
@@ -1,0 +1,137 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = 123}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"Name"         = "SomeName"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'Name'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Get-PASPlatform).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Get-PASPlatform -verbose
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/Platforms/SomeName"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 7
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Platform
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASPolicyACL.Tests.ps1
+++ b/Tests/Get-PASPolicyACL.Tests.ps1
@@ -1,0 +1,138 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[pscustomobject]@{"ListPolicyPrivilegedCommandsResult" = [pscustomobject]@{"some" = "thing"; "other" = "thing"}}
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"PolicyID"     = "UNIXSSH"
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'PolicyId'}
+
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Get-PASPolicyACL).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Get-PASPolicyACL
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Policy/UNIXSSH/PrivilegedCommands"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 6
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.ACL.Policy
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASPublicSSHKey.Tests.ps1
+++ b/Tests/Get-PASPublicSSHKey.Tests.ps1
@@ -1,0 +1,143 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{"GetUserAuthorizedKeysResult" = [PSCustomObject]@{"KeyID" = "SomeID"; "PublicSSHKey" = "SomeKey"}}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"UserName"     = "SomeUser"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'UserName'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Get-PASPublicSSHKey).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Get-PASPublicSSHKey
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Users/SomeUser/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 7
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.PublicSSHKey
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+			It "returns username property in response" {
+
+				$response.UserName | Should Be SomeUser
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASRequest.Tests.ps1
+++ b/Tests/Get-PASRequest.Tests.ps1
@@ -1,0 +1,212 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{
+				"MyRequests"       = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "val2"}
+				"IncomingRequests" = [PSCustomObject]@{"PropA" = "ValA"; "PropB" = "ValB"; "PropC" = "ValC"}
+			}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'RequestType'},
+			@{Parameter = 'OnlyWaiting'},
+			@{Parameter = 'Expired'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Get-PASRequest).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		Context "Input - MyRequests" {
+
+			$InputObj | Get-PASRequest -RequestType MyRequests -OnlyWaiting $true -Expired $true
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/MyRequests?onlywaiting=true&expired=true"
+
+				} -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Context
+
+			}
+
+		}
+
+		Context "Input - IncomingRequests" {
+
+			$InputObj | Get-PASRequest -RequestType IncomingRequests -OnlyWaiting $true -Expired $true
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/IncomingRequests?onlywaiting=true&expired=true"
+
+				} -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Context
+
+			}
+
+		}
+
+		Context "Output - MyRequests" {
+
+			$response = $InputObj | Get-PASRequest -RequestType MyRequests -OnlyWaiting $true -Expired $false
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 6
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Request.Details
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+		Context "Output - IncomingRequests" {
+
+			$response = $InputObj | Get-PASRequest -RequestType IncomingRequests -OnlyWaiting $true -Expired $false
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 7
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Request.Details
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASRequestDetail.Tests.ps1
+++ b/Tests/Get-PASRequestDetail.Tests.ps1
@@ -1,0 +1,173 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "val2"; "PropA" = "ValA"; "PropB" = "ValB"; "PropC" = "ValC"}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"RequestID"    = "SomeID"
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'RequestType'},
+			@{Parameter = 'RequestID'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Get-PASRequestDetail).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		Context "Input - MyRequests" {
+
+			$InputObj | Get-PASRequestDetail -RequestType MyRequests
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/MyRequests/SomeID"
+
+				} -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Context
+
+			}
+
+		}
+
+		Context "Input - IncomingRequests" {
+
+			$InputObj | Get-PASRequestDetail -RequestType IncomingRequests
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/IncomingRequests/SomeID"
+
+				} -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Context
+
+			}
+
+		}
+
+		Context "Output" {
+
+			$response = $InputObj | Get-PASRequestDetail -RequestType MyRequests
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 9
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Request.Extended
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASSafe.Tests.ps1
+++ b/Tests/Get-PASSafe.Tests.ps1
@@ -1,0 +1,283 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{
+				"SearchSafesResult" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2"}
+				"GetSafesResult"    = [PSCustomObject]@{"PropA" = "ValA"; "PropB" = "ValB"; "PropC" = "ValC"}
+				"GetSafeResult"     = [PSCustomObject]@{"Prop5" = "Val5"; "Prop6" = "Val6"; "Prop7" = "Val7"; "Prop8" = "Val8"}
+			}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Get-PASSafe).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+
+
+		Context "Input - byAll ParameterSet" {
+
+			$InputObj | Get-PASSafe -FindAll
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Safes"
+
+				} -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Context
+
+			}
+
+		}
+
+		Context "Input - byName ParameterSet" {
+
+			$InputObj | Get-PASSafe -SafeName SomeSafe
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Safes/SomeSafe"
+
+				} -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Context
+
+			}
+
+		}
+
+		Context "Input - byQuery ParameterSet" {
+
+			$InputObj | Get-PASSafe -query "SomeSafe"
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Safes?query=SomeSafe"
+
+				} -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Context
+
+			}
+
+		}
+
+		Context "Output - byAll ParameterSet" {
+
+			$response = $InputObj | Get-PASSafe -FindAll
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 7
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Safe
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+		Context "Output - byName ParameterSet" {
+
+			$response = $InputObj | Get-PASSafe -SafeName SomeSafe
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 8
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Safe
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+		Context "Output - byQuery ParameterSet" {
+
+			$response = $InputObj | Get-PASSafe -query "SomeSafe"
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 6
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Safe
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASSafeMember.Tests.ps1
+++ b/Tests/Get-PASSafeMember.Tests.ps1
@@ -1,0 +1,161 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{
+				"members" = [PSCustomObject]@{
+					"UserName"    = "SomeMember"
+					"Permissions" = [pscustomobject]@{
+						"Key1"            = $true
+						"Key2"            = $true
+						"FalseKey"        = $false
+						"AnotherKey"      = $true
+						"AnotherFalseKey" = $false
+					}
+				}
+			}
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"SafeName"     = "SomeSafe"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'SafeName'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Get-PASSafeMember).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Get-PASSafeMember
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Safes/SomeSafe/Members"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 7
+
+			}
+
+			It "has expected number of nested array elements" {
+
+				($response.permissions).count | Should Be 3
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.SafeMember
+
+			}
+
+			it "outputs object with expected safename property" {
+
+				$response.SafeName | Should Be "SomeSafe"
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASSafeShareLogo.Tests.ps1
+++ b/Tests/Get-PASSafeShareLogo.Tests.ps1
@@ -1,0 +1,111 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			Write-output "Squint and This is an Image"
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'ImageType'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Get-PASSafeShareLogo).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Get-PASSafeShareLogo -ImageType Square
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Logo?type=Square"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASServer.Tests.ps1
+++ b/Tests/Get-PASServer.Tests.ps1
@@ -1,0 +1,117 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2"}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Get-PASServer).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Get-PASServer
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Server"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 2
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASServerWebService.Tests.ps1
+++ b/Tests/Get-PASServerWebService.Tests.ps1
@@ -1,0 +1,121 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{
+				"ServerName"            = "Val1";
+				"ServerID"              = "Val2";
+				"ApplicationName"       = "AppName";
+				"AuthenticationMethods" = "SomeThing"
+			}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Get-PASServerWebService).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Get-PASServerWebService
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Verify"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 4
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASUser.Tests.ps1
+++ b/Tests/Get-PASUser.Tests.ps1
@@ -1,0 +1,137 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{"Detail1" = "Detail"; "Detail2" = "Detail"}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"UserName"     = "SomeUser"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'UserName'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Get-PASUser).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Get-PASUser
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Users/SomeUser"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 6
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.User
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Invoke-PASCredChange.Tests.ps1
+++ b/Tests/Invoke-PASCredChange.Tests.ps1
@@ -54,7 +54,6 @@ Describe $FunctionName {
 			@{Parameter = 'SessionToken'},
 			@{Parameter = 'UpdateVaultOnly'},
 			@{Parameter = 'SetNextPassword'},
-			@{Parameter = 'NewCredentials'},
 			@{Parameter = 'AccountID'}
 
 			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
@@ -62,6 +61,18 @@ Describe $FunctionName {
 				param($Parameter)
 
 				(Get-Command Invoke-PASCredChange).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+			It "specifies parameter NewCredentials as mandatory for ParameterSet Password/Update" {
+
+				(Get-Command Invoke-PASCredChange).Parameters["NewCredentials"].ParameterSets["Password/Update"].IsMandatory | Should be $true
+
+			}
+
+			It "specifies parameter NewCredentials as mandatory for ParameterSet SetNextPassword" {
+
+				(Get-Command Invoke-PASCredChange).Parameters["NewCredentials"].ParameterSets["SetNextPassword"].IsMandatory | Should be $true
 
 			}
 

--- a/Tests/Invoke-PASCredChange.Tests.ps1
+++ b/Tests/Invoke-PASCredChange.Tests.ps1
@@ -1,0 +1,223 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"AccountID"    = "99_9"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'UpdateVaultOnly'},
+			@{Parameter = 'SetNextPassword'},
+			@{Parameter = 'NewCredentials'},
+			@{Parameter = 'AccountID'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				{((Get-Command $FunctionName).Parameters["$Parameter"].Attributes).Mandatory} |
+					Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Invoke-PASCredChange -ChangeCredsForGroup $true #-verbose
+
+		Context "Input - Change ParameterSet" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/Accounts/99_9/Change"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 1
+
+			}
+
+		}
+
+		Context "Input - Password/Update ParameterSet" {
+
+			$newcreds = "test" | ConvertTo-SecureString -AsPlainText -Force
+			$response = $InputObj | Invoke-PASCredChange -ChangeCredsForGroup $true -UpdateVaultOnly -NewCredentials $newcreds
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/Accounts/99_9/Password/Update"
+
+				} -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody) -ne $null
+
+				} -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 2
+
+			}
+
+		}
+
+		Context "Input - SetNextPassword ParameterSet" {
+
+			$newcreds = "test" | ConvertTo-SecureString -AsPlainText -Force
+			$response = $InputObj | Invoke-PASCredChange -SetNextPassword -NewCredentials $newcreds
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/Accounts/99_9/SetNextPassword"
+
+				} -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody) -ne $null
+
+				} -Times 1 -Exactly -Scope Context
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 1
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Invoke-PASCredChange.Tests.ps1
+++ b/Tests/Invoke-PASCredChange.Tests.ps1
@@ -61,8 +61,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				{((Get-Command $FunctionName).Parameters["$Parameter"].Attributes).Mandatory} |
-					Should Be $true
+				(Get-Command Invoke-PASCredChange).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
 
 			}
 

--- a/Tests/Invoke-PASCredReconcile.Tests.ps1
+++ b/Tests/Invoke-PASCredReconcile.Tests.ps1
@@ -58,8 +58,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				{((Get-Command $FunctionName).Parameters["$Parameter"].Attributes).Mandatory} |
-					Should Be $true
+				(Get-Command Invoke-PASCredReconcile).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
 
 			}
 

--- a/Tests/Invoke-PASCredReconcile.Tests.ps1
+++ b/Tests/Invoke-PASCredReconcile.Tests.ps1
@@ -1,0 +1,114 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			Write-Output @{}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"AccountID"    = "11_1"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'AccountID'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				{((Get-Command $FunctionName).Parameters["$Parameter"].Attributes).Mandatory} |
+					Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Invoke-PASCredReconcile
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/Accounts/11_1/Reconcile"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Invoke-PASCredVerify.Tests.ps1
+++ b/Tests/Invoke-PASCredVerify.Tests.ps1
@@ -1,0 +1,114 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			Write-Output @{}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"AccountID"    = "11_1"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'AccountID'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				{((Get-Command $FunctionName).Parameters["$Parameter"].Attributes).Mandatory} |
+					Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Invoke-PASCredVerify
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/Accounts/11_1/Verify"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Invoke-PASCredVerify.Tests.ps1
+++ b/Tests/Invoke-PASCredVerify.Tests.ps1
@@ -58,8 +58,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				{((Get-Command $FunctionName).Parameters["$Parameter"].Attributes).Mandatory} |
-					Should Be $true
+				(Get-Command Invoke-PASCredVerify).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
 
 			}
 

--- a/Tests/Invoke-PASRestMethod.Tests.ps1
+++ b/Tests/Invoke-PASRestMethod.Tests.ps1
@@ -1,0 +1,202 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		$requestArgs1 = @{
+			"URI"             = "https://CyberArk_URL"
+			"Method"          = "GET"
+			"SessionVariable" = "varSession"
+		}
+
+		$requestArgs2 = @{
+			"URI"        = "https://CyberArk_URL"
+			"Method"     = "GET"
+			"WebSession" = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		}
+
+		Context "Standard Operation" {
+
+			Mock Invoke-WebRequest -MockWith {
+
+				return [pscustomobject]@{"StatusCode" = 201}
+
+			}
+
+			It "does not throw" {
+
+				{Invoke-PASRestMethod @requestArgs2} | Should Not throw
+
+			}
+
+			#If Tls12 Security Protocol is available
+			if([Net.SecurityProtocolType].GetEnumNames() -contains "Tls12") {
+
+				It "uses TLS12" {
+					[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls11
+					Invoke-PASRestMethod @requestArgs2
+					[System.Net.ServicePointManager]::SecurityProtocol | Should Be Tls12
+				}
+
+			}
+
+		}
+
+		Context "application/json responses" {
+
+			Set-Variable varSession -Value "valSession"
+
+			$MockResult = [pscustomobject] @{
+
+				"headers"    = @{
+					"Content-Type" = "application/json"
+				};
+				"StatusCode" = 200;
+				"content"    = (@{
+						"prop1"   = "value1";
+						"prop2"   = "value2";
+						"prop123" = 123
+						"test"    = 321
+					}| ConvertTo-Json)
+			}
+
+			Mock Invoke-WebRequest -MockWith {
+
+				return $MockResult
+			}
+
+			It "sends a web request" {
+				Invoke-PASRestMethod @requestArgs1
+				Assert-MockCalled "Invoke-WebRequest" -Times 1 -Scope It -Exactly
+			}
+
+			It "returns expected number of properties when session variable is supplied" {
+				$result = Invoke-PASRestMethod @requestArgs1
+				($result | Get-Member -MemberType NoteProperty).length | Should Be 5
+			}
+
+			It "returns a websession" {
+				$result = Invoke-PASRestMethod @requestArgs1
+				$result.WebSession | Should Not BeNullOrEmpty
+			}
+
+			It "returns websession sessionvariable value" {
+				$result = Invoke-PASRestMethod @requestArgs1
+				$result.WebSession | Should Be "valSession"
+			}
+
+			It "returns expected number of properties when websession is supplied" {
+				$result = Invoke-PASRestMethod @requestArgs2
+				($result | Get-Member -MemberType NoteProperty).length | Should Be 4
+			}
+
+		}
+
+		Context "text/html responses" {
+
+			$MockResult = [pscustomobject] @{
+
+				"headers"    = @{
+					"Content-Type" = "text/html"
+				};
+				"StatusCode" = 200;
+				"content"    = '"Value"'
+			}
+
+			Mock Invoke-WebRequest -MockWith {
+
+				return $MockResult
+			}
+
+			It "returns expected (unquoted) string for text/html responses" {
+				$result = Invoke-PASRestMethod @requestArgs2
+				$result | Should Be 'Value'
+			}
+
+		}
+
+		Context "application/octet-stream responses" {
+
+			$MockResult = [pscustomobject] @{
+
+				"headers"    = @{
+					"Content-Type" = "application/octet-stream"
+				};
+				"StatusCode" = 200;
+				"content"    = [System.Text.Encoding]::Ascii.GetBytes("Expected")
+			}
+
+			Mock Invoke-WebRequest -MockWith {
+
+				return $MockResult
+			}
+
+			It "returns expected output for application/octet-stream responses" {
+				$result = Invoke-PASRestMethod @requestArgs2
+				$result | Should Be "Expected"
+			}
+
+		}
+
+		Context "Request Fail" {
+
+			$requestArgs = @{
+				"URI"        = "https://www.google.co.uk"
+				"Method"     = "PUT"
+				"WebSession" = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			}
+
+			It "outputs expected exception" {
+				{
+					$ErrorActionPreference = "Stop"
+					Invoke-PASRestMethod @requestArgs
+				} | Should throw
+			}
+
+			#Context "Error Output" {
+			$ErrorActionPreference = "Stop"
+			$ErrorMessage = "TestMessage"
+			$ErrorCode = "12345"
+
+			Mock Invoke-WebRequest -MockWith {
+
+				throw [pscustomobject]@{"ErrorMessage" = $ErrorMessage; "ErrorCode" = $ErrorCode} | ConvertTo-Json
+			}
+
+			Try {
+				Invoke-PASRestMethod @requestArgs
+			} Catch {
+				it "outputs expected error message" {
+					$_.exception | should match $ErrorMessage
+				}
+
+				it "outputs expected error id" {
+					$_.FullyQualifiedErrorId | should match $ErrorCode
+				}
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/New-PASAccountGroup.Tests.ps1
+++ b/Tests/New-PASAccountGroup.Tests.ps1
@@ -1,0 +1,128 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken"  = @{"Authorization" = "P_AuthValue"}
+			"WebSession"    = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"       = "https://P_URI"
+			"PVWAAppName"   = "P_App"
+			"GroupName"     = "SomeName"
+			"GroupPlatform" = "SomePlatform"
+			"Safe"          = "SomeSafe"
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'GroupName'},
+			@{Parameter = 'GroupPlatform'},
+			@{Parameter = 'Safe'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command New-PASAccountGroup).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | New-PASAccountGroup
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/AccountGroups/"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 3
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/New-PASAccountGroup.Tests.ps1
+++ b/Tests/New-PASAccountGroup.Tests.ps1
@@ -40,13 +40,13 @@ Describe $FunctionName {
 		}
 
 		$InputObj = [pscustomobject]@{
-			"sessionToken"  = @{"Authorization" = "P_AuthValue"}
-			"WebSession"    = New-Object Microsoft.PowerShell.Commands.WebRequestSession
-			"BaseURI"       = "https://P_URI"
-			"PVWAAppName"   = "P_App"
-			"GroupName"     = "SomeName"
-			"GroupPlatform" = "SomePlatform"
-			"Safe"          = "SomeSafe"
+			"sessionToken"    = @{"Authorization" = "P_AuthValue"}
+			"WebSession"      = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"         = "https://P_URI"
+			"PVWAAppName"     = "P_App"
+			"GroupName"       = "SomeName"
+			"GroupPlatformID" = "SomePlatform"
+			"Safe"            = "SomeSafe"
 		}
 
 		Context "Mandatory Parameters" {

--- a/Tests/New-PASAccountGroup.Tests.ps1
+++ b/Tests/New-PASAccountGroup.Tests.ps1
@@ -54,7 +54,7 @@ Describe $FunctionName {
 			$Parameters = @{Parameter = 'BaseURI'},
 			@{Parameter = 'SessionToken'},
 			@{Parameter = 'GroupName'},
-			@{Parameter = 'GroupPlatform'},
+			@{Parameter = 'GroupPlatformID'},
 			@{Parameter = 'Safe'}
 
 			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {

--- a/Tests/New-PASOnboardingRule.Tests.ps1
+++ b/Tests/New-PASOnboardingRule.Tests.ps1
@@ -1,0 +1,153 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2"}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken"       = @{"Authorization" = "P_AuthValue"}
+			"WebSession"         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"            = "https://P_URI"
+			"PVWAAppName"        = "P_App"
+			"DecisionPlatformId" = "SomePlatform"
+			"DecisionSafeName"   = "SomeSafe"
+			"SystemTypeFilter"   = "Windows"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'DecisionPlatformId'},
+			@{Parameter = 'DecisionSafeName'},
+			@{Parameter = 'SystemTypeFilter'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command New-PASOnboardingRule).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | New-PASOnboardingRule
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/api/AutomaticOnboardingRules"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 3
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 6
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.OnboardingRule
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/New-PASRequest.Tests.ps1
+++ b/Tests/New-PASRequest.Tests.ps1
@@ -1,0 +1,166 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "val2"; "PropA" = "ValA"; "PropB" = "ValB"; "PropC" = "ValC"}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken"        = @{"Authorization" = "P_AuthValue"}
+			"WebSession"          = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"             = "https://P_URI"
+			"PVWAAppName"         = "P_App"
+			"AccountID"           = "SomeID"
+			"Reason"              =	"Some Important Reason"
+			"TicketingSystemName" = "SomeName"
+			"TicketID"            = "TicketID123"
+			"MultipleAccess"      = $true
+			"FromDate"            = (Get-Date 1-1-2018)
+			"ToDate"              = (Get-Date 12-12-2018)
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'AccountID'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command New-PASRequest).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | New-PASRequest
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/MyRequests"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 7
+
+			}
+
+			It "converts datetime 'FromDate' to expected value" {
+
+				$Script:RequestBody.FromDate | Should Be 1514764800
+
+			}
+
+			It "converts datetime 'ToDate' to expected value" {
+
+				$Script:RequestBody.ToDate | Should Be 1544572800
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 9
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Request
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/New-PASSAMLSession.Tests.ps1
+++ b/Tests/New-PASSAMLSession.Tests.ps1
@@ -1,0 +1,194 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{
+				"CyberArkLogonResult" = "AAAAAAA\\\REEEAAAAALLLLYYYYY\\\\LOOOOONNNNGGGGG\\\ACCCCCEEEEEEEESSSSSSS\\\\\\TTTTTOOOOOKKKKKEEEEEN"
+				"WebSession"          = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			}
+		}
+
+		$Credentials = New-Object System.Management.Automation.PSCredential ("SomeUser", $(ConvertTo-SecureString "SomePassword" -AsPlainText -Force))
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'Credential'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command New-PASSAMLSession).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $Credentials | New-PASSAMLSession -BaseURI "https://P_URI" -PVWAAppName "SomeApp"
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "https://P_URI/SomeApp/WebServices/auth/SAML/SAMLAuthenticationService.svc/Logon"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 0
+
+			}
+
+			It "sends request with expected header" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Headers -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends header with expected key" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Headers.keys -eq "Authorization"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends header with expected value" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$EncodedValue = $Headers["Authorization"] -replace "Basic ", ""
+					[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($EncodedValue)) -eq "SomeUser:SomePassword"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 4
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be System.Management.Automation.PSCustomObject
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+			It "outputs sessionToken in expected format" {
+
+				$response.sessiontoken.gettype() | Should be Hashtable
+
+			}
+
+			It "outputs sessionToken with expected key name" {
+
+				$response.sessiontoken.keys | Should be "Authorization"
+
+			}
+
+			It "outputs sessionToken with expected value" {
+
+				$response.sessiontoken["Authorization"] | Should be "AAAAAAA\\\REEEAAAAALLLLYYYYY\\\\LOOOOONNNNGGGGG\\\ACCCCCEEEEEEEESSSSSSS\\\\\\TTTTTOOOOOKKKKKEEEEEN"
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/New-PASSession.Tests.ps1
+++ b/Tests/New-PASSession.Tests.ps1
@@ -1,0 +1,182 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{
+				"CyberArkLogonResult" = "AAAAAAA\\\REEEAAAAALLLLYYYYY\\\\LOOOOONNNNGGGGG\\\ACCCCCEEEEEEEESSSSSSS\\\\\\TTTTTOOOOOKKKKKEEEEEN"
+				"WebSession"          = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			}
+		}
+
+		$Credentials = New-Object System.Management.Automation.PSCredential ("SomeUser", $(ConvertTo-SecureString "SomePassword" -AsPlainText -Force))
+
+		$NewPass = $secpasswd = ConvertTo-SecureString "SomeNewPassword" -AsPlainText -Force
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'Credential'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command New-PASSession).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $Credentials | New-PASSession -BaseURI "https://P_URI" -PVWAAppName "SomeApp" -newPassword $NewPass
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "https://P_URI/SomeApp/WebServices/auth/Cyberark/CyberArkAuthenticationService.svc/Logon"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 3
+
+			}
+
+			It "sends expected username in request" {
+
+				$Script:RequestBody.username | Should Be SomeUser
+
+			}
+
+			It "sends expected password in request" {
+
+				$Script:RequestBody.password | Should Be SomePassword
+
+			}
+
+			It "sends expected new password in request" {
+
+				$Script:RequestBody.newpassword | Should Be SomeNewPassword
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 5
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be System.Management.Automation.PSCustomObject
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+			It "outputs sessionToken in expected format" {
+
+				$response.sessiontoken.gettype() | Should be Hashtable
+
+			}
+
+			It "outputs sessionToken with expected key name" {
+
+				$response.sessiontoken.keys | Should be "Authorization"
+
+			}
+
+			It "outputs sessionToken with expected value" {
+
+				$response.sessiontoken["Authorization"] | Should be "AAAAAAA\\\REEEAAAAALLLLYYYYY\\\\LOOOOONNNNGGGGG\\\ACCCCCEEEEEEEESSSSSSS\\\\\\TTTTTOOOOOKKKKKEEEEEN"
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/New-PASSharedSession.Tests.ps1
+++ b/Tests/New-PASSharedSession.Tests.ps1
@@ -1,0 +1,159 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{
+				"CyberArkLogonResult" = "AAAAAAA\\\REEEAAAAALLLLYYYYY\\\\LOOOOONNNNGGGGG\\\ACCCCCEEEEEEEESSSSSSS\\\\\\TTTTTOOOOOKKKKKEEEEEN"
+				"WebSession"          = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			}
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command New-PASSharedSession).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = New-PASSharedSession -BaseURI "https://P_URI" -PVWAAppName "SomeApp"
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "https://P_URI/SomeApp/WebServices/auth/Shared/RestfulAuthenticationService.svc/Logon"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 0
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 4
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be System.Management.Automation.PSCustomObject
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+			It "outputs sessionToken in expected format" {
+
+				$response.sessiontoken.gettype() | Should be Hashtable
+
+			}
+
+			It "outputs sessionToken with expected key name" {
+
+				$response.sessiontoken.keys | Should be "Authorization"
+
+			}
+
+			It "outputs sessionToken with expected value" {
+
+				$response.sessiontoken["Authorization"] | Should be "AAAAAAA\\\REEEAAAAALLLLYYYYY\\\\LOOOOONNNNGGGGG\\\ACCCCCEEEEEEEESSSSSSS\\\\\\TTTTTOOOOOKKKKKEEEEEN"
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/New-PASUser.Tests.ps1
+++ b/Tests/New-PASUser.Tests.ps1
@@ -1,0 +1,154 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{"Detail1" = "Detail"; "Detail2" = "Detail"}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken"    = @{"Authorization" = "P_AuthValue"}
+			"WebSession"      = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"         = "https://P_URI"
+			"PVWAAppName"     = "P_App"
+			"UserName"        = "SomeUser"
+			"InitialPassword" = $("P_Password" | ConvertTo-SecureString -AsPlainText -Force)
+			"FirstName"       = "Some"
+			"LastName"        = "User"
+			"ExpiryDate"      = "10/31/2018"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'UserName'},
+			@{Parameter = 'InitialPassword'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command New-PASUser).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | New-PASUser
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Users"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 5
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 6
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.User
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Remove-PASAccount.Tests.ps1
+++ b/Tests/Remove-PASAccount.Tests.ps1
@@ -58,8 +58,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				{((Get-Command $FunctionName).Parameters["$Parameter"].Attributes).Mandatory} |
-					Should Be $true
+				(Get-Command Remove-PASAccount).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
 
 			}
 

--- a/Tests/Remove-PASAccount.Tests.ps1
+++ b/Tests/Remove-PASAccount.Tests.ps1
@@ -1,0 +1,114 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			Write-Output @{}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"AccountID"    = "11_1"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'AccountID'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				{((Get-Command $FunctionName).Parameters["$Parameter"].Attributes).Mandatory} |
+					Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Remove-PASAccount
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Accounts/11_1"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Remove-PASAccountACL.Tests.ps1
+++ b/Tests/Remove-PASAccountACL.Tests.ps1
@@ -1,0 +1,122 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			#[pscustomobject]@{"AddAccountPrivilegedCommandResult" = [pscustomobject]@{"some" = "thing"}}
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken"    = @{"Authorization" = "P_AuthValue"}
+			"WebSession"      = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"         = "https://P_URI"
+			"PVWAAppName"     = "P_App"
+			"AccountPolicyID" = "UNIXSSH"
+			"AccountAddress"  = "ServerA.domain.com"
+			"AccountUserName" = "root"
+			"Id"              = 22
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'AccountPolicyId'},
+			@{Parameter = 'AccountAddress'},
+			@{Parameter = 'AccountUserName'},
+			@{Parameter = 'Id'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Remove-PASAccountACL).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Remove-PASAccountACL
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Account/ServerA.domain.com|root|UNIXSSH/PrivilegedCommands/22"
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Body -eq @{}
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Remove-PASAccountGroupMember.Tests.ps1
+++ b/Tests/Remove-PASAccountGroupMember.Tests.ps1
@@ -1,0 +1,115 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"AccountID"    = "99_9"
+			"GroupID"      = "88_8"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'AccountID'},
+			@{Parameter = 'GroupID'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Remove-PASAccountGroupMember).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Remove-PASAccountGroupMember
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/AccountGroups/88_8/Members/99_9"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Remove-PASApplication.Tests.ps1
+++ b/Tests/Remove-PASApplication.Tests.ps1
@@ -1,0 +1,113 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"AppID"        = "SomeApplication"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'AppID'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Remove-PASApplication).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Remove-PASApplication
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Applications/SomeApplication/"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Remove-PASApplicationAuthenticationMethod.Tests.ps1
+++ b/Tests/Remove-PASApplicationAuthenticationMethod.Tests.ps1
@@ -1,0 +1,115 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"AppID"        = "SomeApplication"
+			"AuthID"       = "SomeAuth"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'AppID'},
+			@{Parameter = 'AuthID'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Remove-PASApplicationAuthenticationMethod).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Remove-PASApplicationAuthenticationMethod
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Applications/SomeApplication/Authentications/SomeAuth"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Remove-PASOnboardingRule.Tests.ps1
+++ b/Tests/Remove-PASOnboardingRule.Tests.ps1
@@ -1,0 +1,113 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"RuleID"       = "SomeRule"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'RuleID'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Remove-PASOnboardingRule).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Remove-PASOnboardingRule
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/api/AutomaticOnboardingRules/SomeRule"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Remove-PASPolicyACL.Tests.ps1
+++ b/Tests/Remove-PASPolicyACL.Tests.ps1
@@ -1,0 +1,118 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			#[pscustomobject]@{"AddAccountPrivilegedCommandResult" = [pscustomobject]@{"some" = "thing"}}
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"PolicyID"     = "UNIXSSH"
+			"Id"           = 22
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'PolicyId'},
+			@{Parameter = 'Id'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Remove-PASPolicyACL).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Remove-PASPolicyACL
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Policy/UNIXSSH/PrivilegedCommands/22"
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Body -eq $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Remove-PASPublicSSHKey.Tests.ps1
+++ b/Tests/Remove-PASPublicSSHKey.Tests.ps1
@@ -1,0 +1,115 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"UserName"     = "SomeUser"
+			"KeyID"        = "SomeKeyID"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'UserName'},
+			@{Parameter = 'KeyID'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Remove-PASPublicSSHKey).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Remove-PASPublicSSHKey
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Users/SomeUser/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys/SomeKeyID"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Remove-PASRequest.Tests.ps1
+++ b/Tests/Remove-PASRequest.Tests.ps1
@@ -1,0 +1,113 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"RequestID"    = "99_9"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'RequestID'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Remove-PASRequest).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Remove-PASRequest
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/MyRequests/99_9"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Remove-PASSafe.Tests.ps1
+++ b/Tests/Remove-PASSafe.Tests.ps1
@@ -1,0 +1,113 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"SafeName"     = "SomeSafe"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'SafeName'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Remove-PASSafe).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Remove-PASSafe
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Safes/SomeSafe"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Remove-PASSafeMember.Tests.ps1
+++ b/Tests/Remove-PASSafeMember.Tests.ps1
@@ -1,0 +1,115 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"MemberName"   = "SomeUser"
+			"SafeName"     = "SomeSafe"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'MemberName'},
+			@{Parameter = 'SafeName'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Remove-PASSafeMember).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Remove-PASSafeMember
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Safes/SomeSafe/Members/SomeUser"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Remove-PASUser.Tests.ps1
+++ b/Tests/Remove-PASUser.Tests.ps1
@@ -1,0 +1,113 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"UserName"     = "ThatUser"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'UserName'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Remove-PASUser).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Remove-PASUser
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Users/ThatUser"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Set-PASAccount.Tests.ps1
+++ b/Tests/Set-PASAccount.Tests.ps1
@@ -165,7 +165,7 @@ Describe $FunctionName {
 			It "returns default property <Property> in response" -TestCases $DefaultProps {
 				param($Property)
 
-				$response.$Property | Should Not Be Null
+				$response.$Property | Should Not BeNullOrEmpty
 
 			}
 

--- a/Tests/Set-PASAccount.Tests.ps1
+++ b/Tests/Set-PASAccount.Tests.ps1
@@ -1,0 +1,176 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[pscustomobject]@{
+				"UpdateAccountResult" = [pscustomobject]@{
+					"Prop1" = "Value1"
+					"Prop2" = "Value2"
+					"Prop3" = "Value3"
+					"Prop4" = "Value4"
+				}
+			}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"AccountID"    = "12_3"
+			"Folder"       = "Root"
+			"AccountName"  = "Name"
+			"Name"         = "SomeName"
+			"PolicyID"     = "SomePolicy"
+			"Safe"         = "SafeName"
+			"Random"       = "Rand"
+			"Random1"      = "RandomValue"
+
+		}
+
+		[void]$InputObj.PSObject.TypeNames.Insert(0, "psPAS.CyberArk.Vault.Account")
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'AccountID'},
+			@{Parameter = 'Folder'},
+			@{Parameter = 'AccountName'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				{((Get-Command $FunctionName).Parameters["$Parameter"].Attributes).Mandatory} |
+					Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Set-PASAccount -Properties @{"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = "Val3"}
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Accounts/12_3"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'PUT' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody.Accounts) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody.Accounts | Get-Member -MemberType NoteProperty).length | Should Be 4
+
+			}
+
+			It "has a request body with expected number of nested properties" {
+
+				($Script:RequestBody.Accounts.Properties).count | Should Be 5
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 9
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Account
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'},
+			@{Property = 'AccountID'}
+
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not Be Null
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Set-PASAccount.Tests.ps1
+++ b/Tests/Set-PASAccount.Tests.ps1
@@ -76,8 +76,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				{((Get-Command $FunctionName).Parameters["$Parameter"].Attributes).Mandatory} |
-					Should Be $true
+				(Get-Command Set-PASAccount).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
 
 			}
 

--- a/Tests/Set-PASSafe.Tests.ps1
+++ b/Tests/Set-PASSafe.Tests.ps1
@@ -1,0 +1,149 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{"UpdateSafeResult" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2"}}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"SafeName"     = "SomeName"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'SafeName'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Add-PASSafe).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Set-PASSafe -NumberOfDaysRetention 1 -ManagingCPM SomeCPM
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Safes/SomeName"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'PUT' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody.safe) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody.safe | Get-Member -MemberType NoteProperty).length | Should Be 3
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 6
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Safe
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Set-PASSafeMember.Tests.ps1
+++ b/Tests/Set-PASSafeMember.Tests.ps1
@@ -1,0 +1,236 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{
+				"member" = [PSCustomObject]@{
+					"MembershipExpirationDate" = "31/12/2018"
+					"Permissions"              = @(
+						[pscustomobject]@{
+							"Key"   = "Key1"
+							"Value" = $true
+						},
+						[pscustomobject]@{
+							"Key"   = "Key2"
+							"Value" = $true
+						},
+						[pscustomobject]@{
+							"Key"   = "TrueKey"
+							"Value" = $true
+						},
+						[pscustomobject]@{
+							"Key"   = "FalseKey"
+							"Value" = $false
+						},
+						[pscustomobject]@{
+							"Key"   = "AnotherKey"
+							"Value" = $true
+						},
+						[pscustomobject]@{
+							"Key"   = "AnotherFalseKey"
+							"Value" = $false
+						}
+
+
+					)
+				}
+			}
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken"                           = @{"Authorization" = "P_AuthValue"}
+			"WebSession"                             = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"                                = "https://P_URI"
+			"PVWAAppName"                            = "P_App"
+			"SafeName"                               = "SomeSafe"
+			"MemberName"                             = "SomeUser"
+			"UseAccounts"                            = $true
+			"RetrieveAccounts"                       = $true
+			"ListAccounts"                           = $true
+			"AddAccounts"                            = $false
+			"UpdateAccountContent"                   = $false
+			"UpdateAccountProperties"                = $false
+			"InitiateCPMAccountManagementOperations" = $true
+			"SpecifyNextAccountContent"              = $false
+			"RenameAccounts"                         = $false
+			"DeleteAccounts"                         = $false
+			"UnlockAccounts"                         = $true
+			"ManageSafe"                             = $false
+			"ManageSafeMembers"                      = $false
+			"BackupSafe"                             = $false
+			"ViewAuditLog"                           = $true
+			"ViewSafeMembers"                        = $true
+			"RequestsAuthorizationLevel"             = 0
+			"AccessWithoutConfirmation"              = $false
+			"CreateFolders"                          = $false
+			"DeleteFolders"                          = $false
+			"MoveAccountsAndFolders"                 = $false
+
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'SafeName'},
+			@{Parameter = 'MemberName'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Set-PASSafeMember).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Set-PASSafeMember -MembershipExpirationDate 12/31/18
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Safes/SomeSafe/Members/SomeUser"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'PUT' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "throws if invalid date pattern specified" {
+
+				{$InputObj | Set-PASSafeMember -MembershipExpirationDate "31/12/18"} | Should throw
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody.member) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody.member | Get-Member -MemberType NoteProperty).length | Should Be 2
+
+			}
+
+			It "has expected number of nested properties" {
+
+				($Script:RequestBody.member.permissions).Count | Should Be 21
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 8
+
+			}
+
+			It "has expected number of nested array elements" {
+
+				($response.permissions).count | Should Be 4
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.SafeMember
+
+			}
+
+			it "outputs object with expected safename property" {
+
+				$response.SafeName | Should Be "SomeSafe"
+
+			}
+
+			it "outputs object with expected username property" {
+
+				$response.UserName | Should Be "SomeUser"
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Set-PASUser.Tests.ps1
+++ b/Tests/Set-PASUser.Tests.ps1
@@ -1,0 +1,153 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{"Detail1" = "Detail"; "Detail2" = "Detail"}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"UserName"     = "SomeUser"
+			"NewPassword"  = $("P_Password" | ConvertTo-SecureString -AsPlainText -Force)
+			"FirstName"    = "Some"
+			"LastName"     = "User"
+			"ExpiryDate"   = "10/31/2018"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'UserName'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Set-PASUser).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Set-PASUser -NewPassword $("P_Password" | ConvertTo-SecureString -AsPlainText -Force) -ExpiryDate "10/31/2018"
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Users/SomeUser"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'PUT' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 2
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 6
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.User
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Start-PASCredChange.Tests.ps1
+++ b/Tests/Start-PASCredChange.Tests.ps1
@@ -1,0 +1,135 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"AccountID"    = "55_5"
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'AccountID'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				{((Get-Command $FunctionName).Parameters["$Parameter"].Attributes).Mandatory} |
+					Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Start-PASCredChange -ImmediateChangeByCPM Yes -ChangeCredsForGroup Yes
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Accounts/55_5/ChangeCredentials"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'PUT' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected header" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$($headers["ImmediateChangeByCPM"]) -eq "Yes"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 1
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Start-PASCredChange.Tests.ps1
+++ b/Tests/Start-PASCredChange.Tests.ps1
@@ -57,8 +57,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				{((Get-Command $FunctionName).Parameters["$Parameter"].Attributes).Mandatory} |
-					Should Be $true
+				(Get-Command Start-PASCredChange).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
 
 			}
 

--- a/Tests/Start-PASCredVerify.Tests.ps1
+++ b/Tests/Start-PASCredVerify.Tests.ps1
@@ -57,8 +57,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				{((Get-Command $FunctionName).Parameters["$Parameter"].Attributes).Mandatory} |
-					Should Be $true
+				(Get-Command Start-PASCredVerify).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
 
 			}
 

--- a/Tests/Start-PASCredVerify.Tests.ps1
+++ b/Tests/Start-PASCredVerify.Tests.ps1
@@ -1,0 +1,125 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"AccountID"    = "55_5"
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'AccountID'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				{((Get-Command $FunctionName).Parameters["$Parameter"].Attributes).Mandatory} |
+					Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Start-PASCredVerify
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Accounts/55_5/VerifyCredentials"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'PUT' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 0
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Stop-PASPSMSession.Tests.ps1
+++ b/Tests/Stop-PASPSMSession.Tests.ps1
@@ -1,0 +1,113 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken"  = @{"Authorization" = "P_AuthValue"}
+			"WebSession"    = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"       = "https://P_URI"
+			"PVWAAppName"   = "P_App"
+			"LiveSessionId" = "SomeSessionID"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'LiveSessionId'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Stop-PASPSMSession).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Stop-PASPSMSession
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/api/LiveSessions/SomeSessionID/Terminate"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should Be $null
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Unblock-PASUser.Tests.ps1
+++ b/Tests/Unblock-PASUser.Tests.ps1
@@ -1,0 +1,148 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{"Detail1" = "Detail"; "Detail2" = "Detail"}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'UserName'},
+			@{Parameter = 'Suspended'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Unblock-PASUser).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Unblock-PASUser -UserName MrFatFingers -Suspended $false
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Users/MrFatFingers"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'PUT' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 1
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 6
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.User
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Unlock-PASAccount.Tests.ps1
+++ b/Tests/Unlock-PASAccount.Tests.ps1
@@ -58,8 +58,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				{((Get-Command $FunctionName).Parameters["$Parameter"].Attributes).Mandatory} |
-					Should Be $true
+				(Get-Command Unlock-PASAccount).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
 
 			}
 

--- a/Tests/Unlock-PASAccount.Tests.ps1
+++ b/Tests/Unlock-PASAccount.Tests.ps1
@@ -1,0 +1,114 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+			"AccountID"    = "22_2"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'AccountID'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				{((Get-Command $FunctionName).Parameters["$Parameter"].Attributes).Mandatory} |
+					Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Unlock-PASAccount
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/Accounts/22_2/CheckIn"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/psPAS.Tests.ps1
+++ b/Tests/psPAS.Tests.ps1
@@ -133,6 +133,10 @@ Describe "Module" {
 
 					}
 
+					It 'has a related pester tests file' {
+						Test-Path (Join-Path $here "$_.Tests.ps1") | Should Be $true
+					}
+
 					Context "Help" {
 
 						$help = Get-Help $_ -Full

--- a/Tests/psPAS.Tests.ps1
+++ b/Tests/psPAS.Tests.ps1
@@ -202,11 +202,27 @@ Describe "Module" {
 
 	}
 
-	Context 'PSScriptAnalyzer' {
+	Describe 'PSScriptAnalyzer' {
 
-		It "passes Invoke-ScriptAnalyzer" {
+		$Scripts = Get-ChildItem "$ModulePath" -Filter '*.ps1' -Exclude '*.ps1xml' -Recurse
 
-			Invoke-ScriptAnalyzer -Path $ModulePath -Recurse | Should be $null
+		$Rules = Get-ScriptAnalyzerRule
+
+		foreach ($Script in $scripts) {
+
+			Context "Checking: $($script.BaseName)" {
+
+				foreach ($rule in $rules) {
+
+					It "passes rule $rule" {
+
+						(Invoke-ScriptAnalyzer -Path $script.FullName -IncludeRule $rule.RuleName ).Count | Should Be 0
+
+					}
+
+				}
+
+			}
 
 		}
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # version format
-version: 1.0.{build}
+version: 1.1.{build}
 
 environment:
   access_token:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,8 @@ environment:
     secure: eWAovbJD8C/F5ObWegnOimwNFyeU1vXzW6lwbJzhHpSUgjT+CMexMcPUBMKrm+Wl
   psgallery_key:
     secure: FuPgJskczZMptxRgdUlBAy7OYmXBQl4zq86kXXSmBt6wKudnM2PK7W6cM7bj0te1
+  coveralls_key:
+    secure: cWv4+OPfqRLSt7I4f+p3lEixKoYZzi42IDc7C4Kf+2WZW/dO+H+RBCM7m0Si2uuP
 
 skip_commits:
   files:

--- a/build/install.ps1
+++ b/build/install.ps1
@@ -14,4 +14,4 @@ Write-Host "`t`tInstalled NuGet version '$($pkg.version)'"
 # Install Required Modules        #
 #---------------------------------#
 Write-Host "`tRequired Modules..."
-Install-Module -Name Pester, PSScriptAnalyzer -Repository PSGallery -Confirm:$false -Force -ErrorAction SilentlyContinue | Out-Null
+Install-Module -Name Pester, PSScriptAnalyzer, coveralls -Repository PSGallery -Confirm:$false -Force -ErrorAction SilentlyContinue | Out-Null

--- a/build/test.ps1
+++ b/build/test.ps1
@@ -12,6 +12,11 @@ $res = Invoke-Pester -Path ".\Tests" -OutputFormat NUnitXml -OutputFile TestsRes
 Write-Host 'Uploading Test Results'
 (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\TestsResults.xml))
 
+Write-Host 'Formating Code Coverage'
+$coverage = Format-Coverage -RootFolder ".\psPAS" -PesterResults $res -CoverallsApiToken $($env:coveralls_key) -BranchName $($env:APPVEYOR_REPO_BRANCH)
+Write-Host 'Publishing Code Coverage'
+Publish-Coverage -Coverage $coverage
+
 #---------------------------------#
 # Validate                        #
 #---------------------------------#

--- a/build/test.ps1
+++ b/build/test.ps1
@@ -7,7 +7,9 @@ Write-Host "Current working directory: $pwd"
 #---------------------------------#
 # Run Pester Tests                #
 #---------------------------------#
-$res = Invoke-Pester -Path ".\Tests" -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru
+$files = Get-ChildItem ".\psPAS" -Include *.ps1 -Recurse
+
+$res = Invoke-Pester -Path ".\Tests" -OutputFormat NUnitXml -OutputFile TestsResults.xml -CodeCoverage $files -PassThru
 
 Write-Host 'Uploading Test Results'
 (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\TestsResults.xml))

--- a/psPAS/Functions/AccountGroups/New-PASAccountGroup.ps1
+++ b/psPAS/Functions/AccountGroups/New-PASAccountGroup.ps1
@@ -14,7 +14,7 @@ The following permissions are required on the safe where the account group will 
 .PARAMETER GroupName
 The name of the group to create
 
-.PARAMETER GroupPlatform
+.PARAMETER GroupPlatformID
 The name of the platform for the group.
 The associated platform must be set to "PolicyType=Group"
 
@@ -65,7 +65,7 @@ Minimum version 9.9.5
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$GroupPlatform,
+		[string]$GroupPlatformID,
 
 		[parameter(
 			Mandatory = $true,

--- a/psPAS/Functions/Accounts/Invoke-PASCredChange.ps1
+++ b/psPAS/Functions/Accounts/Invoke-PASCredChange.ps1
@@ -196,7 +196,7 @@ function Invoke-PASCredChange {
 		$URI = "$baseURI/$PVWAAppName/API/Accounts/$AccountID/$($PSCmdlet.ParameterSetName)"
 
 		#Get all parameters that will be sent in the request
-		$boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove UpdateVaultOnly, SetNextPassword
+		$boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove UpdateVaultOnly, SetNextPassword, AccountID
 
 		#deal with NewCredentials SecureString
 		If($PSBoundParameters.ContainsKey("NewCredentials")) {

--- a/psPAS/Functions/Accounts/Invoke-PASCredChange.ps1
+++ b/psPAS/Functions/Accounts/Invoke-PASCredChange.ps1
@@ -166,7 +166,7 @@ function Invoke-PASCredChange {
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateNotNullOrEmpty()]
-		[hashtable]$SessionToken,
+		[hashtable]$sessionToken,
 
 		[parameter(
 			ValueFromPipelinebyPropertyName = $true

--- a/psPAS/Functions/Accounts/Set-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Set-PASAccount.ps1
@@ -216,7 +216,7 @@ To move accounts to a different folder, Move accounts/folders permission is requ
 		$URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Accounts/$AccountID"
 
 		#Get all parameters that will be sent in the request
-		$boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove InputObject
+		$boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove InputObject, AccountID
 
 		if($PSBoundParameters.ContainsKey("Properties")) {
 

--- a/psPAS/Functions/Accounts/Start-PASCredChange.ps1
+++ b/psPAS/Functions/Accounts/Start-PASCredChange.ps1
@@ -85,7 +85,7 @@ None
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateNotNullOrEmpty()]
-		[hashtable]$SessionToken,
+		[hashtable]$sessionToken,
 
 		[parameter(
 			ValueFromPipelinebyPropertyName = $true

--- a/psPAS/Functions/Accounts/Start-PASCredChange.ps1
+++ b/psPAS/Functions/Accounts/Start-PASCredChange.ps1
@@ -126,7 +126,7 @@ None
 
 		#ImmediateChangeByCPM must be sent in the request header
 		#remove it from the body of the request
-		Get-PASParameter -ParametersToRemove "ImmediateChangeByCPM"
+		Get-PASParameter -ParametersToRemove "ImmediateChangeByCPM", AccountID
 
 		#add ImmediateChangeByCPM to header as key=value pair
 		$header["ImmediateChangeByCPM"] = $ImmediateChangeByCPM

--- a/psPAS/Functions/Authentication/New-PASSAMLSession.ps1
+++ b/psPAS/Functions/Authentication/New-PASSAMLSession.ps1
@@ -85,8 +85,7 @@ other functions from this return object.
 	PROCESS {
 
 		#Create base64 encoded token for header
-		$Token = [System.Text.Encoding]::UTF8.GetBytes("$($Credential.UserName):$($Credential.GetNetworkCredential().Password)")
-		$EncodedToken = [System.Convert]::ToBase64String($Token)
+		$EncodedToken = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($Credential.UserName + ':' + $Credential.GetNetworkCredential().Password))
 
 		#add token to header
 		$Header = @{"Authorization" = "Basic $EncodedToken"}
@@ -97,7 +96,7 @@ other functions from this return object.
 		if($PSCmdlet.ShouldProcess("$baseURI/$PVWAAppName", "Logon Using SAML Authentication")) {
 
 			#Send Logon Request
-			$PASSession = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -Header $Header -SessionVariable $SessionVariable
+			$PASSession = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -Headers $Header -SessionVariable $SessionVariable
 
 			#Return Object
 			[pscustomobject]@{

--- a/psPAS/Functions/Connections/Get-PASPSMConnectionParameter.ps1
+++ b/psPAS/Functions/Connections/Get-PASPSMConnectionParameter.ps1
@@ -135,7 +135,7 @@ Minimum CyberArk Version 9.10
 		$URI = "$baseURI/$PVWAAppName/API/Accounts/$($AccountID)/PSMConnect"
 
 		#Create body of request
-		$body = $PSBoundParameters | Get-PASParameter | ConvertTo-Json
+		$body = $PSBoundParameters | Get-PASParameter -ParametersToRemove AccountID | ConvertTo-Json
 
 		#send request to PAS web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $body -Headers $sessionToken -WebSession $WebSession

--- a/psPAS/Functions/OnboardingRules/Get-PASOnboardingRule.ps1
+++ b/psPAS/Functions/OnboardingRules/Get-PASOnboardingRule.ps1
@@ -62,13 +62,13 @@ Not Tested
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$BaseURI<#,
+		[string]$BaseURI,
 
-        [parameter(
-            Mandatory = $false,
-            ValueFromPipelinebyPropertyName = $true
-        )]
-        [string]$PVWAAppName = "PasswordVault"#>
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
 	)
 
 	BEGIN {}#begin
@@ -90,7 +90,7 @@ Not Tested
 			"sessionToken" = $sessionToken
 			"WebSession"   = $WebSession
 			"BaseURI"      = $BaseURI
-			#"PVWAAppName"  = $PVWAAppName
+			"PVWAAppName"  = $PVWAAppName
 
 		}
 

--- a/psPAS/Functions/OnboardingRules/New-PASOnboardingRule.ps1
+++ b/psPAS/Functions/OnboardingRules/New-PASOnboardingRule.ps1
@@ -126,13 +126,13 @@ Not Tested
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$BaseURI<#,
+		[string]$BaseURI,
 
-        [parameter(
-            Mandatory = $false,
-            ValueFromPipelinebyPropertyName = $true
-        )]
-        [string]$PVWAAppName = "PasswordVault"#>
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
 	)
 
 	BEGIN {}#begin
@@ -155,7 +155,7 @@ Not Tested
 				"sessionToken" = $sessionToken
 				"WebSession"   = $WebSession
 				"BaseURI"      = $BaseURI
-				#"PVWAAppName"  = $PVWAAppName
+				"PVWAAppName"  = $PVWAAppName
 
 			}
 

--- a/psPAS/Functions/OnboardingRules/Remove-PASOnboardingRule.ps1
+++ b/psPAS/Functions/OnboardingRules/Remove-PASOnboardingRule.ps1
@@ -65,13 +65,13 @@ None
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$BaseURI<#,
+		[string]$BaseURI,
 
-        [parameter(
-            Mandatory = $false,
-            ValueFromPipelinebyPropertyName = $true
-        )]
-        [string]$PVWAAppName = "PasswordVault"#>
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
 	)
 
 	BEGIN {}#begin

--- a/psPAS/Functions/Requests/Approve-PASRequest.ps1
+++ b/psPAS/Functions/Requests/Approve-PASRequest.ps1
@@ -91,7 +91,7 @@ Minimum CyberArk Version 9.10
 		$URI = "$baseURI/$PVWAAppName/API/IncomingRequests/$($RequestID)/Confirm"
 
 		#Create body of request
-		$body = $PSBoundParameters | Get-PASParameter | ConvertTo-Json
+		$body = $PSBoundParameters | Get-PASParameter -ParametersToRemove RequestId | ConvertTo-Json
 
 		if($PSCmdlet.ShouldProcess($RequestId, "Confirm Request for Account Access")) {
 

--- a/psPAS/Functions/Requests/Deny-PASRequest.ps1
+++ b/psPAS/Functions/Requests/Deny-PASRequest.ps1
@@ -91,7 +91,7 @@ Minimum CyberArk Version 9.10
 		$URI = "$baseURI/$PVWAAppName/API/IncomingRequests/$($RequestID)/Reject"
 
 		#Create body of request
-		$body = $PSBoundParameters | Get-PASParameter -ParametersToRemove  RequestId | ConvertTo-Json
+		$body = $PSBoundParameters | Get-PASParameter -ParametersToRemove RequestId | ConvertTo-Json
 
 		if($PSCmdlet.ShouldProcess($RequestId, "Reject Request for Account Access")) {
 

--- a/psPAS/Functions/SafeMembers/Add-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Add-PASSafeMember.ps1
@@ -7,17 +7,6 @@ Adds a Safe Member to safe
 Adds an existing user as a Safe member.
 "Manage Safe Members" permission is required by the authenticated user account sending request.
 
-.PARAMETER WebSession
-WebRequestSession object returned from New-PASSession
-
-.PARAMETER BaseURI
-PVWA Web Address
-Do not include "/PasswordVault/"
-
-.PARAMETER PVWAAppName
-The name of the CyberArk PVWA Virtual Directory.
-Defaults to PasswordVault
-
 .PARAMETER SafeName
 The name of the safe to add the member to
 

--- a/psPAS/Private/Get-EscapedString.ps1
+++ b/psPAS/Private/Get-EscapedString.ps1
@@ -6,7 +6,7 @@ Outputs escaped string value.
 .DESCRIPTION
 Wrapper for the System.Uri EscapeDataString method.
 When provided with an input string, an escaped string will be output.
-This can be used for forming URLs and query srings where spaces are not allowed.
+This can be used for forming URLs and query strings where spaces are not allowed.
 
 .PARAMETER inputString
 String to escape

--- a/psPAS/Private/Get-PASParameter.ps1
+++ b/psPAS/Private/Get-PASParameter.ps1
@@ -78,6 +78,9 @@ Hashtable/$PSBoundParameters object, with defined parameters removed.
 			"SessionVariable",
 			"WebSession",
 			"PVWAAppName",
+			"InformationAction",
+			"InformationVariable",
+			"UseTransaction",
 			"RequestID",
 			"OnlyWaiting")
 	)
@@ -95,6 +98,7 @@ Hashtable/$PSBoundParameters object, with defined parameters removed.
 
 		ForEach-Object {
 
+			#TODO: add condition to reduce debug output - only report on removed params
 			Write-Debug "Removing Parameter: $_"
 			#remove specified parameters from passed values
 			$Parameters.Remove($_)

--- a/psPAS/Private/Get-PASParameter.ps1
+++ b/psPAS/Private/Get-PASParameter.ps1
@@ -79,9 +79,7 @@ Hashtable/$PSBoundParameters object, with defined parameters removed.
 			"PVWAAppName",
 			"InformationAction",
 			"InformationVariable",
-			"UseTransaction",
-			"RequestID",
-			"OnlyWaiting")
+			"UseTransaction")
 	)
 
 	BEGIN {

--- a/psPAS/Private/Get-PASParameter.ps1
+++ b/psPAS/Private/Get-PASParameter.ps1
@@ -74,7 +74,6 @@ Hashtable/$PSBoundParameters object, with defined parameters removed.
 			"Confirm",
 			"sessionToken",
 			"BaseURI"
-			"AccountID",
 			"SessionVariable",
 			"WebSession",
 			"PVWAAppName",


### PR DESCRIPTION
## Summary

Initial Pester tests for module files - 99% coverage.
Added Coveralls integration into test scripts.
Fixes for some issues identified though unit tests..

This PR fixes/implements the following **bugs/features**:

Added initial Pester tests for all functions.
Add-PASAccountGroupMember was not sending AccountID with request, now fixed.
New-PASAccountGroup fixed an incorrect parameter name (GroupPlatformID).
New-PASSAMLSession - authentication token was not being sent in request header, now fixed.
Get-PASOnboardingRule, New-PASOnboardingRule & Remove-PASOnboardingRule, parameters updated to allow specification of alternate PVWA application name (in-line with the rest of the module's functions).

## Test Plan

.... Pester Tests all pass!

## Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes. -->
Fixes #55 

