### PR TITLE
Issue 101

### DIFF
--- a/psPAS/Functions/Accounts/Get-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccount.ps1
@@ -38,6 +38,7 @@ A limit for the number of results to return.
 
 .PARAMETER filter
 A filter for the search.
+Requires format: "SafeName eq YourSafe"
 
 .PARAMETER Keywords
 Keyword to search for.
@@ -75,6 +76,11 @@ This will only work from version 10.4 onwards.
 $token | Get-PASAccount -search root -sort name -offset 100 -limit 5
 
 Returns all accounts matching "root", sorted by AccountName, Search results offset by 100 and limited to 5.
+
+.EXAMPLE
+$token | Get-PASAccount -filter "SafeName eq TargetSafe"
+
+Returns all accounts found in TargetSafe
 
 .EXAMPLE
 $token | Get-PASAccount -Keywords root -Safe UNIX

--- a/psPAS/Functions/Accounts/Get-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccount.ps1
@@ -166,6 +166,7 @@ New functionality added in version 10.4, limited functionality before this versi
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = "v10ByQuery"
 		)]
+		[ValidateRange(1, 1000)]
 		[int]$limit,
 
 		[parameter(


### PR DESCRIPTION
## Summary
Adds additional parameter validation to Get-PASAccount

This PR implements the following **features**:
- Enforces maximum value of 1000 on "`limit`" parameter in-line with API criteria.
- Adds help text related to "`filter`" parameter and its usage.
