### PR TITLE
Fix New-PASUser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ _2 years since first commit Anniversary Edition_
       - Allows One Time Passcode to be provided, which is then sent with the password value.
         - Tested with Duo RADIUS.
     - Removed `$SecureMode` & `$AdditionalInfo` parameters.
+- Fixes
+  - `New-PASUser`
+    - Added `ChangePassOnNextLogon` parameter for working with latest API method
+    - Fixes issue where `New-PASUser` was failing to set the change password at next logon flag for a new user.
 
 ## 2.6.17 (May 16th 2019)
 

--- a/psPAS/Functions/User/New-PASUser.ps1
+++ b/psPAS/Functions/User/New-PASUser.ps1
@@ -51,6 +51,9 @@ Valid values:
 • BackupAllSafes
 • RestoreAllSafes
 
+.PARAMETER ChangePassOnNextLogon
+Whether or not user will be forced to change password on first logon
+
 .PARAMETER workStreet
 Business Address detail for the user
 
@@ -250,6 +253,8 @@ To force all output to be shown, pipe to Select-Object *
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = "10_9"
 		)]
+		[boolean]$ChangePassOnNextLogon,
+
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,


### PR DESCRIPTION
## Summary
- `New-PASUser`
  - Added parameter `ChangePassOnNextLogon` to 10_9 parameterset.
  - Removed `ChangePasswordOnTheNextLogon` from 10_9 parameterset.
  - Fixes issue where `New-PASUser` was failing to set the change password at next logon flag for a new user.