### PR TITLE
Add Session Functions

### DIFF
--- a/Tests/Add-PASAccount.Tests.ps1
+++ b/Tests/Add-PASAccount.Tests.ps1
@@ -118,6 +118,7 @@ Describe $FunctionName {
 					"remoteMachines"                   = "someMachine"
 					"accessRestrictedToRemoteMachines" = $false
 				}
+				$Script:ExternalVersion = "0.0"
 
 			}
 
@@ -238,7 +239,6 @@ Describe $FunctionName {
 			}
 
 			It "throws error if version requirement not met" {
-$Script:ExternalVersion = "1.0"
 
 				$Script:ExternalVersion = "1.0"
 				{ $InputObjV10 | Add-PASAccount } | Should Throw
@@ -272,6 +272,7 @@ $Script:ExternalVersion = "1.0"
 					"automaticManagementEnabled" = $true
 					"remoteMachines"             = "someMachine"
 				}
+				$Script:ExternalVersion = "0.0"
 
 			}
 

--- a/Tests/Close-PASSession.Tests.ps1
+++ b/Tests/Close-PASSession.Tests.ps1
@@ -42,6 +42,10 @@ Describe $FunctionName {
 
 		}
 
+		Mock Clear-Variable -MockWith {
+
+		}
+
 		$response = Close-PASSession -UseV9API -verbose
 
 		Context "Input" {

--- a/Tests/Get-PASSession.Tests.ps1
+++ b/Tests/Get-PASSession.Tests.ps1
@@ -1,0 +1,71 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if ( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+	$Script:BaseURI = "https://SomeURL/SomeApp"
+	$Script:ExternalVersion = "0.0"
+	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Mock Get-PASLoggedOnUser -MockWith {
+			[PSCustomObject]@{"Username" = "SomeUser"; "Prop2" = "Val2" }
+		}
+
+		$response = Get-PASSession
+
+		Context "Standard Operation" {
+
+			it "provides output" {
+
+				$response | Should not BeNullOrEmpty
+
+			}
+
+			It "has output with expected number of properties" {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should Be 4
+
+			}
+
+			it "outputs object with expected typename" {
+
+				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Session
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Remove-PASAccount.Tests.ps1
+++ b/Tests/Remove-PASAccount.Tests.ps1
@@ -97,7 +97,7 @@ Describe $FunctionName {
 		}
 
 		Context "Input V10 API" {
-
+			$Script:ExternalVersion = "0.0"
 			$response = $InputObj | Remove-PASAccount
 
 			It "sends request" {

--- a/Tests/Remove-PASDirectory.Tests.ps1
+++ b/Tests/Remove-PASDirectory.Tests.ps1
@@ -13,7 +13,7 @@ $ModulePath = Resolve-Path "$Here\..\$ModuleName"
 #Define Path to Module Manifest
 $ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+if ( -not (Get-Module -Name $ModuleName -All)) {
 
 	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
@@ -48,76 +48,76 @@ Describe $FunctionName {
 
 				(Get-Command Remove-PASDirectory).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
 
+			}
+
+		}
+
+		Context "Input" {
+
+			BeforeEach {
+				$Script:ExternalVersion = "0.0"
+				Mock Invoke-PASRestMethod -MockWith { }
+
+				$response = Remove-PASDirectory -id SomeDir
+
+			}
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request to expected endpoint" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/api/Configuration/LDAP/Directories/SomeDir"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'DELETE' } -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
+
+			}
+
+			It "throws error if version requirement not met" {
+				$Script:ExternalVersion = "1.0"
+				{ Get-PASDirectory } | Should Throw
+				$Script:ExternalVersion = "0.0"
+			}
+
+		}
+
+		Context "Output" {
+
+			BeforeEach {
+				$Script:ExternalVersion = "0.0"
+				Mock Invoke-PASRestMethod -MockWith { }
+
+				$response = Remove-PASDirectory -id SomeDir
+
+			}
+
+			it "provides no output" {
+
+				$response | Should BeNullOrEmpty
+
+			}
+
+
+
 		}
 
 	}
-
-	Context "Input" {
-
-		BeforeEach {
-
-			Mock Invoke-PASRestMethod -MockWith { }
-
-			$response = Remove-PASDirectory -id SomeDir
-
-	}
-
-	It "sends request" {
-
-		Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
-
-	}
-
-	It "sends request to expected endpoint" {
-
-		Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-
-			$URI -eq "$($Script:BaseURI)/api/Configuration/LDAP/Directories/SomeDir"
-
-		} -Times 1 -Exactly -Scope It
-
-	}
-
-	It "uses expected method" {
-
-		Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'DELETE' } -Times 1 -Exactly -Scope It
-
-	}
-
-	It "sends request with no body" {
-
-		Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
-
-	}
-
-	It "throws error if version requirement not met" {
-$Script:ExternalVersion = "1.0"
-		{ Get-PASDirectory  } | Should Throw
-$Script:ExternalVersion = "0.0"
-}
-
-}
-
-Context "Output" {
-
-	BeforeEach {
-
-		Mock Invoke-PASRestMethod -MockWith { }
-
-		$response = Remove-PASDirectory -id SomeDir
-
-}
-
-it "provides no output" {
-
-	$response | Should BeNullOrEmpty
-
-}
-
-
-
-}
-
-}
 
 }

