### PR TITLE
Issue 81

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # psPAS Changelog
 
+## 2.0.x (July X 2018)
+
+- Updated Function
+  - `Set-PASAccount`, updated to support new 10.4 API features.
+    - Thanks [Assaf](https://github.com/AssafMiron)!
+
+
 ## 2.0.0 (July 1st 2018)
 
-_The 1 year since first commit aniversary edition_
+_The 1 year since first commit anniversary edition_
 
 ### Module update to cover CyberArk 10.4 API features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 # psPAS Changelog
 
-## 2.0.x (July X 2018)
+## 2.0.4 (July 8th 2018)
 
 - Updated Function
   - `Set-PASAccount`, updated to support new 10.4 API features.
     - Thanks [Assaf](https://github.com/AssafMiron)!
-
 
 ## 2.0.0 (July 1st 2018)
 

--- a/README.md
+++ b/README.md
@@ -317,12 +317,16 @@ See the [CONTRIBUTING.md](CONTRIBUTING.md) for a few more details.
 
 Hat Tips:
 
+**Assaf Miron**
+([AssafMiron](https://github.com/AssafMiron))
+For the JSON formatting assistance.
+
 **Warren Frame**
 ([RamblingCookieMonster](https://github.com/RamblingCookieMonster)) for the borrowed [Add-ObjectDetail.ps1](https://github.com/RamblingCookieMonster/PowerShell/blob/master/Add-ObjectDetail.ps1)
 & </br>[New-DynamicParam.ps1](https://github.com/RamblingCookieMonster/PowerShell/blob/master/New-DynamicParam.ps1)
 helper functions.
 
 **Joe Garcia** ([infamousjoeg](https://github.com/infamousjoeg))
-for the unofficial API documentation
+for the unofficial API documentation.
 
 Chapeau!

--- a/Tests/Set-PASAccount.Tests.ps1
+++ b/Tests/Set-PASAccount.Tests.ps1
@@ -35,42 +35,16 @@ Describe $FunctionName {
 
 	InModuleScope $ModuleName {
 
-		Mock Invoke-PASRestMethod -MockWith {
-			[pscustomobject]@{
-				"UpdateAccountResult" = [pscustomobject]@{
-					"Prop1" = "Value1"
-					"Prop2" = "Value2"
-					"Prop3" = "Value3"
-					"Prop4" = "Value4"
-				}
-			}
-		}
-
-		$InputObj = [pscustomobject]@{
-			"sessionToken" = @{"Authorization" = "P_AuthValue"}
-			"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
-			"BaseURI"      = "https://P_URI"
-			"PVWAAppName"  = "P_App"
-			"AccountID"    = "12_3"
-			"Folder"       = "Root"
-			"AccountName"  = "Name"
-			"Name"         = "SomeName"
-			"PolicyID"     = "SomePolicy"
-			"Safe"         = "SafeName"
-			"Random"       = "Rand"
-			"Random1"      = "RandomValue"
-
-		}
-
-		[void]$InputObj.PSObject.TypeNames.Insert(0, "psPAS.CyberArk.Vault.Account")
-
 		Context "Mandatory Parameters" {
 
 			$Parameters = @{Parameter = 'BaseURI'},
 			@{Parameter = 'SessionToken'},
 			@{Parameter = 'AccountID'},
 			@{Parameter = 'Folder'},
-			@{Parameter = 'AccountName'}
+			@{Parameter = 'AccountName'},
+			@{Parameter = 'op'},
+			@{Parameter = 'path'},
+			@{Parameter = 'value'}
 
 			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
 
@@ -82,53 +56,138 @@ Describe $FunctionName {
 
 		}
 
-		$response = $InputObj | Set-PASAccount -Properties @{"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = "Val3"}
-
 		Context "Input" {
 
-			It "sends request" {
+			BeforeEach {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Mock Invoke-PASRestMethod -MockWith {}
+
+				$InputObj = [pscustomobject]@{
+					"sessionToken" = @{"Authorization" = "P_AuthValue"}
+					"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+					"BaseURI"      = "https://P_URI"
+					"PVWAAppName"  = "P_App"
+					"AccountID"    = "12_3"
+					"Folder"       = "Root"
+					"AccountName"  = "Name"
+					"Name"         = "SomeName"
+					"PolicyID"     = "SomePolicy"
+					"Safe"         = "SafeName"
+					"Random"       = "Rand"
+					"Random1"      = "RandomValue"
+
+				}
+				[void]$InputObj.PSObject.TypeNames.Insert(0, "psPAS.CyberArk.Vault.Account")
+
+				$InputObjV10 = [pscustomobject]@{
+					"sessionToken" = @{"Authorization" = "P_AuthValue"}
+					"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+					"BaseURI"      = "https://P_URI"
+					"PVWAAppName"  = "P_App"
+					"AccountID"    = "12_3"
+				}
 
 			}
 
-			It "sends request to expected endpoint" {
+			It "sends request - V9 ParameterSet" {
+				$InputObj | Set-PASAccount -Properties @{"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = "Val3"}
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
+			}
+
+			It "sends request - V10 ParameterSet" {
+
+				$InputObj | Set-PASAccount -op Add -path "/somepath" -value SomeValue
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request to expected endpoint - V9 ParameterSet" {
+				$InputObj | Set-PASAccount -Properties @{"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = "Val3"}
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/WebServices/PIMServices.svc/Accounts/12_3"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "uses expected method" {
+			It "sends request to expected endpoint - V10 ParameterSet" {
+				$InputObjV10 | Set-PASAccount -op Remove -path "/somepath" -value SomeValue
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'PUT' } -Times 1 -Exactly -Scope Describe
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/api/Accounts/12_3"
+
+				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It "uses expected method - V9 ParameterSet" {
+				$InputObj | Set-PASAccount -Properties @{"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = "Val3"}
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'PUT' } -Times 1 -Exactly -Scope It
+
+			}
+
+			It "uses expected method - V10 ParameterSet" {
+				$InputObjV10 | Set-PASAccount -op Replace -path "/somepath" -value SomeValue
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'PATCH' } -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request with expected body - V9 ParameterSet" {
+				$InputObj | Set-PASAccount -Properties @{"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = "Val3"}
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					($Body | ConvertFrom-Json | select-Object -ExpandProperty Accounts) -ne $null
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request with expected body - V10 ParameterSet" {
+				$InputObjV10 | Set-PASAccount -op Replace -path "/somepath" -value SomeValue
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					($Body | ConvertFrom-Json | select-Object -ExpandProperty Operations) -ne $null
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "has a request body with expected number of properties - V9 ParameterSet" {
+				$InputObj | Set-PASAccount -Properties @{"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = "Val3"}
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					($Body | ConvertFrom-Json | select-Object -ExpandProperty Accounts | Get-Member -MemberType NoteProperty).length -eq 4
+
+				} -Times 1 -Exactly -Scope It
+			}
+
+			It "has a request body with expected number of properties - V10 ParameterSet" {
+				$InputObjV10 | Set-PASAccount -op Replace -path "/somepath" -value SomeValue
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					($Body | ConvertFrom-Json | select-Object -ExpandProperty Operations | Get-Member -MemberType NoteProperty).length -eq 3
+
+				} -Times 1 -Exactly -Scope It
+			}
+
+			It "has a request body with expected number of nested properties - V9 ParameterSet" {
+
+				$InputObj | Set-PASAccount -Properties @{"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = "Val3"}
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$Script:RequestBody = $Body | ConvertFrom-Json
+					($Body | ConvertFrom-Json | select-Object -ExpandProperty Accounts | Select-Object -ExpandProperty Properties).count -eq 5
 
-					($Script:RequestBody.Accounts) -ne $null
 
-				} -Times 1 -Exactly -Scope Describe
-
-			}
-
-			It "has a request body with expected number of properties" {
-
-				($Script:RequestBody.Accounts | Get-Member -MemberType NoteProperty).length | Should Be 4
+				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "has a request body with expected number of nested properties" {
+			It "throws error if version requirement not met" {
 
-				($Script:RequestBody.Accounts.Properties).count | Should Be 5
+				{$InputObjV10 | Set-PASAccount -op Replace -path "/somepath" -value SomeValue -ExternalVersion 1.2} | Should throw
 
 			}
 
@@ -136,21 +195,79 @@ Describe $FunctionName {
 
 		Context "Output" {
 
-			it "provides output" {
+			BeforeEach {
 
+				Mock Invoke-PASRestMethod -MockWith {
+					[pscustomobject]@{
+						"UpdateAccountResult" = [pscustomobject]@{
+							"Prop1" = "Value1"
+							"Prop2" = "Value2"
+							"Prop3" = "Value3"
+							"Prop4" = "Value4"
+						}
+					}
+				}
+
+				$InputObj = [pscustomobject]@{
+					"sessionToken" = @{"Authorization" = "P_AuthValue"}
+					"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+					"BaseURI"      = "https://P_URI"
+					"PVWAAppName"  = "P_App"
+					"AccountID"    = "12_3"
+					"Folder"       = "Root"
+					"AccountName"  = "Name"
+					"Name"         = "SomeName"
+					"PolicyID"     = "SomePolicy"
+					"Safe"         = "SafeName"
+					"Random"       = "Rand"
+					"Random1"      = "RandomValue"
+
+				}
+				[void]$InputObj.PSObject.TypeNames.Insert(0, "psPAS.CyberArk.Vault.Account")
+
+				$InputObjV10 = [pscustomobject]@{
+					"sessionToken" = @{"Authorization" = "P_AuthValue"}
+					"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+					"BaseURI"      = "https://P_URI"
+					"PVWAAppName"  = "P_App"
+					"AccountID"    = "12_3"
+				}
+
+			}
+
+			it "provides output - V9 ParameterSet" {
+				$response = $InputObj | Set-PASAccount -Properties @{"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = "Val3"}
 				$response | Should not BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			it "provides output - V10 ParameterSet" {
+				$response = $InputObjV10 | Set-PASAccount -op Replace -path "/somepath" -value SomeValue
+				$response | Should not BeNullOrEmpty
 
+			}
+
+			It "has output with expected number of properties - V9 ParameterSet" {
+				$response = $InputObj | Set-PASAccount -Properties @{"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = "Val3"}
 				($response | Get-Member -MemberType NoteProperty).length | Should Be 10
 
 			}
 
-			it "outputs object with expected typename" {
+			It "has output with expected number of properties - V10 ParameterSet" {
+				$response = $InputObjV10 | Set-PASAccount -op Replace -path "/somepath" -value SomeValue
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 10
 
+			}
+
+			it "outputs object with expected typename - V9 ParameterSet" {
+				$response = $InputObj | Set-PASAccount -Properties @{"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = "Val3"}
 				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Account
+
+			}
+
+			it "outputs object with expected typename - V10 ParameterSet" {
+				$response = $InputObjV10 | Set-PASAccount -op Replace -path "/somepath" -value SomeValue
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Account.V10
 
 			}
 
@@ -164,8 +281,7 @@ Describe $FunctionName {
 
 			It "returns default property <Property> in response" -TestCases $DefaultProps {
 				param($Property)
-
-				$response.$Property | Should Not BeNullOrEmpty
+				($InputObj | Set-PASAccount -Properties @{"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = "Val3"}).$Property | Should Not BeNullOrEmpty
 
 			}
 

--- a/Tests/Set-PASAccount.Tests.ps1
+++ b/Tests/Set-PASAccount.Tests.ps1
@@ -148,7 +148,7 @@ Describe $FunctionName {
 				$InputObjV10 | Set-PASAccount -op Replace -path "/somepath" -value SomeValue
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					($Body | ConvertFrom-Json | select-Object -ExpandProperty Operations) -ne $null
+					($Body | ConvertFrom-Json) -ne $null
 
 				} -Times 1 -Exactly -Scope It
 
@@ -167,7 +167,7 @@ Describe $FunctionName {
 				$InputObjV10 | Set-PASAccount -op Replace -path "/somepath" -value SomeValue
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					($Body | ConvertFrom-Json | select-Object -ExpandProperty Operations | Get-Member -MemberType NoteProperty).length -eq 3
+					(($Body | ConvertFrom-Json)[0] | Get-Member -MemberType NoteProperty).length -eq 3
 
 				} -Times 1 -Exactly -Scope It
 			}
@@ -255,7 +255,7 @@ Describe $FunctionName {
 
 			It "has output with expected number of properties - V10 ParameterSet" {
 				$response = $InputObjV10 | Set-PASAccount -op Replace -path "/somepath" -value SomeValue
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 10
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 7
 
 			}
 

--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -13,7 +13,7 @@ object to be used on subsequent calls to the web service.
 
 .PARAMETER Method
 The method for the REST Method.
-Only accepts GET, POST, PUT or DELETE
+Only accepts GET, POST, PUT, PATCH or DELETE
 
 .PARAMETER URI
 The address of the API or service to send the request to.
@@ -54,7 +54,7 @@ to ensure session persistence.
 	param
 	(
 		[Parameter(Mandatory = $true)]
-		[ValidateSet('GET', 'POST', 'PUT', 'DELETE')]
+		[ValidateSet('GET', 'POST', 'PUT', 'DELETE', 'PATCH')]
 		[String]$Method,
 
 		[Parameter(Mandatory = $true)]


### PR DESCRIPTION
## Summary

Adds support for new account update mechanism present from CyberArk version 10.4.
Invoke-PASRestMethod updated to allow required PATCH method.
Now, single properties can be added, replaced or removed from accounts, multiple update operations in single command execution also supported.

## Test Plan

Tested and confirmed as working against CyberArk 10.4.
Pester tests updated as required

## Closes issues

Closes #81 

<!--
## Code formatting

 See the `CONTRIBUTING` guide.

_Ensure your code adheres to the project's PowerShell Styleguide_
-->