### PR TITLE
Allow connectionNumber for v10 API

### DIFF
--- a/psPAS/Functions/Authentication/New-PASSession.ps1
+++ b/psPAS/Functions/Authentication/New-PASSession.ps1
@@ -185,6 +185,11 @@ To force all output to be shown, pipe to Select-Object *
 			ValueFromPipeline = $false,
 			ParameterSetName = "v9"
 		)]
+		[Parameter(
+			Mandatory = $false,
+			ValueFromPipeline = $false,
+			ParameterSetName = "v10"
+		)]
 		[ValidateRange(1, 100)]
 		[int]$connectionNumber,
 

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -4,7 +4,7 @@
 	RootModule        = 'psPAS.psm1'
 
 	# Version number of this module.
-	ModuleVersion     = '2.6.17'
+	ModuleVersion     = '2.7.0'
 
 	# ID used to uniquely identify this module
 	GUID              = '11c880d2-1430-4bd2-b6e8-f324741b460b'


### PR DESCRIPTION
## Summary

This PR fixes/implements the following bugs:

During authentication, the "connectionNumber" parameter is available from version 9.0 (Cyberark accounts or version 9.7 (LDAP and Radius) onward. Since the parameter is not part of the v10 parameter set, you cannot use it with this module.

Expected behavior: 
$cred | New-PASSession -BaseURI "https://$CyberarkFQDN" -type LDAP -connectionNumber 42 | select -exp ConnectionNumber

64

Actual behavior:
$cred | New-PASSession -BaseURI "https://$CyberarkFQDN" -type LDAP -connectionNumber 42 | select -exp ConnectionNumber

New-PASSession : Parameter set cannot be resolved using the specified named parameters.

## Test Plan

none

## Closes issues

Fixes #

Closes #
