### PR TITLE
UPDATE Logon Process

### DIFF
--- a/Tests/New-PASSession.Tests.ps1
+++ b/Tests/New-PASSession.Tests.ps1
@@ -49,7 +49,8 @@ Describe $FunctionName {
 		Context "Mandatory Parameters" {
 
 			$Parameters = @{Parameter = 'BaseURI'},
-			@{Parameter = 'Credential'}
+			@{Parameter = 'Credential'},
+			@{Parameter = 'Type'}
 
 			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
 
@@ -61,7 +62,7 @@ Describe $FunctionName {
 
 		}
 
-		$response = $Credentials | New-PASSession -BaseURI "https://P_URI" -PVWAAppName "SomeApp" -newPassword $NewPass
+		$response = $Credentials | New-PASSession -BaseURI "https://P_URI" -PVWAAppName "SomeApp" -newPassword $NewPass -UseV9API
 
 		Context "Input" {
 
@@ -123,6 +124,39 @@ Describe $FunctionName {
 
 			}
 
+			It "sends request to expected v10 URL for CyberArk Authentication" {
+
+				$response = $Credentials | New-PASSession -BaseURI "https://P_URI" -type CyberArk
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "https://P_URI/PasswordVault/api/AUTH/CyberArk/Logon"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request to expected v10 URL for LDAP Authentication" {
+
+				$response = $Credentials | New-PASSession -BaseURI "https://P_URI" -type LDAP
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "https://P_URI/PasswordVault/api/AUTH/LDAP/Logon"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request to expected v10 URL for RADIUS Authentication" {
+
+				$response = $Credentials | New-PASSession -BaseURI "https://P_URI" -type RADIUS
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "https://P_URI/PasswordVault/api/AUTH/RADIUS/Logon"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
 		}
 
 		Context "Output" {
@@ -178,14 +212,14 @@ Describe $FunctionName {
 			It "throws error if authentication request fails" {
 
 				Mock Invoke-PASRestMethod -MockWith {Write-Error -Message "Some Error" -ErrorId 12345}
-				{$Credentials | New-PASSession -BaseURI "https://P_URI" -ErrorAction Stop} | Should throw
+				{$Credentials | New-PASSession -BaseURI "https://P_URI"  -UseV9API -ErrorAction Stop} | Should throw
 
 			}
 
 			It "returns no output if authentication request fails" {
 
 				Mock Invoke-PASRestMethod -MockWith {Write-Error -Message "Some Error" -ErrorId 12345}
-				$Credentials | New-PASSession -BaseURI "https://P_URI" -ErrorAction SilentlyContinue | Should BeNullOrEmpty
+				$Credentials | New-PASSession -BaseURI "https://P_URI" -UseV9API -ErrorAction SilentlyContinue | Should BeNullOrEmpty
 
 			}
 

--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -81,7 +81,10 @@ to ensure session persistence.
 
 	Begin {
 
+		#Get the name of the function which invoked this one
+		$CallingFunction = (Get-Variable MyInvocation -Scope 1).Value.MyCommand.Name
 		Write-Debug "Function: $($MyInvocation.InvocationName)"
+		Write-Debug "Calling Function: $CallingFunction"
 
 		#Add ContentType for all function calls
 		$PSBoundParameters.Add("ContentType", 'application/json')
@@ -206,6 +209,21 @@ to ensure session persistence.
 							#Create Return Object from Returned JSON
 							$PASResponse = ConvertFrom-Json -InputObject $webResponse.content
 
+							#Handle Version 10 Logon Token Return
+							If(($CallingFunction -eq "New-PASSession") -and ($PASResponse.length -eq 180)) {
+
+								Write-Verbose "Assigning token to CyberArkLogonResult"
+								#If calling function is New-PASSession, and result is a 180 character token
+								#Create a new object and assign the token to the CyberArkLogonResult property.
+								#This ensures an object is returned instead of a string (which would cause issues).
+								$PASResponse = [PSCustomObject]@{
+
+									CyberArkLogonResult = $PASResponse
+
+								}
+
+							}
+
 							#If Session Variable passed as argument
 							If($PSBoundParameters.ContainsKey("SessionVariable")) {
 
@@ -223,6 +241,12 @@ to ensure session persistence.
 
 							#Return Object
 							$PASResponse
+
+						}
+
+						Else {
+
+							throw $([System.Text.Encoding]::ASCII.GetString($($webResponse.content)))
 
 						}
 


### PR DESCRIPTION
Return value for authentication using the version 10 api differs from version 9.
Version 9 returns the token as the value of the CyberArkLogonResult property.
Version 10 returns the raw value with no property.

Logon process updated to include the additional parameters and URL endpoint for version 10.
If Invoke-PASRestMethod is called from New-PASSession, and the raw value is returned (i.e. its a version 10 authentication request), the return value will be added to the CyberArkLogonResult property.

Additional exception handling added to cater for failures related to v10 endpoint being used with a v9 solution.

<!-- _A similar PR may already be submitted.
Please search existing `Pull Requests` before creating one._

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.  -->

## Summary

Updates logon process to cater for V10 API

This PR fixes/implements the following **bugs**:

LDAP authentication from the module to CyberArk 10.3

<!-- You can skip this if you're fixing a typo. -->

_Explain the **motivation** for making this change. What existing problem does the pull request solve?_

<!-- Example: When "Amended logic in function _X_ to achieve _Y_", explain why it is necessary to have a way to do _Y_. -->

Added parameters, parameterset and endpoint URL to New-PASSession for v10 auth.
Ammended Invoke-PASRestMethod to return logon token as the value of the CyberArkLogonResult property (as it is in v9).
This is required because in v10 the CyberArkLogonResult property is not present, and only the raw value of the logontoken is returned.

## Test Plan

_Demonstrate the code is solid. Example: The exact commands you ran and their output._
Pester Tests updated and all tests pass


## Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes. -->
Closes #71

<!--
## Code formatting

 See the `CONTRIBUTING` guide.

_Ensure your code adheres to the project's PowerShell Styleguide_
-->