### PR TITLE
CyberArk 10.5 Features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # psPAS
 
+## 2.3.0 (November 1st 2018)
+
+### Module update to cover CyberArk 10.5 API features
+
+- New Functions
+  - `Get-PASGroup`
+    - Enables querying of Vault Groups
+  - `Remove-PASGroupMember`
+    - Enables removal of vault group members
+  - `Set-PASOnboardingRule`
+    - Enables updates to existing Onboarding Rules
+  - `Add-PASDiscoveredAccount`
+    - Enables addition of discovered accounts or SSH keys as a pending account in the accounts feed
+  - `Connect-PASPSMSession`
+    - Retrieves parameters needed to monitor an in-progress PSM session
+
+- Updated Functions
+  - `Get-PASDirectory`
+    - Now possible to query LDAP Directory by name
+  - `Get-PASAccountGroup`
+    - Updated to use API endpoint in 10.5
+  - `Get-PASPSMConnectionParameter`
+    - Updated to cater for Ad-Hoc Connections with unmanaged accounts
+
+- Bug Fixes
+  - Use of TLS 1.2 Protocol enforced when using PSCore
+
+## 2.2.22 (October 21st 2018)
+
+- Update
+  - `New-PASSession`
+    - Option added to use Windows integrated authentication with default credentials
+      - Thanks [steveredden](https://github.com/steveredden)!
+
 ## 2.2.10 (September 23rd 2018)
 
 - Bug Fix

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Use PowerShell to manage CyberArk via the Web Services REST API.
 
-Contains all published methods of the API up to CyberArk v10.4.
+Contains all published methods of the API up to CyberArk v10.5.
 
 ----------
 
@@ -222,6 +222,11 @@ requires version 9.8+).
 [`Get-PASPTARule`][Get-PASPTARule]                                                       |**10.4**            |List all new Risky </br>Command rules from PTA
 [`Set-PASPTARemediation`][Set-PASPTARemediation]                                         |**10.4**            |Update automatic</br>response config in PTA
 [`Set-PASPTARule`][Set-PASPTARule]                                                       |**10.4**            |Update a Risky Command</br>rule in PTA
+[`Get-PASGroup`][Get-PASGroup]                                                           |**10.5**            |Return vault group information
+[`Remove-PASGroupMember`][Remove-PASGroupMember]                                         |**10.5**            |Remove vault group members
+[`Set-PASOnboardingRule`][Set-PASOnboardingRule]                                         |**10.5**            |Update Onboarding Rules
+[`Add-PASDiscoveredAccount`][Add-PASDiscoveredAccount]                                   |**10.5**            |Add of discovered accounts</br>to the accounts feed
+[`Connect-PASPSMSession`][Connect-PASPSMSession]                                         |**10.5**            |Get required parameters to </br>connect to live PSM Sessions
 
 [New-PASSession]:/psPAS/Functions/Authentication/New-PASSession.ps1
 [Close-PASSession]:/psPAS/Functions/Authentication/Close-PASSession.ps1
@@ -311,6 +316,11 @@ requires version 9.8+).
 [Get-PASPTARule]:/psPAS/Functions/EventSecurity/Get-PASPTARule.ps1
 [Set-PASPTARemediation]:/psPAS/Functions/EventSecurity/Set-PASPTARemediation.ps1
 [Set-PASPTARule]:/psPAS/Functions/EventSecurity/Set-PASPTARule.ps1
+[Get-PASGroup]:/psPAS/Functions/User/Get-PASGroup.ps1
+[Remove-PASGroupMember]:/psPAS/Functions/User/Remove-PASGroupMember.ps1
+[Set-PASOnboardingRule]:/psPAS/Functions/OnboardingRules/Set-PASOnboardingRule.ps1
+[Add-PASDiscoveredAccount]:/psPAS/Functions/Accounts/Add-PASDiscoveredAccount.ps1
+[Connect-PASPSMSession]:/psPAS/Functions/Monitoring/Connect-PASPSMSession.ps1
 
 ## Installation
 

