### PR TITLE
Introduce SkipCertificateCheck

### DIFF
--- a/Tests/Skip-CertificateCheck.Tests.ps1
+++ b/Tests/Skip-CertificateCheck.Tests.ps1
@@ -1,0 +1,54 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$Global:ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if ( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$Global:ManifestPath" -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	#$Script:RequestBody = $null
+
+}
+
+AfterAll {
+
+	#$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Context "General" {
+
+			BeforeEach {
+
+			}
+
+			It "does not throw" {
+
+				{ Skip-CertificateCheck } | Should -Not -Throw
+
+			}
+
+		}
+
+	}
+
+}

--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -46,6 +46,9 @@
 	See Invoke-WebRequest
 	The thumbprint of the certificate to use for client certificate authentication.
 
+	.PARAMETER SkipCertificateCheck
+	Skips certificate validation checks.
+
 	.EXAMPLE
 	Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
 
@@ -86,7 +89,10 @@
 		[int]$TimeoutSec,
 
 		[Parameter(Mandatory = $false)]
-		[string]$CertificateThumbprint
+		[string]$CertificateThumbprint,
+
+		[Parameter(Mandatory = $false)]
+		[switch]$SkipCertificateCheck
 	)
 
 	Begin {
@@ -101,6 +107,58 @@
 
 			$PSBoundParameters.Add("SkipHeaderValidation", $true)
 			$PSBoundParameters.Add("SslProtocol", "TLS12")
+
+		}
+
+		Switch ($PSBoundParameters.ContainsKey("SkipCertificateCheck")) {
+
+			$true {
+
+				#SkipCertificateCheck Declared
+				if ( -not ($IsCoreCLR)) {
+
+					#Remove parameter, incompatible with PowerShell
+					$PSBoundParameters.Remove("SkipCertificateCheck") | Out-Null
+
+					if ($SkipCertificateCheck) {
+
+						#Skip SSL Validation
+						Skip-CertificateCheck
+
+					}
+
+				} else {
+
+					#PWSH
+					if ($SkipCertificateCheck) {
+
+						#Ongoing SSL Validation Bypass Required
+						$Script:SkipCertificateCheck = $true
+
+					}
+
+				}
+
+			}
+
+			$false {
+
+				#SkipCertificateCheck Not Declared
+				#SSL Validation Bypass Previously Requested
+				If ($Script:SkipCertificateCheck) {
+
+					#PWSH Zone
+					if ($IsCoreCLR) {
+
+						#Add SkipCertificateCheck to PS Core command
+						#Parameter must be included for all pwsh invocations of Invoke-WebRequest
+						$PSBoundParameters.Add("SkipCertificateCheck", $true)
+
+					}
+
+				}
+
+			}
 
 		}
 

--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -103,7 +103,7 @@
 
 		#Bypass strict RFC header parsing in PS Core
 		#Use TLS 1.2
