### PR TITLE
Feature 10 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # psPAS
 
 [![Build status](https://ci.appveyor.com/api/projects/status/j45hbplm4dq4vfye/branch/master?svg=true)](https://ci.appveyor.com/project/pspete/pspas/branch/master)
+[![AppVeyor tests](https://img.shields.io/appveyor/tests/pspete/pspas.svg)](https://ci.appveyor.com/project/pspete/pspas)
 [![Coverage Status](https://coveralls.io/repos/github/pspete/psPAS/badge.svg)](https://coveralls.io/github/pspete/psPAS)
 [![PowerShell Gallery](https://img.shields.io/powershellgallery/v/psPAS.svg)](https://www.powershellgallery.com/packages/psPAS)
 [![license](https://img.shields.io/github/license/pspete/psPAS.svg)](https://github.com/pspete/psPAS/blob/master/LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # psPAS
 
-[![Build status](https://ci.appveyor.com/api/projects/status/j45hbplm4dq4vfye/branch/master?svg=true)](https://ci.appveyor.com/project/pspete/pspas/branch/master) [![Coverage Status](https://coveralls.io/repos/github/pspete/psPAS/badge.svg)](https://coveralls.io/github/pspete/psPAS)
+[![Build status](https://ci.appveyor.com/api/projects/status/j45hbplm4dq4vfye/branch/master?svg=true)](https://ci.appveyor.com/project/pspete/pspas/branch/master)
+[![Coverage Status](https://coveralls.io/repos/github/pspete/psPAS/badge.svg)](https://coveralls.io/github/pspete/psPAS)
+[![PowerShell Gallery](https://img.shields.io/powershellgallery/v/psPAS.svg)](https://www.powershellgallery.com/packages/psPAS)
 
 ## **Table of Contents**
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 - [psPAS](#pspas)
   - [CyberArk PowerShell Module](#cyberark-powershell-module)
-  - [Latest Update](#latest-update)
+  - [Latest Updates](#latest-updates)
   - [Getting Started](#getting-started)
     - [Prerequisites](#prerequisites)
     - [Install and Use](#install-and-use)
@@ -25,13 +25,20 @@
 
 PowerShell module for CyberArk Privileged Account Security Web Services REST API.
 
-Exposes the available methods of the web service for CyberArk PAS up to v10.1.
+Exposes the available methods of the web service for CyberArk PAS up to v10.2.
 
 ----------
 
-## Latest Update
+## Latest Updates
 
-- Added initial Pester tests for all functions.
+- Module updated to cover CyberArk 10.2 API features:
+  - `New-PASOnboardingRule` has added parameters available from 10.2 onwards. The 9.8 & 10.2 parameters are configured as separate parametersets.
+  - `Get-PASOnboardingRule` has a new parameter added, allowing search of Onboarding rules by name in version 10.2
+  - `Import-PASPlatform` function added, allowing import of CPM Platforms
+  - `Get-PASPSMConnectionParameters` updated to facilitate return of HTML5 connection data when PSMGW is configured.
+  - `Suspend-PASPSMSession` & `Resume-PASPSMSession` functions added, expanding on the automatic mitigation capability for PSM Sessions.
+
+- Majority of codebase covered by initial Pester tests (check out that code coverage^). Further development and expansion of the module tests is planned.
 - Bug Fixes:
   - ```Add-PASAccountGroupMember``` was not sending AccountID with request, now fixed.
   - ```New-PASAccountGroup``` fixed an incorrect parameter name (_GroupPlatformID_).
@@ -257,8 +264,9 @@ Chapeau!
 |9.5|All Previous Functions, and:<br/>`Set-PASAccount`<br/><br/>|
 |9.6|All Previous Functions, and:<br/>`Add-PASPublicSSHKey`<br/>`Get-PASPublicSSHKey`<br/>`Remove-PASPublicSSHKey`<br/><br/>|
 |9.7|All Previous Functions, and:<br/>`New-PASSession` (CyberArk, LDAP, RADIUS Authentication)<br/>`New-PASSAMLSession`<br/>`Close-PASSAMLSession` <br/>`New-PASSharedSession`<br/>`Close-PASSharedSession`<br/>`Get-PASServerWebService`<br/>`Get-PASSafeShareLogo`<br/>`Get-PASServer`<br/>`New-PASUser`<br/>`Set-PASUser`<br/>`Remove-PASUser`<br/>`Get-PASLoggedOnUser`<br/>`Get-PASUser`<br/>`Unblock-PASUser`<br/>`Add-PASGroupMember`<br/>`Add-PASPendingAccount`<br/>`Get-PASAccountPassword` (_Limited Functionality_)<br/>`Start-PASCredVerify`<br/>`Get-PASAccountActivity`<br/>`Get-PASSafe`<br/>`Get-PASSafeMember`<br/><br/>|
-|9.8|All Previous Functions, and:<br/>`New-PASOnboardingRule`<br/>`Remove-PASOnboardingRule`<br/>`Get-PASOnboardingRule`<br/><br/>|
+|9.8|All Previous Functions, and:<br/>`New-PASOnboardingRule` (_Limited Functionality_)<br/>`Remove-PASOnboardingRule`<br/>`Get-PASOnboardingRule` (_Limited Functionality_)<br/><br/>|
 |9.9|All Previous Functions|
 |9.9.5|All Previous Functions, and:<br/>`New-PASAccountGroup`<br/>`Add-PASAccountGroupMember`<br/><br/>|
-|9.10|All Previous Functions, and:<br/>`Invoke-PASCredChange` (_Limited Functionality_)<br/>`Invoke-PASCredVerify`<br/>`Invoke-PASCredReconcile`<br/>`Unlock-PASAccount`<br/>`Get-PASAccountGroup`<br/>`Get-PASAccountGroupMember`<br/>`Remove-PASAccountGroupMember`<br/>`New-PASRequest`<br/>`Get-PASRequest`<br/>`Get-PASRequestDetail`<br/>`Remove-PASRequest`<br/>`Approve-PASRequest`<br/>`Deny-PASRequest`<br/>`Get-PASPlatform`<br/>`Get-PASRecording`<br/>`Get-PASLiveSession`<br/>`Get-PASPSMConnectionParameter`<br/><br/>|
+|9.10|All Previous Functions, and:<br/>`Invoke-PASCredChange` (_Limited Functionality_)<br/>`Invoke-PASCredVerify`<br/>`Invoke-PASCredReconcile`<br/>`Unlock-PASAccount`<br/>`Get-PASAccountGroup`<br/>`Get-PASAccountGroupMember`<br/>`Remove-PASAccountGroupMember`<br/>`New-PASRequest`<br/>`Get-PASRequest`<br/>`Get-PASRequestDetail`<br/>`Remove-PASRequest`<br/>`Approve-PASRequest`<br/>`Deny-PASRequest`<br/>`Get-PASPlatform`<br/>`Get-PASRecording`<br/>`Get-PASLiveSession`<br/>`Get-PASPSMConnectionParameter` (_Limited Functionality_)<br/><br/>|
 |10.1|All Previous Functions, and:<br/>`Invoke-PASCredChange` (_Updated for 10.1_)<br/>`Get-PASAccountPassword` (_Updated for 10.1_)<br/>`Stop-PASPSMSession`<br/>`Get-PASComponentSummary`<br/>`Get-PASComponentDetail`<br/><br/>|
+|10.2|All Previous Functions, and:<br/>`Get-PASPSMConnectionParameters` (_Updated for 10.2_)<br/>`New-PASOnboardingRule` (_Updated for 10.2_)<br/>`Get-PASOnboardingRule` (_Updated for 10.2_)<br/>`Suspend-PASPSMSession`<br/>`Resume-PASPSMSession`<br/>`Import-PASPSMPlatform`<br/><br/>|

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Exposes the available methods of the web service for CyberArk PAS up to v10.2.
   - `Get-PASPSMConnectionParameters` updated to facilitate return of HTML5 connection data when PSMGW is configured.
   - `Suspend-PASPSMSession` & `Resume-PASPSMSession` functions added, expanding on the automatic mitigation capability for PSM Sessions.
 
-- Majority of codebase covered by initial Pester tests (check out that code coverage^). Further development and expansion of the module tests is planned.
+- Attained 100% Code Coverage in the Tests for the module.
+
 - Bug Fixes:
   - ```Add-PASAccountGroupMember``` was not sending AccountID with request, now fixed.
   - ```New-PASAccountGroup``` fixed an incorrect parameter name (_GroupPlatformID_).

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/j45hbplm4dq4vfye/branch/master?svg=true)](https://ci.appveyor.com/project/pspete/pspas/branch/master)
 [![Coverage Status](https://coveralls.io/repos/github/pspete/psPAS/badge.svg)](https://coveralls.io/github/pspete/psPAS)
 [![PowerShell Gallery](https://img.shields.io/powershellgallery/v/psPAS.svg)](https://www.powershellgallery.com/packages/psPAS)
+[![license](https://img.shields.io/github/license/pspete/psPAS.svg)](https://github.com/pspete/psPAS/blob/master/LICENSE.md)
 
 ## **Table of Contents**
 

--- a/Tests/Get-PASOnboardingRule.Tests.ps1
+++ b/Tests/Get-PASOnboardingRule.Tests.ps1
@@ -45,7 +45,7 @@ Describe $FunctionName {
 			"BaseURI"      = "https://P_URI"
 			"PVWAAppName"  = "P_App"
 			"AccountID"    = "99_9"
-			"name"         = "SomeRule,SomeRule2"
+			"Names"        = "SomeRule,SomeRule2"
 
 		}
 
@@ -78,7 +78,7 @@ Describe $FunctionName {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/api/AutomaticOnboardingRules/?Name=SomeRule,SomeRule2"
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/api/AutomaticOnboardingRules?Names=SomeRule,SomeRule2"
 
 				} -Times 1 -Exactly -Scope Describe
 

--- a/Tests/Get-PASOnboardingRule.Tests.ps1
+++ b/Tests/Get-PASOnboardingRule.Tests.ps1
@@ -45,6 +45,7 @@ Describe $FunctionName {
 			"BaseURI"      = "https://P_URI"
 			"PVWAAppName"  = "P_App"
 			"AccountID"    = "99_9"
+			"name"         = "SomeRule,SomeRule2"
 
 		}
 
@@ -77,7 +78,7 @@ Describe $FunctionName {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/api/AutomaticOnboardingRules/"
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/api/AutomaticOnboardingRules/?Name=SomeRule,SomeRule2"
 
 				} -Times 1 -Exactly -Scope Describe
 

--- a/Tests/Get-PASPSMConnectionParameter.Tests.ps1
+++ b/Tests/Get-PASPSMConnectionParameter.Tests.ps1
@@ -66,7 +66,7 @@ Describe $FunctionName {
 
 		}
 
-		$response = $InputObj | Get-PASPSMConnectionParameter
+		$response = $InputObj | Get-PASPSMConnectionParameter -ConnectionMethod RDP
 
 		Context "Input" {
 
@@ -107,6 +107,24 @@ Describe $FunctionName {
 			It "has a request body with expected number of properties" {
 
 				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 1
+
+			}
+
+			It "has expected Accept key in header" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Headers["Accept"] -eq 'application/json' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "specifies expected Accept key in header for PSMGW requests" {
+
+				$InputObj | Get-PASPSMConnectionParameter -ConnectionMethod PSMGW
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Headers["Accept"] -eq '* / *' } -Times 1 -Exactly -Scope It
 
 			}
 

--- a/Tests/Import-PASPlatform.Tests.ps1
+++ b/Tests/Import-PASPlatform.Tests.ps1
@@ -1,0 +1,171 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{"PlatformID" = "SomePlatform"}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken" = @{"Authorization" = "P_AuthValue"}
+			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"      = "https://P_URI"
+			"PVWAAppName"  = "P_App"
+		}
+
+		#Create a 512b file to test with
+		$file = [System.IO.File]::Create("$env:Temp\testPlatform.zip")
+		$file.SetLength(0.5kb)
+		$file.Close()
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'ImportFile'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Import-PASPlatform).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Import-PASPlatform -ImportFile $($file.name)
+
+		Context "Input" {
+
+			It "throws if InputFile does not exist" {
+				{$InputObj | Import-PASPlatform -ImportFile SomeFile.txt} | Should throw
+			}
+
+			It "throws if InputFile resolves to a folder" {
+				{$InputObj | Import-PASPlatform -ImportFile $pwd} | Should throw
+			}
+
+			It "throws if InputFile does not have a zip extention" {
+				{$InputObj | Import-PASPlatform -ImportFile README.MD} | Should throw
+			}
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/Platforms/Import"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody.ImportFile) -ne $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 1
+
+			}
+
+			It "has body content of expected length" {
+
+				($Script:RequestBody.ImportFile).length | Should Be 512
+
+			}
+
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 1
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be System.Management.Automation.PSCustomObject
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "does not return default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Be $null
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/New-DynamicParam.Tests.ps1
+++ b/Tests/New-DynamicParam.Tests.ps1
@@ -1,0 +1,76 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repo Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		It "throws if DPDictionary is not expected type" {
+			{$Dictionary = New-Object psobject
+				New-DynamicParam -Name AlwaysParam -ValidateSet @( gwmi win32_volume |
+						% {$_.driveletter} | sort ) -DPDictionary $Dictionary} |should throw
+		}
+
+		$testParam = New-DynamicParam -Name SomeParam -Type String -Alias SomeAlias -ValidateSet "Some,Set" `
+			-Mandatory $true -ParameterSetName SomeSet -Position 1 -ValueFromPipelineByPropertyName $true `
+			-HelpMessage "Some Message" -DPDictionary $false
+
+		it "outputs parameter with expected name" {
+			$testParam["SomeParam"].Name | Should Be SomeParam
+		}
+
+		it "outputs parameter with expected type" {
+			$testParam["SomeParam"].ParameterType.Name | Should Be String
+		}
+		it "outputs parameter with expected alias" {
+			$testParam["SomeParam"].Attributes.AliasNames | Should Be SomeAlias
+		}
+		it "outputs parameter with expected ValidateSet declaration" {
+			$testParam["SomeParam"].Attributes.ValidValues | Should Be "Some,Set"
+		}
+		it "outputs parameter with expected Mandatory declaration" {
+			$testParam["SomeParam"].Attributes.Mandatory | Should Be $true
+		}
+		it "outputs parameter with expected ParameterSetName declaration" {
+			$testParam["SomeParam"].Attributes.ParameterSetName | Should Be SomeSet
+		}
+		it "outputs parameter with expected position" {
+			$testParam["SomeParam"].Attributes.Position | Should Be 1
+		}
+		it "outputs parameter with expected ValueFromPipelineByPropertyName declaration" {
+			$testParam["SomeParam"].Attributes.ValueFromPipelineByPropertyName | Should Be $true
+		}
+		it "outputs parameter with expected HelpMessage" {
+			$testParam["SomeParam"].Attributes.HelpMessage | Should Be "Some Message"
+		}
+
+		it "outputs parameter to existing Dictionary Object" {
+			$Dictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
+			$testParam = New-DynamicParam -Name SomeParam -Type String -Alias SomeAlias -ValidateSet "Some,Set" `
+				-Mandatory $true -ParameterSetName SomeSet -Position 1 -ValueFromPipelineByPropertyName $true `
+				-HelpMessage "Some Message" -DPDictionary $Dictionary
+
+			$Dictionary["SomeParam"] | Should Not BeNullOrEmpty
+
+		}
+	}
+
+}

--- a/Tests/New-PASOnboardingRule.Tests.ps1
+++ b/Tests/New-PASOnboardingRule.Tests.ps1
@@ -56,7 +56,9 @@ Describe $FunctionName {
 			@{Parameter = 'SessionToken'},
 			@{Parameter = 'DecisionPlatformId'},
 			@{Parameter = 'DecisionSafeName'},
-			@{Parameter = 'SystemTypeFilter'}
+			@{Parameter = 'SystemTypeFilter'},
+			@{Parameter = 'TargetPlatformId'},
+			@{Parameter = 'TargetSafeName'}
 
 			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
 
@@ -109,6 +111,23 @@ Describe $FunctionName {
 			It "has a request body with expected number of properties" {
 
 				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 3
+
+			}
+
+			It "accepts alternative parameterset input" {
+
+				$InputObj = [pscustomobject]@{
+					"sessionToken"     = @{"Authorization" = "P_AuthValue"}
+					"WebSession"       = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+					"BaseURI"          = "https://P_URI"
+					"PVWAAppName"      = "P_App"
+					"TargetPlatformId" = "SomePlatform"
+					"TargetSafeName"   = "SomeSafe"
+					"SystemTypeFilter" = "Windows"
+
+				}
+
+				{$InputObj | New-PASOnboardingRule} | Should Not Throw
 
 			}
 

--- a/Tests/Resume-PASPSMSession.Tests.ps1
+++ b/Tests/Resume-PASPSMSession.Tests.ps1
@@ -1,0 +1,113 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken"  = @{"Authorization" = "P_AuthValue"}
+			"WebSession"    = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"       = "https://P_URI"
+			"PVWAAppName"   = "P_App"
+			"LiveSessionId" = "SomeSessionID"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'LiveSessionId'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Resume-PASPSMSession).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Resume-PASPSMSession
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/api/LiveSessions/SomeSessionID/Resume"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should Be $null
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Suspend-PASPSMSession.Tests.ps1
+++ b/Tests/Suspend-PASPSMSession.Tests.ps1
@@ -1,0 +1,113 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken"  = @{"Authorization" = "P_AuthValue"}
+			"WebSession"    = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"       = "https://P_URI"
+			"PVWAAppName"   = "P_App"
+			"LiveSessionId" = "SomeSessionID"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'LiveSessionId'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Suspend-PASPSMSession).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Suspend-PASPSMSession
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/api/LiveSessions/SomeSessionID/Suspend"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+
+				$response | Should Be $null
+
+			}
+
+		}
+
+	}
+
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # version format
-version: 1.1.{build}
+version: 1.2.{build}
 
 environment:
   access_token:

--- a/build/test.ps1
+++ b/build/test.ps1
@@ -15,7 +15,7 @@ Write-Host 'Uploading Test Results'
 (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\TestsResults.xml))
 
 Write-Host 'Formating Code Coverage'
-$coverage = Format-Coverage -RootFolder ".\psPAS" -PesterResults $res -CoverallsApiToken $($env:coveralls_key) -BranchName $($env:APPVEYOR_REPO_BRANCH)
+$coverage = Format-Coverage -PesterResults $res -CoverallsApiToken $($env:coveralls_key) -BranchName $($env:APPVEYOR_REPO_BRANCH)
 Write-Host 'Publishing Code Coverage'
 Publish-Coverage -Coverage $coverage
 

--- a/psPAS/Functions/Monitoring/Resume-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Resume-PASPSMSession.ps1
@@ -1,0 +1,96 @@
+function Stop-PASPSMSession {
+	<#
+.SYNOPSIS
+Resumes a Suspended PSM Session.
+
+.DESCRIPTION
+Resumes a Suspended PSM Session identified by the unique ID of the PSM Session.
+
+.PARAMETER LiveSessionId
+The unique ID/SessionGuid of a Suspended PSM Session.
+
+.PARAMETER sessionToken
+Hashtable containing the session token returned from New-PASSession
+
+.PARAMETER WebSession
+WebRequestSession object returned from New-PASSession
+
+.PARAMETER BaseURI
+PVWA Web Address
+Do not include "/PasswordVault/"
+
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
+.EXAMPLE
+$token | Resume-PASPSMSession -LiveSessionId $SessionUUID
+
+Terminates Live PSM Session identified by the session UUID.
+
+.INPUTS
+All parameters can be piped by property name
+
+.OUTPUTS
+None
+
+.NOTES
+Minimum CyberArk Version 10.2
+
+.LINK
+
+#>
+	[CmdletBinding(SupportsShouldProcess)]
+	param(
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[Alias("SessionGuid")]
+		[string]$LiveSessionId,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[hashtable]$sessionToken,
+
+		[parameter(
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[Microsoft.PowerShell.Commands.WebRequestSession]$WebSession,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$BaseURI,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
+	)
+
+	BEGIN {}#begin
+
+	PROCESS {
+
+		#Create URL for Request
+		$URI = "$baseURI/$PVWAAppName/api/LiveSessions/$($LiveSessionId | Get-EscapedString)/Resume"
+
+		if($PSCmdlet.ShouldProcess($LiveSessionId, "Resume PSM Session")) {
+
+			#send request to PAS web service
+			Invoke-PASRestMethod -Uri $URI -Method POST -Headers $sessionToken -WebSession $WebSession
+
+		}
+
+	} #process
+
+	END {}#end
+
+}

--- a/psPAS/Functions/Monitoring/Resume-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Resume-PASPSMSession.ps1
@@ -4,7 +4,8 @@ function Resume-PASPSMSession {
 Resumes a Suspended PSM Session.
 
 .DESCRIPTION
-Resumes a Suspended PSM Session identified by the unique ID of the PSM Session.
+Resumes a suspended, active PSM session, identified by the unique ID of the PSM Session,
+allowing a privileged user to continue working.
 
 .PARAMETER LiveSessionId
 The unique ID/SessionGuid of a Suspended PSM Session.

--- a/psPAS/Functions/Monitoring/Resume-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Resume-PASPSMSession.ps1
@@ -1,4 +1,4 @@
-function Stop-PASPSMSession {
+function Resume-PASPSMSession {
 	<#
 .SYNOPSIS
 Resumes a Suspended PSM Session.

--- a/psPAS/Functions/Monitoring/Suspend-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Suspend-PASPSMSession.ps1
@@ -1,4 +1,4 @@
-function Stop-PASPSMSession {
+function Resume-PASPSMSession {
 	<#
 .SYNOPSIS
 Suspends a Live PSM Session.

--- a/psPAS/Functions/Monitoring/Suspend-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Suspend-PASPSMSession.ps1
@@ -4,7 +4,8 @@ function Suspend-PASPSMSession {
 Suspends a Live PSM Session.
 
 .DESCRIPTION
-Suspends a Live PSM Session identified by the unique ID of the PSM Session.
+Suspends a Live PSM session, identified by the unique ID of the PSM Session,
+preventing further  interaction in the session until it is resumed by Resume-PASPSMSession.
 
 .PARAMETER LiveSessionId
 The unique ID/SessionGuid of a Live PSM Session.

--- a/psPAS/Functions/Monitoring/Suspend-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Suspend-PASPSMSession.ps1
@@ -1,0 +1,96 @@
+function Stop-PASPSMSession {
+	<#
+.SYNOPSIS
+Suspends a Live PSM Session.
+
+.DESCRIPTION
+Suspends a Live PSM Session identified by the unique ID of the PSM Session.
+
+.PARAMETER LiveSessionId
+The unique ID/SessionGuid of a Live PSM Session.
+
+.PARAMETER sessionToken
+Hashtable containing the session token returned from New-PASSession
+
+.PARAMETER WebSession
+WebRequestSession object returned from New-PASSession
+
+.PARAMETER BaseURI
+PVWA Web Address
+Do not include "/PasswordVault/"
+
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
+.EXAMPLE
+$token | Suspend-PASPSMSession -LiveSessionId $SessionUUID
+
+Terminates Live PSM Session identified by the session UUID.
+
+.INPUTS
+All parameters can be piped by property name
+
+.OUTPUTS
+None
+
+.NOTES
+Minimum CyberArk Version 10.2
+
+.LINK
+
+#>
+	[CmdletBinding(SupportsShouldProcess)]
+	param(
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[Alias("SessionGuid")]
+		[string]$LiveSessionId,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[hashtable]$sessionToken,
+
+		[parameter(
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[Microsoft.PowerShell.Commands.WebRequestSession]$WebSession,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$BaseURI,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
+	)
+
+	BEGIN {}#begin
+
+	PROCESS {
+
+		#Create URL for Request
+		$URI = "$baseURI/$PVWAAppName/api/LiveSessions/$($LiveSessionId | Get-EscapedString)/Suspend"
+
+		if($PSCmdlet.ShouldProcess($LiveSessionId, "Suspend PSM Session")) {
+
+			#send request to PAS web service
+			Invoke-PASRestMethod -Uri $URI -Method POST -Headers $sessionToken -WebSession $WebSession
+
+		}
+
+	} #process
+
+	END {}#end
+
+}

--- a/psPAS/Functions/Monitoring/Suspend-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Suspend-PASPSMSession.ps1
@@ -1,4 +1,4 @@
-function Resume-PASPSMSession {
+function Suspend-PASPSMSession {
 	<#
 .SYNOPSIS
 Suspends a Live PSM Session.

--- a/psPAS/Functions/OnboardingRules/Get-PASOnboardingRule.ps1
+++ b/psPAS/Functions/OnboardingRules/Get-PASOnboardingRule.ps1
@@ -1,11 +1,17 @@
 ﻿function Get-PASOnboardingRule {
 	<#
 .SYNOPSIS
-Gets all automatic onboarding rules
+Gets all automatic on-boarding rules
 
 .DESCRIPTION
-Returns information on all defined on-boarding rules.
+Returns information on defined on-boarding rules.
 Vault Admin membership required.
+
+.PARAMETER Name
+A filter that specifies the rule name.
+Separate a list of rules with commas.
+If not specified, all rules will be returned.
+For version 10.2 onwards (not a supported parameter on earlier versions)
 
 .PARAMETER sessionToken
 Hashtable containing the session token returned from New-PASSession
@@ -47,6 +53,13 @@ Not Tested
 	[CmdletBinding()]
 	param(
 		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[string]$Name,
+
+		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
@@ -77,6 +90,23 @@ Not Tested
 
 		#Create URL for request
 		$URI = "$baseURI/$PVWAAppName/api/AutomaticOnboardingRules/"
+
+		If($PSBoundParameters.ContainsKey("name")) {
+
+			#Get Parameters to include in request
+			$boundParameters = $PSBoundParameters | Get-PASParameter
+
+			#Create Query String, escaped for inclusion in request URL
+			$queryString = ($boundParameters.keys | ForEach-Object {
+
+					"$_=$($boundParameters[$_])"
+
+				})
+
+			#Build URL from base URL
+			$URI = "$URI`?$queryString"
+
+		}
 
 		#send request to web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -Headers $sessionToken -WebSession $WebSession

--- a/psPAS/Functions/OnboardingRules/Get-PASOnboardingRule.ps1
+++ b/psPAS/Functions/OnboardingRules/Get-PASOnboardingRule.ps1
@@ -7,7 +7,7 @@ Gets all automatic on-boarding rules
 Returns information on defined on-boarding rules.
 Vault Admin membership required.
 
-.PARAMETER Name
+.PARAMETER Names
 A filter that specifies the rule name.
 Separate a list of rules with commas.
 If not specified, all rules will be returned.
@@ -31,6 +31,11 @@ Defaults to PasswordVault
 $token | Get-PASOnboardingRule
 
 List information on all On-boarding rules
+
+.EXAMPLE
+$token | Get-PASOnboardingRule -Names Rule1,Rule2
+
+List information on On-boarding rules "Rule1" & "Rule2"
 
 .INPUTS
 All parameters can be piped by property name
@@ -57,7 +62,7 @@ Not Tested
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateNotNullOrEmpty()]
-		[string]$Name,
+		[string]$Names,
 
 		[parameter(
 			Mandatory = $true,
@@ -89,9 +94,9 @@ Not Tested
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$baseURI/$PVWAAppName/api/AutomaticOnboardingRules/"
+		$URI = "$baseURI/$PVWAAppName/api/AutomaticOnboardingRules"
 
-		If($PSBoundParameters.ContainsKey("name")) {
+		If($PSBoundParameters.ContainsKey("Names")) {
 
 			#Get Parameters to include in request
 			$boundParameters = $PSBoundParameters | Get-PASParameter

--- a/psPAS/Functions/OnboardingRules/New-PASOnboardingRule.ps1
+++ b/psPAS/Functions/OnboardingRules/New-PASOnboardingRule.ps1
@@ -7,27 +7,73 @@ Adds a new on-boarding rule to the Vault
 Adds a new on-boarding rule to the Vault, that filters discovered local privileged pending accounts.
 When a discovered pending account matches a rule, it will be automatically on-boarded to the safe that
 is defined in the rule and the password will be reconciled.
+If a newly discovered account does not match any rule, it will be added to the PendingAccounts list.
 
 This function must be run with a Vault Admin account.
 
 .PARAMETER DecisionPlatformId
 The ID of the platform that will be associated to the on-boarded account.
+For Versions 9.8 to 10.1
+
+.PARAMETER TargetPlatformID
+The ID of the platform that will be associated to the on-boarded account.
+For Version 10.2 onwards
 
 .PARAMETER DecisionSafeName
 The name of the Safe where the on-boarded account will be stored.
+For Versions 9.8 to 10.1
+
+.PARAMETER TargetSafeName
+The name of the Safe where the on-boarded account will be stored.
+For Version 10.2 onwards
 
 .PARAMETER IsAdminUIDFilter
 Whether or not only pending accounts whose UID is set to will be on-boarded
 automatically according to this rule.
+For Versions 9.8 to 10.1
+
+.PARAMETER IsAdminIDFilter
+Whether or not UNIX accounts with UID=0 or Windows accounts with SID ending in 500 will be onboarded automatically
+using this rule.
+If set to false, all accounts matching the rule will be onboarded.
+For Version 10.2 onwards
 
 .PARAMETER MachineTypeFilter
 The Machine Type by which to filter.
+Leave blank for "Any"
 
 .PARAMETER SystemTypeFilter
 The System Type by which to filter.
 
 .PARAMETER UserNameFilter
 The name of the user by which to filter.
+
+.PARAMETER UserNameMethod
+The method to use when applying the user name filter (Equals / Begins with/ Ends with).
+This parameter is ignored if UserNameFilter is not specified.
+For Version 10.2 onwards
+
+.PARAMETER AddressFilter
+IP Address or DNS name of the machine by which to filter.
+For Version 10.2 onwards
+
+.PARAMETER AddressMethod
+The method to use when applying the address filter (Equals / Begins with/ Ends with).
+This parameter is ignored if AddressFilter is not specified.
+For Version 10.2 onwards
+
+.PARAMETER AccountCategoryFilter
+Filter for Privileged or Non-Privileged accounts.
+For Version 10.2 onwards
+
+.PARAMETER RuleName
+Name of the rule
+If left blank, a name will be generated automatically.
+For Version 10.2 onwards
+
+.PARAMETER RuleDescription
+A description of the rule.
+For Version 10.2 onwards
 
 .PARAMETER sessionToken
 Hashtable containing the session token returned from New-PASSession
@@ -61,33 +107,63 @@ Output format is defined via psPAS.Format.ps1xml.
 To force all output to be shown, pipe to Select-Object *
 
 .NOTES
-Not Tested
+Before running:
+Create the Safe and the reconcile account according to the rule’s definition.
+Associate the reconcile account with the platform that is defined in the rule.
+Make sure that the user whose credentials will be used for this session is a member of
+the Safe specified in the TargetSafeName parameter with the Add accounts permission.
 
 .LINK
 
 #>
-	[CmdletBinding(SupportsShouldProcess)]
+	[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = "pre_V10_2")]
 	param(
 		[parameter(
 			Mandatory = $true,
-			ValueFromPipelinebyPropertyName = $true
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "pre_V10_2"
 		)]
 		[ValidateLength(1, 99)]
 		[string]$DecisionPlatformId,
 
 		[parameter(
 			Mandatory = $true,
-			ValueFromPipelinebyPropertyName = $true
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "post_V10_2"
+		)]
+		[ValidateLength(1, 99)]
+		[string]$TargetPlatformId,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "pre_V10_2"
 		)]
 		[ValidateLength(1, 28)]
 		[string]$DecisionSafeName,
 
 		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "post_V10_2"
+		)]
+		[ValidateLength(1, 28)]
+		[string]$TargetSafeName,
+
+		[parameter(
 			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "pre_V10_2"
 		)]
 		[ValidateSet("Yes", "No")]
 		[String]$IsAdminUIDFilter,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "post_V10_2"
+		)]
+		[boolean]$IsAdminIDFilter,
 
 		[parameter(
 			Mandatory = $false,
@@ -109,6 +185,51 @@ Not Tested
 		)]
 		[ValidateLength(0, 512)]
 		[string]$UserNameFilter,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "post_V10_2"
+		)]
+		[ValidateSet("Equals", "Begins", "Ends")]
+		[string]$UserNameMethod,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateLength(0, 255)]
+		[string]$AddressFilter,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "post_V10_2"
+		)]
+		[ValidateSet("Equals", "Begins", "Ends")]
+		[string]$AddressMethod,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "post_V10_2"
+		)]
+		[ValidateSet("Any", "Privileged", "Non-Privileged")]
+		[string]$AccountCategoryFilter,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateLength(0, 255)]
+		[string]$RuleName,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateLength(0, 255)]
+		[string]$RuleDescription,
 
 		[parameter(
 			Mandatory = $true,
@@ -145,7 +266,22 @@ Not Tested
 		#create request body
 		$body = $PSBoundParameters | Get-PASParameter | ConvertTo-Json
 
-		if($PSCmdlet.ShouldProcess($DecisionSafeName, "Add On-Boarding Rule Using '$DecisionPlatformID'")) {
+		#Get Values for ShouldProcess Message
+		If($PSCmdlet.ParameterSetName -eq "post_V10_2") {
+
+			#version 10.2 parameters
+			$SafeName = $TargetSafeName
+			$PlatformID = $TargetPlatformId
+
+		} ElseIf($PSCmdlet.ParameterSetName -eq "pre_V10_2") {
+
+			#pre 10.2 parameters
+			$SafeName = $DecisionSafeName
+			$PlatformID = $DecisionPlatformId
+
+		}
+
+		if($PSCmdlet.ShouldProcess($SafeName, "Add On-Boarding Rule Using '$PlatformID'")) {
 
 			#send request to web service
 			$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -Headers $sessionToken -WebSession $WebSession

--- a/psPAS/Functions/OnboardingRules/New-PASOnboardingRule.ps1
+++ b/psPAS/Functions/OnboardingRules/New-PASOnboardingRule.ps1
@@ -214,7 +214,7 @@ the Safe specified in the TargetSafeName parameter with the Add accounts permiss
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = "post_V10_2"
 		)]
-		[ValidateSet("Any", "Privileged", "Non-Privileged")]
+		[ValidateSet("Any", "Privileged", "NonPrivileged")]
 		[string]$AccountCategoryFilter,
 
 		[parameter(

--- a/psPAS/Functions/Platforms/Import-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Import-PASPlatform.ps1
@@ -1,0 +1,99 @@
+function Import-PASPlatform {
+	<#
+	.SYNOPSIS
+	Import a new platform
+
+	.DESCRIPTION
+	Import a new CPM platform.
+
+	.PARAMETER ImportFile
+	The zip file that contains the platform.
+
+	.PARAMETER sessionToken
+	Hashtable containing the session token returned from New-PASSession
+
+	.PARAMETER WebSession
+	WebRequestSession object returned from New-PASSession
+
+	.PARAMETER BaseURI
+	PVWA Web Address
+	Do not include "/PasswordVault/"
+
+	.PARAMETER PVWAAppName
+	The name of the CyberArk PVWA Virtual Directory.
+	Defaults to PasswordVault
+
+	.EXAMPLE
+	$token | Import-PASPlatform -ImportFile CustomApp.zip
+
+	Imports CustomApp.zip Platform package
+
+	.INPUTS
+	SessionToken, ImportFile, WebSession & BaseURI can be piped by  property name
+
+	.OUTPUTS
+	None
+
+	.NOTES
+	Minimum CyberArk version 10.2
+
+	#>
+	[CmdletBinding(SupportsShouldProcess)]
+	param(
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[ValidateScript( { Test-Path -Path $_ -PathType Leaf})]
+		[ValidatePattern( '\.zip$' )]
+		[string]$ImportFile,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[hashtable]$SessionToken,
+
+		[parameter(
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[Microsoft.PowerShell.Commands.WebRequestSession]$WebSession,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$BaseURI,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
+	)
+
+	BEGIN {}#begin
+
+	PROCESS {
+
+		#Create URL for request
+		$URI = "$baseURI/$PVWAAppName/API/Platforms/Import"
+
+		$FileBytes = [System.IO.File]::ReadAllBytes($ImportFile)
+
+		$Body = @{"ImportFile" = $FileBytes} | ConvertTo-Json
+
+		if($PSCmdlet.ShouldProcess($ImportFile, "Imports Platform Package")) {
+
+			#send request to web service
+			Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -Headers $SessionToken -WebSession $WebSession
+
+		}
+
+	}#process
+
+	END {}#end
+
+}

--- a/psPAS/Private/Get-PASParameter.ps1
+++ b/psPAS/Private/Get-PASParameter.ps1
@@ -95,10 +95,13 @@ Hashtable/$PSBoundParameters object, with defined parameters removed.
 
 		ForEach-Object {
 
-			#TODO: add condition to reduce debug output - only report on removed params
-			Write-Debug "Removing Parameter: $_"
-			#remove specified parameters from passed values
-			$Parameters.Remove($_)
+			If($Parameters.Contains($_)) {
+
+				Write-Debug "Removing Parameter: $_"
+				#remove specified parameters from passed values
+				$Parameters.Remove($_)
+
+			}
 
 		}
 

--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -50,7 +50,7 @@ to ensure session persistence.
 .LINK
 
 #>
-	[CmdletBinding()]
+	[CmdletBinding(DefaultParameterSetName = "WebSession")]
 	param
 	(
 		[Parameter(Mandatory = $true)]

--- a/psPAS/about_psPAS.help.txt
+++ b/psPAS/about_psPAS.help.txt
@@ -79,4 +79,5 @@ KEYWORDS
     CyberArk
 
 SEE ALSO
+    about_psPAS_Versions
     https://github.com/pspete/psPAS

--- a/psPAS/about_psPAS_Versions.help.txt
+++ b/psPAS/about_psPAS_Versions.help.txt
@@ -1,0 +1,108 @@
+TOPIC
+    about_psPAS_Versions
+
+SHORT DESCRIPTION
+    psPAS supports operations via CyberArk REST Web Services versions 9.0 - 10.2.
+
+LONG DESCRIPTION
+    The CyberArk REST Web Services evolves with each release, as psPAS exposes all functionality present in the API,
+	it is the version of CyberArk being worked with that will determine which functions (and sometimes parameters)
+	can be used.
+	When new functionality becomes available via the API, this may affect what actions psPAS functions can perform in
+	different versions. Backwards compatibility in the module will be maintained where possible.
+
+Version Compatibility Details
+
+	The below matrix shows which psPAS module functions can be used with different minimum CyberArk version:
+
+	psPAS Function								Minimum CyberArk API Version
+
+	Add-PASAccount											9.0
+	Add-PASAccountACL										9.0
+	Add-PASAccountGroupMember								9.9.5
+	Add-PASApplication										9.1
+	Add-PASApplicationAuthenticationMethod					9.1
+	Add-PASGroupMember										9.7
+	Add-PASPendingAccount									9.7
+	Add-PASPolicyACL										9.0
+	Add-PASPublicSSHKey										9.6
+	Add-PASSafe												9.2
+	Add-PASSafeMember										9.3
+	Approve-PASRequest										9.10
+	Close-PASSAMLSession 									9.7
+	Close-PASSession										9.0
+	Close-PASSharedSession									9.7
+	Deny-PASRequest											9.10
+	Get-PASAccount											9.3
+	Get-PASAccountACL										9.0
+	Get-PASAccountActivity									9.7
+	Get-PASAccountGroup										9.10
+	Get-PASAccountGroupMember								9.10
+	Get-PASAccountPassword (Initial)						9.7
+	Get-PASAccountPassword (Updated)						10.1
+	Get-PASApplication										9.1
+	Get-PASApplicationAuthenticationMethod					9.1
+	Get-PASComponentDetail									10.1
+	Get-PASComponentSummary									10.1
+	Get-PASLiveSession										9.10
+	Get-PASLoggedOnUser										9.7
+	Get-PASOnboardingRule (Initial)							9.8
+	Get-PASOnboardingRule (Updated)							10.2
+	Get-PASPlatform											9.10
+	Get-PASPolicyACL										9.0
+	Get-PASPSMConnectionParameter (Initial)					9.10
+	Get-PASPSMConnectionParameters (Updated)				10.2
+	Get-PASPublicSSHKey										9.6
+	Get-PASRecording										9.10
+	Get-PASRequest											9.10
+	Get-PASRequestDetail									9.10
+	Get-PASSafe												9.7
+	Get-PASSafeMember										9.7
+	Get-PASSafeShareLogo									9.7
+	Get-PASServer											9.7
+	Get-PASServerWebService									9.7
+	Get-PASUser												9.7
+	Import-PASPSMPlatform									10.2
+	Invoke-PASCredChange (Initial)							9.10
+	Invoke-PASCredChange (Updated)							10.1
+	Invoke-PASCredReconcile									9.10
+	Invoke-PASCredVerify									9.10
+	New-PASAccountGroup										9.9.5
+	New-PASOnboardingRule (Initial)							9.8
+	New-PASOnboardingRule (Updated)							10.2
+	New-PASRequest											9.10
+	New-PASSAMLSession										9.7
+	New-PASSession (CyberArk Authentication Only)			9.0
+	New-PASSession (CyberArk, LDAP, RADIUS Authentication)	9.7
+	New-PASSharedSession									9.7
+	New-PASUser												9.7
+	Remove-PASAccount										9.3
+	Remove-PASAccountACL									9.0
+	Remove-PASAccountGroupMember							9.10
+	Remove-PASApplication									9.1
+	Remove-PASApplicationAuthenticationMethod				9.1
+	Remove-PASOnboardingRule								9.8
+	Remove-PASPolicyACL										9.0
+	Remove-PASPublicSSHKey									9.6
+	Remove-PASRequest										9.10
+	Remove-PASSafe											9.3
+	Remove-PASSafeMember									9.3
+	Remove-PASUser											9.7
+	Resume-PASPSMSession									10.2
+	Set-PASAccount											9.5
+	Set-PASSafe												9.3
+	Set-PASSafeMember										9.3
+	Set-PASUser												9.7
+	Start-PASCredChange										9.3
+	Start-PASCredVerify										9.7
+	Stop-PASPSMSession										10.1
+	Suspend-PASPSMSession									10.2
+	Unblock-PASUser											9.7
+	Unlock-PASAccount										9.10
+
+KEYWORDS
+    CyberArk
+
+SEE ALSO
+	about_psPAS
+    https://github.com/pspete/psPAS

--- a/psPAS/psPAS.Format.ps1xml
+++ b/psPAS/psPAS.Format.ps1xml
@@ -500,32 +500,44 @@
       <ViewSelectedBy>
         <TypeName>psPAS.CyberArk.Vault.OnboardingRule</TypeName>
       </ViewSelectedBy>
-      <TableControl>
-        <TableHeaders>
-          <TableColumnHeader />
-          <TableColumnHeader />
-          <TableColumnHeader />
-          <TableColumnHeader />
-        </TableHeaders>
-        <TableRowEntries>
-          <TableRowEntry>
-            <TableColumnItems>
-              <TableColumnItem>
+      <ListControl>
+        <ListEntries>
+          <ListEntry>
+            <ListItems>
+              <ListItem>
                 <PropertyName>RuleId</PropertyName>
-              </TableColumnItem>
-              <TableColumnItem>
+              </ListItem>
+              <ListItem>
                 <PropertyName>RuleName</PropertyName>
-              </TableColumnItem>
-              <TableColumnItem>
+              </ListItem>
+              <ListItem>
+                <ItemSelectionCondition>
+                  <ScriptBlock>$_.DecisionPlatformId</ScriptBlock>
+                </ItemSelectionCondition>
                 <PropertyName>DecisionPlatformId</PropertyName>
-              </TableColumnItem>
-              <TableColumnItem>
+              </ListItem>
+              <ListItem>
+                <ItemSelectionCondition>
+                  <ScriptBlock>$_.DecisionSafeName</ScriptBlock>
+                </ItemSelectionCondition>
                 <PropertyName>DecisionSafeName</PropertyName>
-              </TableColumnItem>
-            </TableColumnItems>
-          </TableRowEntry>
-        </TableRowEntries>
-      </TableControl>
+              </ListItem>
+              <ListItem>
+                <ItemSelectionCondition>
+                  <ScriptBlock>$_.TargetPlatformId</ScriptBlock>
+                </ItemSelectionCondition>
+                <PropertyName>TargetPlatformId</PropertyName>
+              </ListItem>
+              <ListItem>
+                <ItemSelectionCondition>
+                  <ScriptBlock>$_.TargetSafeName</ScriptBlock>
+                </ItemSelectionCondition>
+                <PropertyName>TargetSafeName</PropertyName>
+              </ListItem>
+            </ListItems>
+          </ListEntry>
+        </ListEntries>
+      </ListControl>
     </View>
     <View>
       <Name>psPAS.CyberArk.Vault.Application</Name>

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -128,7 +128,9 @@
 		'Get-PASPSMSession',
 		'Stop-PASPSMSession',
 		'Get-PASComponentSummary',
-		'Get-PASComponentDetail'
+		'Get-PASComponentDetail',
+		'Suspend-PASPSMSession',
+		'Resume-PASPSMSession'
 	)
 
 	AliasesToExport   = @(

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -130,7 +130,8 @@
 		'Get-PASComponentSummary',
 		'Get-PASComponentDetail',
 		'Suspend-PASPSMSession',
-		'Resume-PASPSMSession'
+		'Resume-PASPSMSession',
+		'Import-PASPlatform'
 	)
 
 	AliasesToExport   = @(


### PR DESCRIPTION
Update to module to include CyberArk 10.2 functionality

This PR implements the following features:

100% Code Coverage through Pester Tests
New-PASOnboardingRule has added parameters available from 10.2 onwards. The 9.8 & 10.2 parameters are configured as separate parametersets.
Get-PASOnboardingRule has a new parameter added, allowing search of Onboarding rules by name in version 10.2
Import-PASPlatform function added, allowing import of CPM Platforms
Get-PASPSMConnectionParameters updated to facilitate return of HTML5 connection data when PSMGW is configured.
Suspend-PASPSMSession & Resume-PASPSMSession functions added, expanding on the automatic mitigation capability for PSM Sessions.
Updates default view for OnboardingRule.
New Badges for the Readme.

Explain the motivation for making this change. What existing problem does the pull request solve?

New API functionality available

Test Plan
Demonstrate the code is solid. Example: The exact commands you ran and their output.
All Pester Tests Pass.
Tests updated where applicable

Closes issues
Closes #56