### PR TITLE
Add Debug Messages

### DIFF
--- a/Tests/Hide-SecretValue.Tests.ps1
+++ b/Tests/Hide-SecretValue.Tests.ps1
@@ -1,0 +1,74 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if ( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		[array]$Secrets = @(
+			"Secret",
+			"Password",
+			"NewCredentials",
+			"NewPassword",
+			"BindPassword",
+			"InitialPassword"
+		)
+
+		$String = [pscustomobject]@{
+			"Property"         = "Value"
+			"Password"         = "SecretValue"
+			"Secret"           = "DontShareThis"
+			"NewCredentials"   = "S3cr3t"
+			"NewPassword"      = "Password123!"
+			"BindPassword"     = "ABCDE123!"
+			"InitialPassword"  = "123456"
+			"InnocentProperty" = "SomeValue"
+		} | ConvertTo-Json
+
+		It 'returns a string' {
+			$ReturnData = Hide-SecretValue -InputValue $String -SecretsToRemove Property
+			$ReturnData | Should BeOfType System.String
+
+		}
+
+		$Secrets | ForEach-Object {
+
+			It "does not include $_ value in return data" {
+				$ReturnData = Hide-SecretValue -InputValue $String -SecretsToRemove Property
+				$ReturnData | ConvertFrom-Json | Select-Object -ExpandProperty $_ | Should Be "******"
+
+			}
+
+		}
+
+		It 'does not return additional specified parameters' {
+			$ReturnData = Hide-SecretValue -InputValue $String -SecretsToRemove Property
+			$ReturnData | ConvertFrom-Json | Select-Object -ExpandProperty Property | Should Be "******"
+		}
+
+		It 'returns expected value' {
+			$ReturnData = Hide-SecretValue -InputValue $String -SecretsToRemove Property
+			$ReturnData | ConvertFrom-Json | Select-Object -ExpandProperty InnocentProperty | Should Be "SomeValue"
+		}
+
+	}
+
+}

