### PR TITLE
UPDATE Add-PASDiscoveredAccount

### DIFF
--- a/Tests/Add-PASDiscoveredAccount.Tests.ps1
+++ b/Tests/Add-PASDiscoveredAccount.Tests.ps1
@@ -161,6 +161,16 @@ Describe $FunctionName {
 				} -Times 1 -Exactly -Scope It
 			}
 
+			It "has a request body with expected platformTypeAccountProperties property for AWS" {
+				$InputObj | Add-PASDiscoveredAccount -awsAccountID 123456777889 -awsAccessKeyID SomeAccessKey
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					($Body | ConvertFrom-Json).platformTypeAccountProperties.awsAccountID -eq "123456777889"
+					($Body | ConvertFrom-Json).platformTypeAccountProperties.awsAccessKeyID -eq "SomeAccessKey"
+
+				} -Times 1 -Exactly -Scope It
+			}
+
 		}
 
 		Context "Output" {


### PR DESCRIPTION
## Summary

<!-- Summary of the PR -->

This PR implements an update to Add-PASDiscoveredAccount to take advantage of the API capability introduced in version 10.8
- Added "AWS", "AWS Access Keys" as valid options for `platformType` parameter.
- Changed `privileged` parameter to boolean to match example in documentation. Existing ValidateSet was causing error on adding of account.
- Added `awsAccountID`, `awsAccessKeyID` & `Dependencies` parameters.
