### PR TITLE
Issue-185 - Add Help Text & Aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # psPAS
 
+## 3.1.X (July X 2019)
+
+- Updates
+  - `Add-PASSafeMember`
+    - Added parameter aliases for permission name equivalent names returned from Get-PASSafeMember.
+  - `Get-PASSafeMember`
+    - Updated help text to detail permission name equivalents returned from the API.
+
 ## 3.1.0 (July 7th 2019)
 
 ### Module update to cover CyberArk 10.10 API features

--- a/psPAS/Functions/SafeMembers/Add-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Add-PASSafeMember.ps1
@@ -7,6 +7,10 @@ Adds a Safe Member to safe
 Adds an existing user as a Safe member.
 "Manage Safe Members" permission is required by the authenticated user account sending request.
 
+Unless otherwise specified, the default permissions applied to a safe member will include:
+ListAccounts, RetrieveAccounts, UseAccounts, ViewAuditLog & ViewSafeMembers.
+If these permissions should not be granted to the safe member, they must be explicitly set to $false in the request.
+
 .PARAMETER SafeName
 The name of the safe to add the member to
 
@@ -23,47 +27,58 @@ Defines when the user's Safe membership expires.
 .PARAMETER UseAccounts
 Boolean value defining if UseAccounts permission will be granted to
 safe member on safe.
+Get-PASSafeMember returns the name of this permission as: RestrictedRetrieve
 
 .PARAMETER RetrieveAccounts
 Boolean value defining if RetrieveAccounts permission will be granted
 to safe member on safe.
+Get-PASSafeMember returns the name of this permission as: Retrieve
 
 .PARAMETER ListAccounts
 Boolean value defining if ListAccounts permission will be granted to
 safe member on safe.
+Get-PASSafeMember returns the name of this permission as: ListContent
 
 .PARAMETER AddAccounts
 Boolean value defining if permission will be granted to safe member
 on safe.
 Includes UpdateAccountProperties (when adding or removing permission).
+Get-PASSafeMember returns the name of this permission as: Add
 
 .PARAMETER UpdateAccountContent
 Boolean value defining if AddAccounts permission will be granted to safe
 member on safe.
+Get-PASSafeMember returns the name of this permission as: Update
 
 .PARAMETER UpdateAccountProperties
 Boolean value defining if UpdateAccountProperties permission will be granted
 to safe member on safe.
+Get-PASSafeMember returns the name of this permission as: UpdateMetadata
 
 .PARAMETER InitiateCPMAccountManagementOperations
 Boolean value defining if InitiateCPMAccountManagementOperations permission
 will be granted to safe member on safe.
+Get-PASSafeMember may not return details of this permission
 
 .PARAMETER SpecifyNextAccountContent
 Boolean value defining if SpecifyNextAccountContent permission will be granted
 to safe member on safe.
+Get-PASSafeMember may not return details of this permission
 
 .PARAMETER RenameAccounts
 Boolean value defining if RenameAccounts permission will be granted to safe
 member on safe.
+Get-PASSafeMember returns the name of this permission as: Rename
 
 .PARAMETER DeleteAccounts
 Boolean value defining if DeleteAccounts permission will be granted to safe
 member on safe.
+Get-PASSafeMember returns the name of this permission as: Delete
 
 .PARAMETER UnlockAccounts
 Boolean value defining if UnlockAccounts permission will be granted to safe
 member on safe.
+Get-PASSafeMember returns the name of this permission as: Unlock
 
 .PARAMETER ManageSafe
 Boolean value defining if ManageSafe permission will be granted to safe member
@@ -80,22 +95,27 @@ on safe.
 .PARAMETER ViewAuditLog
 Boolean value defining if ViewAuditLog permission will be granted to safe member
 on safe.
+Get-PASSafeMember returns the name of this permission as: ViewAudit
 
 .PARAMETER ViewSafeMembers
 Boolean value defining if ViewSafeMembers permission will be granted to safe member
 on safe.
+Get-PASSafeMember returns the name of this permission as: ViewMembers
 
 .PARAMETER RequestsAuthorizationLevel
 Integer value defining level assigned to RequestsAuthorizationLevel for safe member.
 Valid Values: 0, 1 or 2
+Get-PASSafeMember may not return details of this permission
 
 .PARAMETER AccessWithoutConfirmation
 Boolean value defining if AccessWithoutConfirmation permission will be granted to
 safe member on safe.
+Get-PASSafeMember may not return details of this permission
 
 .PARAMETER CreateFolders
 Boolean value defining if CreateFolders permission will be granted to safe member
 on safe.
