### PR TITLE
UPDATE Get-PASAccountPassword

### DIFF
--- a/psPAS/Functions/Accounts/Get-PASAccountPassword.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccountPassword.ps1
@@ -216,8 +216,15 @@ From version 10.1 onwards both passwords and ssh keys can be retrieved.#>
 				$result = [System.Text.Encoding]::ASCII.GetString([PSCustomObject]$result.Content)
 
 			}
+			elseif ($PSCmdlet.ParameterSetName -eq "v10") {
+				
+				#Unescape returned string and remove enclosing quotes.
+				$result = $([System.Text.RegularExpressions.Regex]::Unescape($result) -replace '^"|"$', '')
 
-			[PSCustomObject] @{"Password" = $($result -replace '^"|"$', '') } |
+			}
+			
+			
+			[PSCustomObject] @{"Password" = $result } |
 
 			Add-ObjectDetail -typename psPAS.CyberArk.Vault.Credential
 


### PR DESCRIPTION
Fixes issue where password values with a "\\" slash character were not unescaped properly when returned using the v10 API.

## Closes issues

Closes #219 