### PR TITLE
Issue 210

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # psPAS
 
+## 3.2.32 (Sept 5th 2019)
+
+- Fixes
+  - `Add-PASSafeMember`
+    - Update validation of MemberName parameter to not accept values containing `&` symbol.
+
 ## 3.2.30 (Sept 1st 2019)
 
 - Update

--- a/docs/collections/_commands/Add-PASSafeMember.md
+++ b/docs/collections/_commands/Add-PASSafeMember.md
@@ -49,6 +49,7 @@ $false in the request.
 
     -MemberName <String>
         Vault or Domain User, or Group, to add as member.
+        Must not contain '&' (ampersand).
 
         Required?                    true
         Position?                    named

--- a/psPAS/Functions/SafeMembers/Add-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Add-PASSafeMember.ps1
@@ -16,6 +16,7 @@ The name of the safe to add the member to
 
 .PARAMETER MemberName
 Vault or Domain User, or Group, to add as member.
+Must not contain '&' (ampersand).
 
 .PARAMETER SearchIn
 The Vault or Domain, defined in the vault,
@@ -169,7 +170,7 @@ To force all output to be shown, pipe to Select-Object *
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateNotNullOrEmpty()]
-		[ValidateScript( { $_ -notmatch ".*(\?).*" })]
+		[ValidateScript( { $_ -notmatch ".*(\?|\&).*" })]
 		[string]$MemberName,
 
 		[parameter(


### PR DESCRIPTION
<!-- _A similar PR may already be submitted.
Please search existing `Pull Requests` before creating one._

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.  -->

## Summary

<!-- Summary of the PR -->

This PR fixes the following **bugs**:

  - `Add-PASSafeMember`
    - Update validation of MemberName parameter to not accept values containing `&` symbol.

## Test Plan

Supplying MemberName containing `&` fails parameter validation as expected

## Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes. -->
Fixes #210 

Closes #

<!--
## Code formatting

 See the `CONTRIBUTING` guide.

_Ensure your code adheres to the project's PowerShell Styleguide_
-->