### PR TITLE
Feature version compare

### DIFF
--- a/Tests/Add-PASAccountGroupMember.Tests.ps1
+++ b/Tests/Add-PASAccountGroupMember.Tests.ps1
@@ -110,6 +110,10 @@ Describe $FunctionName {
 
 			}
 
+			It "throws error if version requirement not met" {
+				{$InputObj | Add-PASAccountGroupMember -ExternalVersion "1.0"} | Should Throw
+			}
+
 		}
 
 		Context "Output" {

--- a/Tests/Approve-PASRequest.Tests.ps1
+++ b/Tests/Approve-PASRequest.Tests.ps1
@@ -109,6 +109,10 @@ Describe $FunctionName {
 
 			}
 
+			It "throws error if version requirement not met" {
+				{$InputObj | Approve-PASRequest -ExternalVersion "1.0"} | Should Throw
+			}
+
 		}
 
 		Context "Output" {

--- a/Tests/Assert-VersionRequirement.Tests.ps1
+++ b/Tests/Assert-VersionRequirement.Tests.ps1
@@ -1,0 +1,92 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repo Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Context 'Minimum Version Met' {
+
+			It 'returns nothing if version requirment is satisfied' {
+				Assert-VersionRequirement -ExternalVersion "0.2" -RequiredVersion "0.1" | Should BeNullOrEmpty
+			}
+
+			It 'does not throw if version requirment is satisfied' {
+				{Assert-VersionRequirement -ExternalVersion "0.2" -RequiredVersion "0.1"} | Should Not Throw
+			}
+
+		}
+
+		Context 'Version Check Skipped' {
+
+			It 'returns nothing if external version is "0.0"' {
+				Assert-VersionRequirement -ExternalVersion "0.0" -RequiredVersion "9.9" | Should BeNullOrEmpty
+			}
+
+			It 'does not throw if external version is "0.0"' {
+				{Assert-VersionRequirement -ExternalVersion "0.0" -RequiredVersion "1.1"} | Should Not Throw
+			}
+
+		}
+
+		Context 'Minimum Version Not Met' {
+
+			Mock Get-ParentFunction -MockWith {
+				[PSCustomObject]@{
+					FunctionName     = "SomeFunction"
+					ParameterSetName = "SomeParameterSet"
+				}
+			}
+			Function Test-Failure {Assert-VersionRequirement -ExternalVersion "1.1" -RequiredVersion "2.0"}
+
+			It 'throws error if external version is less than required version' {
+				{Test-Failure} | should Throw
+			}
+
+			It 'throws expected error if no custom parameterset has been used in the parent function' {
+
+				Mock Get-ParentFunction -MockWith {
+					[PSCustomObject]@{
+						FunctionName     = "Test-Example"
+						ParameterSetName = "__AllParameterSets"
+					}
+				}
+
+				{Test-Failure} | should Throw "CyberArk 1.1 does not meet the minimum version requirement of 2.0 for Test-Example (using ParameterSet: __AllParameterSets)"
+			}
+
+			It 'throws expected error if a custom parameterset has been used in the parent function' {
+				Mock Get-ParentFunction -MockWith {
+					[PSCustomObject]@{
+						FunctionName     = "Test-Example"
+						ParameterSetName = "SomeParamSet"
+					}
+				}
+				{Test-Failure} | should Throw "CyberArk 1.1 does not meet the minimum version requirement of 2.0 for Test-Example (using ParameterSet: SomeParamSet)"
+			}
+		}
+
+
+
+
+	}
+
+}

--- a/Tests/Compare-MinimumVersion.Tests.ps1
+++ b/Tests/Compare-MinimumVersion.Tests.ps1
@@ -31,9 +31,9 @@ Describe $FunctionName {
 			Compare-MinimumVersion -Version "9.8.0" -MinimumVersion "9.9.0" | Should Be $false
 		}
 
-		It 'returns nothing if version is 0.0' {
+		It 'returns TRUE if version is 0.0' {
 
-			Compare-MinimumVersion -Version "0.0" -MinimumVersion "1.1.0" | Should BeNullOrEmpty
+			Compare-MinimumVersion -Version "0.0" -MinimumVersion "1.1.0" | Should Be $true
 
 		}
 

--- a/Tests/Compare-MinimumVersion.Tests.ps1
+++ b/Tests/Compare-MinimumVersion.Tests.ps1
@@ -1,0 +1,44 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repo Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		It 'returns TRUE if version is greater than minimum version' {
+			Compare-MinimumVersion -Version "9.8.0" -MinimumVersion "8.9.0" | Should Be $true
+		}
+
+		It 'returns FALSE if version is less than minimum version' {
+			Compare-MinimumVersion -Version "9.8.0" -MinimumVersion "9.9.0" | Should Be $false
+		}
+
+		It 'returns nothing if version is 0.0' {
+
+			Compare-MinimumVersion -Version "0.0" -MinimumVersion "1.1.0" | Should BeNullOrEmpty
+
+		}
+
+
+
+	}
+
+}

--- a/Tests/Deny-PASRequest.Tests.ps1
+++ b/Tests/Deny-PASRequest.Tests.ps1
@@ -109,6 +109,10 @@ Describe $FunctionName {
 
 			}
 
+			It "throws error if version requirement not met" {
+				{$InputObj | Deny-PASRequest -ExternalVersion "1.0"} | Should Throw
+			}
+
 		}
 
 		Context "Output" {

--- a/Tests/Get-PASAccountGroup.Tests.ps1
+++ b/Tests/Get-PASAccountGroup.Tests.ps1
@@ -96,6 +96,10 @@ Describe $FunctionName {
 
 			}
 
+			It "throws error if version requirement not met" {
+				{$InputObj | Get-PASAccountGroup -ExternalVersion "1.0"} | Should Throw
+			}
+
 		}
 
 		Context "Output" {

--- a/Tests/Get-PASAccountGroupMember.Tests.ps1
+++ b/Tests/Get-PASAccountGroupMember.Tests.ps1
@@ -96,6 +96,10 @@ Describe $FunctionName {
 
 			}
 
+			It "throws error if version requirement not met" {
+				{$InputObj | Get-PASAccountGroupMember -ExternalVersion "1.0"} | Should Throw
+			}
+
 		}
 
 		Context "Output" {

--- a/Tests/Get-PASAccountPassword.Tests.ps1
+++ b/Tests/Get-PASAccountPassword.Tests.ps1
@@ -143,6 +143,11 @@ Describe $FunctionName {
 			}
 
 
+			It "throws error if version requirement not met" {
+				{$InputObj | Get-PASAccountPassword -UseV10API -Reason "SomeReason" -TicketingSystemName "someSystem" -TicketId 12345 -ExternalVersion "1.0"} | Should Throw
+			}
+
+
 		}
 
 		Context "Output" {

--- a/Tests/Get-PASComponentDetail.Tests.ps1
+++ b/Tests/Get-PASComponentDetail.Tests.ps1
@@ -95,6 +95,10 @@ Describe $FunctionName {
 
 			}
 
+			It "throws error if version requirement not met" {
+				{$InputObj | Get-PASComponentDetail -ComponentID PVWA -ExternalVersion "1.0"} | Should Throw
+			}
+
 		}
 
 		Context "Output" {

--- a/Tests/Get-PASComponentSummary.Tests.ps1
+++ b/Tests/Get-PASComponentSummary.Tests.ps1
@@ -97,6 +97,10 @@ Describe $FunctionName {
 
 			}
 
+			It "throws error if version requirement not met" {
+				{$InputObj | Get-PASComponentSummary -ExternalVersion "1.0"} | Should Throw
+			}
+
 		}
 
 		Context "Output" {

--- a/Tests/Get-PASOnboardingRule.Tests.ps1
+++ b/Tests/Get-PASOnboardingRule.Tests.ps1
@@ -96,6 +96,10 @@ Describe $FunctionName {
 
 			}
 
+			It "throws error if version requirement not met" {
+				{$InputObj | Get-PASOnboardingRule -ExternalVersion "1.0"} | Should Throw
+			}
+
 		}
 
 		Context "Output" {

--- a/Tests/Get-PASPSMConnectionParameter.Tests.ps1
+++ b/Tests/Get-PASPSMConnectionParameter.Tests.ps1
@@ -128,6 +128,14 @@ Describe $FunctionName {
 
 			}
 
+			It "throws error if version requirement not met for RDP connection method" {
+				{$InputObj | Get-PASPSMConnectionParameter -ConnectionMethod RDP -ExternalVersion "9.8"} | Should Throw
+			}
+
+			It "throws error if version requirement not met for PSMGW connection method" {
+				{$InputObj | Get-PASPSMConnectionParameter -ConnectionMethod PSMGW -ExternalVersion "9.10"} | Should Throw
+			}
+
 		}
 
 		Context "Output" {

--- a/Tests/Get-PASPSMRecording.Tests.ps1
+++ b/Tests/Get-PASPSMRecording.Tests.ps1
@@ -95,6 +95,10 @@ Describe $FunctionName {
 
 			}
 
+			It "throws error if version requirement not met" {
+				{$InputObj | Get-PASPSMRecording -ExternalVersion "1.0"} | Should Throw
+			}
+
 		}
 
 		Context "Output" {

--- a/Tests/Get-PASPSMSession.Tests.ps1
+++ b/Tests/Get-PASPSMSession.Tests.ps1
@@ -95,6 +95,10 @@ Describe $FunctionName {
 
 			}
 
+			It "throws error if version requirement not met" {
+				{$InputObj | Get-PASPSMSession -ExternalVersion "1.0"} | Should Throw
+			}
+
 		}
 
 		Context "Output" {

--- a/Tests/Get-PASPlatform.Tests.ps1
+++ b/Tests/Get-PASPlatform.Tests.ps1
@@ -96,6 +96,10 @@ Describe $FunctionName {
 
 			}
 
+			It "throws error if version requirement not met" {
+				{$InputObj | Get-PASPlatform -ExternalVersion "1.0"} | Should Throw
+			}
+
 		}
 
 		Context "Output" {

--- a/Tests/Get-PASRequest.Tests.ps1
+++ b/Tests/Get-PASRequest.Tests.ps1
@@ -99,6 +99,10 @@ Describe $FunctionName {
 
 			}
 
+			It "throws error if version requirement not met" {
+				{$InputObj | Get-PASRequest -RequestType MyRequests -OnlyWaiting $true -Expired $true -ExternalVersion "1.0"} | Should Throw
+			}
+
 		}
 
 		Context "Input - IncomingRequests" {

--- a/Tests/Get-PASRequestDetail.Tests.ps1
+++ b/Tests/Get-PASRequestDetail.Tests.ps1
@@ -96,6 +96,10 @@ Describe $FunctionName {
 
 			}
 
+			It "throws error if version requirement not met" {
+				{$InputObj | Get-PASRequestDetail -RequestType MyRequests -ExternalVersion "1.0"} | Should Throw
+			}
+
 		}
 
 		Context "Input - IncomingRequests" {

--- a/Tests/Get-ParentFunction.Tests.ps1
+++ b/Tests/Get-ParentFunction.Tests.ps1
@@ -1,0 +1,44 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repo Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		It 'returns parent function name' {
+			Function Test-Parent {Test-Child}
+			Function Test-Child {Get-ParentFunction}
+
+			Test-Parent | Should Be Test-Parent
+		}
+
+		It 'returns expected parent function name from expected scope' {
+			Function Test-Example {Test-Parent}
+			Function Test-Parent {Test-Child}
+			Function Test-Child {Get-ParentFunction -Scope 3}
+
+			Test-Example | Should Be Test-Example
+		}
+
+
+	}
+
+}

