### PR TITLE
Splat -TimeoutSec, Implement account pagination

### DIFF
--- a/psPAS/Functions/Accounts/Get-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccount.ps1
@@ -51,6 +51,10 @@ Separate keywords with a space.
 The name of a Safe to search. The search will be carried out only in the Safes in the Vault
 that the authenticated used is authorized to access.
 
+.PARAMETER TimeoutSec
+See Invoke-WebRequest
+Specify a timeout value in seconds
+
 .PARAMETER sessionToken
 Hashtable containing the session token returned from New-PASSession
 
@@ -135,6 +139,7 @@ To force all output to be shown, pipe to Select-Object *
 
 .NOTES
 New functionality added in version 10.4, limited functionality before this version.
+As of psPAS v2.5.1+, the use of 'limit' and 'offset' parameters is discouraged - nextLink functionality was added
 
 .LINK
 #>
@@ -199,6 +204,12 @@ New functionality added in version 10.4, limited functionality before this versi
 		)]
 		[ValidateLength(0, 28)]
 		[string]$Safe,
+		
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelineByPropertyName = $false
+		)]
+		[int]$TimeoutSec,
 
 		[parameter(
 			Mandatory = $true,
@@ -239,154 +250,167 @@ New functionality added in version 10.4, limited functionality before this versi
 		#Get Parameters to include in request
 		$boundParameters = $PSBoundParameters | Get-PASParameter
 
-	#Create Query String, escaped for inclusion in request URL
-	$query = ($boundParameters.keys | ForEach-Object {
+		#Create Query String, escaped for inclusion in request URL
+		$query = ($boundParameters.keys | ForEach-Object {
 
 			"$_=$($boundParameters[$_] | Get-EscapedString)"
 
 		}) -join '&'
 
-#Version 10.4 process
-If($PSCmdlet.ParameterSetName -match "v10") {
-
-	#check minimum version
-	Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
-
-	#assign new type name
-	$typeName = "psPAS.CyberArk.Vault.Account.V10"
-
-	#define base URL
-	$URI = "$baseURI/$PVWAAppName/api/Accounts"
-
-	If($PSCmdlet.ParameterSetName -eq "v10ByQuery") {
-		#define query URL
-		$URI = "$URI`?$query"
-	}
-
-	If($PSCmdlet.ParameterSetName -eq "v10ByID") {
-
-		#define "by ID" URL
-		$URI = "$URI/$id"
-
-	}
-
-}
-
-#legacy process
-If($PSCmdlet.ParameterSetName -eq "v9") {
-
-	#assign type name
-	$typeName = "psPAS.CyberArk.Vault.Account"
-
-	#Create request URL
-	$URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Accounts?$query"
-
-}
-
-#Send request to web service
-$result = Invoke-PASRestMethod -Uri $URI -Method GET -Headers $sessionToken -WebSession $WebSession
-
-if($result) {
-
-	#Get count of accounts found
-	$count = $($result.count)
-
-	#Version 10.4 individual account process
-	If($PSCmdlet.ParameterSetName -eq "v10ByID") {
-
-		$return = $result
-
-	}
-
-	#If accounts found
-	if($count -gt 0) {
-
-		Write-Verbose "Accounts Found: $count"
-
-		#Version 10.4 query process
-		If($PSCmdlet.ParameterSetName -eq "v10ByQuery") {
-
-			#get results
-			$return = ($result | Select-Object value).value
-
-	}
-
-	#legacy process
-	If($PSCmdlet.ParameterSetName -eq "v9") {
-
-		#If multiple accounts found
-		if($count -gt 1) {
-
-			#Alert that web service only displays information on first result
-			Write-Warning "$count matching accounts found. Only the first result will be returned"
-
+		#Version 10.4 process
+		If($PSCmdlet.ParameterSetName -match "v10") {
+		
+			#check minimum version
+			Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
+		
+			#assign new type name
+			$typeName = "psPAS.CyberArk.Vault.Account.V10"
+		
+			#define base URL
+			$URI = "$baseURI/$PVWAAppName/api/Accounts"
+		
+			If($PSCmdlet.ParameterSetName -eq "v10ByQuery") {
+				#define query URL
+				$URI = "$URI`?$query"
+			}
+		
+			If($PSCmdlet.ParameterSetName -eq "v10ByID") {
+		
+				#define "by ID" URL
+				$URI = "$URI/$id"
+		
+			}
+		
+		}
+		
+		#legacy process
+		If($PSCmdlet.ParameterSetName -eq "v9") {
+		
+			#assign type name
+			$typeName = "psPAS.CyberArk.Vault.Account"
+		
+			#Create request URL
+			$URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Accounts?$query"
+		
+		}
+		
+		#Send request to web service
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET -Headers $sessionToken -WebSession $WebSession -TimeoutSec $TimeoutSec
+		
+		if($result) {
+		
+			#Get count of accounts found
+			$count = $($result.count)
+		
+			#Version 10.4 individual account process
+			If($PSCmdlet.ParameterSetName -eq "v10ByID") {
+		
+				$return = $result
+		
+			}
+		
+			#If accounts found
+			if($count -gt 0) {
+		
+				Write-Verbose "Accounts Found: $count"
+		
+				#Version 10.4 query process
+				If($PSCmdlet.ParameterSetName -eq "v10ByQuery") {
+		
+					#get results
+					$AccountArray = @()
+					$AccountArray += ($result | Select-Object value).value
+		
+					#iterate any nextLinks
+					$NextLink = $result.nextLink
+					While ( $null -ne $NextLink ) {
+						Write-Verbose "Processing nextLink: $NextLink"
+						$URI = "$baseURI/$PVWAAppName/$NextLink"
+						$result = Invoke-PASRestMethod -Uri $URI -Method GET -Headers $sessionToken -WebSession $WebSession -TimeoutSec $TimeoutSec
+						$NextLink = $result.nextLink
+						$AccountArray += ($result | Select-Object value).value
+					}
+		
+					$return = $AccountArray
+		
+				}
+		
+				#legacy process
+				If($PSCmdlet.ParameterSetName -eq "v9") {
+			
+					#If multiple accounts found
+					if($count -gt 1) {
+			
+						#Alert that web service only displays information on first result
+						Write-Warning "$count matching accounts found. Only the first result will be returned"
+			
+					}
+			
+					#Get account details from search result
+					$account = ($result | Select-Object accounts).accounts
+					
+					#Get account properties from found account
+					$properties = ($account | Select-Object -ExpandProperty properties)
+					
+					#Get internal properties from found account
+					$InternalProperties = ($account | Select-Object -ExpandProperty InternalProperties)
+					
+					$InternalProps = New-object -TypeName psobject
+					
+					#For every account property
+					For($int = 0; $int -lt $InternalProperties.length; $int++) {
+					
+						$InternalProps |
+					
+							#Add each property name and value as object property of $InternalProps
+							Add-ObjectDetail -PropertyToAdd @{$InternalProperties[$int].key = $InternalProperties[$int].value } -Passthru $false
+					
+					}
+					
+					#Create output object
+					$return = New-object -TypeName psobject -Property @{
+					
+						#Internal Unique ID of Account
+						"AccountID"         = $($account | Select-Object -ExpandProperty AccountID)
+					
+						#InternalProperties object
+						"InternalProperties" = $InternalProps
+					
+					}
+					
+					#For every account property
+					For($int = 0; $int -lt $properties.length; $int++) {
+					
+						$return |
+					
+							#Add each property name and value to results
+							Add-ObjectDetail -PropertyToAdd @{$properties[$int].key = $properties[$int].value } -Passthru $false
+					
+					}
+					
+				}
+				
+			}
+				
+		}
+		
+		if($return) {
+		
+			#Return Results
+			$return | Add-ObjectDetail -typename $typeName -PropertyToAdd @{
+		
+				"sessionToken"    = $sessionToken
+				"WebSession"      = $WebSession
+				"BaseURI"         = $BaseURI
+				"PVWAAppName"     = $PVWAAppName
+				"ExternalVersion" = $ExternalVersion
+		
+			}
+		
 		}
 
-		#Get account details from search result
-		$account = ($result | Select-Object accounts).accounts
+	}#process
 
-	#Get account properties from found account
-	$properties = ($account | Select-Object -ExpandProperty properties)
-
-#Get internal properties from found account
-$InternalProperties = ($account | Select-Object -ExpandProperty InternalProperties)
-
-$InternalProps = New-object -TypeName psobject
-
-#For every account property
-For($int = 0; $int -lt $InternalProperties.length; $int++) {
-
-	$InternalProps |
-
-		#Add each property name and value as object property of $InternalProps
-		Add-ObjectDetail -PropertyToAdd @{$InternalProperties[$int].key = $InternalProperties[$int].value } -Passthru $false
-
-}
-
-#Create output object
-$return = New-object -TypeName psobject -Property @{
-
-	#Internal Unique ID of Account
-	"AccountID"         = $($account | Select-Object -ExpandProperty AccountID)
-
-#InternalProperties object
-"InternalProperties" = $InternalProps
-
-}
-
-#For every account property
-For($int = 0; $int -lt $properties.length; $int++) {
-
-	$return |
-
-		#Add each property name and value to results
-		Add-ObjectDetail -PropertyToAdd @{$properties[$int].key = $properties[$int].value } -Passthru $false
-
-}
-
-}
-
-}
-
-}
-
-if($return) {
-
-	#Return Results
-	$return | Add-ObjectDetail -typename $typeName -PropertyToAdd @{
-
-		"sessionToken"    = $sessionToken
-		"WebSession"      = $WebSession
-		"BaseURI"         = $BaseURI
-		"PVWAAppName"     = $PVWAAppName
-		"ExternalVersion" = $ExternalVersion
-
-	}
-
-}
-
-}#process
-
-END { }#end
+	END { }#end
 
 }

--- a/psPAS/Functions/Accounts/Get-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccount.ps1
@@ -204,7 +204,7 @@ As of psPAS v2.5.1+, the use of 'limit' and 'offset' parameters is discouraged -
 		)]
 		[ValidateLength(0, 28)]
 		[string]$Safe,
