### PR TITLE
Add Add-LDAPDirectory SSLConnect Parameter

### DIFF
--- a/psPAS/Functions/LDAPDirectories/Add-PASDirectory.ps1
+++ b/psPAS/Functions/LDAPDirectories/Add-PASDirectory.ps1
@@ -35,6 +35,9 @@ The address of the domain
 .PARAMETER DomainBaseContext
 The base context of the External Directory.
 
+.PARAMETER SSLConnect
+Whether or not to connect to the external directory with SSL.
+
 .PARAMETER sessionToken
 Hashtable containing the session token returned from New-PASSession
 
@@ -129,6 +132,12 @@ LDAP Directory Details
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[string]$DomainBaseContext,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[bool]$SSLConnect,
 
 		[parameter(
 			Mandatory = $true,

--- a/psPAS/Functions/LDAPDirectories/Add-PASDirectory.ps1
+++ b/psPAS/Functions/LDAPDirectories/Add-PASDirectory.ps1
@@ -36,7 +36,7 @@ The address of the domain
 The base context of the External Directory.
 
 .PARAMETER SSLConnect
-Whether or not to connect to the external directory with SSL.
+Boolean value defining whether or not to connect to the external directory with SSL.
 
 .PARAMETER sessionToken
 Hashtable containing the session token returned from New-PASSession
@@ -137,7 +137,7 @@ LDAP Directory Details
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[bool]$SSLConnect,
+		[boolean]$SSLConnect,
 
 		[parameter(
 			Mandatory = $true,


### PR DESCRIPTION
<!-- _A similar PR may already be submitted.
Please search existing `Pull Requests` before creating one._

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.  -->

## Summary

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**:

<!-- You can skip this if you're fixing a typo. -->

The "SSLConnect" parameter is required if adding LDAPS hosts. Without it, the following error is returned:

"LDAP Directory can't contains diffrenet DCs with diffrenet ports/ssl configurations". 

<!-- Example: When "Amended logic in function _X_ to achieve _Y_", explain why it is necessary to have a way to do _Y_. -->

## Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes. -->
Fixes #

Closes #

<!--
## Code formatting

 See the `CONTRIBUTING` guide.

_Ensure your code adheres to the project's PowerShell Styleguide_
-->