### PR TITLE
Issue 100

### DIFF
--- a/psPAS/Functions/Accounts/Get-PASAccountPassword.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccountPassword.ps1
@@ -121,6 +121,7 @@ From version 10.1 onwards both passwords and ssh keys can be retrieved.
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[Alias("id")]
 		[string]$AccountID,
 
 		[parameter(


### PR DESCRIPTION
## Summary
Adds "id" alias to "AccountID" parameter.

This PR fixes the following **bugs**:
Allows Get-PASAccountPassword to accept both AccountID and ID from pipeline.

<!--
## Code formatting

 See the `CONTRIBUTING` guide.

_Ensure your code adheres to the project's PowerShell Styleguide_
-->