### PR TITLE
Issue 86 - FIX Export-PASPlatform File Creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # psPAS Changelog
 
+## 2.2.0 (July 27th 2018)
+
+- Bug Fix
+  - `Export-PASPlatform`
+    - Exported files were invalid, now fixed.
+    - Thanks [jmk-foofus](https://github.com/jmk-foofus)!
+
 ## 2.1.0 (July 18th 2018)
 
 - New Functions

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # version format
-version: 2.1.{build}
+version: 2.2.{build}
 
 environment:
   access_token:

--- a/psPAS/Functions/Platforms/Export-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Export-PASPlatform.ps1
@@ -117,7 +117,7 @@ function Export-PASPlatform {
 
 				try {
 
-					$output = [PSCustomObject]@{
+					$output = @{
 						Path     = $path
 						Value    = $result
 						Encoding = "Byte"
@@ -125,13 +125,14 @@ function Export-PASPlatform {
 
 					If($IsCoreCLR) {
 
-						#amend object properties if we are in Core
-						$output = $output | Add-Member "AsByteStream" $true -PassThru | Select-Object -Property * -ExcludeProperty Encoding
+						#amend parameters for splatting if we are in Core
+						$output.Add("AsByteStream", $true)
+						$output.Remove("Encoding")
 
 					}
 
 					#write it to a file
-					$output | Set-Content -ErrorAction Stop
+					Set-Content @output -ErrorAction Stop
 
 				} catch {throw "Error Saving $path"}
 


### PR DESCRIPTION
<!-- _A similar PR may already be submitted.
Please search existing `Pull Requests` before creating one._

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.  -->

## Summary

Fixes issue where Export-PASPlatform was not creating ZIP archives in the correct way.

This PR fixes the following **bug**:

Call to set-content was creating an invalid ZIP archive. Code now corrected and valid files are being produced.

## Test Plan

Tested in Both PowerShell 5 & PSCore 6.1. Confirmed that exported platforms are valid ZIP files and have the expected content.

## Closes issues

Closes #86

<!--
## Code formatting

 See the `CONTRIBUTING` guide.

_Ensure your code adheres to the project's PowerShell Styleguide_
-->