### PR TITLE
Add Feature - Radius Challenge Support

### DIFF
--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -214,16 +214,16 @@
 
 		} finally {
 
+			#If Session Variable passed as argument
+			If ($PSCmdlet.ParameterSetName -eq "SessionVariable") {
+
+				#Make the WebSession available in the module scope
+				Set-Variable -Name WebSession -Value $(Get-Variable $(Get-Variable sessionVariable).Value).Value -Scope Script
+
+			}
+
 			#If Command Succeeded
 			if ($?) {
-
-				#If Session Variable passed as argument
-				If ($PSCmdlet.ParameterSetName -eq "SessionVariable") {
-
-					#Make the WebSession available in the module scope
-					Set-Variable -Name WebSession -Value $(Get-Variable $(Get-Variable sessionVariable).Value).Value -Scope Script
-
-				}
 
 				#Status code indicates success
 				If ($APIResponse.StatusCode -match '^20\d$') {


### PR DESCRIPTION
## Summary

Add Support for Responding to Radius Challenge

This PR implements the following **features**:

<!-- You can skip this if you're fixing a typo. -->

When Radius Authentication is configured in Challenge Mode, initial authentication request will raise a `ITATS542I` exception.
`New-PASSession` now catches this error, and submits the required value for the Radius challenge back to the API.
Added feature for Radius in "Append" mode to allow specification of custom delimiter when appending OTP to password value.

<!-- Example: When "Amended logic in function _X_ to achieve _Y_", explain why it is necessary to have a way to do _Y_. -->

## Test Plan

Confirmation of functionality: 
https://github.com/pspete/psPAS/issues/195#issuecomment-526147226
https://github.com/pspete/psPAS/issues/195#issuecomment-526307471
Pester tests updated to cover new code/features.

## Closes issues

Closes #195 

<!--
## Code formatting

 See the `CONTRIBUTING` guide.

_Ensure your code adheres to the project's PowerShell Styleguide_
-->