### PR TITLE
UPDATE Minimum PowerShellVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # psPAS
 
+## 3.2.29 (Sept 1st 2019)
+
+- Update
+  - Raise minimum required PowerShell version to 5.0.
+
 ## 3.2.27 (Sept 1st 2019)
 
 - Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # psPAS
 
-## 3.2.29 (Sept 1st 2019)
+## 3.2.30 (Sept 1st 2019)
 
 - Update
   - Raise minimum required PowerShell version to 5.0.

--- a/README.md
+++ b/README.md
@@ -924,7 +924,7 @@ Check the output of `Get-Help` for the `psPAS` functions for further details of 
 
 ### Prerequisites
 
-- Requires Powershell v3 (minimum)
+- Powershell v5 (minimum), or PowerShell Core
 - CyberArk PAS REST API/Web Service
 - A user with which to authenticate, with appropriate Vault/Safe permissions.
 
@@ -938,7 +938,7 @@ Use one of the following methods:
 
 #### Option 1: Install from PowerShell Gallery
 
-**PowerShell 5.0 or above required.**
+**PowerShell 5.0 or above must be used**
 
 To download the module from the [PowerShell Gallery](https://www.powershellgallery.com/packages/psPAS/), </br>
 from a PowerShell prompt, run:

--- a/docs/collections/_docs/00-install.md
+++ b/docs/collections/_docs/00-install.md
@@ -6,7 +6,7 @@ last_modified_at: 2019-09-01T01:33:52-00:00
 ---
 
 {% capture notice-text %}
-- Requires Powershell v3 (minimum)
+- Powershell v5 (minimum), or PowerShell Core
 - CyberArk PAS REST API/Web Service
 - A user with which to authenticate, with appropriate Vault/Safe permissions.
 {% endcapture %}
@@ -30,7 +30,7 @@ Choose one of the following methods to obtain & install the module:
 Install-Module -Name psPAS -Scope CurrentUser
 ```
 
-**PowerShell 5.0 or above is required** to download the module from the [PowerShell Gallery](https://www.powershellgallery.com/packages/psPAS/).
+**PowerShell 5.0 or above** must be used to download the module from the [PowerShell Gallery](https://www.powershellgallery.com/packages/psPAS/).
 {: .notice--warning}
 
 ## Option 2: Manual Install

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -22,7 +22,7 @@
 	Description       = 'Module for CyberArk Privileged Access Security Web Service REST API'
 
 	# Minimum version of the Windows PowerShell engine required by this module
-	PowerShellVersion = '3.0'
+	PowerShellVersion = '5.0'
 
 	# Name of the Windows PowerShell host required by this module
 	# PowerShellHostName = ''


### PR DESCRIPTION
Raising the minimum required version from 3.0, to 5.0.
Some instances of syntax which is not compatible with PowerShell versions earlier than v5 exist in the module. 

Relates to #207 