--- a/Tests/Get-ParentFunction.Tests.ps1
+++ b/Tests/Get-ParentFunction.Tests.ps1
@@ -26,16 +26,36 @@ Describe $FunctionName {
 		It 'returns parent function name' {
 			Function Test-Parent {Test-Child}
 			Function Test-Child {Get-ParentFunction}
+			$ThisTest = Test-Parent
 
-			Test-Parent | Should Be Test-Parent
+			$ThisTest.FunctionName | Should Be Test-Parent
 		}
 
 		It 'returns expected parent function name from expected scope' {
-			Function Test-Example {Test-Parent}
+			Function Test-Example {
+				[CmdletBinding()]
+				param([parameter(ParameterSetName = "ExampleParamSet")][string]$Name)
+				Test-Parent
+			}
 			Function Test-Parent {Test-Child}
 			Function Test-Child {Get-ParentFunction -Scope 3}
+			$ThisTest = Test-Example -Name "test"
 
-			Test-Example | Should Be Test-Example
+			$ThisTest.FunctionName | Should Be "Test-Example"
+
+		}
+
+		It 'returns expected ParameterSetName from expected scope' {
+			Function Test-Example {
+				[CmdletBinding()]
+				param([parameter(ParameterSetName = "ExampleParamSet")][string]$Name)
+				Test-Parent
+			}
+			Function Test-Parent {Test-Child}
+			Function Test-Child {Get-ParentFunction -Scope 3}
+			$ThisTest = Test-Example -Name "test"
+
+			$ThisTest.ParameterSetName | Should Be "ExampleParamSet"
 		}
 
 

--- a/Tests/Import-PASConnectionComponent.Tests.ps1
+++ b/Tests/Import-PASConnectionComponent.Tests.ps1
@@ -129,6 +129,9 @@ Describe $FunctionName {
 
 			}
 
+			It "throws error if version requirement not met" {
+				{$InputObj | Import-PASConnectionComponent -ImportFile $($file.name) -ExternalVersion "1.0"} | Should Throw
+			}
 
 		}
 

--- a/Tests/Import-PASPlatform.Tests.ps1
+++ b/Tests/Import-PASPlatform.Tests.ps1
@@ -129,6 +129,10 @@ Describe $FunctionName {
 
 			}
 
+			It "throws error if version requirement not met" {
+				{$InputObj | Import-PASPlatform -ImportFile $($file.name) -ExternalVersion "1.0"} | Should Throw
+			}
+
 
 		}
 

--- a/Tests/Invoke-PASCredChange.Tests.ps1
+++ b/Tests/Invoke-PASCredChange.Tests.ps1
@@ -122,6 +122,10 @@ Describe $FunctionName {
 
 			}
 
+			It "throws error if version requirement not met" {
+				{$InputObj | Invoke-PASCredChange -ChangeCredsForGroup $true -ExternalVersion "1.0"} | Should Throw
+			}
+
 		}
 
 		Context "Input - Password/Update ParameterSet" {
@@ -169,6 +173,10 @@ Describe $FunctionName {
 
 			}
 
+			It "throws error if version requirement not met" {
+				{$InputObj | Invoke-PASCredChange -ChangeCredsForGroup $true -UpdateVaultOnly -NewCredentials $newcreds -ExternalVersion "9.11"} | Should Throw
+			}
+
 		}
 
 		Context "Input - SetNextPassword ParameterSet" {
@@ -214,6 +222,10 @@ Describe $FunctionName {
 
 				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 1
 
+			}
+
+			It "throws error if version requirement not met" {
+				{$InputObj | Invoke-PASCredChange -SetNextPassword -NewCredentials $newcreds -ExternalVersion "9.11"} | Should Throw
 			}
 
 		}

--- a/Tests/Invoke-PASCredReconcile.Tests.ps1
+++ b/Tests/Invoke-PASCredReconcile.Tests.ps1
@@ -96,6 +96,10 @@ Describe $FunctionName {
 
 			}
 
