### PR TITLE
Bypass strict RFC header parsing in PS Core

### DIFF
--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -86,6 +86,13 @@ to ensure session persistence.
 		#Add ContentType for all function calls
 		$PSBoundParameters.Add("ContentType", 'application/json')
 
+		#Bypass strict RFC header parsing in PS Core
+		if ($PSVersionTable.PSEdition -eq "Core") {
+
+			$PSBoundParameters.Add("SkipHeaderValidation", $true)
+
+		}
+
 		#If Tls12 Security Protocol is available
 		if(([Net.SecurityProtocolType].GetEnumNames() -contains "Tls12") -and
 
@@ -108,10 +115,6 @@ to ensure session persistence.
 	Process {
 
 		Write-Debug $PSBoundParameters.GetEnumerator()
-
-		if ($PSVersionTable.PSEdition -eq "Core") {
-			$PSBoundParameters.Add("SkipHeaderValidation", $true)
-		}
 
 		try {
 

--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -109,6 +109,10 @@ to ensure session persistence.
 
 		Write-Debug $PSBoundParameters.GetEnumerator()
 
+		if ($PSVersionTable.PSEdition -eq "Core") {
+			$PSBoundParameters.Add("SkipHeaderValidation", $true)
+		}
+
 		try {
 
 			#make web request, splat PSBoundParameters


### PR DESCRIPTION

## Summary

This PR fixes the following bug that is only reproducible in PowerShell Core:

```
$vaultToken | Get-PASAccount -Keywords $userName

The format of value '{{ Base64 String }}' is invalid.
At C:\Program Files\PowerShell\Modules\psPAS\1.2.3\Functions\Accounts\Get-PASAccount.ps1:151 char:13
+ ...   $result = Invoke-PASRestMethod -Uri $URI -Method GET -Headers $sess ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
+ FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,Invoke-PASRestMethod
```
Such behavior is caused by the following breaking change in PowerShell Core:
* Strict RFC header parsing is now default for the `-Headers` and `-UserAgent` parameter. This can be bypassed with `-SkipHeaderValidation`.

Source: [Breaking Changes for PowerShell 6.0 - Changes to Web Cmdlets](https://github.com/PowerShell/PowerShell/blob/master/docs/BREAKINGCHANGES.md#changes-to-web-cmdlets)

