### PR TITLE
FIX New-PASSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # psPAS
 
+## 3.1.13 (July 19th 2019)
+
+- Fixes
+  - `New-PASSession`
+    - Fixes issue where authentication token was not available to other module functions after authenticating via the v10 API endpoint from CyberArk v9.X.
+
 ## 3.1.10 (July 16th 2019)
 
 - Fixes

--- a/psPAS/Functions/Authentication/New-PASSession.ps1
+++ b/psPAS/Functions/Authentication/New-PASSession.ps1
@@ -1,14 +1,16 @@
 ﻿function New-PASSession {
 	<#
 	.SYNOPSIS
-	Authenticates a user to CyberArk Vault.
+	Authenticates a user to CyberArk Vault/API.
 
 	.DESCRIPTION
 	Authenticates a user to a CyberArk Vault and stores an authentication token and a webrequest session object
 	which are used in subsequent calls to the API.
 	In addition, this method allows you to set a new password.
-	Authenticate using CyberArk, LDAP, RADIUS, SAML or Shared authentication (From CyberArk version 9.7 up),
-	Windows authentication is supported (from CyberArk 10.4 up).
+	Will attempt authentication against the V10 API by default.
+	For older CyberArk versions, specify the -UseClassicAPI switch parameter to force use of the V9 API endpoint.
+	Windows authentication is only supported (from CyberArk 10.4+).
+	Authenticate using CyberArk, LDAP, RADIUS, SAML or Shared authentication (From CyberArk version 9.7+),
 	For CyberArk version older than 9.7:
 		Only CyberArk Authentication method is supported.
 		newPassword Parameter is not supported.
@@ -376,7 +378,7 @@
 			If ($PASSession) {
 
 				#Version 10
-				If ($PASSession.length -eq 180) {
+				If ($PASSession.length -ge 180) {
 
 					#V10 Auth Token.
 


### PR DESCRIPTION
<!-- _A similar PR may already be submitted.
Please search existing `Pull Requests` before creating one._

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.  -->

## Summary

Updated to assign a response of 180 characters or more to the Authorization header element.

This PR fixes the following **bugs**:

Previously the API response was expected to be exactly 180 characters long if coming from the v10 API endpoint.
When authenticating from v9.x, but using v10 API endpoint (where available), the response could be longer than 180 characters. 
`New-PASSession` updated to expect a response of 180 characters or more.

## Test Plan

Able to authenticate against the v10 endpoint using 9.95
Able to authenticate against the v10 endpoint using 10.x

## Closes issues

Closes #189 

<!--
## Code formatting

 See the `CONTRIBUTING` guide.

_Ensure your code adheres to the project's PowerShell Styleguide_
-->