-		
+
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelineByPropertyName = $false
@@ -259,68 +259,68 @@ As of psPAS v2.5.1+, the use of 'limit' and 'offset' parameters is discouraged -
 
 		#Version 10.4 process
 		If($PSCmdlet.ParameterSetName -match "v10") {
-		
+
 			#check minimum version
 			Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
-		
+
 			#assign new type name
 			$typeName = "psPAS.CyberArk.Vault.Account.V10"
-		
+
 			#define base URL
 			$URI = "$baseURI/$PVWAAppName/api/Accounts"
-		
+
 			If($PSCmdlet.ParameterSetName -eq "v10ByQuery") {
 				#define query URL
 				$URI = "$URI`?$query"
 			}
-		
+
 			If($PSCmdlet.ParameterSetName -eq "v10ByID") {
-		
+
 				#define "by ID" URL
 				$URI = "$URI/$id"
-		
+
 			}
-		
+
 		}
-		
+
 		#legacy process
 		If($PSCmdlet.ParameterSetName -eq "v9") {
-		
+
 			#assign type name
 			$typeName = "psPAS.CyberArk.Vault.Account"
-		
+
 			#Create request URL
 			$URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Accounts?$query"
-		
+
 		}
-		
+
 		#Send request to web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -Headers $sessionToken -WebSession $WebSession -TimeoutSec $TimeoutSec