--- a/Tests/Add-PASDiscoveredAccount.Tests.ps1
+++ b/Tests/Add-PASDiscoveredAccount.Tests.ps1
@@ -1,0 +1,219 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'UserName'},
+			@{Parameter = 'Address'},
+			@{Parameter = 'discoveryDate'},
+			@{Parameter = 'AccountEnabled'},
+			@{Parameter = 'fingerprint'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Add-PASDiscoveredAccount ).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		Context "Input" {
+
+			BeforeEach {
+
+				Mock Invoke-PASRestMethod -MockWith {}
+
+				$InputObj = [pscustomobject]@{
+					"sessionToken"   = @{"Authorization" = "P_AuthValue"}
+					"WebSession"     = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+					"BaseURI"        = "https://P_URI"
+					"PVWAAppName"    = "P_App"
+					"UserName"       = "SomeUser"
+					"Address"        = "SomeDomain"
+					"discoveryDate"  = "$(Get-Date 1/1/1971)"
+					"AccountEnabled" = $true
+
+				}
+
+			}
+
+			It "sends request" {
+				$InputObj | Add-PASDiscoveredAccount
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request to expected endpoint" {
+				$InputObj | Add-PASDiscoveredAccount
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/api/DiscoveredAccounts"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "uses expected method" {
+				$InputObj | Add-PASDiscoveredAccount
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request with expected body" {
+				$InputObj | Add-PASDiscoveredAccount
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+					($Body) -ne $null
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "has a request body with expected number of properties" {
+				$InputObj | Add-PASDiscoveredAccount
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					($Body | ConvertFrom-Json | Get-Member -MemberType NoteProperty).length -eq 4
+
+				} -Times 1 -Exactly -Scope It
+			}
+
+			It "converts date to expected UNIX time" {
+				$InputObj | Add-PASDiscoveredAccount
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					($Body | ConvertFrom-Json).discoveryDate -eq 31536000
+
+				} -Times 1 -Exactly -Scope It
+			}
+
+			It "throws error if version requirement not met" {
+
+				{$InputObj | Add-PASDiscoveredAccount -ExternalVersion 1.2} | Should throw
+
+			}
+
+			It "has a request body with expected platformTypeAccountProperties property for Windows" {
+				$InputObj | Add-PASDiscoveredAccount -sid 1234
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					($Body | ConvertFrom-Json).platformTypeAccountProperties.SID -eq "1234"
+
+				} -Times 1 -Exactly -Scope It
+			}
+
+			It "has a request body with expected platformTypeAccountProperties property for UNIX" {
+				$InputObj | Add-PASDiscoveredAccount -uid 1234 -gid 1
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					($Body | ConvertFrom-Json).platformTypeAccountProperties.UID -eq "1234"
+					($Body | ConvertFrom-Json).platformTypeAccountProperties.GID -eq "1"
+
+				} -Times 1 -Exactly -Scope It
+			}
+
+			It "has a request body with expected platformTypeAccountProperties property for UNIXSSHKey" {
+				$InputObj | Add-PASDiscoveredAccount -uid 1234 -gid 1 -fingerprint "SomePrint" -Path "SomePath" -format "SomeFormat"
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					($Body | ConvertFrom-Json).platformTypeAccountProperties.UID -eq "1234"
+					($Body | ConvertFrom-Json).platformTypeAccountProperties.GID -eq "1"
+					($Body | ConvertFrom-Json).platformTypeAccountProperties.fingerprint -eq "SomePrint"
+					($Body | ConvertFrom-Json).platformTypeAccountProperties.Path -eq "SomePath"
+					($Body | ConvertFrom-Json).platformTypeAccountProperties.format -eq "SomeFormat"
+
+				} -Times 1 -Exactly -Scope It
+			}
+
+		}
+
+		Context "Output" {
+
+			BeforeEach {
+
+				Mock Invoke-PASRestMethod -MockWith {
+
+					[pscustomobject]@{
+						"id"     = "Value1"
+						"status" = "Value2"
+					}
+
+
+
+				}
+
+
+				$InputObj = [pscustomobject]@{
+					"sessionToken"   = @{"Authorization" = "P_AuthValue"}
+					"WebSession"     = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+					"BaseURI"        = "https://P_URI"
+					"PVWAAppName"    = "P_App"
+					"UserName"       = "SomeUser"
+					"Address"        = "SomeDomain"
+					"discoveryDate"  = "$(Get-Date 1/1/1971)"
+					"AccountEnabled" = $true
+
+				}
+
+			}
+
+			it "provides output" {
+				$response = $InputObj | Add-PASDiscoveredAccount
+				$response | Should Not BeNullOrEmpty
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'},
+			@{Property = 'ExternalVersion'}
+
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+				($InputObj | Add-PASDiscoveredAccount).$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Connect-PASPSMSession.Tests.ps1
+++ b/Tests/Connect-PASPSMSession.Tests.ps1
@@ -1,0 +1,165 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Invoke-PASRestMethod -MockWith {
+			[PSCustomObject]@{"Prop1" = "VAL1"; "Prop2" = "Val2"; "Prop3" = "Val3"}
+		}
+
+		$InputObj = [pscustomobject]@{
+			"sessionToken"     = @{"Authorization" = "P_AuthValue"}
+			"WebSession"       = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"BaseURI"          = "https://P_URI"
+			"PVWAAppName"      = "P_App"
+			"SessionId"        = "SomeSession"
+			"ConnectionMethod" = "RDP"
+
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'SessionId'},
+			@{Parameter = 'ConnectionMethod'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Connect-PASPSMSession).Parameters["$Parameter"].Attributes.Mandatory | Select-Object -Unique | Should Be $true
+
+			}
+
+		}
+
+		$response = $InputObj | Connect-PASPSMSession -ConnectionMethod RDP
+
+		Context "Input" {
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request to expected endpoint for PSMConnect" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/LiveSessions/SomeSession/monitor"
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Body -eq $null
+
+				} -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "has expected Accept key in header" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Headers["Accept"] -eq 'application/json' } -Times 1 -Exactly -Scope Describe
+
+			}
+
+			It "specifies expected Accept key in header for PSMGW requests" {
+
+				$InputObj | Connect-PASPSMSession -ConnectionMethod PSMGW
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Headers["Accept"] -eq '* / *' } -Times 1 -Exactly -Scope It
+
+			}
+
+			It "throws error if version requirement not met" {
+				{$InputObj | Connect-PASPSMSession -ConnectionMethod RDP -ExternalVersion "9.8"} | Should Throw
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 3
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be System.Management.Automation.PSCustomObject
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'}
+
+			It "does not return default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+
+				$response.$Property | Should Be $null
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASAccountGroup.Tests.ps1
+++ b/Tests/Get-PASAccountGroup.Tests.ps1
@@ -64,7 +64,7 @@ Describe $FunctionName {
 
 		}
 
-		$response = $InputObj | Get-PASAccountGroup -verbose
+		$response = $InputObj | Get-PASAccountGroup -UseV9API -verbose
 
 		Context "Input" {
 
@@ -98,6 +98,22 @@ Describe $FunctionName {
 
 			It "throws error if version requirement not met" {
 				{$InputObj | Get-PASAccountGroup -ExternalVersion "1.0"} | Should Throw
+			}
+
+			It "sends request to expected endpoint - V10 ParameterSet" {
+
+				$InputObj | Get-PASAccountGroup -safe "SomeSafe" -verbose
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/Safes/SomeSafe/AccountGroups"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "throws error if version requirement not met" {
+				{$InputObj | Get-PASAccountGroup -safe "SomeSafe" -ExternalVersion 1.1} | Should Throw
 			}
 
 		}

--- a/Tests/Get-PASDirectory.Tests.ps1
+++ b/Tests/Get-PASDirectory.Tests.ps1
@@ -62,7 +62,7 @@ Describe $FunctionName {
 
 		}
 
-		$response = $InputObj | Get-PASDirectory
+		$response = $InputObj | Get-PASDirectory -id SomeDir
 
 		Context "Input" {
 
@@ -76,7 +76,7 @@ Describe $FunctionName {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/api/Configuration/LDAP/Directories"
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/api/Configuration/LDAP/Directories/SomeDir/"
 
 				} -Times 1 -Exactly -Scope Describe
 

--- a/Tests/Get-PASGroup.Tests.ps1
+++ b/Tests/Get-PASGroup.Tests.ps1
@@ -1,0 +1,168 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Get-PASGroup).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		Context "Input" {
+
+			BeforeEach {
+
+				Mock Invoke-PASRestMethod -MockWith {}
+
+				$InputObj = [pscustomobject]@{
+					"sessionToken" = @{"Authorization" = "P_AuthValue"}
+					"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+					"BaseURI"      = "https://P_URI"
+					"PVWAAppName"  = "P_App"
+
+				}
+
+			}
+
+			It "sends request" {
+				$InputObj | Get-PASGroup
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request to expected endpoint" {
+				$InputObj | Get-PASGroup
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/UserGroups?"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request with expected query" {
+				$InputObj | Get-PASGroup -filter "groupType eq Directory" -search "Search Term"
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					($URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/UserGroups?search=Search%20Term&filter=groupType%20eq%20Directory") -or ($URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/UserGroups?filter=groupType%20eq%20Directory&search=Search%20Term")
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "uses expected method" {
+				$InputObj | Get-PASGroup
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request with no body" {
+				$InputObj | Get-PASGroup
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "throws error if version requirement not met" {
+
+				{$InputObj | Get-PASGroup -ExternalVersion 1.2} | Should throw
+
+			}
+
+		}
+
+		Context "Output" {
+
+			BeforeEach {
+
+				Mock Invoke-PASRestMethod -MockWith {
+					[pscustomobject]@{
+						"value" = [pscustomobject]@{
+							"Prop1" = "Value1"
+							"Prop2" = "Value2"
+							"Prop3" = "Value3"
+							"Prop4" = "Value4"
+						}
+					}
+				}
+
+				$InputObj = [pscustomobject]@{
+					"sessionToken" = @{"Authorization" = "P_AuthValue"}
+					"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+					"BaseURI"      = "https://P_URI"
+					"PVWAAppName"  = "P_App"
+				}
+
+			}
+
+			it "provides output" {
+				$response = $InputObj | Get-PASGroup
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+				$response = $InputObj | Get-PASGroup
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 9
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'},
+			@{Property = 'ExternalVersion'}
+
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+				($InputObj | Get-PASGroup).$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/New-PASSession.Tests.ps1
+++ b/Tests/New-PASSession.Tests.ps1
@@ -173,6 +173,17 @@ Describe $FunctionName {
 
 			}
 
+			It "sends request to expected v10 URL for WINDOWS Authentication" {
+
+				$response = New-PASSession -BaseURI "https://P_URI" -UseDefaultCredentials
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "https://P_URI/PasswordVault/api/Auth/Windows/Logon"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
 			It "calls Get-PASServer" {
 
 				$response = $Credentials | New-PASSession -BaseURI "https://P_URI" -type LDAP
@@ -186,6 +197,8 @@ Describe $FunctionName {
 				Assert-MockCalled Get-PASServer -Times 0 -Exactly -Scope It
 
 			}
+
+
 
 		}
 

--- a/Tests/Remove-PASGroupMember.Tests.ps1
+++ b/Tests/Remove-PASGroupMember.Tests.ps1
@@ -1,0 +1,131 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'GroupID'},
+			@{Parameter = 'Member'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Remove-PASGroupMember ).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		Context "Input" {
+
+			BeforeEach {
+
+				Mock Invoke-PASRestMethod -MockWith {}
+
+				$InputObj = [pscustomobject]@{
+					"sessionToken" = @{"Authorization" = "P_AuthValue"}
+					"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+					"BaseURI"      = "https://P_URI"
+					"PVWAAppName"  = "P_App"
+
+				}
+
+			}
+
+			It "sends request" {
+				$InputObj | Remove-PASGroupMember -GroupID X1_Y2 -Member TargetUser
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request to expected endpoint" {
+				$InputObj | Remove-PASGroupMember -GroupID X1_Y2 -Member TargetUser
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/API/UserGroups/X1_Y2/members/TargetUser"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "uses expected method" {
+				$InputObj | Remove-PASGroupMember -GroupID X1_Y2 -Member TargetUser
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request with no body" {
+				$InputObj | Remove-PASGroupMember -GroupID X1_Y2 -Member TargetUser
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "throws error if version requirement not met" {
+
+				{$InputObj | Remove-PASGroupMember -GroupID X1_Y2 -Member TargetUser -ExternalVersion 1.2} | Should throw
+
+			}
+
+		}
+
+		Context "Output" {
+
+			BeforeEach {
+
+				Mock Invoke-PASRestMethod -MockWith {}
+			}
+
+			$InputObj = [pscustomobject]@{
+				"sessionToken" = @{"Authorization" = "P_AuthValue"}
+				"WebSession"   = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+				"BaseURI"      = "https://P_URI"
+				"PVWAAppName"  = "P_App"
+			}
+
+			it "provides no output" {
+				$response = $InputObj | Remove-PASGroupMember -GroupID X1_Y2 -Member TargetUser
+				$response | Should BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Set-PASOnboardingRule.Tests.ps1
+++ b/Tests/Set-PASOnboardingRule.Tests.ps1
@@ -1,0 +1,185 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'BaseURI'},
+			@{Parameter = 'SessionToken'},
+			@{Parameter = 'Id'},
+			@{Parameter = 'TargetPlatformId'},
+			@{Parameter = 'TargetSafeName'},
+			@{Parameter = 'SystemTypeFilter'}
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Set-PASOnboardingRule ).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		Context "Input" {
+
+			BeforeEach {
+
+				Mock Invoke-PASRestMethod -MockWith {}
+
+				$InputObj = [pscustomobject]@{
+					"sessionToken"     = @{"Authorization" = "P_AuthValue"}
+					"WebSession"       = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+					"BaseURI"          = "https://P_URI"
+					"PVWAAppName"      = "P_App"
+					"SystemTypeFilter" = "Windows"
+					"TargetSafeName"   = "SomeSafe"
+					"TargetPlatformId" = "SomePlatform"
+					"Id"               = "123"
+
+				}
+
+			}
+
+			It "sends request" {
+				$InputObj | Set-PASOnboardingRule
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request to expected endpoint" {
+				$InputObj | Set-PASOnboardingRule
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($InputObj.BaseURI)/$($InputObj.PVWAAppName)/api/AutomaticOnboardingRules/123"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "uses expected method" {
+				$InputObj | Set-PASOnboardingRule
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'PUT' } -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request with expected body" {
+				$InputObj | Set-PASOnboardingRule
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+					($Body) -ne $null
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "has a request body with expected number of properties" {
+				$InputObj | Set-PASOnboardingRule
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					($Body | ConvertFrom-Json | Get-Member -MemberType NoteProperty).length -eq 3
+
+				} -Times 1 -Exactly -Scope It
+			}
+
+			It "throws error if version requirement not met" {
+
+				{$InputObj | Set-PASOnboardingRule -ExternalVersion 1.2} | Should throw
+
+			}
+
+		}
+
+		Context "Output" {
+
+			BeforeEach {
+
+				Mock Invoke-PASRestMethod -MockWith {
+
+					[pscustomobject]@{
+						"Prop1" = "Value1"
+						"Prop2" = "Value2"
+						"Prop3" = "Value3"
+						"Prop4" = "Value4"
+					}
+
+
+
+				}
+
+
+				$InputObj = [pscustomobject]@{
+					"sessionToken"     = @{"Authorization" = "P_AuthValue"}
+					"WebSession"       = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+					"BaseURI"          = "https://P_URI"
+					"PVWAAppName"      = "P_App"
+					"SystemTypeFilter" = "Windows"
+					"TargetSafeName"   = "SomeSafe"
+					"TargetPlatformId" = "SomePlatform"
+					"Id"               = "123"
+
+				}
+
+			}
+
+			it "provides output" {
+				$response = $InputObj | Set-PASOnboardingRule
+				$response | Should Not BeNullOrEmpty
+
+			}
+
+			it "outputs object with expected typename" {
+				$response = $InputObj | Set-PASOnboardingRule
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.OnboardingRule
+
+			}
+
+			$DefaultProps = @{Property = 'sessionToken'},
+			@{Property = 'WebSession'},
+			@{Property = 'BaseURI'},
+			@{Property = 'PVWAAppName'},
+			@{Property = 'ExternalVersion'}
+
+
+			It "returns default property <Property> in response" -TestCases $DefaultProps {
+				param($Property)
+				($InputObj | Set-PASOnboardingRule).$Property | Should Not BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # version format
-version: 2.2.{build}
+version: 2.3.{build}
 
 environment:
   access_token:

--- a/psPAS/Functions/AccountGroups/Get-PASAccountGroup.ps1
+++ b/psPAS/Functions/AccountGroups/Get-PASAccountGroup.ps1
@@ -14,6 +14,9 @@ The following permissions are required on the safe where the account group will 
 .PARAMETER Safe
 The Safe where the account groups are.
 
+.PARAMETER UseV9API
+Specify this switch to force usage of the legacy API endpoint.
+
 .PARAMETER sessionToken
 Hashtable containing the session token returned from New-PASSession
 
@@ -64,6 +67,13 @@ Minimum CyberArk version 9.10
 		[string]$Safe,
 
 		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $false,
+			ParameterSetName = "v9"
+		)]
+		[switch]$UseV9API,
+
+		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
@@ -101,10 +111,25 @@ Minimum CyberArk version 9.10
 
 	PROCESS {
 
-		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
+		If($PSCmdlet.ParameterSetName -eq "v9") {
 
-		#Create URL for Request
-		$URI = "$baseURI/$PVWAAppName/API/AccountGroups?Safe=$($Safe | Get-EscapedString)"
+			Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
+
+			#Create URL for Request
+			$URI = "$baseURI/$PVWAAppName/API/AccountGroups?Safe=$($Safe | Get-EscapedString)"
+
+		}
+
+		Else {
+
+			[System.Version]$RequiredVersion = "10.5"
+
+			Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $RequiredVersion
+
+			#Create URL for Request
+			$URI = "$baseURI/$PVWAAppName/API/Safes/$($Safe | Get-EscapedString)/AccountGroups"
+
+		}
 
 		#send request to PAS web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -Headers $sessionToken -WebSession $WebSession

--- a/psPAS/Functions/Accounts/Add-PASDiscoveredAccount.ps1
+++ b/psPAS/Functions/Accounts/Add-PASDiscoveredAccount.ps1
@@ -130,8 +130,7 @@ All parameters can be piped by property name
 .LINK
 
 #>
-	#[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '', Justification = "Username not used for authentication")]
-	#[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', 'lastPasswordSetDateTime', Justification = "Parameter does not hold password")]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '', Justification = "Username not used for authentication")]
 	[CmdletBinding(DefaultParameterSetName = "Windows")]
 	param(
 		[parameter(
@@ -425,7 +424,7 @@ All parameters can be piped by property name
 		if($result) {
 
 			#Return Results
-			$result | Add-ObjectDetail -PropertyToAdd @{
+			$result | Add-ObjectDetail -DefaultProperties id, status -PropertyToAdd @{
 
 				"sessionToken"    = $sessionToken
 				"WebSession"      = $WebSession

--- a/psPAS/Functions/Accounts/Add-PASDiscoveredAccount.ps1
+++ b/psPAS/Functions/Accounts/Add-PASDiscoveredAccount.ps1
@@ -1,0 +1,313 @@
+﻿function Add-PASDiscoveredAccount {
+	<#
+.SYNOPSIS
+Adds discovered account or SSH key as a pending account in the accounts feed.
+
+.DESCRIPTION
+Enables an account or SSH key that is discovered by an external scanner to be added
+as a pending account to the Accounts Feed.
+Users can identify privileged accounts and determine which are on-boarded to the vault.
+
+.PARAMETER UserName
+The name of the account user
+
+.PARAMETER Address
+The name or address of the machine where the account is used.
+
+.PARAMETER discoveryDate
+The date when the account was discovered.
+
+.PARAMETER accountEnabled
+The account status in the discovery source.
+
+.PARAMETER OSGroups
+The name of the group that the account belongs to
+
+.PARAMETER platformType
+Platform where discovered account is used
+
+.PARAMETER Domain
+The domain of the account.
+
+.PARAMETER LastLogonDate
+Date, according to discovery source, when the account was last used to logon.
+
+.PARAMETER LastPasswordSetDateTime
+Date, according to discovery source, when the password for the account was last set
+
+.PARAMETER PasswordNeverExpires
+If the password will ever expire in the discovery source
+
+.PARAMETER OSVersion
+OS Version where the account was discovered
+
+.PARAMETER privileged
+Whether the discovered account is privileged or non-privileged.
+
+.PARAMETER privilegedCriteria
+Criteria that determines whether or not the discovered account is privileged.
+For example, the user or groupname, etc.
+Separate multiple strings with ";".
+
+.PARAMETER UserDisplayName
+User's display name
+
+.PARAMETER Description
+A description of the user, as defined in the discovery source.
+This will be saved as an account after it is added to the pending accounts.
+
+.PARAMETER passwordExpirationDateTime
+The account expiration date defined in the discovery source.
+
+.PARAMETER OSFamily
+The type of machine where the account was discovered.
+
+.PARAMETER additionalProperties
+
+.PARAMETER organizationalUnit
+.PARAMETER platformTypeAccountProperties
+.PARAMETER
+.PARAMETER sessionToken
+Hashtable containing the session token returned from New-PASSession
+
+.PARAMETER WebSession
+WebRequestSession object returned from New-PASSession
+
+.PARAMETER BaseURI
+PVWA Web Address
+Do not include "/PasswordVault/"
+
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
+.EXAMPLE
+$token | Add-PASPendingAccount -UserName Administrator -Address ServerA.domain.com -AccountDiscoveryDate 2017-01-01T00:00:00Z `
+-AccountEnabled enabled
+
+Adds matching discovered account as pending account.
+
+.INPUTS
+All parameters can be piped by property name
+
+.OUTPUTS
+None
+
+.NOTES
+
+.LINK
+
+#>
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '', Justification = "Username not used for authentication")]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', 'LastPasswordSet', Justification = "Parameter does not hold password")]
+	[CmdletBinding()]
+	param(
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[string]$UserName,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$Address,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[datetime]$AccountDiscoveryDate,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateSet("Windows", "Unix")]
+		[string]$OSType,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateSet("enabled", "disabled")]
+		[string]$AccountEnabled,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$AccountOSGroups,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateSet("domain", "local")]
+		[string]$AccountType,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$DiscoveryPlatformType,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$Domain,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$LastLogonDate,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$LastPasswordSet,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[boolean]$PasswordNeverExpires,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$OSVersion,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$OU,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateSet("Privileged", "Non-privileged")]
+		[string]$AccountCategory,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$AccountCategoryCriteria,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$UserDisplayName,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$AccountDescription,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$AccountExpirationDate,
+
+		[string]$UID,
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$GID,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateSet("Workstation", "Server")]
+		[string]$MachineOSFamily,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[hashtable]$sessionToken,
+
+		[parameter(
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[Microsoft.PowerShell.Commands.WebRequestSession]$WebSession,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$BaseURI,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$PVWAAppName = "PasswordVault"
+	)
+
+	BEGIN {}#begin
+
+	PROCESS {
+
+		#Create URL for Request
+		$URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/PendingAccounts"
+
+		#Get all parameters that will be sent in the request
+		$boundParameters = $PSBoundParameters | Get-PASParameter
+
+		If($PSBoundParameters.ContainsKey("AccountDiscoveryDate")) {
+
+			#Convert ExpiryDate to string in Required format
+			$Date = (Get-Date $AccountDiscoveryDate.ToUniversalTime() -Format "yyyy-MM-ddTHH:mm:ssZ").ToString()
+
+			#Include date string in request
+			$boundParameters["AccountDiscoveryDate"] = $Date
+
+		}
+
+		#Create body of request
+		$body = @{
+
+			#pendingaccount node
+			"pendingAccount" = $boundParameters | Get-PASParameter
+
+			#JSON object
+		} | ConvertTo-Json
+
+		#send request to PAS web service
+		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -Headers $sessionToken -WebSession $WebSession
+
+		if($result) {
+
+			#Return Results
+			$result | Add-ObjectDetail -PropertyToAdd @{
+
+				"sessionToken"    = $sessionToken
+				"WebSession"      = $WebSession
+				"BaseURI"         = $BaseURI
+				"PVWAAppName"     = $PVWAAppName
+				"ExternalVersion" = $ExternalVersion
+
+			}
+
+		}
+
+	}#process
+
+	END {}#end
+}

--- a/psPAS/Functions/Accounts/Add-PASDiscoveredAccount.ps1
+++ b/psPAS/Functions/Accounts/Add-PASDiscoveredAccount.ps1
@@ -243,13 +243,6 @@ All parameters can be piped by property name
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("Windows", "Unix")]
-		[string]$OSType,
-
-		[parameter(
-			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true
-		)]
 		[hashtable]$additionalProperties,
 
 		[parameter(

--- a/psPAS/Functions/Connections/Get-PASPSMConnectionParameter.ps1
+++ b/psPAS/Functions/Connections/Get-PASPSMConnectionParameter.ps1
@@ -178,7 +178,7 @@ Ad-Hoc connections require 10.5
 			ParameterSetName = "PSMConnect"
 		)]
 		[parameter(
-			Mandatory = $false,
+			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = "AdHocConnect"
 		)]

--- a/psPAS/Functions/Connections/Get-PASPSMConnectionParameter.ps1
+++ b/psPAS/Functions/Connections/Get-PASPSMConnectionParameter.ps1
@@ -14,6 +14,21 @@ or the HTML5 Gateway.
 .PARAMETER AccountID
 The unique ID of the account to retrieve and use to connect to the target via PSM
 
+.PARAMETER userName
+For Ad-Hoc connections: the username of the account to connect with.
+
+.PARAMETER secret
+For Ad-Hoc connections: The target account password.
+
+.PARAMETER address
+For Ad-Hoc connections: The target account address.
+
+.PARAMETER platformID
+For Ad-Hoc connections: A configured secure connect platform.
+
+.PARAMETER extraFields
+For Ad-Hoc connections: Additional needed parameters for the various connection components.
+
 .PARAMETER reason
 The reason that is required to request access to this account.
 
@@ -71,6 +86,7 @@ To force all output to be shown, pipe to Select-Object *
 .NOTES
 Minimum CyberArk Version 9.10
 PSMGW connections require 10.2
+Ad-Hoc connections require 10.5
 
 .LINK
 
@@ -79,46 +95,116 @@ PSMGW connections require 10.2
 	param(
 		[parameter(
 			Mandatory = $true,
-			ValueFromPipelinebyPropertyName = $true
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "PSMConnect"
 		)]
 		[ValidateNotNullOrEmpty()]
 		[string]$AccountID,
 
 		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "AdHocConnect"
+		)]
+		[string]$userName,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "AdHocConnect"
+		)]
+		[securestring]$secret,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "AdHocConnect"
+		)]
+		[string]$address,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "AdHocConnect"
+		)]
+		[string]$platformID,
+
+		[parameter(
 			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "AdHocConnect"
+		)]
+		[string]$extraFields,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "PSMConnect"
+		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "AdHocConnect"
 		)]
 		[string]$reason,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Ticketing"
+			ParameterSetName = "PSMConnect"
+		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "AdHocConnect"
 		)]
 		[string]$TicketingSystemName,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Ticketing"
+			ParameterSetName = "PSMConnect"
+		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "AdHocConnect"
 		)]
 		[string]$TicketId,
 
 		[parameter(
 			Mandatory = $true,
-			ValueFromPipelinebyPropertyName = $true
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "PSMConnect"
+		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "AdHocConnect"
 		)]
 		[string]$ConnectionComponent,
 
 		[parameter(
 			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "PSMConnect"
+		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "AdHocConnect"
 		)]
 		[hashtable]$ConnectionParams,
 
 		[parameter(
 			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "PSMConnect"
+		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "AdHocConnect"
 		)]
 		[ValidateSet("RDP", "PSMGW")]
 		[string]$ConnectionMethod,
@@ -158,14 +244,52 @@ PSMGW connections require 10.2
 	BEGIN {
 		$MinimumVersion = [System.Version]"9.10"
 		$RequiredVersion = [System.Version]"10.2"
+		$AdHocVersion = [System.Version]"10.5"
+
+		$AdHocParameters = @("ConnectionComponent", "reason", "ticketingSystemName", "ticketId")
+
+
 	}#begin
 
 	PROCESS {
 
-		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
+		if($PSCmdlet.ParameterSetName -eq "PSMConnect") {
 
-		#Create URL for Request
-		$URI = "$baseURI/$PVWAAppName/API/Accounts/$($AccountID)/PSMConnect"
+			Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
+
+			#Create URL for Request
+			$URI = "$baseURI/$PVWAAppName/API/Accounts/$($AccountID)/PSMConnect"
+
+			#Create body of request
+			$body = $PSBoundParameters | Get-PASParameter -ParametersToRemove AccountID, ConnectionMethod | ConvertTo-Json
+
+		} elseif($PSCmdlet.ParameterSetName -eq "AdHocConnect") {
+
+			Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $AdHocVersion
+
+			#Create URL for Request
+			$URI = "$baseURI/$PVWAAppName/API/Accounts/AdHocConnect"
+
+			#Get all parameters that will be sent in the request
+			$boundParameters = $PSBoundParameters | Get-PASParameter
+
+			#Include decoded password in request
+			$boundParameters["secret"] = $(ConvertTo-InsecureString -SecureString $secret)
+
+			$PSMConnectPrerequisites = @{}
+
+			$boundParameters.keys | Where-Object {$AdHocParameters -contains $_} | ForEach-Object {
+
+				#add key=value to hashtable
+				$PSMConnectPrerequisites[$_] = $boundParameters[$_]
+
+			}
+
+			$boundParameters["PSMConnectPrerequisites"] = $PSMConnectPrerequisites
+
+			$body = $boundParameters | Get-PASParameter -ParametersToRemove $AdHocParameters | ConvertTo-Json -Depth 4
+
+		}
 
 		$Header = $sessionToken
 
@@ -191,9 +315,6 @@ PSMGW connections require 10.2
 			$Header["Accept"] = $Accept
 
 		}
-
-		#Create body of request
-		$body = $PSBoundParameters | Get-PASParameter -ParametersToRemove AccountID, ConnectionMethod | ConvertTo-Json
 
 		#send request to PAS web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $body -Headers $Header -WebSession $WebSession

--- a/psPAS/Functions/LDAPDirectories/Get-PASDirectory.ps1
+++ b/psPAS/Functions/LDAPDirectories/Get-PASDirectory.ps1
@@ -8,6 +8,9 @@ Returns a list of existing directories in the Vault.
 Each directory will be returned with its own data.
 Membership of the Vault Admins group required.
 
+.PARAMETER id
+The ID or Name of the directory to return information on.
+
 .PARAMETER sessionToken
 Hashtable containing the session token returned from New-PASSession
 
@@ -45,6 +48,14 @@ LDAP Directory Details
 #>
 	[CmdletBinding()]
 	param(
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "v10_5"
+		)]
+		[Alias("DomainName")]
+		[string]$id,
+
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
@@ -87,6 +98,16 @@ LDAP Directory Details
 
 		#Create URL for request
 		$URI = "$baseURI/$PVWAAppName/api/Configuration/LDAP/Directories"
+
+		if($PSCmdlet.ParameterSetName -eq "v10_5") {
+
+			[System.Version]$RequiredVersion = "10.5"
+			Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $RequiredVersion
+
+			#Update URL for request
+			$URI = "$URI/$id/"
+
+		}
 
 		#send request to web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -Headers $sessionToken -WebSession $WebSession

--- a/psPAS/Functions/Monitoring/Connect-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Connect-PASPSMSession.ps1
@@ -1,0 +1,149 @@
+function Connect-PASPSMSession {
+	<#
+.SYNOPSIS
+Connect to Live PSM Sessions
+
+.DESCRIPTION
+Returns connection data necessary to monitor an active PSM session.
+
+.PARAMETER SessionId
+The unique ID of the PSM Live Session.
+
+.PARAMETER ConnectionMethod
+The expected parameters to be returned, either RDP or PSMGW.
+
+.PARAMETER sessionToken
+Hashtable containing the session token returned from New-PASSession
+
+.PARAMETER WebSession
+WebRequestSession object returned from New-PASSession
+
+.PARAMETER BaseURI
+PVWA Web Address
+Do not include "/PasswordVault/"
+
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
+.PARAMETER ExternalVersion
+The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+If the minimum version requirement of this function is not satisfied, execution will be halted.
+Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
+.EXAMPLE
+$token | Connect-PASPSMSession -LiveSessionId $SessionUUID -ConnectionMethod RDP
+
+Returns parameters to connect to Live PSM Session via RDP.
+
+.EXAMPLE
+$token | Connect-PASPSMSession -LiveSessionId $SessionUUID -ConnectionMethod PSMGW
+
+Returns parameters to connect to Live PSM Session via HTML5 GW.
+
+.INPUTS
+
+.OUTPUTS
+
+.NOTES
+Minimum CyberArk Version 10.5
+
+.LINK
+
+#>
+	[CmdletBinding()]
+	param(
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[string]$SessionId,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateSet("RDP", "PSMGW")]
+		[string]$ConnectionMethod,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[hashtable]$sessionToken,
+
+		[parameter(
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[Microsoft.PowerShell.Commands.WebRequestSession]$WebSession,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$BaseURI,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
+	)
+
+	BEGIN {
+		$MinimumVersion = [System.Version]"10.5"
+	}#begin
+
+	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
+
+		#Create URL for Request
+		$URI = "$baseURI/$PVWAAppName/API/LiveSessions/$($SessionId | Get-EscapedString)/monitor"
+
+		$Header = $sessionToken
+
+		#if a connection method is specified
+		If($PSBoundParameters.ContainsKey("ConnectionMethod")) {
+
+			#The information needs to passed in the header
+			if($PSBoundParameters["ConnectionMethod"] -eq "RDP") {
+
+				#RDP accept "application/json" response
+				$Accept = "application/json"
+
+			} elseif($PSBoundParameters["ConnectionMethod"] -eq "PSMGW") {
+
+				#PSMGW accept * / * response
+				$Accept = "* / *"
+
+			}
+
+			#add detail to header
+			$Header["Accept"] = $Accept
+
+		}
+
+		#send request to PAS web service
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET -Headers $Header -WebSession $WebSession
+
+		If($result) {
+
+			$result
+
+		} #process
+
+	}
+
+	END {}#end
+
+}

--- a/psPAS/Functions/OnboardingRules/Set-PASOnboardingRule.ps1
+++ b/psPAS/Functions/OnboardingRules/Set-PASOnboardingRule.ps1
@@ -1,0 +1,258 @@
+﻿function Set-PASOnboardingRule {
+	<#
+.SYNOPSIS
+Updates an automatic onboarding rule.
+
+.DESCRIPTION
+Updates an existing automatic onboarding rule.
+
+.PARAMETER Id
+The ID of the rule to update.
+
+.PARAMETER TargetPlatformID
+The ID of the platform that will be associated to the on-boarded account.
+
+.PARAMETER TargetSafeName
+The name of the Safe where the on-boarded account will be stored.
+
+.PARAMETER IsAdminIDFilter
+Whether or not UNIX accounts with UID=0 or Windows accounts with SID ending in 500 will be onboarded automatically
+using this rule.
+If set to false, all accounts matching the rule will be onboarded.
+
+.PARAMETER MachineTypeFilter
+The Machine Type by which to filter.
+Leave blank for "Any"
+
+.PARAMETER SystemTypeFilter
+The System Type by which to filter.
+
+.PARAMETER UserNameFilter
+The name of the user by which to filter.
+
+.PARAMETER UserNameMethod
+The method to use when applying the user name filter (Equals / Begins with/ Ends with).
+This parameter is ignored if UserNameFilter is not specified.
+
+.PARAMETER AddressFilter
+IP Address or DNS name of the machine by which to filter.
+
+.PARAMETER AddressMethod
+The method to use when applying the address filter (Equals / Begins with/ Ends with).
+This parameter is ignored if AddressFilter is not specified.
+
+.PARAMETER AccountCategoryFilter
+Filter for Privileged or Non-Privileged accounts.
+
+.PARAMETER RuleName
+Name of the rule
+If left blank, a name will be generated automatically.
+
+.PARAMETER RuleDescription
+A description of the rule.
+
+.PARAMETER sessionToken
+Hashtable containing the session token returned from New-PASSession
+
+.PARAMETER WebSession
+WebRequestSession object returned from New-PASSession
+
+.PARAMETER BaseURI
+PVWA Web Address
+Do not include "/PasswordVault/"
+
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
+.PARAMETER ExternalVersion
+The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+If the minimum version requirement of this function is not satisfied, execution will be halted.
+Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
+.EXAMPLE
+$token | Set-PASOnboardingRule -Id 1 -TargetPlatformId WINDOMAIN -TargetSafeName SafeName -SystemTypeFilter Windows
+
+Updates Onboarding Rule with ID 1
+
+.INPUTS
+All parameters can be piped by property name
+
+.OUTPUTS
+Outputs Object of Custom Type psPAS.CyberArk.Vault.OnboardingRule
+SessionToken, WebSession, BaseURI are passed through and
+contained in output object for inclusion in subsequent
+pipeline operations.
+
+Output format is defined via psPAS.Format.ps1xml.
+To force all output to be shown, pipe to Select-Object *
+
+.NOTES
+Minimum Version: 10.5
+
+.LINK
+
+#>
+	[CmdletBinding(SupportsShouldProcess)]
+	param(
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[int]$Id,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateLength(1, 99)]
+		[string]$TargetPlatformId,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateLength(1, 28)]
+		[string]$TargetSafeName,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[boolean]$IsAdminIDFilter,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateSet("Workstation", "Server")]
+		[string]$MachineTypeFilter,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateSet("Windows", "Unix")]
+		[string]$SystemTypeFilter,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateLength(0, 512)]
+		[string]$UserNameFilter,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateSet("Equals", "Begins", "Ends")]
+		[string]$UserNameMethod,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateLength(0, 255)]
+		[string]$AddressFilter,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateSet("Equals", "Begins", "Ends")]
+		[string]$AddressMethod,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateSet("Any", "Privileged", "NonPrivileged")]
+		[string]$AccountCategoryFilter,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateLength(0, 255)]
+		[string]$RuleName,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateLength(0, 255)]
+		[string]$RuleDescription,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[hashtable]$sessionToken,
+
+		[parameter(
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[Microsoft.PowerShell.Commands.WebRequestSession]$WebSession,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$BaseURI,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
+	)
+
+	BEGIN {
+		$MinimumVersion = [System.Version]"10.5"
+	}#begin
+
+	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
+
+		#Create URL for request
+		$URI = "$baseURI/$PVWAAppName/api/AutomaticOnboardingRules/$Id"
+
+		#create request body
+		$body = $PSBoundParameters | Get-PASParameter -ParametersToRemove Id | ConvertTo-Json
+
+		if($PSCmdlet.ShouldProcess($TargetPlatformId, "Update On-Boarding Rule $ID")) {
+
+			#send request to web service
+			$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body -Headers $sessionToken -WebSession $WebSession
+
+			if($result) {
+
+				$result | Add-ObjectDetail -typename psPAS.CyberArk.Vault.OnboardingRule -PropertyToAdd @{
+
+					"sessionToken"    = $sessionToken
+					"WebSession"      = $WebSession
+					"BaseURI"         = $BaseURI
+					"PVWAAppName"     = $PVWAAppName
+					"ExternalVersion" = $ExternalVersion
+
+				}
+
+			}
+
+		}
+
+	}#process
+
+	END {}#end
+
+}

--- a/psPAS/Functions/User/Get-PASGroup.ps1
+++ b/psPAS/Functions/User/Get-PASGroup.ps1
@@ -7,7 +7,7 @@ List groups from the vault
 Returns a list of all existing user groups.
 
 The user performing this task:
-- Must have Audit users permissions in the Safe.
+- Must have Audit users permissions in the Vault.
 - Can see groups either only on the same level, or lower in the Vault hierarchy.
 
 .PARAMETER filter
@@ -55,13 +55,19 @@ $token | Get-PASGroup -search "Vault Admins"
 
 Returns all groups matching all search terms
 
+.EXAMPLE
+$token | Get-PASGroup -search "Vault Admins" -filter 'groupType eq Directory'
+
+Returns all existing Directory groups matching all search terms
+
 .INPUTS
 All parameters can be piped by property name
 
 .OUTPUTS
-None
+psPAS.CyberArk.Vault.Group Object
 
 .NOTES
+Minimum Version 10.5
 
 .LINK
 

--- a/psPAS/Functions/User/Get-PASGroup.ps1
+++ b/psPAS/Functions/User/Get-PASGroup.ps1
@@ -1,0 +1,161 @@
+﻿function Get-PASGroup {
+	<#
+.SYNOPSIS
+List groups from the vault
+
+.DESCRIPTION
+Returns a list of all existing user groups.
+
+The user performing this task:
+- Must have Audit users permissions in the Safe.
+- Can see groups either only on the same level, or lower in the Vault hierarchy.
+
+.PARAMETER filter
+Filter according to REST standard.
+
+.PARAMETER search
+Search will match when ALL search terms appear in the group name.
+
+.PARAMETER sessionToken
+Hashtable containing the session token returned from New-PASSession
+
+.PARAMETER WebSession
+WebRequestSession object returned from New-PASSession
+
+.PARAMETER BaseURI
+PVWA Web Address
+Do not include "/PasswordVault/"
+
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
+.PARAMETER ExternalVersion
+The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+If the minimum version requirement of this function is not satisfied, execution will be halted.
+Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
+.EXAMPLE
+$token | Get-PASGroup
+
+Returns all existing groups
+
+.EXAMPLE
+$token | Get-PASGroup -filter 'groupType eq Directory'
+
+Returns all existing Directory groups
+
+.EXAMPLE
+$token | Get-PASGroup -filter 'groupType eq Vault'
+
+Returns all existing Vault groups
+
+.EXAMPLE
+$token | Get-PASGroup -search "Vault Admins"
+
+Returns all groups matching all search terms
+
+.INPUTS
+All parameters can be piped by property name
+
+.OUTPUTS
+None
+
+.NOTES
+
+.LINK
+
+#>
+	[CmdletBinding()]
+	param(
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateSet("groupType eq Directory", "groupType eq Vault")]
+		[string]$filter,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$search,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[hashtable]$sessionToken,
+
+		[parameter(
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[Microsoft.PowerShell.Commands.WebRequestSession]$WebSession,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$BaseURI,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
+	)
+
+	BEGIN {
+		$MinimumVersion = [System.Version]"10.5"
+	}#begin
+
+	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
+
+		#Create URL for request
+		$URI = "$baseURI/$PVWAAppName/API/UserGroups"
+
+		#Get Parameters to include in request
+		$boundParameters = $PSBoundParameters | Get-PASParameter
+
+		#Create Query String, escaped for inclusion in request URL
+		$queryString = ($boundParameters.keys | ForEach-Object {
+
+				"$_=$($boundParameters[$_] | Get-EscapedString)"
+
+			}) -join '&'
+
+		#Build URL from base URL
+		$URI = "$URI`?$queryString"
+
+		#send request to web service
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET -Headers $sessionToken -WebSession $WebSession
+
+		if($result) {
+
+			$result.value | Add-ObjectDetail -typename psPAS.CyberArk.Vault.Group -PropertyToAdd @{
+
+				"sessionToken"    = $sessionToken
+				"WebSession"      = $WebSession
+				"BaseURI"         = $BaseURI
+				"PVWAAppName"     = $PVWAAppName
+				"ExternalVersion" = $ExternalVersion
+
+			}
+
+		}
+
+	}#process
+
+	END {}#end
+
+}

--- a/psPAS/Functions/User/Remove-PASGroupMember.ps1
+++ b/psPAS/Functions/User/Remove-PASGroupMember.ps1
@@ -109,13 +109,7 @@ None
 		if($PSCmdlet.ShouldProcess($GroupID, "Remove Group Member $Member")) {
 
 			#send request to web service
-			$result = Invoke-PASRestMethod -Uri $URI -Method DELETE -Headers $sessionToken -WebSession $WebSession
-
-			if($result) {
-
-				$result
-
-			}
+			Invoke-PASRestMethod -Uri $URI -Method DELETE -Headers $sessionToken -WebSession $WebSession
 
 		}
 

--- a/psPAS/Functions/User/Remove-PASGroupMember.ps1
+++ b/psPAS/Functions/User/Remove-PASGroupMember.ps1
@@ -1,0 +1,126 @@
+﻿function Remove-PASGroupMember {
+	<#
+.SYNOPSIS
+Removes a vault user from a group
+
+.DESCRIPTION
+Removes an existing member from an existing group in the vault
+
+.PARAMETER GroupID
+The ID of the group
+
+.PARAMETER Member
+The name of the group member
+
+.PARAMETER sessionToken
+Hashtable containing the session token returned from New-PASSession
+
+.PARAMETER WebSession
+WebRequestSession object returned from New-PASSession
+
+.PARAMETER BaseURI
+PVWA Web Address
+Do not include "/PasswordVault/"
+
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
+
+.PARAMETER ExternalVersion
+The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
+If the minimum version requirement of this function is not satisfied, execution will be halted.
+Omitting a value for this parameter, or supplying a version of "0.0" will skip the version check.
+
+.EXAMPLE
+$token | Remove-PASGroupMember -GroupID X1_Y2 -Member TargetUser
+
+Removes TargetUser from group
+
+.INPUTS
+All parameters can be piped by property name
+
+.OUTPUTS
+None
+
+.NOTES
+
+.LINK
+
+#>
+	[CmdletBinding(SupportsShouldProcess)]
+	param(
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[Alias("ID")]
+		[string]$GroupID,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[Alias("UserName")]
+		[string]$Member,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[hashtable]$sessionToken,
+
+		[parameter(
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[Microsoft.PowerShell.Commands.WebRequestSession]$WebSession,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$BaseURI,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$PVWAAppName = "PasswordVault",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[System.Version]$ExternalVersion = "0.0"
+
+	)
+
+	BEGIN {
+		$MinimumVersion = [System.Version]"10.5"
+	}#begin
+
+	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
+
+		#Create URL for request
+		$URI = "$baseURI/$PVWAAppName/API/UserGroups/$GroupID/members/$Member"
+
+		if($PSCmdlet.ShouldProcess($GroupID, "Remove Group Member $Member")) {
+
+			#send request to web service
+			$result = Invoke-PASRestMethod -Uri $URI -Method DELETE -Headers $sessionToken -WebSession $WebSession
+
+			if($result) {
+
+				$result
+
+			}
+
+		}
+
+	}#process
+
+	END {}#end
+
+}

--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -100,6 +100,7 @@ to ensure session persistence.
 		if ($PSVersionTable.PSEdition -eq "Core") {
 
 			$PSBoundParameters.Add("SkipHeaderValidation", $true)
+			$PSBoundParameters.Add("SslProtocol", "TLS12")
 
 		}
 

--- a/psPAS/psPAS.CyberArk.Vault.Group.Formats.ps1xml
+++ b/psPAS/psPAS.CyberArk.Vault.Group.Formats.ps1xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Configuration>
+	<ViewDefinitions>
+		<View>
+			<Name>psPAS.CyberArk.Vault.Group</Name>
+			<ViewSelectedBy>
+				<TypeName>psPAS.CyberArk.Vault.Group</TypeName>
+			</ViewSelectedBy>
+			<TableControl>
+				<TableHeaders>
+					<TableColumnHeader />
+					<TableColumnHeader />
+					<TableColumnHeader />
+					<TableColumnHeader />
+					<TableColumnHeader />
+					<TableColumnHeader />
+				</TableHeaders>
+				<TableRowEntries>
+					<TableRowEntry>
+						<TableColumnItems>
+							<TableColumnItem>
+								<PropertyName>id</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<PropertyName>groupName</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<PropertyName>groupType</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<PropertyName>location</PropertyName>
+							</TableColumnItem>
+						</TableColumnItems>
+					</TableRowEntry>
+				</TableRowEntries>
+			</TableControl>
+		</View>
+		<View>
+			<Name>psPAS.CyberArk.Vault.Group</Name>
+			<ViewSelectedBy>
+				<TypeName>psPAS.CyberArk.Vault.Group</TypeName>
+			</ViewSelectedBy>
+			<ListControl>
+				<ListEntries>
+					<ListEntry>
+						<ListItems>
+							<ListItem>
+								<PropertyName>id</PropertyName>
+							</ListItem>
+							<ListItem>
+								<PropertyName>groupName</PropertyName>
+							</ListItem>
+							<ListItem>
+								<PropertyName>groupType</PropertyName>
+							</ListItem>
+							<ListItem>
+								<PropertyName>description</PropertyName>
+							</ListItem>
+							<ListItem>
+								<PropertyName>location</PropertyName>
+							</ListItem>
+							<ListItem>
+								<PropertyName>directory</PropertyName>
+							</ListItem>
+							<ListItem>
+								<PropertyName>dn</PropertyName>
+							</ListItem>
+						</ListItems>
+					</ListEntry>
+				</ListEntries>
+			</ListControl>
+		</View>
+	</ViewDefinitions>
+</Configuration>

--- a/psPAS/psPAS.CyberArk.Vault.Group.Formats.ps1xml
+++ b/psPAS/psPAS.CyberArk.Vault.Group.Formats.ps1xml
@@ -12,8 +12,6 @@
 					<TableColumnHeader />
 					<TableColumnHeader />
 					<TableColumnHeader />
-					<TableColumnHeader />
-					<TableColumnHeader />
 				</TableHeaders>
 				<TableRowEntries>
 					<TableRowEntry>

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -163,7 +163,8 @@
 		'Set-PASPTARemediation',
 		'Get-PASPTARule',
 		'Set-PASPTARule',
-		'Add-PASPTARule'
+		'Add-PASPTARule',
+		'Get-PASGroup'
 	)
 
 	AliasesToExport   = @(

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -165,7 +165,8 @@
 		'Set-PASPTARule',
 		'Add-PASPTARule',
 		'Get-PASGroup',
-		'Remove-PASGroupMember'
+		'Remove-PASGroupMember',
+		'Set-PASOnboardingRule'
 	)
 
 	AliasesToExport   = @(

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -166,7 +166,8 @@
 		'Add-PASPTARule',
 		'Get-PASGroup',
 		'Remove-PASGroupMember',
-		'Set-PASOnboardingRule'
+		'Set-PASOnboardingRule',
+		'Add-PASDiscoveredAccount'
 	)
 
 	AliasesToExport   = @(

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -164,7 +164,8 @@
 		'Get-PASPTARule',
 		'Set-PASPTARule',
 		'Add-PASPTARule',
-		'Get-PASGroup'
+		'Get-PASGroup',
+		'Remove-PASGroupMember'
 	)
 
 	AliasesToExport   = @(

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -167,7 +167,8 @@
 		'Get-PASGroup',
 		'Remove-PASGroupMember',
 		'Set-PASOnboardingRule',
-		'Add-PASDiscoveredAccount'
+		'Add-PASDiscoveredAccount',
+		'Connect-PASPSMSession'
 	)
 
 	AliasesToExport   = @(

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -72,7 +72,7 @@
 		'psPAS.CyberArk.Vault.User.Formats.ps1xml',
 		'psPAS.CyberArk.Vault.Directory.Formats.ps1xml',
 		'psPAS.CyberArk.Vault.PTA.Formats.ps1xml',
-		'psPAS.CyberArk.Vault.Group.Formats'
+		'psPAS.CyberArk.Vault.Group.Formats.ps1xml'
 	)
 
 	# Functions to export from this module

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -71,7 +71,8 @@
 		'psPAS.CyberArk.Vault.Safe.Formats.ps1xml',
 		'psPAS.CyberArk.Vault.User.Formats.ps1xml',
 		'psPAS.CyberArk.Vault.Directory.Formats.ps1xml',
-		'psPAS.CyberArk.Vault.PTA.Formats.ps1xml'
+		'psPAS.CyberArk.Vault.PTA.Formats.ps1xml',
+		'psPAS.CyberArk.Vault.Group.Formats'
 	)
 
 	# Functions to export from this module


### PR DESCRIPTION
<!-- _A similar PR may already be submitted.
Please search existing `Pull Requests` before creating one._

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.  -->

## Summary

Includes support for CyberArk 10.5 features:

- Remove Group Members
- Get Groups
- Add Discovered Accounts
- Monitor Active PSM Session
- Update Automatic Onboarding Rule
- Get LDAP Directory by Name
- Get Safe Account Groups
- Connect with PSM (for Ad-Hoc Connections)

Also now explicitly specifies that TLS 1.2 is used for web requests when using PSCore.

## Test Plan

Developed and tested against 10.5 API.
Pester Tests updated or created where necessary

## Closes issues

Closes #109 #111 

<!--
## Code formatting

 See the `CONTRIBUTING` guide.

_Ensure your code adheres to the project's PowerShell Styleguide_
-->