### PR TITLE
Add Client Certificate Authentication Support

### DIFF
--- a/Tests/Invoke-PASRestMethod.Tests.ps1
+++ b/Tests/Invoke-PASRestMethod.Tests.ps1
@@ -154,6 +154,42 @@ Describe $FunctionName {
 
 		}
 
+		Context "Shared Authentication" {
+			$RandomString = "ZDE0YTY3MzYtNTk5Ni00YjFiLWFhMWUtYjVjMGFhNjM5MmJiOzY0MjY0NkYyRkE1NjY3N0M7MDAwMDAwMDI4ODY3MDkxRDUzMjE3NjcxM0ZBODM2REZGQTA2MTQ5NkFCRTdEQTAzNzQ1Q0JDNkRBQ0Q0NkRBMzRCODcwNjA0MDAwMDAwMDA7"
+
+			$MockResult = [pscustomobject] @{
+
+				"headers"    = @{
+					"Content-Type" = "application/json"
+				};
+				"StatusCode" = 200;
+				"content"    = [PSCustomObject]@{
+
+					LogonResult = $RandomString
+
+				} | ConvertTo-Json
+			}
+
+			Mock Get-ParentFunction -MockWith {
+
+				[PSCustomObject]@{
+					FunctionName = "New-PASSession"
+				}
+
+			}
+
+			Mock Invoke-WebRequest -MockWith {
+
+				return $MockResult
+
+			}
+
+			It "handles shared authentication authentication LogonResult value" {
+				$result = Invoke-PASRestMethod @requestArgs2
+				$result.CyberArkLogonResult | Should Be $RandomString
+			}
+		}
+
 		Context "text/html responses" {
 
 			$MockResult = [pscustomobject] @{

--- a/Tests/New-PASSession.Tests.ps1
+++ b/Tests/New-PASSession.Tests.ps1
@@ -252,6 +252,18 @@ Describe $FunctionName {
 
 			}
 
+			It "includes expected certificate thumbprint in request" {
+
+				New-PASSession -BaseURI "https://P_URI" -UseSharedAuthentication -CertificateThumbprint "SomeCertificateThumbprint"
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$CertificateThumbprint -eq "SomeCertificateThumbprint"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
 			It "`$Script:ExternalVersion has expected value on Get-PASServer error" {
 				Mock Get-PASServer -MockWith {
 					throw "Some Error"

--- a/psPAS/Functions/Authentication/New-PASSession.ps1
+++ b/psPAS/Functions/Authentication/New-PASSession.ps1
@@ -72,6 +72,10 @@
 	See Invoke-WebRequest
 	Uses the credentials of the current user to send the web request
 
+	.PARAMETER CertificateThumbprint
+	See Invoke-WebRequest
+	The thumbprint of the certificate to use for client certificate authentication.
+
 	.EXAMPLE
 	Logon to Version 10 with LDAP credential:
 
@@ -135,6 +139,11 @@
 	Logon to Version 10 using RADIUS & Push Authentication (works with DUO 2FA):
 
 	New-PASSession -Credential $cred -BaseURI https://PVWA -type RADIUS -OTP push
+
+	.EXAMPLE
+	If authentication via certificates is configured, provide CertificateThumbprint details.
+
+	New-PASSession -UseSharedAuthentication -BaseURI https://pvwa.some.co -CertificateThumbprint 0e194289c57e666115109d6e2800c24fb7db6edb
 	#>
 	[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = "v10")]
 	param(
@@ -264,7 +273,14 @@
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $false
 		)]
-		[string]$SessionVariable = "PASSession"
+		[string]$SessionVariable = "PASSession",
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipeline = $false,
+			ValueFromPipelinebyPropertyName = $false
+		)]
+		[string]$CertificateThumbprint
 
 	)
 
@@ -277,6 +293,9 @@
 		$LogonRequest["Method"] = "POST"
 		$LogonRequest["SessionVariable"] = $SessionVariable
 		$LogonRequest["UseDefaultCredentials"] = $UseDefaultCredentials.IsPresent
+		If ($CertificateThumbprint) {
+			$LogonRequest["CertificateThumbprint"] = $CertificateThumbprint
+		}
 
 		Switch ($PSCmdlet.ParameterSetName) {
 
@@ -322,7 +341,7 @@
 	PROCESS {
 
 		#Get request parameters
-		$boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove Credential, UseV9API, SkipVersionCheck, UseDefaultCredentials
+		$boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove Credential, UseV9API, SkipVersionCheck, UseDefaultCredentials, CertificateThumbprint
 
 		If (($PSCmdlet.ParameterSetName -eq "v9") -or ($PSCmdlet.ParameterSetName -eq "v10") ) {
 

--- a/psPAS/Functions/Authentication/New-PASSession.ps1
+++ b/psPAS/Functions/Authentication/New-PASSession.ps1
@@ -52,13 +52,6 @@
 	If the SkipVersionCheck switch is specified, Get-PASServer will not be called after
 	successfully authenticating. Get-PASServer is not supported before version 9.7.
 
-	.PARAMETER SessionVariable
-	After successful execution of this function, and authentication to the Vault, a WebSession
-	object, that contains information about the connection and the request, including cookies,
-	will be created and passed back in the return object.
-	This can be passed to subsequent requests to ensure websessions are persistant when the
-	PAS Web Service exists accross PVWA servers behind a load balancer.
-
 	.PARAMETER BaseURI
 	A string containing the base web address to send te request to.
 	Pass the portion the PVWA HTTP address.
@@ -273,13 +266,6 @@
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $false
 		)]
-		[string]$SessionVariable = "PASSession",
-
-		[parameter(
-			Mandatory = $false,
-			ValueFromPipeline = $false,
-			ValueFromPipelinebyPropertyName = $false
-		)]
 		[string]$CertificateThumbprint
 
 	)
