### PR TITLE
Issue 92

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# psPAS Changelog
+# psPAS
+
+## 2.2.2 (September 12th 2018)
+
+- Bug Fix
+  - `Get-PASAccountPassword`
+    - Backward compatibility for retrieving password values from  CyberArk version 9 restored.
 
 ## 2.2.0 (July 27th 2018)
 

--- a/Tests/Get-PASAccountPassword.Tests.ps1
+++ b/Tests/Get-PASAccountPassword.Tests.ps1
@@ -158,6 +158,26 @@ Describe $FunctionName {
 
 			}
 
+			it "outputs string value for CyberArk version 9 byte array result" {
+
+				Mock Invoke-PASRestMethod -MockWith {
+					[system.Text.Encoding]::UTF8.GetBytes("psPAS")
+				}
+				$response = $InputObj | Get-PASAccountPassword -verbose
+				$response.Password | Should be "psPAS"
+
+			}
+
+			it "outputs string value for CyberArk version 10 string result" {
+
+				Mock Invoke-PASRestMethod -MockWith {
+					Write-Output "psPAS"
+				}
+				$response = $InputObj | Get-PASAccountPassword -verbose
+				$response.Password | Should be "psPAS"
+
+			}
+
 			It "has output with expected number of properties" {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should Be 6

--- a/psPAS/Functions/Accounts/Get-PASAccountPassword.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccountPassword.ps1
@@ -263,6 +263,12 @@ From version 10.1 onwards both passwords and ssh keys can be retrieved.
 
 		If($result) {
 
+			If($result.GetType().Name -eq "Object[]") {
+
+				$result = [System.Text.Encoding]::ASCII.GetString($result)
+
+			}
+
 			[PSCustomObject] @{"Password" = $result} |
 
 			Add-ObjectDetail -typename psPAS.CyberArk.Vault.Credential -PropertyToAdd @{


### PR DESCRIPTION
## Summary

Fixes issue where Byte Array of password string value was returned instead of string value when querying CyberArk 9.X

This PR fixes/implements the following **bugs**:

A bug was introduced when Invoke-PASRestMethod was updated for the psPAS 2.0 release.
CyberArk V9 returns a Byte Array of an accounts password, this PR reinstates the conversion of this into a string value. 
 
## Test Plan

Pester tests updated to check for issue with backwards compatibility.

## Closes issues

Closes #92 

<!--
## Code formatting

 See the `CONTRIBUTING` guide.

_Ensure your code adheres to the project's PowerShell Styleguide_
-->