--- a/Tests/Invoke-PASRestMethod.Tests.ps1
+++ b/Tests/Invoke-PASRestMethod.Tests.ps1
@@ -39,6 +39,7 @@ Describe $FunctionName {
 			"URI"        = "https://CyberArk_URL"
 			"Method"     = "GET"
 			"WebSession" = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"Body"       = "something"
 		}
 
 		Context "Standard Operation" {

--- a/Tests/Invoke-PASRestMethod.Tests.ps1
+++ b/Tests/Invoke-PASRestMethod.Tests.ps1
@@ -39,6 +39,8 @@ Describe $FunctionName {
 			"URI"        = "https://CyberArk_URL"
 			"Method"     = "GET"
 			"WebSession" = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			"Debug"      = $true
+			"Body"       = "something"
 		}
 
 		Context "Standard Operation" {

--- a/Tests/Invoke-PASRestMethod.Tests.ps1
+++ b/Tests/Invoke-PASRestMethod.Tests.ps1
@@ -39,7 +39,6 @@ Describe $FunctionName {
 			"URI"        = "https://CyberArk_URL"
 			"Method"     = "GET"
 			"WebSession" = New-Object Microsoft.PowerShell.Commands.WebRequestSession
-			"Body"       = "something"
 		}
 
 		Context "Standard Operation" {
@@ -52,7 +51,7 @@ Describe $FunctionName {
 
 			It "does not throw" {
 
-				{ Invoke-PASRestMethod @requestArgs2 } | Should Not throw
+				{ Invoke-PASRestMethod @requestArgs2 -Debug 5>&1 } | Should Not throw
 
 			}
 
@@ -313,8 +312,6 @@ Describe $FunctionName {
 				"URI"        = "https://www.google.co.uk"
 				"Method"     = "PUT"
 				"WebSession" = New-Object Microsoft.PowerShell.Commands.WebRequestSession
-				"Debug"      = $true
-				"Body"       = "Something"
 			}
 
 			It "outputs expected exception" {

--- a/Tests/Invoke-PASRestMethod.Tests.ps1
+++ b/Tests/Invoke-PASRestMethod.Tests.ps1
@@ -39,7 +39,6 @@ Describe $FunctionName {
 			"URI"        = "https://CyberArk_URL"
 			"Method"     = "GET"
 			"WebSession" = New-Object Microsoft.PowerShell.Commands.WebRequestSession
-			"Debug"      = $true
 			"Body"       = "something"
 		}
 
@@ -314,6 +313,8 @@ Describe $FunctionName {
 				"URI"        = "https://www.google.co.uk"
 				"Method"     = "PUT"
 				"WebSession" = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+				"Debug"      = $true
+				"Body"       = "Something"
 			}
 
 			It "outputs expected exception" {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ only_commits:
     - Tests\
 
 #os: WMF 5
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 install:
 #  - ps: . .\build\install.ps1

--- a/psPAS/Private/Hide-SecretValue.ps1
+++ b/psPAS/Private/Hide-SecretValue.ps1
@@ -1,0 +1,100 @@
+﻿Function Hide-SecretValue {
+	<#
+    .SYNOPSIS
+    Hide a secret value by converting it to "******"
+
+    .DESCRIPTION
+    Matches a pattern in a JSON formatted string which is expected to contain a secret value.
+    Replaces all secret values with "******", and returns a sanitised string.
+    Enables a request body to be included in debug/verbose streams without exposing secret values.
+
+    .PARAMETER InputValue
+    JSON body of API request
+
+    .PARAMETER SecretsToRemove
+    Any additional JSON properties which should be sanitised.
+
+    .PARAMETER Secrets
+    psPAS default JSON properties known to contain secrets
+
+    .EXAMPLE
+    Remove Secret Values from $String
+
+    $String = [pscustomobject]@{
+        "Property"="Value"
+        "Password"="SecretValue"
+        "Secret"="DontShareThis"
+        "NewCredentials"="S3cr3t"
+        "NewPassword"="Password123!"
+        "BindPassword"="ABCDE123!"
+        "InitialPassword"="123456"
+        "InnocentProperty"="SomeValue"
+    } | ConvertTo-Json
+
+    Hide-SecretValue -InputValue $String
+
+    {
+        "Property":  "Value",
+        "Password":  "******",
+        "Secret":  "******",
+        "NewCredentials":  "******",
+        "NewPassword":  "******",
+        "BindPassword":  "******",
+        "InitialPassword":  "******",
+        "InnocentProperty":  "SomeValue"
+    }
+
+    #>
+	[CmdletBinding()]
+	param(
+		[parameter(
+			Position = 0,
+			Mandatory = $true,
+			ValueFromPipeline = $true)]
+		[String]$InputValue,
+
+		[parameter(
+			Mandatory = $false)]
+		[array]$SecretsToRemove = @(),
+
+		[parameter(
+			Mandatory = $false)]
+		[array]$Secrets = @(
+			"Secret",
+			"Password",
+			"NewCredentials",
+			"NewPassword",
+			"BindPassword",
+			"InitialPassword"
+		)
+	)
+
+	BEGIN {
+
+
+
+	}#begin
+
+	PROCESS {
+
+		$OutputValue = $InputValue
+
+		#Combine base parameters and any additional parameters to remove
+		($SecretsToRemove + $Secrets) |
+
+		ForEach-Object {
+
+			$OutputValue = $OutputValue -replace "(`"$_`":).+", "`$1  `"******`","
+
+		}
+
+	}#process
+
+	END {
+
+		#Return Output
+		$OutputValue
+
+	}#end
+
+}

--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -125,6 +125,17 @@ WebRequestSession object if the SessionVariable parameter was specified.
 
 	Process {
 
+		#Show sanitised request body if in debug mode
+		If ([System.Management.Automation.ActionPreference]::SilentlyContinue -ne $DebugPreference) {
+
+			If ($PSBoundParameters.ContainsKey("Body")) {
+
+				Write-Debug "[Body] $(Hide-SecretValue -InputValue $Body)"
+
+			}
+
+		}
+
 		try {
 
 			#make web request, splat PSBoundParameters
@@ -144,6 +155,8 @@ WebRequestSession object if the SessionVariable parameter was specified.
 		}
 
 		finally {
+
+			Write-Debug "[Status Code] $StatusCode"
 
 			if ( -not ($StatusCode -match "20*")) {
 


### PR DESCRIPTION
## Summary

Adds output to debug stream from `Invoke-PASRestMethod`

This PR implements the following **features**:

if Debug is enabled
- outputs request status code
- outputs request body (if present)
- if request body contains a value assumed to be secret, it is replaced with `"****"`