### PR TITLE
Implement Windows Integrated Auth

### DIFF
--- a/Tests/New-PASSession.Tests.ps1
+++ b/Tests/New-PASSession.Tests.ps1
@@ -61,7 +61,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command New-PASSession).Parameters["$Parameter"].Attributes.Mandatory | Select-Object -Unique | Should Be $true
+				(Get-Command New-PASSession).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
 
 			}
 

--- a/Tests/New-PASSession.Tests.ps1
+++ b/Tests/New-PASSession.Tests.ps1
@@ -54,16 +54,15 @@ Describe $FunctionName {
 
 		Context "Mandatory Parameters" {
 
-			It "specifies parameter 'BaseURI' as mandatory" {
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'Credential'}
 
-				(Get-Command New-PASSession).Parameters["BaseURI"].Attributes.Mandatory | Should Be $true
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
 
-			}
-			
-			It "specifies parameter 'Credential' as mandatory {
-			
-				(Get-Command New-PASSession).Parameters["Credentials"].Attributes.Mandatory | Should Be @($true, $true)  #v10 and v9 ParameterSets
-				
+				param($Parameter)
+
+				(Get-Command New-PASSession).Parameters["$Parameter"].Attributes.Mandatory | Select-Object -Unique | Should Be $true
+
 			}
 
 		}

--- a/Tests/New-PASSession.Tests.ps1
+++ b/Tests/New-PASSession.Tests.ps1
@@ -54,15 +54,16 @@ Describe $FunctionName {
 
 		Context "Mandatory Parameters" {
 
-			$Parameters = @{Parameter = 'BaseURI'},
-			@{Parameter = 'Credential'}
+			It "specifies parameter 'BaseURI' as mandatory" {
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+				(Get-Command New-PASSession).Parameters["BaseURI"].Attributes.Mandatory | Should Be $true
 
-				param($Parameter)
-
-				(Get-Command New-PASSession).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
-
+			}
+			
+			It "specifies parameter 'Credential' as mandatory {
+			
+				(Get-Command New-PASSession).Parameters["Credentials"].Attributes.Mandatory | Should Be @($true, $true)  #v10 and v9 ParameterSets
+				
 			}
 
 		}

--- a/psPAS/Functions/Authentication/New-PASSession.ps1
+++ b/psPAS/Functions/Authentication/New-PASSession.ps1
@@ -111,7 +111,7 @@ To force all output to be shown, pipe to Select-Object *
 	[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = "v10")]
 	param(
 		[parameter(
-			Mandatory = $true,
+			Mandatory = $false,
 			ValueFromPipeline = $true
 		)]
 		[ValidateNotNullOrEmpty()]
@@ -211,11 +211,15 @@ To force all output to be shown, pipe to Select-Object *
 
 		#Get request parameters
 		$boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove Credential, UseV9API, SkipVersionCheck
+		
+		If($PSBoundParameters.ContainsKey("Credential")) {
 
-		#Add user name from credential object
-		$boundParameters["username"] = $($Credential.UserName)
-		#Add decoded password value from credential object
-		$boundParameters["password"] = $($Credential.GetNetworkCredential().Password)
+			#Add user name from credential object
+			$boundParameters["username"] = $($Credential.UserName)
+			#Add decoded password value from credential object
+			$boundParameters["password"] = $($Credential.GetNetworkCredential().Password)
+		
+		}
 
 		#deal with newPassword SecureString
 		If($PSBoundParameters.ContainsKey("newPassword")) {
@@ -231,7 +235,7 @@ To force all output to be shown, pipe to Select-Object *
 		if($PSCmdlet.ShouldProcess("$baseURI/$PVWAAppName", "Logon with User '$($boundParameters["username"])'")) {
 
 			#Send Logon Request
-			$PASSession = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -SessionVariable $SessionVariable
+			$PASSession = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -SessionVariable $SessionVariable -UseDefaultCredentials:($type -eq 'Windows')
 
 			#If Logon Result
 			If($PASSession) {

--- a/psPAS/Functions/Authentication/New-PASSession.ps1
+++ b/psPAS/Functions/Authentication/New-PASSession.ps1
@@ -79,6 +79,11 @@ Logon to Version 10 with CyberArk credential:
 New-PASSession -Credential $cred -BaseURI https://PVWA -type CyberArk
 
 .EXAMPLE
+Logon to Version 10 with Windows Integrated Authentication
+
+New-PASSession -BaseURI https://PVWA -UseDefaultCredentials
+
+.EXAMPLE
 Logon to Version 9 with credential and save auth token:
 
 $token = New-PASSession -Credential $cred -BaseURI https://PVWA -UseV9API
@@ -124,11 +129,6 @@ To force all output to be shown, pipe to Select-Object *
 			ValueFromPipeline = $true,
 			ParameterSetName = "v9"
 		)]
-		[parameter(
-			Mandatory = $false,
-			ValueFromPipeline = $false,
-			ParameterSetName = "integrated"
-		)]
 		[ValidateNotNullOrEmpty()]
 		[PSCredential]$Credential,
 
@@ -141,7 +141,13 @@ To force all output to be shown, pipe to Select-Object *
 
 		[Parameter(
 			Mandatory = $false,
-			ValueFromPipeline = $false
+			ValueFromPipeline = $false,
+			ParameterSetName = "v10"
+		)]
+		[Parameter(
+			Mandatory = $false,
+			ValueFromPipeline = $false,
+			ParameterSetName = "v9"
 		)]
 		[SecureString]$newPassword,
 
@@ -247,9 +253,7 @@ To force all output to be shown, pipe to Select-Object *
 			
 			$userDisplay = $boundParameters["username"]
 		
-		}
-		
-		ElseIf($PSBoundParameters.ContainsKey("UseDefaultCredentials")) {
+		} ElseIf($PSBoundParameters.ContainsKey("UseDefaultCredentials")) {
 			
 			$userDisplay = "$env:USERDOMAIN\$env:USERNAME"
 		

--- a/psPAS/Functions/Authentication/New-PASSession.ps1
+++ b/psPAS/Functions/Authentication/New-PASSession.ps1
@@ -211,7 +211,7 @@ To force all output to be shown, pipe to Select-Object *
 			ValueFromPipeline = $false
 		)]
 		[string]$PVWAAppName = "PasswordVault",
