### PR TITLE
Issue 152

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Update for new PTA API methods.
 - Support for CyberArk 10.8.
 
-## 2.5.10 (April 29th 2019)
+## 2.5.11 (April 30th 2019)
 
 - Updates
   - `Get-PASSafeMember`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,28 @@
 - Update for new PTA API methods.
 - Support for CyberArk 10.8.
 
-## 2.5.6 (April 6th 2019)
+## 2.5.10 (April 29th 2019)
+
+- Updates
+  - `Get-PASSafeMember`
+    - Added `MemberName` parameter
+      - Returns all safe permissions of a specific user.
+  - `Get-PASAccountActivity`
+    - Added Alias `id` to `AccountID` parameter
+  - `Invoke-PASCredChange`
+    - Added Alias `id` to `AccountID` parameter
+  - `Invoke-PASCredReconcile`
+    - Added Alias `id` to `AccountID` parameter
+  - `Invoke-PASCredVerify`
+    - Added Alias `id` to `AccountID` parameter
+  - `Start-PASCredChange`
+    - Added Alias `id` to `AccountID` parameter
+  - `Start-PASCredVerify`
+    - Added Alias `id` to `AccountID` parameter
+  - `Unlock-PASAccount`
+    - Added Alias `id` to `AccountID` parameter
+
+## 2.5.6 (April 11th 2019)
 
 - Fix
   - `Add-PASApplication`
@@ -13,7 +34,7 @@
 
 ## 2.5.2 (April 6th 2019)
 