-		
+
 		if($result) {
-		
+
 			#Get count of accounts found
 			$count = $($result.count)
-		
+
 			#Version 10.4 individual account process
 			If($PSCmdlet.ParameterSetName -eq "v10ByID") {
-		
+
 				$return = $result
-		
+
 			}
-		
+
 			#If accounts found
 			if($count -gt 0) {
-		
+
 				Write-Verbose "Accounts Found: $count"
-		
+
 				#Version 10.4 query process
 				If($PSCmdlet.ParameterSetName -eq "v10ByQuery") {
-		
+
 					#get results
 					$AccountArray = @()
 					$AccountArray += ($result | Select-Object value).value
-		
+
 					#iterate any nextLinks
 					$NextLink = $result.nextLink
 					While ( $null -ne $NextLink ) {
@@ -330,83 +330,83 @@ As of psPAS v2.5.1+, the use of 'limit' and 'offset' parameters is discouraged -
 						$NextLink = $result.nextLink
 						$AccountArray += ($result | Select-Object value).value
 					}
-		
+
 					$return = $AccountArray
-		
+
 				}
-		
+
 				#legacy process
 				If($PSCmdlet.ParameterSetName -eq "v9") {
-			
+
 					#If multiple accounts found
 					if($count -gt 1) {
-			
+
 						#Alert that web service only displays information on first result
 						Write-Warning "$count matching accounts found. Only the first result will be returned"
-			
+
 					}
-			
+
 					#Get account details from search result
 					$account = ($result | Select-Object accounts).accounts
-					
+
 					#Get account properties from found account
 					$properties = ($account | Select-Object -ExpandProperty properties)
-					
+
 					#Get internal properties from found account
 					$InternalProperties = ($account | Select-Object -ExpandProperty InternalProperties)
-					
+
 					$InternalProps = New-object -TypeName psobject
-					
+
 					#For every account property
 					For($int = 0; $int -lt $InternalProperties.length; $int++) {
-					
+
 						$InternalProps |
-					
+
 							#Add each property name and value as object property of $InternalProps
 							Add-ObjectDetail -PropertyToAdd @{$InternalProperties[$int].key = $InternalProperties[$int].value } -Passthru $false
-					
+
 					}
-					
+
 					#Create output object
 					$return = New-object -TypeName psobject -Property @{
-					
+
 						#Internal Unique ID of Account
 						"AccountID"         = $($account | Select-Object -ExpandProperty AccountID)
-					
+
 						#InternalProperties object
 						"InternalProperties" = $InternalProps
-					
+
 					}
-					
+
 					#For every account property
 					For($int = 0; $int -lt $properties.length; $int++) {
-					
+
 						$return |
-					
+
 							#Add each property name and value to results
 							Add-ObjectDetail -PropertyToAdd @{$properties[$int].key = $properties[$int].value } -Passthru $false
-					
+
 					}
-					
+
 				}
-				
+
 			}
-				
+
 		}