+Get-PASSafeMember returns the name of this permission as: AddRenameFolder
 
 .PARAMETER DeleteFolders
 Boolean value defining if DeleteFolders permission will be granted to safe member
@@ -104,12 +124,26 @@ on safe.
 .PARAMETER MoveAccountsAndFolders
 Boolean value defining if MoveAccountsAndFolders permission will be granted to safe
 member on safe.
+Get-PASSafeMember returns the name of this permission as: MoveFilesAndFolders
 
 .EXAMPLE
 Add-PASSafeMember -SafeName Windows_Safe -MemberName winUser -SearchIn Vault -UseAccounts $true `
 -RetrieveAccounts $true -ListAccounts $true
 
 Adds winUser to Windows_Safe with Use, Retrieve & List permissions
+
+.EXAMPLE
+$Role = [PSCustomObject]@{
+  UseAccounts                            = $true
+  ListAccounts                           = $true
+  RetrieveAccounts						 = $true
+  ViewAuditLog                           = $false
+  ViewSafeMembers                        = $false
+}
+
+PS > $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn Vault
+
+Grant User23 UseAccounts, RetrieveAccounts & ListAccounts only
 
 .INPUTS
 All parameters can be piped by property name
@@ -135,7 +169,7 @@ To force all output to be shown, pipe to Select-Object *
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateNotNullOrEmpty()]
-		[ValidateScript( {$_ -notmatch ".*(\?).*"})]
+		[ValidateScript( { $_ -notmatch ".*(\?).*" })]
 		[string]$MemberName,
 
 		[parameter(
@@ -154,36 +188,42 @@ To force all output to be shown, pipe to Select-Object *
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[Alias("RestrictedRetrieve")]
 		[boolean]$UseAccounts,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[Alias("Retrieve")]
 		[boolean]$RetrieveAccounts,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[Alias("ListContent")]
 		[boolean]$ListAccounts,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[Alias("Add")]
 		[boolean]$AddAccounts,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[Alias("Update")]
 		[boolean]$UpdateAccountContent,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[Alias("UpdateMetadata")]
 		[boolean]$UpdateAccountProperties,
 
 		[parameter(
@@ -204,18 +244,21 @@ To force all output to be shown, pipe to Select-Object *
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[Alias("Rename")]
 		[boolean]$RenameAccounts,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[Alias("Delete")]
 		[boolean]$DeleteAccounts,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[Alias("Unlock")]
 		[boolean]$UnlockAccounts,
 
 		[parameter(
@@ -240,12 +283,14 @@ To force all output to be shown, pipe to Select-Object *
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[Alias("ViewAudit")]
 		[boolean]$ViewAuditLog,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[Alias("ViewMembers")]
 		[boolean]$ViewSafeMembers,
 
 		[parameter(
@@ -265,6 +310,7 @@ To force all output to be shown, pipe to Select-Object *
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[Alias("AddRenameFolder")]
 		[boolean]$CreateFolders,
 
 		[parameter(
@@ -277,6 +323,7 @@ To force all output to be shown, pipe to Select-Object *
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[Alias("MoveFilesAndFolders")]
 		[boolean]$MoveAccountsAndFolders
 	)
 
@@ -286,7 +333,7 @@ To force all output to be shown, pipe to Select-Object *
 		$baseParameters = @("MemberName", "SearchIn", "MembershipExpirationDate", "SafeName")
 
 		#Create empty hashtable to hold permission related parameters
-		$permissions = @{}
+		$permissions = @{ }
 
 		#array for parameter names which will do not appear in the top-tier of the JSON object
 		[array]$keysToRemove += "SafeName"
@@ -303,7 +350,7 @@ To force all output to be shown, pipe to Select-Object *
 		#Get Parameters for request body
 		$boundParameters = $PSBoundParameters | Get-PASParameter
 
-		If($PSBoundParameters.ContainsKey("MembershipExpirationDate")) {
+		If ($PSBoundParameters.ContainsKey("MembershipExpirationDate")) {
 
 			#Convert MembershipExpirationDate to string in Required format
 			$Date = (Get-Date $MembershipExpirationDate -Format MM/dd/yyyy).ToString()
@@ -314,7 +361,7 @@ To force all output to be shown, pipe to Select-Object *
 		}
 
 		#For every passed permission ("Non-Base") parameter
-		$boundParameters.keys | Where-Object {$baseParameters -notcontains $_} | ForEach-Object {
+		$boundParameters.keys | Where-Object { $baseParameters -notcontains $_ } | ForEach-Object {
 
 			#Add Key=Value pair to permissions hashtable
 			$permissions[$_] = $boundParameters[$_]
@@ -325,7 +372,7 @@ To force all output to be shown, pipe to Select-Object *
 		}
 
 		#add all required permissions  as value to "Permissions" key
-		$boundParameters["Permissions"] = @($permissions.getenumerator() | ForEach-Object {$_})
+		$boundParameters["Permissions"] = @($permissions.getenumerator() | ForEach-Object { $_ })
 
 		#Create required request object
 		$body = @{
@@ -340,18 +387,18 @@ To force all output to be shown, pipe to Select-Object *
 		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
 
 
-		if($result) {
+		if ($result) {
 
 			#format output
 			$result.member | Select-Object MemberName, MembershipExpirationDate, SearchIn,
 
 			@{Name = "Permissions"; "Expression" = {
 
-					$_.Permissions | Where-Object {$_.value} | Select-Object -ExpandProperty key}
+					$_.Permissions | Where-Object { $_.value } | Select-Object -ExpandProperty key }
 
 			} | Add-ObjectDetail -typename psPAS.CyberArk.Vault.Safe.Member.Extended -PropertyToAdd @{
 
-				"SafeName"        = $SafeName
+				"SafeName" = $SafeName
 
 			}
 
@@ -359,6 +406,6 @@ To force all output to be shown, pipe to Select-Object *
 
 	}#process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/SafeMembers/Get-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Get-PASSafeMember.ps1
@@ -7,9 +7,55 @@ Lists the members of a Safe
 Lists the members of a Safe.
 View Safe Members permission is required.
 
-If a Safe Member Name is provided, the full permissions of the member on the Safe will be returned.
-Includes AccessWithoutConfirmation, InitiateCPMAccountManagementOperations, RequestsAuthorizationLevel &
-SpecifyNextAccountContent which are not included when querying by safe only.
+When querying all members of a safe, the permissions are reported as per the following table:
+
+List accounts							ListContent
+Retrieve accounts							Retrieve
+Add accounts (includes update properties)				Add
+Update account content						Update
+Update account properties						UpdateMetadata
+Rename accounts							Rename
+Delete accounts							Delete
+View Audit log							ViewAudit
+View Safe Members							ViewMembers
+Use accounts							RestrictedRetrieve
+Initiate CPM account management operations				<NOT RETURNED>
+Specify next account content					<NOT RETURNED>
+Create folders							AddRenameFolder
+Delete folders							DeleteFolder
+Unlock accounts							Unlock
+Move accounts/folders						MoveFilesAndFolders
+Manage Safe								ManageSafe
+Manage Safe Members							ManageSafeMembers
+Validate Safe Content						ValidateSafeContent
+Backup Safe								BackupSafe
+Access Safe without confirmation					<NOT RETURNED>
+Authorize account requests (level1, level2)				<NOT RETURNED>
+
+If a Safe Member Name is provided, the full permissions of the member on the Safe will be returned:
+
+List accounts							ListAccounts
+Retrieve accounts							RetrieveAccounts
+Add accounts (includes update properties)				AddAccounts
+Update account content						UpdateAccountContent
+Update account properties						UpdateAccountProperties
+Rename accounts							RenameAccounts
+Delete accounts							DeleteAccounts
+View Audit log							ViewAuditLog
+View Safe Members							ViewSafeMembers
+Use accounts							UseAccounts
+Initiate CPM account management operations				InitiateCPMAccountManagementOperations
+Specify next account content					SpecifyNextAccountContent
+Create folders							CreateFolders
+Delete folders							DeleteFolder
+Unlock accounts							UnlockAccounts
+Move accounts/folders						MoveAccountsAndFolders
+Manage Safe								ManageSafe
+Manage Safe Members							ManageSafeMembers
+Validate Safe Content						<NOT RETURNED>
+Backup Safe								BackupSafe
+Access Safe without confirmation					AccessWithoutConfirmation
+Authorize account requests (level1, level2)				RequestsAuthorizationLevel
 
 .PARAMETER SafeName
 The name of the safe to get the members of


### PR DESCRIPTION
## Summary
  - `Add-PASSafeMember`
    - Added parameter aliases for permission name equivalent names returned from Get-PASSafeMember.
  - `Get-PASSafeMember`
    - Updated help text to detail permission name equivalents returned from the API.

## Test Plan

No changes to function output.
New parameter aliases can be used, but request body remains the same as it is currently.

## Closes issues

Closes #185 