+			It "throws error if version requirement not met" {
+				{$InputObj | Invoke-PASCredReconcile -ExternalVersion "1.0"} | Should Throw
+			}
+
 		}
 
 		Context "Output" {

--- a/Tests/Invoke-PASCredVerify.Tests.ps1
+++ b/Tests/Invoke-PASCredVerify.Tests.ps1
@@ -96,6 +96,10 @@ Describe $FunctionName {
 
 			}
 
+			It "throws error if version requirement not met" {
+				{$InputObj | Invoke-PASCredVerify -ExternalVersion "1.0"} | Should Throw
+			}
+
 		}
 
 		Context "Output" {

--- a/Tests/Invoke-PASRestMethod.Tests.ps1
+++ b/Tests/Invoke-PASRestMethod.Tests.ps1
@@ -126,15 +126,9 @@ Describe $FunctionName {
 				"content"    = $RandomString | ConvertTo-Json
 			}
 
-			Mock Get-Variable -MockWith {
+			Mock Get-ParentFunction -MockWith {
 
-				[PSCustomObject]@{
-					Value = [PSCustomObject]@{
-						MyCommand = [PSCustomObject]@{
-							Name = "New-PASSession"
-						}
-					}
-				}
+				"New-PASSession"
 
 			}
 

--- a/Tests/Invoke-PASRestMethod.Tests.ps1
+++ b/Tests/Invoke-PASRestMethod.Tests.ps1
@@ -128,7 +128,9 @@ Describe $FunctionName {
 
 			Mock Get-ParentFunction -MockWith {
 
-				"New-PASSession"
+				[PSCustomObject]@{
+					FunctionName = "New-PASSession"
+				}
 
 			}
 
@@ -156,6 +158,15 @@ Describe $FunctionName {
 				"content"    = '"Value"'
 			}
 
+			$MockHTML = [pscustomobject] @{
+
+				"headers"    = @{
+					"Content-Type" = "text/html"
+				};
+				"StatusCode" = 200;
+				"content"    = '<HTML><HEAD><BODY><P>Test</P></BODY></HEAD></HTML>'
+			}
+
 			Mock Invoke-WebRequest -MockWith {
 
 				return $MockResult
@@ -164,6 +175,19 @@ Describe $FunctionName {
 			It "returns expected (unquoted) string for text/html responses" {
 				$result = Invoke-PASRestMethod @requestArgs2
 				$result | Should Be 'Value'
+			}
+
+			It 'throws an error if response contains actual HTML' {
+				Mock Invoke-WebRequest -MockWith {
+
+					return $MockHTML
+				}
+
+				{
+					$ErrorActionPreference = "Stop"
+					$request = Invoke-PASRestMethod @requestArgs2
+				} | Should throw "Guru Meditation"
+
 			}
 
 		}

--- a/Tests/New-PASAccountGroup.Tests.ps1
+++ b/Tests/New-PASAccountGroup.Tests.ps1
@@ -111,6 +111,10 @@ Describe $FunctionName {
 
 			}
 
+			It "throws error if version requirement not met" {
+				{$InputObj | New-PASAccountGroup -ExternalVersion "1.0"} | Should Throw
+			}
+
 		}
 
 		Context "Output" {

--- a/Tests/New-PASOnboardingRule.Tests.ps1
+++ b/Tests/New-PASOnboardingRule.Tests.ps1
@@ -114,6 +114,10 @@ Describe $FunctionName {
 
 			}
 
+			It "throws error if minimum version requirement not met" {
+				{$InputObj | New-PASOnboardingRule -ExternalVersion "1.0"} | Should Throw
+			}
+
 			It "accepts alternative parameterset input" {
 
 				$InputObj = [pscustomobject]@{
@@ -130,6 +134,24 @@ Describe $FunctionName {
 				{$InputObj | New-PASOnboardingRule} | Should Not Throw
 
 			}
+
+			It "throws error if parameterset version requirement not met" {
+
+				$InputObj = [pscustomobject]@{
+					"sessionToken"     = @{"Authorization" = "P_AuthValue"}
+					"WebSession"       = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+					"BaseURI"          = "https://P_URI"
+					"PVWAAppName"      = "P_App"
+					"TargetPlatformId" = "SomePlatform"
+					"TargetSafeName"   = "SomeSafe"
+					"SystemTypeFilter" = "Windows"
+
+				}
+
+				{$InputObj | New-PASOnboardingRule -ExternalVersion "10.1.0"} | Should Throw
+			}
+
+
 
 		}
 

--- a/Tests/New-PASRequest.Tests.ps1
+++ b/Tests/New-PASRequest.Tests.ps1
@@ -125,6 +125,10 @@ Describe $FunctionName {
 
 			}
 
+			It "throws error if version requirement not met" {
+				{$InputObj | New-PASRequest -ExternalVersion "1.0"} | Should Throw
+			}
+
 		}
 
 		Context "Output" {

--- a/Tests/New-PASSAMLSession.Tests.ps1
+++ b/Tests/New-PASSAMLSession.Tests.ps1
@@ -179,7 +179,8 @@ Describe $FunctionName {
 			$DefaultProps = @{Property = 'sessionToken'},
 			@{Property = 'WebSession'},
 			@{Property = 'BaseURI'},
-			@{Property = 'PVWAAppName'}
+			@{Property = 'PVWAAppName'},
+			@{Property = 'ExternalVersion'}
 
 			It "returns default property <Property> in response" -TestCases $DefaultProps {
 				param($Property)
@@ -208,20 +209,20 @@ Describe $FunctionName {
 
 			It "outputs Version with expected value" {
 
-				$response.Version | Should be "6.6.6"
+				$response.ExternalVersion | Should be "6.6.6"
 
 			}
 
 			It "outputs Version in expected format" {
 
-				$response.Version.gettype() | Should be Version
+				$response.ExternalVersion.gettype() | Should be Version
 
 			}
 
 			It "outputs Version with expected value on SkipVersionCheck" {
 
 				$response = $Credentials | New-PASSAMLSession -BaseURI "https://P_URI" -PVWAAppName "SomeApp" -SkipVersionCheck
-				$response.Version | Should be "Skipped"
+				$response.ExternalVersion | Should be "0.0"
 
 			}
 
@@ -230,7 +231,7 @@ Describe $FunctionName {
 					throw "Some Error"
 				}
 				$response = $Credentials | New-PASSAMLSession -BaseURI "https://P_URI" -PVWAAppName "SomeApp" -WarningAction SilentlyContinue
-				$response.Version | Should be "Skipped"
+				$response.ExternalVersion | Should be "0.0"
 
 			}
 

--- a/Tests/New-PASSession.Tests.ps1
+++ b/Tests/New-PASSession.Tests.ps1
@@ -201,7 +201,7 @@ Describe $FunctionName {
 
 			$DefaultProps = @{Property = 'sessionToken'},
 			@{Property = 'WebSession'},
-			@{Property = 'Version'},
+			@{Property = 'ExternalVersion'},
 			@{Property = 'BaseURI'},
 			@{Property = 'PVWAAppName'}
 
@@ -232,20 +232,20 @@ Describe $FunctionName {
 
 			It "outputs Version with expected value" {
 
-				$response.Version | Should be "6.6.6"
+				$response.ExternalVersion | Should be "6.6.6"
 
 			}
 
 			It "outputs Version in expected format" {
 
-				$response.Version.gettype() | Should be Version
+				$response.ExternalVersion.gettype() | Should be Version
 
 			}
 
 			It "outputs Version with expected value on SkipVersionCheck" {
 
 				$response = $Credentials | New-PASSession -BaseURI "https://P_URI" -type LDAP -SkipVersionCheck
-				$response.Version | Should be "Skipped"
+				$response.ExternalVersion | Should be "0.0"
 
 			}
 
@@ -254,7 +254,7 @@ Describe $FunctionName {
 					throw "Some Error"
 				}
 				$response = $Credentials | New-PASSession -BaseURI "https://P_URI" -type LDAP -WarningAction SilentlyContinue
-				$response.Version | Should be "Skipped"
+				$response.ExternalVersion | Should be "0.0"
 
 			}
 

--- a/Tests/New-PASSharedSession.Tests.ps1
+++ b/Tests/New-PASSharedSession.Tests.ps1
@@ -145,7 +145,8 @@ Describe $FunctionName {
 			$DefaultProps = @{Property = 'sessionToken'},
 			@{Property = 'WebSession'},
 			@{Property = 'BaseURI'},
-			@{Property = 'PVWAAppName'}
+			@{Property = 'PVWAAppName'},
+			@{Property = 'ExternalVersion'}
 
 			It "returns default property <Property> in response" -TestCases $DefaultProps {
 				param($Property)
@@ -174,20 +175,20 @@ Describe $FunctionName {
 
 			It "outputs Version with expected value" {
 
-				$response.Version | Should be "6.6.6"
+				$response.ExternalVersion | Should be "6.6.6"
 
 			}
 
 			It "outputs Version in expected format" {
 
-				$response.Version.gettype() | Should be Version
+				$response.ExternalVersion.gettype() | Should be Version
 
 			}
 
 			It "outputs Version with expected value on SkipVersionCheck" {
 
 				$response = New-PASSharedSession -BaseURI "https://P_URI" -PVWAAppName "SomeApp" -SkipVersionCheck
-				$response.Version | Should be "Skipped"
+				$response.ExternalVersion | Should be "0.0"
 
 			}
 
@@ -196,7 +197,7 @@ Describe $FunctionName {
 					throw "Some Error"
 				}
 				$response = New-PASSharedSession -BaseURI "https://P_URI" -PVWAAppName "SomeApp" -WarningAction SilentlyContinue
-				$response.Version | Should be "Skipped"
+				$response.ExternalVersion | Should be "0.0"
 
 			}
 

--- a/Tests/Remove-PASAccountGroupMember.Tests.ps1
+++ b/Tests/Remove-PASAccountGroupMember.Tests.ps1
@@ -98,6 +98,10 @@ Describe $FunctionName {
 
 			}
 
+			It "throws error if version requirement not met" {
+				{$InputObj | Remove-PASAccountGroupMember -ExternalVersion "1.0"} | Should Throw
+			}
+
 		}
 
 		Context "Output" {

--- a/Tests/Remove-PASRequest.Tests.ps1
+++ b/Tests/Remove-PASRequest.Tests.ps1
@@ -96,6 +96,10 @@ Describe $FunctionName {
 
 			}
 
+			It "throws error if version requirement not met" {
+				{$InputObj | Remove-PASRequest -ExternalVersion "1.0"} | Should Throw
+			}
+
 		}
 
 		Context "Output" {

--- a/Tests/Resume-PASPSMSession.Tests.ps1
+++ b/Tests/Resume-PASPSMSession.Tests.ps1
@@ -96,6 +96,10 @@ Describe $FunctionName {
 
 			}
 
+			It "throws error if version requirement not met" {
+				{$InputObj | Resume-PASPSMSession -ExternalVersion "1.0"} | Should Throw
+			}
+
 		}
 
 		Context "Output" {

--- a/Tests/Stop-PASPSMSession.Tests.ps1
+++ b/Tests/Stop-PASPSMSession.Tests.ps1
@@ -96,6 +96,10 @@ Describe $FunctionName {
 
 			}
 
+			It "throws error if version requirement not met" {
+				{$InputObj | Stop-PASPSMSession -ExternalVersion "1.0"} | Should Throw
+			}
+
 		}
 
 		Context "Output" {

--- a/Tests/Suspend-PASPSMSession.Tests.ps1
+++ b/Tests/Suspend-PASPSMSession.Tests.ps1
@@ -96,6 +96,10 @@ Describe $FunctionName {
 
 			}
 
+			It "throws error if version requirement not met" {
+				{$InputObj | Suspend-PASPSMSession -ExternalVersion "1.0"} | Should Throw
+			}
+
 		}
 
 		Context "Output" {

--- a/psPAS/Functions/AccountGroups/Add-PASAccountGroupMember.ps1
+++ b/psPAS/Functions/AccountGroups/Add-PASAccountGroupMember.ps1
@@ -32,6 +32,11 @@ Do not include "/PasswordVault/"
 The name of the CyberArk PVWA Virtual Directory.
 Defaults to PasswordVault
 
+.PARAMETER ExternalVersion
+The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+If the minimum version requirement of this function is not satisfied, execution will be halted.
+Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
 .EXAMPLE
 Add-PASAccountGroupMember -GroupID $groupID -AccountID $accID -sessionToken $ST -BaseURI $URL
 
@@ -86,12 +91,23 @@ Minimum version 9.9.5
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault"
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
 	)
 
-	BEGIN {}#begin
+	BEGIN {
+		$MinimumVersion = [System.Version]"9.9.5"
+	}#begin
 
 	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
 
 		#Create URL for Request
 		$URI = "$baseURI/$PVWAAppName/API/AccountGroups/$($GroupID |

--- a/psPAS/Functions/AccountGroups/Get-PASAccountGroup.ps1
+++ b/psPAS/Functions/AccountGroups/Get-PASAccountGroup.ps1
@@ -28,6 +28,11 @@ Do not include "/PasswordVault/"
 The name of the CyberArk PVWA Virtual Directory.
 Defaults to PasswordVault
 
+.PARAMETER ExternalVersion
+The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+If the minimum version requirement of this function is not satisfied, execution will be halted.
+Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
 .EXAMPLE
 $token | Get-PASAccountGroup -Safe SafeName
 
@@ -80,12 +85,23 @@ Minimum CyberArk version 9.10
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault"
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
 	)
 
-	BEGIN {}#begin
+	BEGIN {
+		$MinimumVersion = [System.Version]"9.10"
+	}#begin
 
 	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
 
 		#Create URL for Request
 		$URI = "$baseURI/$PVWAAppName/API/AccountGroups?Safe=$($Safe | Get-EscapedString)"

--- a/psPAS/Functions/AccountGroups/Get-PASAccountGroupMember.ps1
+++ b/psPAS/Functions/AccountGroups/Get-PASAccountGroupMember.ps1
@@ -29,6 +29,11 @@ Do not include "/PasswordVault/"
 The name of the CyberArk PVWA Virtual Directory.
 Defaults to PasswordVault
 
+.PARAMETER ExternalVersion
+The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+If the minimum version requirement of this function is not satisfied, execution will be halted.
+Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
 .EXAMPLE
 $token | Get-PASAccountGroupMember -GroupID 21_9
 
@@ -81,12 +86,23 @@ Minimum CyberArk version 9.10
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault"
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
 	)
 
-	BEGIN {}#begin
+	BEGIN {
+		$MinimumVersion = [System.Version]"9.10"
+	}#begin
 
 	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
 
 		#Create URL for Request
 		$URI = "$baseURI/$PVWAAppName/API/AccountGroups/$GroupID/Members"

--- a/psPAS/Functions/AccountGroups/New-PASAccountGroup.ps1
+++ b/psPAS/Functions/AccountGroups/New-PASAccountGroup.ps1
@@ -35,6 +35,11 @@ Do not include "/PasswordVault/"
 The name of the CyberArk PVWA Virtual Directory.
 Defaults to PasswordVault
 
+.PARAMETER ExternalVersion
+The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+If the minimum version requirement of this function is not satisfied, execution will be halted.
+Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
 .EXAMPLE
 New-PASAccountGroup -GroupName UATGroup -GroupPlatform UnixGroup-NonProd -Safe UAT-Team -sessionToken $token.sessionToken -BaseURI $url
 
@@ -95,12 +100,23 @@ Minimum version 9.9.5
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault"
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
 	)
 
-	BEGIN {}#begin
+	BEGIN {
+		$MinimumVersion = [System.Version]"9.9.5"
+	}#begin
 
 	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
 
 		#Create URL for Request
 		$URI = "$baseURI/$PVWAAppName/API/AccountGroups/"

--- a/psPAS/Functions/AccountGroups/Remove-PASAccountGroupMember.ps1
+++ b/psPAS/Functions/AccountGroups/Remove-PASAccountGroupMember.ps1
@@ -32,6 +32,11 @@ Do not include "/PasswordVault/"
 The name of the CyberArk PVWA Virtual Directory.
 Defaults to PasswordVault
 
+.PARAMETER ExternalVersion
+The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+If the minimum version requirement of this function is not satisfied, execution will be halted.
+Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
 .EXAMPLE
 $token | Remove-PASAccountGroupMember -AccountID 21_7 -GroupID 21_9
 
@@ -85,12 +90,23 @@ Minimum CyberArk version 9.10
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault"
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
 	)
 
-	BEGIN {}#begin
+	BEGIN {
+		$MinimumVersion = [System.Version]"9.10"
+	}#begin
 
 	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
 
 		#Create URL for Request
 		$URI = "$baseURI/$PVWAAppName/API/AccountGroups/$GroupID/Members/$AccountID"

--- a/psPAS/Functions/Accounts/Get-PASAccountPassword.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccountPassword.ps1
@@ -63,6 +63,11 @@ Do not include "/PasswordVault/"
 The name of the CyberArk PVWA Virtual Directory.
 Defaults to PasswordVault
 
+.PARAMETER ExternalVersion
+The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+If the minimum version requirement of this function is not satisfied, execution will be halted.
+Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
 .EXAMPLE
 $token | Get-PASAccount -Keywords root -Safe Prod_Safe | Get-PASAccountPassword
 
@@ -197,16 +202,26 @@ From version 10.1 onwards both passwords and ssh keys can be retrieved.
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault"
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
 
 	)
 
-	BEGIN {}#begin
+	BEGIN {
+		$MinimumVersion = [System.Version]"10.1"
+	}#begin
 
 	PROCESS {
 
 		#Build Request
 		if($($PSCmdlet.ParameterSetName) -eq "v10") {
+
+			Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
 
 			#For Version 10.1+
 			$Request = @{

--- a/psPAS/Functions/Accounts/Invoke-PASCredChange.ps1
+++ b/psPAS/Functions/Accounts/Invoke-PASCredChange.ps1
@@ -61,6 +61,11 @@ function Invoke-PASCredChange {
 	The name of the CyberArk PVWA Virtual Directory.
 	Defaults to PasswordVault
 
+	.PARAMETER ExternalVersion
+	The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+	If the minimum version requirement of this function is not satisfied, execution will be halted.
+	Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
 	.EXAMPLE
 	$token | Invoke-PASCredChange -AccountID 21_3
 
@@ -183,12 +188,24 @@ function Invoke-PASCredChange {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault"
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
 	)
 
-	BEGIN {}#begin
+	BEGIN {
+		$MinimumVersion = [System.Version]"9.10"
+		$RequiredVersion = [System.Version]"10.1"
+	}#begin
 
 	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
 
 		Write-Debug "ParameterSet $($PSCmdlet.ParameterSetName)"
 
@@ -200,6 +217,8 @@ function Invoke-PASCredChange {
 
 		#deal with NewCredentials SecureString
 		If($PSBoundParameters.ContainsKey("NewCredentials")) {
+
+			Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $RequiredVersion
 
 			#Create New Credential object
 			$Pwd = New-Object -TypeName "System.Management.Automation.PSCredential" -ArgumentList $(

--- a/psPAS/Functions/Accounts/Invoke-PASCredReconcile.ps1
+++ b/psPAS/Functions/Accounts/Invoke-PASCredReconcile.ps1
@@ -25,6 +25,11 @@ function Invoke-PASCredReconcile {
 	The name of the CyberArk PVWA Virtual Directory.
 	Defaults to PasswordVault
 
+	.PARAMETER ExternalVersion
+	The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+	If the minimum version requirement of this function is not satisfied, execution will be halted.
+	Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
 	.EXAMPLE
 	$token | Invoke-PASCredReconcile -AccountID 21_3
 
@@ -76,12 +81,23 @@ function Invoke-PASCredReconcile {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault"
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
 	)
 
-	BEGIN {}#begin
+	BEGIN {
+		$MinimumVersion = [System.Version]"9.10"
+	}#begin
 
 	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
 
 		#Create URL for request
 		$URI = "$baseURI/$PVWAAppName/API/Accounts/$AccountID/Reconcile"

--- a/psPAS/Functions/Accounts/Invoke-PASCredVerify.ps1
+++ b/psPAS/Functions/Accounts/Invoke-PASCredVerify.ps1
@@ -25,6 +25,11 @@ Do not include "/PasswordVault/"
 The name of the CyberArk PVWA Virtual Directory.
 Defaults to PasswordVault
 
+.PARAMETER ExternalVersion
+The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+If the minimum version requirement of this function is not satisfied, execution will be halted.
+Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
 .EXAMPLE
 $token | Invoke-PASCredVerify -AccountID 19_1
 
@@ -71,12 +76,23 @@ Can be used in versions from v9.10.
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault"
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
 	)
 
-	BEGIN {}#begin
+	BEGIN {
+		$MinimumVersion = [System.Version]"9.10"
+	}#begin
 
 	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
 
 		#Create URL for request
 		$URI = "$baseURI/$PVWAAppName/API/Accounts/$AccountID/Verify"

--- a/psPAS/Functions/Authentication/New-PASSAMLSession.ps1
+++ b/psPAS/Functions/Authentication/New-PASSAMLSession.ps1
@@ -45,7 +45,7 @@ A WebSession object; This contains information about the connection and the requ
 including cookies. Can be supplied to other web service requests.
 baseURI; this is the URL provided as an input to this function, it can be piped to
 other functions from this return object.
-Version; The External Version number retrieved from CyberArk.
+ExternalVersion; The External Version number retrieved from CyberArk.
 
 .NOTES
 
@@ -117,7 +117,7 @@ Version; The External Version number retrieved from CyberArk.
 				$WebSession = $PASSession | Select-Object -ExpandProperty WebSession
 
 				#Initial Value for Version variable
-				$Version = "Skipped"
+				[System.Version]$Version = "0.0"
 
 				if( -not ($SkipVersionCheck)) {
 
@@ -136,19 +136,19 @@ Version; The External Version number retrieved from CyberArk.
 				[pscustomobject]@{
 
 					#Authentication Token - required for all subsequent Web Service Calls
-					"sessionToken" = $SessionToken
+					"sessionToken"    = $SessionToken
 
 					#WebSession
-					"WebSession"   = $WebSession
+					"WebSession"      = $WebSession
 
 					#The Web Service URL the request was sent to
-					"BaseURI"      = $BaseURI
+					"BaseURI"         = $BaseURI
 
 					#PVWA Application Name/Virtual Directory
-					"PVWAAppName"  = $PVWAAppName
+					"PVWAAppName"     = $PVWAAppName
 
 					#ExternalVersion
-					"Version"      = $Version
+					"ExternalVersion" = $Version
 
 					#Set default properties to display in output
 				} | Add-ObjectDetail -DefaultProperties sessionToken, BaseURI

--- a/psPAS/Functions/Authentication/New-PASSession.ps1
+++ b/psPAS/Functions/Authentication/New-PASSession.ps1
@@ -98,7 +98,7 @@ including cookies. Can be supplied to other web service requests.
 baseURI; this is the URL provided as an input to this function, it can be piped to
 other functions from this return object.
 ConnectionNumber; the connectionNumber provided to this function.
-Version; The External Version number retrieved from CyberArk.
+ExternalVersion; The External Version number retrieved from CyberArk.
 
 Output uses defined default properties.
 To force all output to be shown, pipe to Select-Object *
@@ -248,7 +248,7 @@ To force all output to be shown, pipe to Select-Object *
 				$WebSession = $PASSession | Select-Object -ExpandProperty WebSession
 
 				#Initial Value for Version variable
-				$Version = "Skipped"
+				[System.Version]$Version = "0.0"
 
 				if( -not ($SkipVersionCheck)) {
 
@@ -282,7 +282,7 @@ To force all output to be shown, pipe to Select-Object *
 					"ConnectionNumber" = $connectionNumber
 
 					#ExternalVersion
-					"Version"          = $Version
+					"ExternalVersion"  = $Version
 
 					#Set default properties to display in output
 				} | Add-ObjectDetail -DefaultProperties sessionToken, BaseURI

--- a/psPAS/Functions/Authentication/New-PASSharedSession.ps1
+++ b/psPAS/Functions/Authentication/New-PASSharedSession.ps1
@@ -41,7 +41,7 @@ A WebSession object; This contains information about the connection and the requ
 including cookies. Can be supplied to other web service requests.
 baseURI; this is the URL provided as an input to this function, it can be piped to
 other functions from this return object.
-Version; The External Version number retrieved from CyberArk.
+ExternalVersion; The External Version number retrieved from CyberArk.
 
 .NOTES
 
@@ -100,7 +100,7 @@ Version; The External Version number retrieved from CyberArk.
 				$WebSession = $PASSession | Select-Object -ExpandProperty WebSession
 
 				#Initial Value for Version variable
-				$Version = "Skipped"
+				[System.Version]$Version = "0.0"
 
 				if( -not ($SkipVersionCheck)) {
 
@@ -119,19 +119,19 @@ Version; The External Version number retrieved from CyberArk.
 				[pscustomobject]@{
 
 					#Authentication Token - required for all subsequent Web Service Calls
-					"sessionToken" = $SessionToken
+					"sessionToken"    = $SessionToken
 
 					#WebSession
-					"WebSession"   = $WebSession
+					"WebSession"      = $WebSession
 
 					#The Web Service URL the request was sent to
-					"BaseURI"      = $BaseURI
+					"BaseURI"         = $BaseURI
 
 					#PVWA Application Name/Virtual Directory
-					"PVWAAppName"  = $PVWAAppName
+					"PVWAAppName"     = $PVWAAppName
 
 					#ExternalVersion
-					"Version"      = $Version
+					"ExternalVersion" = $Version
 
 					#Set default properties to display in output
 				} | Add-ObjectDetail -DefaultProperties sessionToken, BaseURI

--- a/psPAS/Functions/Connections/Get-PASPSMConnectionParameter.ps1
+++ b/psPAS/Functions/Connections/Get-PASPSMConnectionParameter.ps1
@@ -48,6 +48,11 @@ Do not include "/PasswordVault/"
 The name of the CyberArk PVWA Virtual Directory.
 Defaults to PasswordVault
 
+.PARAMETER ExternalVersion
+The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+If the minimum version requirement of this function is not satisfied, execution will be halted.
+Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
 .EXAMPLE
 Get-PASPSMConnectionParameter -AccountID $ID -ConnectionComponent PSM-SSH -reason "Fix XYZ" -sessionToken $ST -BaseURI $url
 
@@ -140,12 +145,24 @@ PSMGW connections require 10.2
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault"
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
 	)
 
-	BEGIN {}#begin
+	BEGIN {
+		$MinimumVersion = [System.Version]"9.10"
+		$RequiredVersion = [System.Version]"10.2"
+	}#begin
 
 	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
 
 		#Create URL for Request
 		$URI = "$baseURI/$PVWAAppName/API/Accounts/$($AccountID)/PSMConnect"
@@ -162,6 +179,8 @@ PSMGW connections require 10.2
 				$Accept = "application/json"
 
 			} elseif($PSBoundParameters["ConnectionMethod"] -eq "PSMGW") {
+
+				Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $RequiredVersion
 
 				#PSMGW accept * / * response
 				$Accept = "* / *"

--- a/psPAS/Functions/Connections/Import-PASConnectionComponent.ps1
+++ b/psPAS/Functions/Connections/Import-PASConnectionComponent.ps1
@@ -24,6 +24,11 @@ function Import-PASConnectionComponent {
 	The name of the CyberArk PVWA Virtual Directory.
 	Defaults to PasswordVault
 
+	.PARAMETER ExternalVersion
+	The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+	If the minimum version requirement of this function is not satisfied, execution will be halted.
+	Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
 	.EXAMPLE
 	$token | Import-PASConnectionComponent -ImportFile ConnectionComponent.zip
 
@@ -72,12 +77,23 @@ function Import-PASConnectionComponent {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault"
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
 	)
 
-	BEGIN {}#begin
+	BEGIN {
+		$MinimumVersion = [System.Version]"10.2"
+	}#begin
 
 	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
 
 		#Create URL for request
 		$URI = "$baseURI/$PVWAAppName/API/ConnectionComponents/Import"

--- a/psPAS/Functions/Monitoring/Get-PASPSMRecording.ps1
+++ b/psPAS/Functions/Monitoring/Get-PASPSMRecording.ps1
@@ -61,6 +61,11 @@ Do not include "/PasswordVault/"
 The name of the CyberArk PVWA Virtual Directory.
 Defaults to PasswordVault
 
+.PARAMETER ExternalVersion
+The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+If the minimum version requirement of this function is not satisfied, execution will be halted.
+Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
 .EXAMPLE
 $token | Get-PASPSMRecording -Limit 10 -Safe PSMRecordings -Sort -FileName
 
@@ -161,12 +166,23 @@ Minimum CyberArk Version 9.10
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault"
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
 	)
 
-	BEGIN {}#begin
+	BEGIN {
+		$MinimumVersion = [System.Version]"9.10"
+	}#begin
 
 	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
 
 		#Create URL for Request
 		$URI = "$baseURI/$PVWAAppName/API/Recordings"

--- a/psPAS/Functions/Monitoring/Get-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Get-PASPSMSession.ps1
@@ -61,6 +61,11 @@ Do not include "/PasswordVault/"
 The name of the CyberArk PVWA Virtual Directory.
 Defaults to PasswordVault
 
+.PARAMETER ExternalVersion
+The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+If the minimum version requirement of this function is not satisfied, execution will be halted.
+Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
 .EXAMPLE
 $token | Get-PASPSMSession
 
@@ -161,12 +166,23 @@ Minimum CyberArk Version 9.10
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault"
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
 	)
 
-	BEGIN {}#begin
+	BEGIN {
+		$MinimumVersion = [System.Version]"9.10"
+	}#begin
 
 	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
 
 		#Create URL for Request
 		$URI = "$baseURI/$PVWAAppName/API/LiveSessions"

--- a/psPAS/Functions/Monitoring/Resume-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Resume-PASPSMSession.ps1
@@ -24,6 +24,11 @@ Do not include "/PasswordVault/"
 The name of the CyberArk PVWA Virtual Directory.
 Defaults to PasswordVault
 
+.PARAMETER ExternalVersion
+The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+If the minimum version requirement of this function is not satisfied, execution will be halted.
+Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
 .EXAMPLE
 $token | Resume-PASPSMSession -LiveSessionId $SessionUUID
 
@@ -73,12 +78,23 @@ Minimum CyberArk Version 10.2
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault"
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
 	)
 
-	BEGIN {}#begin
+	BEGIN {
+		$MinimumVersion = [System.Version]"10.2"
+	}#begin
 
 	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
 
 		#Create URL for Request
 		$URI = "$baseURI/$PVWAAppName/api/LiveSessions/$($LiveSessionId | Get-EscapedString)/Resume"

--- a/psPAS/Functions/Monitoring/Stop-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Stop-PASPSMSession.ps1
@@ -23,6 +23,11 @@ Do not include "/PasswordVault/"
 The name of the CyberArk PVWA Virtual Directory.
 Defaults to PasswordVault
 
+.PARAMETER ExternalVersion
+The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+If the minimum version requirement of this function is not satisfied, execution will be halted.
+Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
 .EXAMPLE
 $token | Stop-PASPSMSession -LiveSessionId $SessionUUID
 
@@ -72,12 +77,23 @@ Minimum CyberArk Version 10.1
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault"
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
 	)
 
-	BEGIN {}#begin
+	BEGIN {
+		$MinimumVersion = [System.Version]"10.1"
+	}#begin
 
 	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
 
 		#Create URL for Request
 		$URI = "$baseURI/$PVWAAppName/api/LiveSessions/$($LiveSessionId | Get-EscapedString)/Terminate"

--- a/psPAS/Functions/Monitoring/Suspend-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Suspend-PASPSMSession.ps1
@@ -24,6 +24,11 @@ Do not include "/PasswordVault/"
 The name of the CyberArk PVWA Virtual Directory.
 Defaults to PasswordVault
 
+.PARAMETER ExternalVersion
+The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+If the minimum version requirement of this function is not satisfied, execution will be halted.
+Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
 .EXAMPLE
 $token | Suspend-PASPSMSession -LiveSessionId $SessionUUID
 
@@ -73,12 +78,23 @@ Minimum CyberArk Version 10.2
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault"
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
 	)
 
-	BEGIN {}#begin
+	BEGIN {
+		$MinimumVersion = [System.Version]"10.2"
+	}#begin
 
 	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
 
 		#Create URL for Request
 		$URI = "$baseURI/$PVWAAppName/api/LiveSessions/$($LiveSessionId | Get-EscapedString)/Suspend"

--- a/psPAS/Functions/OnboardingRules/Get-PASOnboardingRule.ps1
+++ b/psPAS/Functions/OnboardingRules/Get-PASOnboardingRule.ps1
@@ -27,6 +27,11 @@ Do not include "/PasswordVault/"
 The name of the CyberArk PVWA Virtual Directory.
 Defaults to PasswordVault
 
+.PARAMETER ExternalVersion
+The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+If the minimum version requirement of this function is not satisfied, execution will be halted.
+Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
 .EXAMPLE
 $token | Get-PASOnboardingRule
 
@@ -59,7 +64,8 @@ Not Tested
 	param(
 		[parameter(
 			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "10_2"
 		)]
 		[ValidateNotNullOrEmpty()]
 		[string]$Names,
@@ -86,10 +92,19 @@ Not Tested
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault"
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
 	)
 
-	BEGIN {}#begin
+	BEGIN {
+		$MinimumVersion = [System.Version]"10.2"
+	}#begin
 
 	PROCESS {
 
@@ -97,6 +112,8 @@ Not Tested
 		$URI = "$baseURI/$PVWAAppName/api/AutomaticOnboardingRules"
 
 		If($PSBoundParameters.ContainsKey("Names")) {
+
+			Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
 
 			#Get Parameters to include in request
 			$boundParameters = $PSBoundParameters | Get-PASParameter

--- a/psPAS/Functions/Platforms/Get-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Get-PASPlatform.ps1
@@ -23,6 +23,11 @@ function Get-PASPlatform {
 	The name of the CyberArk PVWA Virtual Directory.
 	Defaults to PasswordVault
 
+	.PARAMETER ExternalVersion
+	The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+	If the minimum version requirement of this function is not satisfied, execution will be halted.
+	Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
 	.EXAMPLE
 	$token | Get-PASPlatform -Name "CyberArk"
 
@@ -60,13 +65,23 @@ function Get-PASPlatform {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault"
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
 
 	)
 
-	BEGIN {}#begin
+	BEGIN {
+		$MinimumVersion = [System.Version]"9.10"
+	}#begin
 
 	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
 
 		#Create request URL
 		$URI = "$baseURI/$PVWAAppName/API/Platforms/$($Name | Get-EscapedString)"

--- a/psPAS/Functions/Platforms/Import-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Import-PASPlatform.ps1
@@ -23,6 +23,11 @@ function Import-PASPlatform {
 	The name of the CyberArk PVWA Virtual Directory.
 	Defaults to PasswordVault
 
+	.PARAMETER ExternalVersion
+	The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+	If the minimum version requirement of this function is not satisfied, execution will be halted.
+	Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
 	.EXAMPLE
 	$token | Import-PASPlatform -ImportFile CustomApp.zip
 
@@ -71,12 +76,23 @@ function Import-PASPlatform {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault"
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
 	)
 
-	BEGIN {}#begin
+	BEGIN {
+		$MinimumVersion = [System.Version]"10.2"
+	}#begin
 
 	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
 
 		#Create URL for request
 		$URI = "$baseURI/$PVWAAppName/API/Platforms/Import"

--- a/psPAS/Functions/Requests/Approve-PASRequest.ps1
+++ b/psPAS/Functions/Requests/Approve-PASRequest.ps1
@@ -26,6 +26,11 @@ Do not include "/PasswordVault/"
 The name of the CyberArk PVWA Virtual Directory.
 Defaults to PasswordVault
 
+.PARAMETER ExternalVersion
+The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+If the minimum version requirement of this function is not satisfied, execution will be halted.
+Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
 .EXAMPLE
 $token | Approve-PASRequest -RequestID <ID> - Reason "<Reason>"
 
@@ -80,12 +85,23 @@ Minimum CyberArk Version 9.10
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault"
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
 	)
 
-	BEGIN {}#begin
+	BEGIN {
+		$MinimumVersion = [System.Version]"9.10"
+	}#begin
 
 	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
 
 		#Create URL for Request
 		$URI = "$baseURI/$PVWAAppName/API/IncomingRequests/$($RequestID)/Confirm"

--- a/psPAS/Functions/Requests/Deny-PASRequest.ps1
+++ b/psPAS/Functions/Requests/Deny-PASRequest.ps1
@@ -26,6 +26,11 @@ Do not include "/PasswordVault/"
 The name of the CyberArk PVWA Virtual Directory.
 Defaults to PasswordVault
 
+.PARAMETER ExternalVersion
+The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+If the minimum version requirement of this function is not satisfied, execution will be halted.
+Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
 .EXAMPLE
 $token | Deny-PASRequest -RequestID <ID> - Reason "<Reason>"
 
@@ -80,12 +85,23 @@ Minimum CyberArk Version 9.10
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault"
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
 	)
 
-	BEGIN {}#begin
+	BEGIN {
+		$MinimumVersion = [System.Version]"9.10"
+	}#begin
 
 	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
 
 		#Create URL for Request
 		$URI = "$baseURI/$PVWAAppName/API/IncomingRequests/$($RequestID)/Reject"

--- a/psPAS/Functions/Requests/Get-PASRequest.ps1
+++ b/psPAS/Functions/Requests/Get-PASRequest.ps1
@@ -29,6 +29,11 @@ Do not include "/PasswordVault/"
 The name of the CyberArk PVWA Virtual Directory.
 Defaults to PasswordVault
 
+.PARAMETER ExternalVersion
+The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+If the minimum version requirement of this function is not satisfied, execution will be halted.
+Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
 .EXAMPLE
 Get-PASRequest -RequestType IncomingRequests -OnlyWaiting $true -sessionToken $token -BaseURI $url
 
@@ -99,12 +104,23 @@ Minimum CyberArk Version 9.10
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault"
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
 	)
 
-	BEGIN {}#begin
+	BEGIN {
+		$MinimumVersion = [System.Version]"9.10"
+	}#begin
 
 	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
 
 		#Create URL for Request
 		$URI = "$baseURI/$PVWAAppName/API/$($RequestType)?onlywaiting=$OnlyWaiting&expired=$Expired"

--- a/psPAS/Functions/Requests/Get-PASRequestDetail.ps1
+++ b/psPAS/Functions/Requests/Get-PASRequestDetail.ps1
@@ -32,6 +32,11 @@ Do not include "/PasswordVault/"
 The name of the CyberArk PVWA Virtual Directory.
 Defaults to PasswordVault
 
+.PARAMETER ExternalVersion
+The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+If the minimum version requirement of this function is not satisfied, execution will be halted.
+Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
 .EXAMPLE
 Get-PASRequestDetail -RequestType IncomingRequests -RequestID $ID -sessionToken $token.sessiontoken -BaseURI $Url
 
@@ -91,12 +96,23 @@ Minimum CyberArk Version 9.10
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault"
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
 	)
 
-	BEGIN {}#begin
+	BEGIN {
+		$MinimumVersion = [System.Version]"9.10"
+	}#begin
 
 	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
 
 		#Create URL for Request
 		$URI = "$baseURI/$PVWAAppName/API/$($RequestType)/$($RequestID)"

--- a/psPAS/Functions/Requests/New-PASRequest.ps1
+++ b/psPAS/Functions/Requests/New-PASRequest.ps1
@@ -58,6 +58,11 @@ Do not include "/PasswordVault/"
 The name of the CyberArk PVWA Virtual Directory.
 Defaults to PasswordVault
 
+.PARAMETER ExternalVersion
+The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+If the minimum version requirement of this function is not satisfied, execution will be halted.
+Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
 .EXAMPLE
 New-PASRequest -AccountId $ID -Reason "Task ABC" -MultipleAccess $true -ConnectionComponent PSM-RDP -sessionToken $ST -BaseURI $url
 
@@ -170,12 +175,23 @@ Minimum CyberArk Version 9.10
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault"
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
 	)
 
-	BEGIN {}#begin
+	BEGIN {
+		$MinimumVersion = [System.Version]"9.10"
+	}#begin
 
 	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
 
 		#Create URL for Request
 		$URI = "$baseURI/$PVWAAppName/API/MyRequests"

--- a/psPAS/Functions/Requests/Remove-PASRequest.ps1
+++ b/psPAS/Functions/Requests/Remove-PASRequest.ps1
@@ -25,6 +25,11 @@ Do not include "/PasswordVault/"
 The name of the CyberArk PVWA Virtual Directory.
 Defaults to PasswordVault
 
+.PARAMETER ExternalVersion
+The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+If the minimum version requirement of this function is not satisfied, execution will be halted.
+Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
 .EXAMPLE
 $token | Remove-PASRequest -RequestID "<ID>"
 
@@ -73,12 +78,23 @@ None
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault"
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
 	)
 
-	BEGIN {}#begin
+	BEGIN {
+		$MinimumVersion = [System.Version]"9.10"
+	}#begin
 
 	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
 
 		#Create URL for request
 		$URI = "$baseURI/$PVWAAppName/API/MyRequests/$($RequestID)"

--- a/psPAS/Functions/SystemHealth/Get-PASComponentDetail.ps1
+++ b/psPAS/Functions/SystemHealth/Get-PASComponentDetail.ps1
@@ -24,6 +24,11 @@ Do not include "/PasswordVault/"
 The name of the CyberArk PVWA Virtual Directory.
 Defaults to PasswordVault
 
+.PARAMETER ExternalVersion
+The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+If the minimum version requirement of this function is not satisfied, execution will be halted.
+Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
 .EXAMPLE
 $token | Get-PASComponentDetail -ComponentID CPM
 
@@ -83,12 +88,23 @@ Requires minimum version of CyberArk 10.1.
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault"
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
 	)
 
-	BEGIN {}#begin
+	BEGIN {
+		$MinimumVersion = [System.Version]"10.1"
+	}#begin
 
 	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
 
 		#Create URL for request
 		$URI = "$baseURI/$PVWAAppName/api/ComponentsMonitoringDetails/$ComponentID"

--- a/psPAS/Functions/SystemHealth/Get-PASComponentSummary.ps1
+++ b/psPAS/Functions/SystemHealth/Get-PASComponentSummary.ps1
@@ -21,6 +21,11 @@ Do not include "/PasswordVault/"
 The name of the CyberArk PVWA Virtual Directory.
 Defaults to PasswordVault
 
+.PARAMETER ExternalVersion
+The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+If the minimum version requirement of this function is not satisfied, execution will be halted.
+Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
 .EXAMPLE
 $token | Get-PASComponentSummary
 
@@ -62,12 +67,23 @@ Requires minimum version of CyberArk 10.1.
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault"
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
 	)
 
-	BEGIN {}#begin
+	BEGIN {
+		$MinimumVersion = [System.Version]"10.1"
+	}#begin
 
 	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
 
 		#Create URL for request
 		$URI = "$baseURI/$PVWAAppName/api/ComponentsMonitoringSummary"

--- a/psPAS/Private/Assert-VersionRequirement.ps1
+++ b/psPAS/Private/Assert-VersionRequirement.ps1
@@ -1,0 +1,66 @@
+Function Assert-VersionRequirement {
+	<#
+.SYNOPSIS
+Affirms that a version satisfies a required level
+
+.DESCRIPTION
+Throws an error if a provided version number odes not meet or exceed a required level.
+
+.PARAMETER ExternalVersion
+A version number to comapre against the required version
+
+.PARAMETER RequiredVersion
+The version number the ExternalVersion Number must meet.v
+
+.EXAMPLE
+Assert-VersionRequirement -ExternalVersion 1.0 -RequiredVersion 2.0
+
+Throws an error as 1.0 does not equal or exceed 2.0
+
+.EXAMPLE
+Assert-VersionRequirement -ExternalVersion 1.0 -RequiredVersion 0.5
+
+Returns nothing as 1.0 exceeds 0.5
+
+.NOTES
+General notes
+#>
+	[CmdletBinding()]
+	Param(
+		# The Current Software Version
+		[Parameter(
+			Mandatory = $true,
+			ValueFromPipelineByPropertyName = $true
+		)]
+		[System.Version]
+		$ExternalVersion,
+
+		# The Required Software Version
+		[Parameter(
+			Mandatory = $true,
+			ValueFromPipelineByPropertyName = $true
+		)]
+		[System.Version]
+		$RequiredVersion
+	)
+
+	Begin {
+
+		$ParentFunction = $((Get-ParentFunction).FunctionName)
+		$UsedParameterSet = $((Get-ParentFunction).ParameterSetName)
+
+	}
+
+	Process {
+
+		If(-not (Compare-MinimumVersion -Version $ExternalVersion -MinimumVersion $RequiredVersion)) {
+
+			Throw "CyberArk $ExternalVersion does not meet the minimum version requirement of $RequiredVersion for $ParentFunction (using ParameterSet: $UsedParameterSet)"
+
+		}
+
+	}
+
+	End {}
+
+}

--- a/psPAS/Private/Compare-MinimumVersion.ps1
+++ b/psPAS/Private/Compare-MinimumVersion.ps1
@@ -1,0 +1,83 @@
+Function Compare-MinimumVersion {
+	<#
+	.SYNOPSIS
+	Compares 2 version numbers
+
+	.DESCRIPTION
+	Compares 2 System.Version numbers.
+	Returns True if Version is greater than or equal to MinimumVersion
+
+	.PARAMETER Version
+	A Version to compare against a Minimum Version
+
+	.PARAMETER MinimumVersion
+	The Minimum Version to compare against
+
+	.EXAMPLE
+	Compare-MinimumVersion -Version "9.8.0" -MinimumVersion "8.9.0"
+
+	Returns True
+
+	.EXAMPLE
+	Compare-MinimumVersion -Version "9.8.0" -MinimumVersion "9.9.0"
+
+	Returns False
+
+	.NOTES
+
+	#>
+	[CmdletBinding()]
+	Param(
+		# A Version to compare against a Minimum Version
+		[Parameter(
+			Mandatory = $true,
+			ValueFromPipelineByPropertyName = $true
+		)]
+		[Alias("ExternalVersion")]
+		[System.Version]
+		$Version,
+
+		# The Minimum Version to compare against
+		[Parameter(
+			Mandatory = $true,
+			ValueFromPipelineByPropertyName = $true
+		)]
+		[System.Version]
+		$MinimumVersion
+	)
+
+	Begin {}
+
+	Process {
+
+		# Only compare if version greater than "0.0"
+		If($Version -gt "0.0") {
+
+			#Determine if Version is greater than or equal to MinimumVersion
+			If($Version -ge $MinimumVersion) {
+
+				#Version is greater than or equal to MinimumVersion
+				$True
+
+			} Else {
+
+				#Version is less than  MinimumVersion
+				$False
+
+			}
+
+		}
+
+		#Version is 0.0
+		Else {
+
+			#Skip
+			Write-Verbose "Version Check Skipped"
+
+		}
+
+	}
+
+	End {}
+
+}

--- a/psPAS/Private/Compare-MinimumVersion.ps1
+++ b/psPAS/Private/Compare-MinimumVersion.ps1
@@ -27,6 +27,7 @@ Function Compare-MinimumVersion {
 
 	#>
 	[CmdletBinding()]
+	[OutputType('System.Boolean')]
 	Param(
 		# A Version to compare against a Minimum Version
 		[Parameter(

--- a/psPAS/Private/Compare-MinimumVersion.ps1
+++ b/psPAS/Private/Compare-MinimumVersion.ps1
@@ -57,11 +57,13 @@ Function Compare-MinimumVersion {
 			#Determine if Version is greater than or equal to MinimumVersion
 			If($Version -ge $MinimumVersion) {
 
+				Write-Verbose "Version Requirement Met"
 				#Version is greater than or equal to MinimumVersion
 				$True
 
 			} Else {
 
+				Write-Verbose "Version Requirement Not Met"
 				#Version is less than  MinimumVersion
 				$False
 
@@ -72,8 +74,9 @@ Function Compare-MinimumVersion {
 		#Version is 0.0
 		Else {
 
-			#Skip
-			Write-Verbose "Version Check Skipped"
+			#Skip - Return True
+			Write-Verbose "Version Requirement Not Checked"
+			$True
 
 		}
 

--- a/psPAS/Private/Get-ParentFunction.ps1
+++ b/psPAS/Private/Get-ParentFunction.ps1
@@ -1,0 +1,43 @@
+Function Get-ParentFunction {
+	<#
+	.SYNOPSIS
+	Returns the name of the calling function from a variable scope
+
+	.DESCRIPTION
+	Long description
+
+	.PARAMETER Scope
+	The Scope number from which to return the calling functions name.
+
+	.EXAMPLE
+	Function Test-Parent {Test-Child}
+	Function Test-Child {Get-ParentFunction}
+	Test-Parent
+
+	Returns Test-Parent
+
+	.EXAMPLE
+	Function Test-Example {Test-Parent}
+	Function Test-Parent {Test-Child}
+	Function Test-Child {Get-ParentFunction -Scope 3}
+	Test-Example
+
+	Returns Test-Example
+
+	.NOTES
+
+	#>
+	[CmdletBinding()]
+	Param(
+		# The scope number from which to retrieve the parent function name
+		[Parameter(
+			Mandatory = $false,
+			ValueFromPipelineByPropertyName = $true
+		)]
+		[Int]
+		$Scope = 2
+	)
+
+	(Get-Variable MyInvocation -Scope $Scope).Value.MyCommand.Name
+
+}

--- a/psPAS/Private/Get-ParentFunction.ps1
+++ b/psPAS/Private/Get-ParentFunction.ps1
@@ -1,28 +1,33 @@
 Function Get-ParentFunction {
 	<#
 	.SYNOPSIS
-	Returns the name of the calling function from a variable scope
+	Returns details of the calling function from a variable scope
 
 	.DESCRIPTION
-	Long description
+	Returns the FunctionName and the ParameterSetName which was used to invoke another function
 
 	.PARAMETER Scope
-	The Scope number from which to return the calling functions name.
+	The Scope number from which to return the calling functions details.
 
 	.EXAMPLE
 	Function Test-Parent {Test-Child}
 	Function Test-Child {Get-ParentFunction}
-	Test-Parent
+	$example = Test-Parent
 
-	Returns Test-Parent
+	$example.FunctionName #Returns Test-Parent
 
 	.EXAMPLE
-	Function Test-Example {Test-Parent}
+	Function Test-Example {
+		[CmdletBinding()]
+		param([parameter(ParameterSetName = "ExampleParamSet")][string]$Name)
+			Test-Parent
+	}
 	Function Test-Parent {Test-Child}
 	Function Test-Child {Get-ParentFunction -Scope 3}
-	Test-Example
+	$example = Test-Example -Name "test"
 
-	Returns Test-Example
+	$example.Function #Returns "Test-Example"
+	$example.ParameterSetName #Returns "ExampleParamSet"
 
 	.NOTES
 
@@ -38,6 +43,9 @@ Function Get-ParentFunction {
 		$Scope = 2
 	)
 
-	(Get-Variable MyInvocation -Scope $Scope).Value.MyCommand.Name
+	[PSCustomObject]@{
+		FunctionName     = (Get-Variable MyInvocation -Scope $Scope).Value.MyCommand.Name
+		ParameterSetName = (Get-Variable PSCmdlet -Scope $Scope -ErrorAction SilentlyContinue).Value.ParameterSetName
+	}
 
 }

--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -82,7 +82,7 @@ to ensure session persistence.
 	Begin {
 
 		#Get the name of the function which invoked this one
-		$CallingFunction = (Get-Variable MyInvocation -Scope 1).Value.MyCommand.Name
+		$CallingFunction = Get-ParentFunction
 		Write-Debug "Function: $($MyInvocation.InvocationName)"
 		Write-Debug "Calling Function: $CallingFunction"
 

--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -82,7 +82,7 @@ to ensure session persistence.
 	Begin {
 
 		#Get the name of the function which invoked this one
-		$CallingFunction = Get-ParentFunction
+		$CallingFunction = Get-ParentFunction | Select-Object -ExpandProperty FunctionName
 		Write-Debug "Function: $($MyInvocation.InvocationName)"
 		Write-Debug "Calling Function: $CallingFunction"
 
@@ -164,7 +164,7 @@ to ensure session persistence.
 
 				} Catch {
 
-					$ErrorMessage = $response
+					$ErrorMessage = $response -replace "`n", " "
 					$ErrorID = $StatusCode
 
 				} Finally {
@@ -199,8 +199,14 @@ to ensure session persistence.
 
 						elseif(($webResponse.headers)["Content-Type"] -match "text/html") {
 
-							#Return only the text between opening and closing quotes
-							[regex]::matches($($webResponse.content), '^"(.*)"$').Groups[1].Value
+							Write-Debug "$($webResponse.content)"
+
+							If($webResponse.content -match '^"(.*)"$') {
+								#Return only the text between opening and closing quotes
+								$matches[1]
+							} ElseIf($webResponse.content -match '<HTML>') {
+								Write-Error -Message "Guru Meditation" -ErrorId 400
+							}
 
 						}
 


### PR DESCRIPTION
<!-- _A similar PR may already be submitted.
Please search existing `Pull Requests` before creating one._

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.  -->

## Summary

<!-- Summary of the PR -->

This PR implements the following **features**:
- for applicable functions, checks that the version of CyberArk meets any minimum required version for the function.

<!-- You can skip this if you're fixing a typo. -->

_Explain the **motivation** for making this change. What existing problem does the pull request solve?_

<!-- Example: When "Amended logic in function _X_ to achieve _Y_", explain why it is necessary to have a way to do _Y_. -->

When using the psPAS module with a version of cyberark other than the latest release, not all functions or features will be supported. Now when authenticating to a version of CyberArk at version 9.7+, the module will query the CyberArk version after a successful authentication.
This version information is used to assert that the API feature being used is supported by the users' version of CyberArk .
Users now get a helpful error message indicating why their operation fails, detailing the minimum version requirement for the function they want to use.

## Test Plan

_Demonstrate the code is solid. Example: The exact commands you ran and their output._
All test cases updated and pass.

## Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes. -->
Closes #70 

<!--
## Code formatting

 See the `CONTRIBUTING` guide.

_Ensure your code adheres to the project's PowerShell Styleguide_
-->