-		
+
 		if($return) {
-		
+
 			#Return Results
 			$return | Add-ObjectDetail -typename $typeName -PropertyToAdd @{
-		
+
 				"sessionToken"    = $sessionToken
 				"WebSession"      = $WebSession
 				"BaseURI"         = $BaseURI
 				"PVWAAppName"     = $PVWAAppName
 				"ExternalVersion" = $ExternalVersion
-		
+
 			}
-		
+
 		}
 
 	}#process

--- a/psPAS/Functions/Safes/Get-PASSafe.ps1
+++ b/psPAS/Functions/Safes/Get-PASSafe.ps1
@@ -88,7 +88,7 @@ To force all output to be shown, pipe to Select-Object *
 			Mandatory = $false,
 			ValueFromPipelineByPropertyName = $false
 		)]
-		[int32]$TimeoutSec,
+		[int]$TimeoutSec,
 
 		[parameter(
 			Mandatory = $true,

--- a/psPAS/Functions/Safes/Get-PASSafe.ps1
+++ b/psPAS/Functions/Safes/Get-PASSafe.ps1
@@ -16,6 +16,10 @@ Query String for safe search in the vault
 Specify to find all safes.
 If SafeName or query are not specified, FindAll is the default behaviour.
 
+.PARAMETER TimeoutSec
+See Invoke-WebRequest
+Specify a timeout value in seconds
+
 .PARAMETER sessionToken
 Hashtable containing the session token returned from New-PASSession
 
@@ -79,6 +83,12 @@ To force all output to be shown, pipe to Select-Object *
 			ParameterSetName = "byAll"
 		)]
 		[switch]$FindAll,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelineByPropertyName = $false
