### PR TITLE
FIX Set-PASAccount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # psPAS
 
-## 3.1.9 (July 16th 2019)
+## 3.1.10 (July 16th 2019)
 
 - Fixes
   - `Set-PASAccount`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # psPAS
 
+## 3.1.9 (July 16th 2019)
+
+- Fixes
+  - `Set-PASAccount`
+    - Fixes non-terminating error when not piping an object into the function and using the Classic API.
+
 ## 3.1.7 (July 13th 2019)
 
 - Updates

--- a/psPAS/Functions/Accounts/Set-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Set-PASAccount.ps1
@@ -302,9 +302,10 @@ To move accounts to a different folder, Move accounts/folders permission is requ
 
 			}
 
-			#If InputObject is psPAS.CyberArk.Vault.Account
-			#i.e. receiving pipeline from Get-PASAccount
-			If (($InputObject | Get-Member).TypeName -eq "psPAS.CyberArk.Vault.Account") {
+			If (($InputObject) -and (($InputObject | Get-Member).TypeName -eq "psPAS.CyberArk.Vault.Account")) {
+
+				#If InputObject is psPAS.CyberArk.Vault.Account
+				#i.e. receiving pipeline from Get-PASAccount
 
 				#Get all existing properties as defined by input object:
 				#Process Pipeline input object properties


### PR DESCRIPTION
## Summary

<!-- Summary of the PR -->

This PR fixes the following **bugs**:

Only check for `TypeName` of `$InputObject` if `$InputObject` exists.
Fixes non-terminating error when not piping an object into the function and using the Classic API.

## Test Plan

No error raised when not piping an object into the function and using the Classic API.