@@ -291,7 +277,7 @@
 
 		#Define Logon Request Parameters
 		$LogonRequest["Method"] = "POST"
-		$LogonRequest["SessionVariable"] = $SessionVariable
+		$LogonRequest["SessionVariable"] = "PASSession"
 		$LogonRequest["UseDefaultCredentials"] = $UseDefaultCredentials.IsPresent
 		If ($CertificateThumbprint) {
 			$LogonRequest["CertificateThumbprint"] = $CertificateThumbprint

--- a/psPAS/Functions/Authentication/New-PASSession.ps1
+++ b/psPAS/Functions/Authentication/New-PASSession.ps1
@@ -87,14 +87,14 @@
 	.EXAMPLE
 	Logon to Version 9 with credential:
 
-	New-PASSession -Credential $cred -BaseURI https://PVWA -UseV9API
+	New-PASSession -Credential $cred -BaseURI https://PVWA -UseClassicAPI
 
 	Request would be sent to PVWA URL https://PVWA/PasswordVault/
 
 	.EXAMPLE
 	Logon to Version 9 where PVWA Virtual Directory has non-default name:
 
-	New-PASSession -Credential $cred -BaseURI https://PVWA -PVWAAppName CustomVault -UseV9API
+	New-PASSession -Credential $cred -BaseURI https://PVWA -PVWAAppName CustomVault -UseClassicAPI
 
 	Request would be sent to PVWA URL https://PVWA/CustomVault/
 

--- a/psPAS/Functions/Authentication/New-PASSession.ps1
+++ b/psPAS/Functions/Authentication/New-PASSession.ps1
@@ -390,7 +390,7 @@
 
 						Set-Variable -Name ExternalVersion -Value $Version -Scope Script
 
-					} Catch { Write-Warning "Could Not Determine CyberArk Version" }
+					} Catch { }
 
 				}
 

--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -229,15 +229,32 @@ to ensure session persistence.
 							#Create Return Object from Returned JSON
 							$PASResponse = ConvertFrom-Json -InputObject $webResponse.content
 
-							#Handle Version 10 Logon Token Return
-							If (($CallingFunction -eq "New-PASSession") -and ($PASResponse.length -eq 180)) {
+							#Handle Logon Token Return
+							If ($CallingFunction -eq "New-PASSession") {
 
-								#If calling function is New-PASSession, and result is a 180 character token
-								#Create a new object and assign the token to the CyberArkLogonResult property.
-								#This ensures an object is returned instead of a string (which would cause issues).
-								$PASResponse = [PSCustomObject]@{
+								#Version 10
+								If ($PASResponse.length -eq 180) {
 
-									CyberArkLogonResult = $PASResponse
+									#If calling function is New-PASSession, and result is a 180 character string
+									#Create a new object and assign the token to the CyberArkLogonResult property.
+									$PASResponse = [PSCustomObject]@{
+
+										CyberArkLogonResult = $PASResponse
+
+									}
+
+								}
+
+								#Shared Auth
+								If ($PASResponse.LogonResult) {
+
+									#If calling function is New-PASSession, and result has a LogonResult property.
+									#Create a new object and assign the LogonResult value to the CyberArkLogonResult property.
+									$PASResponse = [PSCustomObject]@{
+
+										CyberArkLogonResult = $PASResponse.LogonResult
+
+									}
 
 								}
 

--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -42,6 +42,10 @@ Used for Integrated Auth
 See Invoke-WebRequest
 Specify a timeout value in seconds
 
+.PARAMETER CertificateThumbprint
+See Invoke-WebRequest
+The thumbprint of the certificate to use for client certificate authentication.
+
 .EXAMPLE
 
 .INPUTS
@@ -90,7 +94,10 @@ to ensure session persistence.
 		[switch]$UseDefaultCredentials,
 
 		[Parameter(Mandatory = $false)]
-		[int]$TimeoutSec
+		[int]$TimeoutSec,
+
+		[Parameter(Mandatory = $false)]
+		[string]$CertificateThumbprint
 	)
 
 	Begin {


### PR DESCRIPTION
## Summary

Implements support for providing a Certificate Thumbprint when Client Certificate Authentication is configured.

This PR implements the following **features**:

- Client Certificate Authentication Support
  - If IIS is configured to require certificates for authentication, details of a certificate thumbprint can be included in the initial authentication request to the api via `New-PASSession`.

This PR fixes the following **bugs**:

- Fixed Shared Authentication
  - Returned session token is now made available to other module functions
    - Previously, LogonResult property containing the session token would not have been saved.

## Test Plan

After providing details of a certificate thumbprint during authentication, the certificate details are saved as expected to the WebSession available in the script scope.
This websession is used for all other requests, and is be included in the web request workflow as required.
Example Websession with certificate details included:

````powershell
Headers                : {[Authorization, O00000000000565600==]}
Cookies                : System.Net.CookieContainer
UseDefaultCredentials  : False
Credentials            :
Certificates           : {[Subject]
                           CN=.....

                         [Issuer]
                           CN=......

                         [Serial Number]
                           420000000000000000000000000000000000006

                         [Not Before]
                           06/06/2019 11:07:57

                         [Not After]
                           05/06/2020 11:07:57

                         [Thumbprint]
                           0E194266657E666116669D666806664FB6666EDB
                         }
UserAgent              : Mozilla/5.0 (Windows NT 10.0; Microsoft Windows 10.0.17763; en-GB) PowerShell/6.2.1
Proxy                  :
MaximumRedirection     : -1
MaximumRetryCount      : 0
RetryIntervalInSeconds : 0
````

## Closes issues

Closes #115 