+		)]
+		[int32]$TimeoutSec,
 
 		[parameter(
 			Mandatory = $true,
@@ -156,7 +166,7 @@ To force all output to be shown, pipe to Select-Object *
 		}
 
 		#send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -Headers $sessionToken -WebSession $WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET -Headers $sessionToken -WebSession $WebSession -TimeoutSec $TimeoutSec
 
 		If($result) {
 

--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -90,7 +90,7 @@ to ensure session persistence.
 		[switch]$UseDefaultCredentials,
 
 		[Parameter(Mandatory = $false)]
-		[int32]$TimeoutSec
+		[int]$TimeoutSec
 	)
 
 	Begin {

--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -38,6 +38,10 @@ Cannot be specified with SessionVariable
 See Invoke-WebRequest
 Used for Integrated Auth
 
+.PARAMETER TimeoutSec
+See Invoke-WebRequest
+Specify a timeout value in seconds
+
 .EXAMPLE
 
 .INPUTS
@@ -83,7 +87,10 @@ to ensure session persistence.
 		[Microsoft.PowerShell.Commands.WebRequestSession]$WebSession,
 
 		[Parameter(Mandatory = $false)]
-		[switch]$UseDefaultCredentials
+		[switch]$UseDefaultCredentials,
+
+		[Parameter(Mandatory = $false)]
+		[int32]$TimeoutSec
 	)
 
 	Begin {

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -4,7 +4,7 @@
 	RootModule        = 'psPAS.psm1'
 
 	# Version number of this module.
-	ModuleVersion     = '2.5.0'
+	ModuleVersion     = '2.5.1'
 
 	# ID used to uniquely identify this module
 	GUID              = '11c880d2-1430-4bd2-b6e8-f324741b460b'


### PR DESCRIPTION
<!-- _A similar PR may already be submitted.
Please search existing `Pull Requests` before creating one._

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.  -->

## Summary

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**:

Fixes #144 
Fixes #142 

## Changes to Code Flow
### Get-PasAccount
With the addition of the nextLink loop, the original uses of 'limit' and 'offset' are essentially invalidated.  There's not many real-world applications of these query parameters outside of pagination, so I believe this is an improvement on the parameters.  This caveat has been mentioned in the documentation fo Get-PASAccount.

## Test Plan
Verify Get-PASAccount returns more than 100 results, implementing the nextLink return value:
```$Test = $Token | Get-PASAccount -Verbose```

Verify Get-PASAccount returns more than 100 results, implementing the nextLink return value, and retains original query:
```$Test = $Token | Get-PASAccount -Verbose -limit 10 -offset 4 -search E```

Verify Get-PASSafe respects the TimeoutSec and fails pretty quickly
```$Test = $Token | Get-PASSafe -TimeoutSec 1```

Verify Get-PASSafe respects the TimeoutSec and does not time out until the specified value
```$Test = $Token | Get-PASSafe -TimeoutSec 1000```

## Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes. -->
Fixes #144 , #142 


<!--
## Code formatting

 See the `CONTRIBUTING` guide.

_Ensure your code adheres to the project's PowerShell Styleguide_
-->