### PR TITLE
ADD Enable-PASCPMAutoManagement

### DIFF
--- a/Tests/Enable-PASCPMAutoManagement.Tests.ps1
+++ b/Tests/Enable-PASCPMAutoManagement.Tests.ps1
@@ -1,0 +1,85 @@
+#Get Current Directory
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get Function Name
+$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+
+#Assume ModuleName from Repository Root folder
+$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+#Resolve Path to Module Directory
+$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+#Define Path to Module Manifest
+$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+if ( -not (Get-Module -Name $ModuleName -All)) {
+
+	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+}
+
+BeforeAll {
+
+	$Script:RequestBody = $null
+	$Script:BaseURI = "https://SomeURL/SomeApp"
+	$Script:ExternalVersion = "0.0"
+	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+}
+
+AfterAll {
+
+	$Script:RequestBody = $null
+
+}
+
+Describe $FunctionName {
+
+	InModuleScope $ModuleName {
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'AccountID' }
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Enable-PASCPMAutoManagement).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+
+			}
+
+		}
+
+		Context "Input" {
+
+			BeforeEach {
+
+				Mock Invoke-PASRestMethod -MockWith { }
+
+				$InputObj = [pscustomobject]@{
+					"AccountID"   = "12_3"
+
+				}
+
+			}
+
+			It "sends request" {
+				$InputObj | Enable-PASCPMAutoManagement
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+
+			}
+
+			It "throws error if version requirement not met" {
+				$Script:ExternalVersion = "1.2"
+
+				{ $InputObj | Enable-PASCPMAutoManagement } | Should throw
+				$Script:ExternalVersion = "0.0"
+			}
+
+		}
+
+	}
+
+}

--- a/psPAS/Functions/Accounts/Enable-PASCPMAutoManagement.ps1
+++ b/psPAS/Functions/Accounts/Enable-PASCPMAutoManagement.ps1
@@ -1,0 +1,69 @@
+﻿function Enable-PASCPMAutoManagement {
+<#
+.SYNOPSIS
+Enables an account for Automatic CPM Management.
+
+.DESCRIPTION
+Enables an account for CPm management by setting automaticManagementEnabled to $true, 
+and clearing any value set for manualManagementReason.
+
+Attempting to set automaticManagementEnabled to $true without clearing manualManagementReason
+at the same time results in an error.
+
+This function requests the API to perform both operations with a single command.
+
+.PARAMETER AccountID
+The ID of the account whose activities will be retrieved.
+
+.EXAMPLE
+Enable-PASCPMAutoManagement -AccountID 543_2
+
+Sets automaticManagementEnabled to $true & clears any value set for manualManagementReason
+on account with ID 543_2
+
+.NOTES
+Applicable to and requires 10.4+
+
+#>
+	[CmdletBinding()]
+	param(
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[Alias("id")]
+		[string]$AccountID
+
+
+	)
+
+	BEGIN { 
+
+		$MinimumVersion = [System.Version]"10.4"
+
+		$ops = @(
+			@{
+				"path"  = "/secretManagement/automaticManagementEnabled"
+				"op"    = "replace"
+				"value" = $true
+			},
+			@{
+				"path"  = "/secretManagement/manualManagementReason"
+				"op"    = "replace"
+				"value" = ""
+			}
+		)
+
+	}#begin
+
+	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $MinimumVersion
+
+		Set-PASAccount -AccountID $AccountID -operations $ops
+
+	}#process
+
+	END { }#end
+
+}

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -175,7 +175,8 @@
 		'Use-PASSession',
 		'Invoke-PASCPMOperation',
 		'Set-PASUserPassword',
-		'Set-PASDirectoryMappingOrder'
+		'Set-PASDirectoryMappingOrder',
+		'Enable-PASCPMAutoManagement'
 	)
 
 	# AliasesToExport   = @( )


### PR DESCRIPTION
Added new function `Enable-PASCPMAutoManagement`.
It is just a wrapper for Set-PASAccount, but performs 2 actions: 
- sets `/secretManagement/automaticManagementEnabled` to `$true`
- clears `/secretManagement/manualManagementReason`.

To enable an account for automatic CPM management, both actions must be performed.


## Closes issues

Closes #217 

