### PR TITLE
FIX Get-PASccountPassword

### DIFF
--- a/Tests/Get-PASResponse.Tests.ps1
+++ b/Tests/Get-PASResponse.Tests.ps1
@@ -80,7 +80,7 @@ Describe $FunctionName {
 			}
 
 			It "returns expected text value" {
-				Get-PASResponse -APIResponse $TextResponse | Should Be "Value"
+				Get-PASResponse -APIResponse $TextResponse | Should Be '"Value"'
 			}
 
 			It "throws if HTML received" {

--- a/psPAS/Functions/Accounts/Get-PASAccountPassword.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccountPassword.ps1
@@ -211,13 +211,13 @@ From version 10.1 onwards both passwords and ssh keys can be retrieved.#>
 
 		If ($result) {
 
-			If ($result.GetType().Name -eq "Object[]") {
+			If ($PSCmdlet.ParameterSetName -eq "ClassicAPI") {
 
-				$result = [System.Text.Encoding]::ASCII.GetString($result)
+				$result = [System.Text.Encoding]::ASCII.GetString([PSCustomObject]$result.Content)
 
 			}
 
-			[PSCustomObject] @{"Password" = $result } |
+			[PSCustomObject] @{"Password" = $($result -replace '^"|"$', '') } |
 
 			Add-ObjectDetail -typename psPAS.CyberArk.Vault.Credential
 

--- a/psPAS/Private/Get-PASResponse.ps1
+++ b/psPAS/Private/Get-PASResponse.ps1
@@ -33,7 +33,7 @@ function Get-PASResponse {
 	BEGIN {	}#begin
 
 	PROCESS {
-
+		$Global:Response = $APIResponse
 		if ($APIResponse.Content) {
 
 			#Default Response - Return Content
@@ -47,13 +47,7 @@ function Get-PASResponse {
 
 				'text/html; charset=utf-8' {
 
-					#text/html response is expected from the Password/Retrieve Uri path.
-					If ($PASResponse -match '^"(.*)"$') {
-
-						#Return only the text between opening and closing quotes
-						$PASResponse = $matches[1]
-
-					} ElseIf ($PASResponse -match '<HTML>') {
+					If ($PASResponse -match '<HTML>') {
 
 						#Fail if HTML received from API
 

--- a/psPAS/Private/Get-PASResponse.ps1
+++ b/psPAS/Private/Get-PASResponse.ps1
@@ -33,7 +33,7 @@ function Get-PASResponse {
 	BEGIN {	}#begin
 
 	PROCESS {
-		$Global:Response = $APIResponse
+
 		if ($APIResponse.Content) {
 
 			#Default Response - Return Content


### PR DESCRIPTION

## Summary

Recent module updates meant password was not getting returned if querying the ClassicAPI.
- `Get-PASAccountPassword` updated to handle output of Get-PASResponse for both Classic & Version 10 API endpoint.
- `Get-PASResponse` updated to send the originally returned string, logic to remove opening & closing quotation marks moved into `Get-PASAccountPassword`.