--- a/Tests/Remove-PASGroupMember.Tests.ps1
+++ b/Tests/Remove-PASGroupMember.Tests.ps1
@@ -58,7 +58,7 @@ Describe $FunctionName {
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith { }
-
+				$Script:ExternalVersion = "0.0"
 			}
 
 			It "sends request" {

--- a/Tests/Use-PASSession.Tests.ps1
+++ b/Tests/Use-PASSession.Tests.ps1
@@ -51,6 +51,26 @@ Describe $FunctionName {
 
 		Context "Standard Operation" {
 
+			BeforeEach {
+				$session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+				$session.Headers["Test"] = "SomeValue"
+
+				$InputObject = [PSCustomObject]@{
+					PSTypeName      = 'psPAS.CyberArk.Vault.Session'
+					User            = "SomeUser"
+					BaseURI         = "SomeURL"
+					ExternalVersion = "6.6"
+					WebSession      = $session
+				}
+
+			}
+
+			it "invokes set-variable the expected number of times" {
+				Mock Set-Variable -MockWith { }
+				Use-PASSession -Session $InputObject
+				Assert-MockCalled Set-Variable -Times 3 -Exactly -Scope It
+			}
+
 			it "sets expected value for BaseURI" {
 				Use-PASSession -Session $InputObject
 
@@ -62,11 +82,11 @@ Describe $FunctionName {
 				$Script:ExternalVersion | Should Be "6.6"
 			}
 
-			it "invokes set-variable the expected number of times" {
-				Mock Set-Variable -MockWith { }
+			it "sets expected value for WebSession" {
 				Use-PASSession -Session $InputObject
-				Assert-MockCalled Set-Variable -Times 3 -Exactly -Scope It
+				$Script:WebSession.Headers["Test"] | Should Be "SomeValue"
 			}
+
 
 		}
 

--- a/Tests/Use-PASSession.Tests.ps1
+++ b/Tests/Use-PASSession.Tests.ps1
@@ -1,0 +1,75 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if ( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		BeforeEach {
+			$session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			$session.Headers["Test"] = "SomeValue"
+
+			$InputObject = [PSCustomObject]@{
+				PSTypeName      = 'psPAS.CyberArk.Vault.Session'
+				User            = "SomeUser"
+				BaseURI         = "SomeURL"
+				ExternalVersion = "6.6"
+				WebSession      = $session
+			}
+
+		}
+
+		Context "Standard Operation" {
+
+			it "sets expected value for BaseURI" {
+				Use-PASSession -Session $InputObject
+
+				$Script:BaseUri | Should Be "SomeURL"
+			}
+
+			it "sets expected value for ExternalVersion" {
+				Use-PASSession -Session $InputObject
+				$Script:ExternalVersion | Should Be "6.6"
+			}
+
+			it "invokes set-variable the expected number of times" {
+				Mock Set-Variable -MockWith { }
+				Use-PASSession -Session $InputObject
+				Assert-MockCalled Set-Variable -Times 3 -Exactly -Scope It
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Use-PASSession.Tests.ps1
+++ b/Tests/Use-PASSession.Tests.ps1
@@ -71,23 +71,6 @@ Describe $FunctionName {
 				Assert-MockCalled Set-Variable -Times 3 -Exactly -Scope It
 			}
 
-			it "sets expected value for BaseURI" {
-				Use-PASSession -Session $InputObject
-
-				$Script:BaseUri | Should Be "SomeURL"
-			}
-
-			it "sets expected value for ExternalVersion" {
-				Use-PASSession -Session $InputObject
-				$Script:ExternalVersion | Should Be "6.6"
-			}
-
-			it "sets expected value for WebSession" {
-				Use-PASSession -Session $InputObject
-				$Script:WebSession.Headers["Test"] | Should Be "SomeValue"
-			}
-
-
 		}
 
 	}

--- a/Tests/Use-PASSession.Tests.ps1
+++ b/Tests/Use-PASSession.Tests.ps1
@@ -35,20 +35,6 @@ Describe $FunctionName {
 
 	InModuleScope $ModuleName {
 
-		BeforeEach {
-			$session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
-			$session.Headers["Test"] = "SomeValue"
-
-			$InputObject = [PSCustomObject]@{
-				PSTypeName      = 'psPAS.CyberArk.Vault.Session'
-				User            = "SomeUser"
-				BaseURI         = "SomeURL"
-				ExternalVersion = "6.6"
-				WebSession      = $session
-			}
-
-		}
-
 		Context "Standard Operation" {
 
 			BeforeEach {

--- a/psPAS/Functions/Authentication/Close-PASSession.ps1
+++ b/psPAS/Functions/Authentication/Close-PASSession.ps1
@@ -108,5 +108,10 @@
 
 	}#process
 
-	END { }#end
+	END {
+		#Clear Module scope variables on logoff
+		Clear-Variable -Name ExternalVersion -Scope Script -ErrorAction SilentlyContinue
+		Clear-Variable -Name BaseURI -Scope Script -ErrorAction SilentlyContinue
+		Clear-Variable -Name WebSession -Scope Script -ErrorAction SilentlyContinue
+	}#end
 }

--- a/psPAS/Functions/Authentication/Get-PASSession.ps1
+++ b/psPAS/Functions/Authentication/Get-PASSession.ps1
@@ -1,0 +1,52 @@
+﻿function Get-PASSession {
+	<#
+	.SYNOPSIS
+	Returns information related to the authenticated session
+
+	.DESCRIPTION
+	For the current session, returns data from the module scope:
+	- Username relating to the session.
+	- BaseURI: URL value used for sending requests to the API.
+	- ExternalVersion: PAS version information.
+	- Websession: Contains Authorization Header, Cookie & Certificate data related to the current session.
+
+	The session information can be saved a variable accessible outside of the module scope for use in requests outside of psPAS.
+
+	.EXAMPLE
+	Show current session related information
+
+	Get-PASSession
+
+	.EXAMPLE
+	Save current session related information
+
+	$session = Get-PASSession
+
+	.EXAMPLE
+	Use session information for Invoke-RestMethod command
+
+	$session = Get-PASSession
+
+	Invoke-RestMethod
+	Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $session.WebSession
+
+	#>
+	[CmdletBinding()]
+	param( )
+
+	BEGIN { }#begin
+
+	PROCESS {
+
+		[PSCustomObject]@{
+			User            = Get-PASLoggedOnUser -ErrorAction Stop | Select-Object -ExpandProperty Username
+			BaseURI         = $Script:BaseURI
+			ExternalVersion = $Script:ExternalVersion
+			WebSession      = $Script:WebSession
+		} | Add-ObjectDetail -typename psPAS.CyberArk.Vault.Session
+
+	}#process
+
+	END { }#end
+
+}

--- a/psPAS/Functions/Authentication/New-PASSession.ps1
+++ b/psPAS/Functions/Authentication/New-PASSession.ps1
@@ -380,6 +380,9 @@
 
 				$Script:WebSession.Headers["Authorization"] = [string]$($PASSession.CyberArkLogonResult)
 
+				#Initial Value for Version variable
+				[System.Version]$Version = "0.0"
+
 				if ( -not ($SkipVersionCheck)) {
 
 					Try {
@@ -388,11 +391,11 @@
 						[System.Version]$Version = Get-PASServer -ErrorAction Stop |
 						Select-Object -ExpandProperty ExternalVersion
 
-						Set-Variable -Name ExternalVersion -Value $Version -Scope Script
-
-					} Catch { }
+					} Catch { [System.Version]$Version = "0.0" }
 
 				}
+
+				Set-Variable -Name ExternalVersion -Value $Version -Scope Script
 
 			}
 

--- a/psPAS/Functions/Authentication/Use-PASSession.ps1
+++ b/psPAS/Functions/Authentication/Use-PASSession.ps1
@@ -1,0 +1,48 @@
+﻿function Use-PASSession {
+	<#
+	.SYNOPSIS
+	Sets module scope variables allowing saved session information to be used for future requests.
+
+	.DESCRIPTION
+	Use session data (BaseURI, ExternalVersion, WebSession (containing Authorization Header)) for future requests.
+	psPAS uses variables in the Module scope to provide required values to all module functions, use this function to
+	set the required values in the module scope, using session information returned from `Get-PASSession`.
+
+	.EXAMPLE
+	Use Saved Session Data for future requests
+
+	Use-PASSession -Session $Session
+
+	.EXAMPLE
+	Save current session, switch to using different session details, switch back to original session.
+
+	$CurrentSession = Get-PASSession
+
+	Use-PASSession -Session $OtherSession
+	...
+	Use-PASSession -Session $CurrentSession
+
+	#>
+	[CmdletBinding()]
+	param(
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipeline = $true
+		)]
+		[psTypeName('psPAS.CyberArk.Vault.Session')]$Session
+
+	)
+
+	BEGIN { }#begin
+
+	PROCESS {
+
+		Set-Variable -Name BaseURI -Value $Session.BaseURI -Scope Script
+		Set-Variable -Name ExternalVersion -Value $Session.ExternalVersion -Scope Script
+		Set-Variable -Name WebSession -Value $Session.WebSession -Scope Script
+
+	}#process
+
+	END { }#end
+
+}

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -177,7 +177,8 @@
 		'Remove-PASDirectory',
 		'Set-PASDirectoryMapping',
 		'Find-PASSafe',
-		'Get-PASSession'
+		'Get-PASSession',
+		'Use-PASSession'
 	)
 
 	# AliasesToExport   = @( )

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -176,7 +176,8 @@
 		'Get-PASDirectoryMapping',
 		'Remove-PASDirectory',
 		'Set-PASDirectoryMapping',
-		'Find-PASSafe'
+		'Find-PASSafe',
+		'Get-PASSession'
 	)
 
 	# AliasesToExport   = @( )

--- a/psPAS/psPAS.psm1
+++ b/psPAS/psPAS.psm1
@@ -41,7 +41,3 @@ ForEach-Object {
 	}
 
 }
-
-#Initial Value for Version variable
-[System.Version]$Version = "0.0"
-Set-Variable -Name ExternalVersion -Value $Version -Scope Script


### PR DESCRIPTION
## Summary

Adds functions `Get-PASSession` & `Use-PASSession`

This PR implements the following **features**:

`Get-PASSession` is used to retrieve module scope variable values which are used to perform each request to the API.

`Use-PASSession` is used to set module scope variable values which are used to perform each request to the API.

This functionality allows the user to 
- store data related to multiple authenticated api sessions.
- switch the context of the authenticated session the module commands will interact with.
- obtain the values required to interact with the API using `invoke-RestMethod`.