-- Updated Functions
+- Updated Functions (Thanks [steveredden](https://github.com/steveredden)!)
   - `Get-PASAccount`
     - Support for nextLink implemented to return maximum number of query results.
     - TimeoutSec parameter added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@
 - Update for new PTA API methods.
 - Support for CyberArk 10.8.
 
+## 2.5.6 (April 6th 2019)
+
+- Fix
+  - `Add-PASApplication`
+    - Parameter `BusinessOwnerPhone` changed to `[string]` type
+
+## 2.5.2 (April 6th 2019)
+
+- Updated Functions
+  - `Get-PASAccount`
+    - Support for nextLink implemented to return maximum number of query results.
+    - TimeoutSec parameter added
+  - `Get-PASSafe`
+    - TimeoutSec parameter added
+
 ## 2.5.0 (March 28th 2019)
 
 ### Module update to cover CyberArk 10.7 API features

--- a/psPAS/Functions/Accounts/Get-PASAccountActivity.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccountActivity.ps1
@@ -62,6 +62,7 @@ To force all output to be shown, pipe to Select-Object *
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[Alias("id")]
 		[string]$AccountID,
 
 		[parameter(
@@ -95,7 +96,7 @@ To force all output to be shown, pipe to Select-Object *
 
 	)
 
-	BEGIN {}#begin
+	BEGIN { }#begin
 
 	PROCESS {
 
@@ -107,7 +108,7 @@ To force all output to be shown, pipe to Select-Object *
 		#Send request to web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -Headers $sessionToken -WebSession $WebSession
 
-		If($result) {
+		If ($result) {
 
 			#Return Results
 			$result.GetAccountActivitiesResult |
@@ -126,6 +127,6 @@ To force all output to be shown, pipe to Select-Object *
 
 	}#process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/Accounts/Invoke-PASCredChange.ps1
+++ b/psPAS/Functions/Accounts/Invoke-PASCredChange.ps1
@@ -110,6 +110,7 @@ function Invoke-PASCredChange {
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateNotNullOrEmpty()]
+		[Alias("id")]
 		[string]$AccountID,
 
 		[parameter(
@@ -216,7 +217,7 @@ function Invoke-PASCredChange {
 		$boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove UpdateVaultOnly, SetNextPassword, AccountID
 
 		#deal with NewCredentials SecureString
-		If($PSBoundParameters.ContainsKey("NewCredentials")) {
+		If ($PSBoundParameters.ContainsKey("NewCredentials")) {
 
 			Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $RequiredVersion
 
@@ -228,7 +229,7 @@ function Invoke-PASCredChange {
 		#create request body
 		$body = $boundParameters | ConvertTo-Json
 
-		if($PSCmdlet.ShouldProcess($AccountID, "Password: $($PSCmdlet.ParameterSetName) Value")) {
+		if ($PSCmdlet.ShouldProcess($AccountID, "Password: $($PSCmdlet.ParameterSetName) Value")) {
 
 			#send request to web service
 			Invoke-PASRestMethod -Uri $URI -Method POST -body $body -Headers $SessionToken -WebSession $WebSession
@@ -237,6 +238,6 @@ function Invoke-PASCredChange {
 
 	}#process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/Accounts/Invoke-PASCredReconcile.ps1
+++ b/psPAS/Functions/Accounts/Invoke-PASCredReconcile.ps1
@@ -57,6 +57,7 @@ function Invoke-PASCredReconcile {
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateNotNullOrEmpty()]
+		[Alias("id")]
 		[string]$AccountID,
 
 		[parameter(
@@ -102,7 +103,7 @@ function Invoke-PASCredReconcile {
 		#Create URL for request
 		$URI = "$baseURI/$PVWAAppName/API/Accounts/$AccountID/Reconcile"
 
-		if($PSCmdlet.ShouldProcess($AccountID, "Mark for password reconcile by CPM")) {
+		if ($PSCmdlet.ShouldProcess($AccountID, "Mark for password reconcile by CPM")) {
 
 			#send request to web service
 			Invoke-PASRestMethod -Uri $URI -Method POST -Headers $SessionToken -WebSession $WebSession
@@ -111,6 +112,6 @@ function Invoke-PASCredReconcile {
 
 	}#process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/Accounts/Invoke-PASCredVerify.ps1
+++ b/psPAS/Functions/Accounts/Invoke-PASCredVerify.ps1
@@ -52,6 +52,7 @@ Can be used in versions from v9.10.
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateNotNullOrEmpty()]
+		[Alias("id")]
 		[string]$AccountID,
 
 		[parameter(
@@ -97,7 +98,7 @@ Can be used in versions from v9.10.
 		#Create URL for request
 		$URI = "$baseURI/$PVWAAppName/API/Accounts/$AccountID/Verify"
 
-		if($PSCmdlet.ShouldProcess($AccountID, "Mark for Immediate Verification")) {
+		if ($PSCmdlet.ShouldProcess($AccountID, "Mark for Immediate Verification")) {
 
 			#send request to web service
 			Invoke-PASRestMethod -Uri $URI -Method POST -Headers $SessionToken -WebSession $WebSession
@@ -106,6 +107,6 @@ Can be used in versions from v9.10.
 
 	}#process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/Accounts/Start-PASCredChange.ps1
+++ b/psPAS/Functions/Accounts/Start-PASCredChange.ps1
@@ -64,6 +64,7 @@ None
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateNotNullOrEmpty()]
+		[Alias("id")]
 		[string]$AccountID,
 
 		[parameter(
@@ -109,7 +110,7 @@ None
 
 		#Create empty hashtable to hold objects for header
 		#CredChange header is non-standard
-		$header = @{}
+		$header = @{ }
 
 	}#begin
 
@@ -134,7 +135,7 @@ None
 		#create request body
 		$body = $boundParameters | ConvertTo-Json
 
-		if($PSCmdlet.ShouldProcess($AccountID, "Mark for Immediate Change by CPM")) {
+		if ($PSCmdlet.ShouldProcess($AccountID, "Mark for Immediate Change by CPM")) {
 
 			#send request to web service
 			Invoke-PASRestMethod -Uri $URI -Method PUT -body $body -Headers $header -WebSession $WebSession
@@ -143,6 +144,6 @@ None
 
 	}#process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/Accounts/Start-PASCredVerify.ps1
+++ b/psPAS/Functions/Accounts/Start-PASCredVerify.ps1
@@ -48,6 +48,7 @@ None
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateNotNullOrEmpty()]
+		[Alias("id")]
 		[string]$AccountID,
 
 		[parameter(
@@ -75,16 +76,16 @@ None
 		[string]$PVWAAppName = "PasswordVault"
 	)
 
-	BEGIN {}#begin
+	BEGIN { }#begin
 
 	PROCESS {
 
 		#Create URL for request
 		$URI = "$baseURI/$PVWAAppName/WebServices/PIMServices.svc/Accounts/$AccountID/VerifyCredentials"
 
-		$body = @{} | ConvertTo-Json
+		$body = @{ } | ConvertTo-Json
 
-		if($PSCmdlet.ShouldProcess($AccountID, "Mark for Immediate Verification")) {
+		if ($PSCmdlet.ShouldProcess($AccountID, "Mark for Immediate Verification")) {
 
 			#send request to web service
 			Invoke-PASRestMethod -Uri $URI -Method PUT -Body $body -Headers $SessionToken -WebSession $WebSession
@@ -93,6 +94,6 @@ None
 
 	}#process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/Accounts/Unlock-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Unlock-PASAccount.ps1
@@ -55,6 +55,7 @@ function Unlock-PASAccount {
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateNotNullOrEmpty()]
+		[Alias("id")]
 		[string]$AccountID,
 
 		[parameter(
@@ -82,14 +83,14 @@ function Unlock-PASAccount {
 		[string]$PVWAAppName = "PasswordVault"
 	)
 
-	BEGIN {}#begin
+	BEGIN { }#begin
 
 	PROCESS {
 
 		#Create URL for request
 		$URI = "$baseURI/$PVWAAppName/API/Accounts/$AccountID/CheckIn"
 
-		if($PSCmdlet.ShouldProcess($AccountID, "Check-In Exclusive Access Account")) {
+		if ($PSCmdlet.ShouldProcess($AccountID, "Check-In Exclusive Access Account")) {
 
 			#send request to web service
 			Invoke-PASRestMethod -Uri $URI -Method POST -Headers $SessionToken -WebSession $WebSession
@@ -98,6 +99,6 @@ function Unlock-PASAccount {
 
 	}#process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/LDAPDirectories/Add-PASDirectory.ps1
+++ b/psPAS/Functions/LDAPDirectories/Add-PASDirectory.ps1
@@ -61,7 +61,7 @@ Adds the Domain.Com directory to the vault
 
 .EXAMPLE
 $token | Add-PASDirectory -DirectoryType "MicrosoftADProfile.ini" -BindUsername "bind@domain.com" -BindPassword $pw -DomainName DOMAIN `
--DomainBaseContext "DC=DOMAIN,DC=COM" -HostAddresses "192.168.99.1","192.168.99.2" -DCList @(@{"Name"="192.168.99.1";"Port"=389;"SSLConnect"=$false},@{"Name"="192.168.99.1";"Port"=389;"SSLConnect"=$false}) -Port 389
+-DomainBaseContext "DC=DOMAIN,DC=COM" -DCList @(@{"Name"="192.168.99.1";"Port"=389;"SSLConnect"=$false},@{"Name"="192.168.99.1";"Port"=389;"SSLConnect"=$false}) -Port 389
 
 (For 10.7+) - Adds the Domain.Com directory to the vault
 
@@ -169,11 +169,11 @@ LDAP Directory Details
 
 	PROCESS {
 
-		if($PSCmdlet.ParameterSetName -eq "v10_7") {
+		if ($PSCmdlet.ParameterSetName -eq "v10_7") {
 
 			Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $RequiredVersion
 
-		} Elseif($PSCmdlet.ParameterSetName -eq "v10_4") {
+		} Elseif ($PSCmdlet.ParameterSetName -eq "v10_4") {
 
 			Assert-VersionRequirement -ExternalVersion $ExternalVersion -RequiredVersion $MinimumVersion
 
@@ -185,37 +185,37 @@ LDAP Directory Details
 		#Get request parameters
 		$boundParameters = $PSBoundParameters | Get-PASParameter
 
-	#deal with BindPassword SecureString
-	If($PSBoundParameters.ContainsKey("BindPassword")) {
+		#deal with BindPassword SecureString
+		If ($PSBoundParameters.ContainsKey("BindPassword")) {
 
-		#Include decoded bind password in request
-		$boundParameters["BindPassword"] = $(ConvertTo-InsecureString -SecureString $BindPassword)
-
-	}
-
-	$body = $boundParameters | ConvertTo-Json
-write-debug $body
-#send request to web service
-$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -Headers $sessionToken -WebSession $WebSession
-
-If($result) {
-
-	#Return Results
-	$result |
-
-		Add-ObjectDetail -typename psPAS.CyberArk.Vault.Directory.Extended -PropertyToAdd @{
-
-			"sessionToken"    = $sessionToken
-			"WebSession"      = $WebSession
-			"BaseURI"         = $BaseURI
-			"PVWAAppName"     = $PVWAAppName
-			"ExternalVersion" = $ExternalVersion
+			#Include decoded bind password in request
+			$boundParameters["BindPassword"] = $(ConvertTo-InsecureString -SecureString $BindPassword)
 
 		}
 
-}
+		$body = $boundParameters | ConvertTo-Json
+		write-debug $body
+		#send request to web service
+		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -Headers $sessionToken -WebSession $WebSession
 
-}#process
+		If ($result) {
 
-END { }#end
+			#Return Results
+			$result |
+
+			Add-ObjectDetail -typename psPAS.CyberArk.Vault.Directory.Extended -PropertyToAdd @{
+
+				"sessionToken"    = $sessionToken
+				"WebSession"      = $WebSession
+				"BaseURI"         = $BaseURI
+				"PVWAAppName"     = $PVWAAppName
+				"ExternalVersion" = $ExternalVersion
+
+			}
+
+		}
+
+	}#process
+
+	END { }#end
 }

--- a/psPAS/Functions/SafeMembers/Get-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Get-PASSafeMember.ps1
@@ -7,8 +7,16 @@ Lists the members of a Safe
 Lists the members of a Safe.
 View Safe Members permission is required.
 
+If a Safe Member Name is provided, the full permissions of the member on the Safe will be returned.
+Includes AccessWithoutConfirmation, InitiateCPMAccountManagementOperations, RequestsAuthorizationLevel &
+SpecifyNextAccountContent which are not included when querying by safe only.
+
 .PARAMETER SafeName
 The name of the safe to get the members of
+
+.PARAMETER MemberName
+Specify the name of a safe member to return their safe permissions in full.
+You cannot report on the permissions of the user authenticated to the API.
 
 .PARAMETER sessionToken
 Hashtable containing the session token returned from New-PASSession
@@ -27,11 +35,15 @@ Defaults to PasswordVault
 .PARAMETER ExternalVersion
 The External CyberArk Version, returned automatically from the New-PASSession function from version 9.7 onwards.
 
-
 .EXAMPLE
 $token | Get-PASSafeMember -SafeName Target_Safe
 
 Lists all members with permissions on Target_Safe
+
+.EXAMPLE
+$token | Get-PASSafeMember -SafeName Target_Safe -MemberName SomeUser
+
+Lists all permissions for member SomeUser on Target_Safe
 
 .INPUTS
 All parameters can be piped by property name
@@ -60,6 +72,15 @@ To force all output to be shown, pipe to Select-Object *
 		)]
 		[ValidateNotNullOrEmpty()]
 		[string]$SafeName,
+
+		[Alias("UserName")]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "MemberPermissions"
+		)]
+		[ValidateNotNullOrEmpty()]
+		[string]$MemberName,
 
 		[parameter(
 			Mandatory = $true,
@@ -93,7 +114,12 @@ To force all output to be shown, pipe to Select-Object *
 
 	)
 
-	BEGIN {}#begin
+	BEGIN {
+
+		$Method = "GET"
+		$Request = @{ }
+
+	}#begin
 
 	PROCESS {
 
@@ -102,21 +128,63 @@ To force all output to be shown, pipe to Select-Object *
 
             Get-EscapedString)/Members"
 
+		#Get full permissions for specific user on safe
+		if ($PSCmdlet.ParameterSetName -eq "MemberPermissions") {
+
+			#Create URL for member specific request
+			$URI = "$URI/$($MemberName | Get-EscapedString)"
+			#Send a PUT Request instead of GET
+			$Method = "PUT"
+			#Send an empty body
+			#Add to Request parameters for PUT Request
+			$Request["Body"] = @{"member" = @{ } } | ConvertTo-Json
+
+		}
+
+		#Build Request Parameters
+		$Request["URI"] = $URI
+		$Request["Method"] = $Method
+		$Request["Headers"] = $sessionToken
+		$Request["WebSession"] = $WebSession
+
 		#Send request to webservice
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -Headers $sessionToken -WebSession $WebSession
+		$result = Invoke-PASRestMethod @Request
 
-		if($result) {
+		if ($result) {
 
-			#output
-			$result.members | Select-Object UserName, @{Name = "Permissions"; "Expression" = {
+			if ($PSCmdlet.ParameterSetName -eq "MemberPermissions") {
 
-					($_.Permissions).psobject.properties |Where-Object {$_.Value -eq $true} |
+				#format output
+				$Output = $result.member | Select-Object MembershipExpirationDate,
 
-					Select-Object -ExpandProperty Name }
+				@{Name = "UserName"; "Expression" = {
 
-			} |
+						$MemberName }
 
-			Add-ObjectDetail -typename psPAS.CyberArk.Vault.Safe.Member -PropertyToAdd @{
+				},
+
+				@{Name = "Permissions"; "Expression" = {
+
+						$_.Permissions | Where-Object { $_.value } | Select-Object -ExpandProperty key }
+
+				}
+
+			}
+
+			Else {
+
+				#output
+				$Output = $result.members | Select-Object UserName, @{Name = "Permissions"; "Expression" = {
+
+						($_.Permissions).psobject.properties | Where-Object { $_.Value -eq $true } |
+
+						Select-Object -ExpandProperty Name }
+
+				}
+
+			}
+
+			$Output | Add-ObjectDetail -typename psPAS.CyberArk.Vault.Safe.Member -PropertyToAdd @{
 
 				"SafeName"        = $SafeName
 				"sessionToken"    = $sessionToken
@@ -131,6 +199,6 @@ To force all output to be shown, pipe to Select-Object *
 
 	}#process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -19,7 +19,7 @@
 	Copyright         = '(c) 2018 Pete Maan. All rights reserved.'
 
 	# Description of the functionality provided by this module
-	Description       = 'Module to expose CyberArk REST API/Web Service functions'
+	Description       = 'Module for CyberArk Privileged Access Security Web Service REST API'
 
 	# Minimum version of the Windows PowerShell engine required by this module
 	PowerShellVersion = '3.0'


### PR DESCRIPTION
## Summary

- Updates
  - `Get-PASSafeMember`
    - Added `MemberName` parameter
      - Returns all safe permissions of a specific user.
  - `Get-PASAccountActivity`
    - Added Alias `id` to `AccountID` parameter
  - `Invoke-PASCredChange`
    - Added Alias `id` to `AccountID` parameter
  - `Invoke-PASCredReconcile`
    - Added Alias `id` to `AccountID` parameter
  - `Invoke-PASCredVerify`
    - Added Alias `id` to `AccountID` parameter
  - `Start-PASCredChange`
    - Added Alias `id` to `AccountID` parameter
  - `Start-PASCredVerify`
    - Added Alias `id` to `AccountID` parameter
  - `Unlock-PASAccount`
    - Added Alias `id` to `AccountID` parameter

This PR fixes the following **bugs**: Fixed pipeline for passing AccountID to Get-PASAccountActivity
This PR implements the following **features**: Update to `Get-PASSafeMember` to return all permissions for a specific user.

## Closes issues

Fixes #152 

