### PR TITLE
FIX issues 100 + 101

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # psPAS
 
+## 2.2.10 (September 23rd 2018)
+
+- Bug Fix
+  - `Get-PASAccountPassword`
+    - Fix applied to allow accountID from version 10 to be accepted from pipeline object.
+  - `Get-PASAccount`
+    - Validation added to `limit` parameter.
+
 ## 2.2.2 (September 12th 2018)
 
 - Bug Fix

--- a/psPAS/Functions/Accounts/Get-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccount.ps1
@@ -38,6 +38,7 @@ A limit for the number of results to return.
 
 .PARAMETER filter
 A filter for the search.
+Requires format: "SafeName eq YourSafe"
 
 .PARAMETER Keywords
 Keyword to search for.
@@ -75,6 +76,11 @@ This will only work from version 10.4 onwards.
 $token | Get-PASAccount -search root -sort name -offset 100 -limit 5
 
 Returns all accounts matching "root", sorted by AccountName, Search results offset by 100 and limited to 5.
+
+.EXAMPLE
+$token | Get-PASAccount -filter "SafeName eq TargetSafe"
+
+Returns all accounts found in TargetSafe
 
 .EXAMPLE
 $token | Get-PASAccount -Keywords root -Safe UNIX
@@ -166,6 +172,7 @@ New functionality added in version 10.4, limited functionality before this versi
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = "v10ByQuery"
 		)]
+		[ValidateRange(1, 1000)]
 		[int]$limit,
 
 		[parameter(

--- a/psPAS/Functions/Accounts/Get-PASAccountPassword.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccountPassword.ps1
@@ -121,6 +121,7 @@ From version 10.1 onwards both passwords and ssh keys can be retrieved.
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[Alias("id")]
 		[string]$AccountID,
 
 		[parameter(


### PR DESCRIPTION
## Summary
Adds pipeline support for version 10 when piping `Get-PASAccount` into `Get-PASAccountPassword`

This PR fixes/implements the following **bugs/features**:
ADD  parameter validation to `Get-PASAccount`
ADD parameter alias for "id" to Get-PASAccountPassword
UPDATE help for `limit` parameter in Get-PASAccount`

## Closes issues

Closes #100 #101