-		if ($IsCoreCLR) {
+		if (Test-IsCoreCLR) {
 
 			$PSBoundParameters.Add("SkipHeaderValidation", $true)
 			$PSBoundParameters.Add("SslProtocol", "TLS12")
@@ -115,7 +115,7 @@
 			$true {
 
 				#SkipCertificateCheck Declared
-				if ( -not ($IsCoreCLR)) {
+				if ( -not (Test-IsCoreCLR)) {
 
 					#Remove parameter, incompatible with PowerShell
 					$PSBoundParameters.Remove("SkipCertificateCheck") | Out-Null
@@ -148,7 +148,7 @@
 				If ($Script:SkipCertificateCheck) {
 
 					#PWSH Zone
-					if ($IsCoreCLR) {
+					if (Test-IsCoreCLR) {
 
 						#Add SkipCertificateCheck to PS Core command
 						#Parameter must be included for all pwsh invocations of Invoke-WebRequest

--- a/psPAS/Private/Out-PASFile.ps1
+++ b/psPAS/Private/Out-PASFile.ps1
@@ -61,7 +61,7 @@ function Out-PASFile {
 					Encoding = "Byte"
 				}
 
-				If ($IsCoreCLR) {
+				If (Test-IsCoreCLR) {
 
 					#amend parameters for splatting if we are in Core
 					$output.Add("AsByteStream", $true)

--- a/psPAS/Private/Skip-CertificateCheck.ps1
+++ b/psPAS/Private/Skip-CertificateCheck.ps1
@@ -1,0 +1,40 @@
+Function Skip-CertificateCheck {
+	<#
+	.SYNOPSIS
+	Bypass SSL Validation
+
+	.DESCRIPTION
+	Enables skipping of ssl certificate validation for current PowerShell session.
+
+	.EXAMPLE
+	Skip-CertificateCheck
+
+	#>
+
+	#Only required to be executed once per ps session
+	$Provider = New-Object Microsoft.CSharp.CSharpCodeProvider
+	$Compiler = $Provider.CreateCompiler()
+	$Params = New-Object System.CodeDom.Compiler.CompilerParameters
+	$Params.GenerateExecutable = $false
+	$Params.GenerateInMemory = $true
+	$Params.IncludeDebugInformation = $false
+	$Params.ReferencedAssemblies.Add("System.DLL") | Out-Null
+	$TASource = @'
+        namespace Local.ToolkitExtensions.Net.CertificatePolicy
+        {
+            public class TrustAll : System.Net.ICertificatePolicy
+            {
+                public bool CheckValidationResult(System.Net.ServicePoint sp,System.Security.Cryptography.X509Certificates.X509Certificate cert, System.Net.WebRequest req, int problem)
+                {
+                    return true;
+                }
+            }
+        }
+'@
+
+	$TAResults = $Provider.CompileAssemblyFromSource($Params, $TASource)
+	$TAAssembly = $TAResults.CompiledAssembly
+	## Create an instance of TrustAll and attach it to the ServicePointManager
+	$TrustAll = $TAAssembly.CreateInstance("Local.ToolkitExtensions.Net.CertificatePolicy.TrustAll")
+	[System.Net.ServicePointManager]::CertificatePolicy = $TrustAll
+}

--- a/psPAS/Private/Skip-CertificateCheck.ps1
+++ b/psPAS/Private/Skip-CertificateCheck.ps1
@@ -11,17 +11,12 @@ Function Skip-CertificateCheck {
 
 	#>
 
-	#Do Not Run in PWSH
-	if ( -not ($IsCoreCLR)) {
-
-		#Only required to be executed once per ps session
-		$CSharpCodeProvider = New-Object Microsoft.CSharp.CSharpCodeProvider
-		$CompilerParameters = New-Object System.CodeDom.Compiler.CompilerParameters
-		$CompilerParameters.GenerateExecutable = $false
-		$CompilerParameters.GenerateInMemory = $true
-		$CompilerParameters.IncludeDebugInformation = $false
-		$CompilerParameters.ReferencedAssemblies.Add("System.DLL") | Out-Null
-		$CertificatePolicy = @'
+	$CompilerParameters = New-Object System.CodeDom.Compiler.CompilerParameters
+	$CompilerParameters.GenerateExecutable = $false
+	$CompilerParameters.GenerateInMemory = $true
+	$CompilerParameters.IncludeDebugInformation = $false
+	$CompilerParameters.ReferencedAssemblies.Add("System.DLL") | Out-Null
+	$CertificatePolicy = @'
         namespace Local.ToolkitExtensions.Net.CertificatePolicy
         {
             public class TrustAll : System.Net.ICertificatePolicy
@@ -34,11 +29,15 @@ Function Skip-CertificateCheck {
         }
 '@
 
+	if ( -not (Test-IsCoreCLR)) {
+
+		$CSharpCodeProvider = New-Object Microsoft.CSharp.CSharpCodeProvider
 		$PolicyResult = $CSharpCodeProvider.CompileAssemblyFromSource($CompilerParameters, $CertificatePolicy)
 		$CompiledAssembly = $PolicyResult.CompiledAssembly
 		## Create an instance of TrustAll and attach it to the ServicePointManager
 		$TrustAll = $CompiledAssembly.CreateInstance("Local.ToolkitExtensions.Net.CertificatePolicy.TrustAll")
 		[System.Net.ServicePointManager]::CertificatePolicy = $TrustAll
+
 	}
 
 }

--- a/psPAS/Private/Test-IsCoreCLR.ps1
+++ b/psPAS/Private/Test-IsCoreCLR.ps1
@@ -1,0 +1,28 @@
+Function Test-IsCoreCLR {
+	<#
+.SYNOPSIS
+Tests for PWSH
+
+.DESCRIPTION
+Returns "$true" if run from PWSH
+Returns "$false" if run from PowerShell
+
+.EXAMPLE
+Test-IsCoreCLR
+
+Returns "$true" if run from PWSH
+Returns "$false" if run from PowerShell
+
+#>
+
+	if ($IsCoreCLR -or $PSEdition -eq 'Core') {
+
+		$true
+
+	} else {
+
+		$false
+
+	}
+
+}


### PR DESCRIPTION
<!-- _A similar PR may already be submitted.
Please search existing `Pull Requests` before creating one._

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.  -->

## Summary

Adds `-SkipCertificateCheck` parameter to `New-PASSession`

This PR implements the following **features**:

`-SkipCertificateCheck` parameter added to `New-PASSession` & `Invoke-PASRestMethod`.
Allows a user to opt to not perform any validation of the SSL certificate securing the API.
`-SkipCertificateCheck` is passed on to `Invoke-PASRestMethod`. 
Added logic to allow bypass of SSL validation in both PWSH & PowerShell.

## Test Plan

Broke my trust with certificate authority.
Developed the feature until I could use the features of the module without any SSL/TLS related issues in PWSH or PowerShell.

## Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes. -->
Fixes #

Closes #196 

<!--
## Code formatting

 See the `CONTRIBUTING` guide.

_Ensure your code adheres to the project's PowerShell Styleguide_
-->