-		
+
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipeline = $false,
@@ -226,9 +226,9 @@ To force all output to be shown, pipe to Select-Object *
 		if($($PSCmdlet.ParameterSetName) -eq "v10") {
 
 			$URI = "$baseURI/$PVWAAppName/api/Auth/$type/Logon"
-			
+
 		} elseif($($PSCmdlet.ParameterSetName) -eq "integrated") {
-		
+
 			$URI = "$baseURI/$PVWAAppName/api/Auth/Windows/Logon"  #hardcode Windows for integrated auth
 
 		} elseif($($PSCmdlet.ParameterSetName) -eq "v9") {
@@ -243,20 +243,20 @@ To force all output to be shown, pipe to Select-Object *
 
 		#Get request parameters
 		$boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove Credential, UseV9API, SkipVersionCheck
-		
+
 		If($PSBoundParameters.ContainsKey("Credential")) {
 
 			#Add user name from credential object
 			$boundParameters["username"] = $($Credential.UserName)
 			#Add decoded password value from credential object
 			$boundParameters["password"] = $($Credential.GetNetworkCredential().Password)
-			
+
 			$userDisplay = $boundParameters["username"]
-		
+
 		} ElseIf($PSBoundParameters.ContainsKey("UseDefaultCredentials")) {
-			
+
 			$userDisplay = "$env:USERDOMAIN\$env:USERNAME"
-		
+
 		}
 
 		#deal with newPassword SecureString

--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -34,6 +34,10 @@ Cannot be specified with WebSession
 Accepts a WebRequestSession object containing session details
 Cannot be specified with SessionVariable
 
+.PARAMETER UseDefaultCredentials
+See Invoke-WebRequest
+Used for Integrated Auth
+
 .EXAMPLE
 
 .INPUTS
@@ -76,7 +80,10 @@ to ensure session persistence.
 			Mandatory = $false,
 			ParameterSetName = "WebSession"
 		)]
-		[Microsoft.PowerShell.Commands.WebRequestSession]$WebSession
+		[Microsoft.PowerShell.Commands.WebRequestSession]$WebSession,
+		
+		[Parameter(Mandatory = $false)]
+		[switch]$UseDefaultCredentials
 	)
 
 	Begin {

--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -81,7 +81,7 @@ to ensure session persistence.
 			ParameterSetName = "WebSession"
 		)]
 		[Microsoft.PowerShell.Commands.WebRequestSession]$WebSession,
-		
+
 		[Parameter(Mandatory = $false)]
 		[switch]$UseDefaultCredentials
 	)


### PR DESCRIPTION
## Summary

<!-- Summary of the PR -->

This PR implements the following features:

Allow for Integrated Auth when Logon type is Windows

<!-- You can skip this if you're fixing a typo. -->

Need to pass -UseDefaultCredentials to use integrated Windows Authentication

<!-- Example: When "Amended logic in function _X_ to achieve _Y_", explain why it is necessary to have a way to do _Y_. -->

## Test Plan

Test New Feature
_$test = New-PASSession -type Windows -BaseURI 'myuri'_

Regression
_$test = New-PASSession -UseV9API -Credential (Get-Credential) -BaseURI 'myuri' -connectionNumber 22_
_$account = $test | Get-PASAccount -search "mine"_

## Closes issues
N/A

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes. -->

<!--
## Code formatting

 See the `CONTRIBUTING` guide.

-->