### PR TITLE
psPAS 3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # psPAS
 
+## 3.4.XX (January XX 2020)
+
+### Module update to cover CyberArk 11.2 API features
+
+- Updates
+  - Breaking Changes
+    - Parameters Changed: `New-PASDirectoryMapping` & `Set-PASDirectoryMapping`
+      - Functions updated to use enum flag for mapping authorization options
+      - `MappingAuthorizations`
+        - Parameter now accepts string values representing the autorizations to configure for the mapping instead of an integer representation of them.
+      - The following parameters are no longer accepted by the functions, the string values must be provided to the `MappingAuthorizations` parameter instead:
+        - `AddUpdateUsers`
+        - `AddSafes`
+        - `AddNetworkAreas`
+        - `ManageServerFileCategories`
+        - `AuditUsers`
+        - `BackupAllSafes`
+        - `RestoreAllSafes`
+        - `ResetUsersPasswords`
+        - `ActivateUsers`
+
+  - New Function
+    - Added `Test-PASPSMRecording`
+
+  - Fixes & Other Updates
+    - Update `Get-PASAccount` to accept `searchType` parameter. Relevant to 11.2+.
+    - Fixed incorrectly declared mandatory parameter in `Set-PASUser`
+    - Performance related updates to internal module mechanics.
+    - All functions help text updated to include link to function documentation on https://pspas.pspete.dev
+    - Corrections & updates to documentation on https://pspas.pspete.dev
+
 ## 3.3.88 (December 13th 2019)
 
 ### Module update to cover CyberArk 11.1 API features
@@ -26,8 +57,8 @@
     - MappingAuthorizations parameter no longer accepts pipeline input
   - `Add-PASDiscoveredAccount`
     - Added features introduced in version 10.8
-    - Supports Account Dependancy & AWS specific parameters
-  - `Get-PASPlatform`
+    - Supports Account Dependency & AWS specific parameters
+  - `Get-PASPlatform`s
     - Added features introduced in version 11.1
     - New options for finding platforms
   - `Remove-PASUser`
@@ -284,7 +315,7 @@ _2 years since first commit Anniversary Edition_
 ## 2.4.3 (February 15th 2019)
 
 - Bug Fix
-  - Remove debug output which could contain plaintex passwords.
+  - Remove debug output which could contain plaintext passwords.
     - Thanks [karrth](https://github.com/karrth)!
 
 ## 2.4.0 (February 1st 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Continued development to encompass any capability updates released for the CyberArk API.
 - psPAS v4.0...
 
-## 3.4.XX (January XX 2020)
+## 3.4.100 (January 27th 2020)
 
 ### Module update to cover CyberArk 11.2 API features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,35 +1,44 @@
 # psPAS
 
+## Planned Updates
+
+- Continued development to encompass any capability updates released for the CyberArk API.
+- psPAS v4.0...
+
 ## 3.4.XX (January XX 2020)
 
 ### Module update to cover CyberArk 11.2 API features
 
-- Updates
-  - Breaking Changes
-    - Parameters Changed: `New-PASDirectoryMapping` & `Set-PASDirectoryMapping`
-      - Functions updated to use enum flag for mapping authorization options
-      - `MappingAuthorizations`
-        - Parameter now accepts string values representing the autorizations to configure for the mapping instead of an integer representation of them.
-      - The following parameters are no longer accepted by the functions, the string values must be provided to the `MappingAuthorizations` parameter instead:
-        - `AddUpdateUsers`
-        - `AddSafes`
-        - `AddNetworkAreas`
-        - `ManageServerFileCategories`
-        - `AuditUsers`
-        - `BackupAllSafes`
-        - `RestoreAllSafes`
-        - `ResetUsersPasswords`
-        - `ActivateUsers`
+- **Breaking Changes**
+  - Parameters Changed: `New-PASDirectoryMapping` & `Set-PASDirectoryMapping`
+    - Functions updated to use enum flag for mapping authorization options
+    - `MappingAuthorizations`
+      - Parameter now accepts string values representing the authorizations to configure for the mapping instead of an integer representation of them.
+    - The following parameters are no longer accepted by the functions, the string values must now be provided to the `MappingAuthorizations` parameter instead:
+      - `AddUpdateUsers`
+      - `AddSafes`
+      - `AddNetworkAreas`
+      - `ManageServerFileCategories`
+      - `AuditUsers`
+      - `BackupAllSafes`
+      - `RestoreAllSafes`
+      - `ResetUsersPasswords`
+      - `ActivateUsers`
 
-  - New Function
-    - Added `Test-PASPSMRecording`
+- New Function
+  - Added `Test-PASPSMRecording`
+    - New in 11.2
 
-  - Fixes & Other Updates
-    - Update `Get-PASAccount` to accept `searchType` parameter. Relevant to 11.2+.
-    - Fixed incorrectly declared mandatory parameter in `Set-PASUser`
-    - Performance related updates to internal module mechanics.
-    - All functions help text updated to include link to function documentation on https://pspas.pspete.dev
-    - Corrections & updates to documentation on https://pspas.pspete.dev
+- Fixes & Other Updates
+  - Update `Get-PASAccount` to accept `searchType` parameter. Relevant to 11.2+.
+  - Fixed incorrectly declared mandatory parameter in `Set-PASUser`
+    - No longer required to set new password on user update.
+  - Update `psPAS.CyberArk.Vault.User.Formats`
+    - Include expiry & last logon date in friendly format.
+    - New table format for displaying user information returned from API requests.
+  - Performance related updates to internal module mechanics.
+  - All functions help text updated to include link to function documentation on https://pspas.pspete.dev
+  - Corrections & updates to documentation on https://pspas.pspete.dev
 
 ## 3.3.88 (December 13th 2019)
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Pete Maan
+Copyright (c) 2020 PSPETE LTD
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,15 +4,17 @@
 
 Use PowerShell to manage CyberArk via the Web Services REST API.
 
-Contains all published methods of the API up to CyberArk v11.1.
+Contains all published methods of the API up to CyberArk v11.2.
+
+Docs: [https://pspas.pspete.dev](https://pspas.pspete.dev)
 
 ----------
 
 ## Module Status
 
-| Master Branch            | Code Coverage            | PowerShell Gallery       | Downloads                  | Latest Build            | License                    |
-|--------------------------|--------------------------|--------------------------|----------------------------|-------------------------|----------------------------|
-|[![appveyor][]][av-site]  | [![coveralls][]][cv-site]|[![psgallery][]][ps-site] |[![downloads][]][ps-site]   |[![tests][]][tests-site] |[![license][]][license-link]|
+| Master Branch            | Code Coverage            | CodeFactor               |  PowerShell Gallery       | Downloads                  | Latest Build            | License                     |
+|--------------------------|--------------------------|--------------------------|---------------------------|----------------------------|-------------------------|-----------------------------|
+|[![appveyor][]][av-site]  | [![coveralls][]][cv-site]|[![codefactor][]][cf-site]| [![psgallery][]][ps-site] |[![downloads][]][ps-site]   |[![tests][]][tests-site] |[![license][]][license-link] |
 
 [appveyor]:https://ci.appveyor.com/api/projects/status/j45hbplm4dq4vfye/branch/master?svg=true
 [av-site]:https://ci.appveyor.com/project/pspete/pspas/branch/master
@@ -25,6 +27,8 @@ Contains all published methods of the API up to CyberArk v11.1.
 [tests]:https://img.shields.io/appveyor/tests/pspete/pspas.svg
 [tests-site]:https://ci.appveyor.com/project/pspete/pspas
 [downloads]:https://img.shields.io/powershellgallery/dt/pspas.svg?color=blue
+[cf-site]:https://www.codefactor.io/repository/github/pspete/pspas
+[codefactor]:https://www.codefactor.io/repository/github/pspete/pspas/badge
 
 ----------
 
@@ -842,6 +846,7 @@ Check the output of `Get-Help` for the `psPAS` functions for further details of 
 [`Remove-PASDirectoryMapping`][Remove-PASDirectoryMapping]                               |**11.1**            |Deletes a Directory Mapping
 [`Enable-PASCPMAutoManagement`][Enable-PASCPMAutoManagement]                             |**10.4**            |Enables Automatic CPM Managment for an account
 [`Disable-PASCPMAutoManagement`][Disable-PASCPMAutoManagement]                           |**10.4**            |Disables Automatic CPM Managment for an account
+[`Test-PASPSMRecording`][Test-PASPSMRecording]                                           | **11.2**           |Determine validity of PSM Session Recording
 
 [New-PASSession]:/psPAS/Functions/Authentication/New-PASSession.ps1
 [Close-PASSession]:/psPAS/Functions/Authentication/Close-PASSession.ps1
@@ -947,6 +952,7 @@ Check the output of `Get-Help` for the `psPAS` functions for further details of 
 [Remove-PASDirectoryMapping]:/psPAS/Functions/LDAPDirectories/Remove-PASDirectoryMapping.ps1
 [Get-PASPlatformSafe]:/psPAS/Functions/Platforms/Get-PASPlatformSafe.ps1
 [New-PASGroup]:/psPAS/Functions/User/New-PASGroup.ps1
+[Test-PASPSMRecording]:/psPAS/Functions/Monitoring/Test-PASPSMRecording.ps1
 
 ## Installation
 

--- a/Tests/Add-PASAccount.Tests.ps1
+++ b/Tests/Add-PASAccount.Tests.ps1
@@ -179,7 +179,7 @@ Describe $FunctionName {
 				$InputObj | Add-PASAccount
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-					($Body | ConvertFrom-Json | Select-Object -ExpandProperty Account | Get-Member -MemberType NoteProperty).length -eq 11
+					($Body | ConvertFrom-Json | Select-Object -ExpandProperty Account | Get-Member -MemberType NoteProperty).length -eq 10
 				} -Times 1 -Exactly -Scope It
 			}
 

--- a/Tests/Add-PASAccountACL.Tests.ps1
+++ b/Tests/Add-PASAccountACL.Tests.ps1
@@ -109,7 +109,7 @@ Describe $FunctionName {
 
 			It "has a request body with expected number of properties" {
 
-				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 5
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 4
 
 			}
 

--- a/Tests/Find-PASSafe.Tests.ps1
+++ b/Tests/Find-PASSafe.Tests.ps1
@@ -70,9 +70,10 @@ Describe $FunctionName {
 
 			It "sends request with expected query" {
 
+				Find-PASSafe -search SomeQuery
+
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					Find-PASSafe -search SomeQuery
 					$URI -eq "$($Script:BaseURI)/api/Safes?limit=25&search=SomeQuery"
 
 				} -Times 1 -Exactly -Scope It
@@ -102,7 +103,13 @@ Describe $FunctionName {
 				Mock Invoke-PASRestMethod -MockWith {
 					[PSCustomObject]@{
 						"Total" = 100
-						"Safes" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+						"Safes" = @(
+							[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" },
+							[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" },
+							[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" },
+							[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" },
+							[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+						)
 					}
 				}
 
@@ -122,7 +129,14 @@ Describe $FunctionName {
 
 				Mock Invoke-PASRestMethod -MockWith {
 					[PSCustomObject]@{
-						"Safes" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+						"Total" = 20
+						"Safes" = @(
+							[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" },
+							[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" },
+							[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" },
+							[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" },
+							[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+						)
 					}
 				}
 
@@ -147,13 +161,19 @@ Describe $FunctionName {
 				Mock Invoke-PASRestMethod -MockWith {
 					[PSCustomObject]@{
 						"Total" = 100
-						"Safes" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+						"Safes" = @(
+							[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" },
+							[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" },
+							[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" },
+							[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" },
+							[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+						)
 					}
 				}
 
 				$response = Find-PASSafe
 
-				$response.count | Should be 4
+				$response.count | Should be 20
 
 			}
 

--- a/Tests/Get-PASAccount.Tests.ps1
+++ b/Tests/Get-PASAccount.Tests.ps1
@@ -58,7 +58,7 @@ Describe $FunctionName {
 
 			It "sends request - v10ByQuery parameterset" {
 
-				Get-PASAccount -search SearchTerm
+				Get-PASAccount -search SearchTerm -searchType contains
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
@@ -124,9 +124,9 @@ Describe $FunctionName {
 			}
 
 			It "throws error if version requirement not met" {
-$Script:ExternalVersion = "1.0"
-				{ Get-PASAccount -ID "SomeID"  } | Should Throw
-$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = "1.0"
+				{ Get-PASAccount -ID "SomeID" } | Should Throw
+				$Script:ExternalVersion = "0.0"
 			}
 
 		}
@@ -236,7 +236,7 @@ $Script:ExternalVersion = "0.0"
 				Mock Invoke-PASRestMethod -MockWith {
 					[pscustomobject]@{
 						"Count" = 30
-						"Value" = [pscustomobject]@{"Prop1" = "Val1" }
+						"Value" = @([pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" })
 					}
 				}
 				$response = Get-PASAccount -search SomeSearchTerm
@@ -250,13 +250,14 @@ $Script:ExternalVersion = "0.0"
 						[pscustomobject]@{
 							"Count"    = 30
 							"nextLink" = "SomeLink"
-							"Value"    = [pscustomobject]@{"Prop1" = "Val1" }
+							"Value"    = @([pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" })
 						}
 						$script:iteration++
-					} else {
+					}
+					else {
 						[pscustomobject]@{
 							"Count" = 30
-							"Value" = [pscustomobject]@{"Prop1" = "Val1" }
+							"Value" = @([pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" })
 						}
 					}
 				}
@@ -282,7 +283,7 @@ $Script:ExternalVersion = "0.0"
 				Mock Invoke-PASRestMethod -MockWith {
 					[pscustomobject]@{
 						"Count" = 30
-						"Value" = [pscustomobject]@{"Prop1" = "Val1" }
+						"Value" = @([pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" })
 					}
 				}
 				$response = Get-PASAccount -search SomeSearch

--- a/Tests/New-PASDirectoryMapping.Tests.ps1
+++ b/Tests/New-PASDirectoryMapping.Tests.ps1
@@ -58,7 +58,7 @@ Describe $FunctionName {
 
 			It "does not throw - v10.4 parameterset" {
 				$Script:ExternalVersion = "10.4"
-				{ $InputObj | New-PASDirectoryMapping -RestoreAllSafes } | Should -Not -Throw
+				{ $InputObj | New-PASDirectoryMapping -MappingAuthorizations RestoreAllSafes } | Should -Not -Throw
 			}
 
 
@@ -73,13 +73,13 @@ Describe $FunctionName {
 			}
 
 			It "sends request" {
-				$InputObj | New-PASDirectoryMapping -RestoreAllSafes
+				$InputObj | New-PASDirectoryMapping -MappingAuthorizations RestoreAllSafes
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request to expected endpoint" {
-				$InputObj | New-PASDirectoryMapping -RestoreAllSafes
+				$InputObj | New-PASDirectoryMapping -MappingAuthorizations RestoreAllSafes
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$URI -eq "$($Script:BaseURI)/api/Configuration/LDAP/Directories/SomeDirectory/Mappings"
@@ -89,14 +89,14 @@ Describe $FunctionName {
 			}
 
 			It "uses expected method" {
-				$InputObj | New-PASDirectoryMapping -RestoreAllSafes
+				$InputObj | New-PASDirectoryMapping -MappingAuthorizations RestoreAllSafes
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "1.0"
-				{ $InputObj | New-PASDirectoryMapping -RestoreAllSafes -BackupAllSafes } | Should -Throw
+				{ $InputObj | New-PASDirectoryMapping -MappingAuthorizations RestoreAllSafes, BackupAllSafes } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 
@@ -108,13 +108,13 @@ Describe $FunctionName {
 
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "10.9"
-				{ $InputObj | New-PASDirectoryMapping -RestoreAllSafes -BackupAllSafes -VaultGroups "Group1", "Group2" -UserActivityLogPeriod 10 } | Should -Throw
+				{ $InputObj | New-PASDirectoryMapping -MappingAuthorizations RestoreAllSafes, BackupAllSafes -VaultGroups "Group1", "Group2" -UserActivityLogPeriod 10 } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 
 			It "does not throw if version requirement met" {
 				$Script:ExternalVersion = "10.10"
-				{ $InputObj | New-PASDirectoryMapping -RestoreAllSafes -BackupAllSafes -VaultGroups "Group1", "Group2" -UserActivityLogPeriod 10 } | Should -Not -Throw
+				{ $InputObj | New-PASDirectoryMapping -MappingAuthorizations RestoreAllSafes, BackupAllSafes -VaultGroups "Group1", "Group2" -UserActivityLogPeriod 10 } | Should -Not -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 

--- a/Tests/Test-PASPSMRecording.Tests.ps1
+++ b/Tests/Test-PASPSMRecording.Tests.ps1
@@ -43,51 +43,44 @@ Describe $FunctionName {
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+					$true
 				}
 
 				$InputObj = [pscustomobject]@{
-					"DirectoryName" = "SomeDirectory"
-					"MappingID"     = "SomeMappingID"
-					"MappingName"   = "SomeName"
-					"LDAPBranch"    = "SomeBranch"
+					"SessionID" = "777_7"
 
 				}
+
+				$response = $InputObj | Test-PASPSMRecording
 
 			}
 
 			It "sends request" {
-				$InputObj | Set-PASDirectoryMapping -MappingAuthorizations AddUpdateUsers ActivateUsers
+
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request to expected endpoint" {
-				$InputObj | Set-PASDirectoryMapping -MappingAuthorizations AddUpdateUsers, ActivateUsers
+
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/LDAP/Directories/SomeDirectory/Mappings/SomeMappingID"
+					$URI -eq "$($Script:BaseURI)/API/Recordings/777_7/valid"
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
-				$InputObj | Set-PASDirectoryMapping -MappingAuthorizations AddUpdateUsers, ActivateUsers
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PUT' } -Times 1 -Exactly -Scope It
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
-				{ $InputObj | Set-PASDirectoryMapping } | Should Throw
-				$Script:ExternalVersion = "0.0"
-			}
+			It "sends request with no body" {
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "10.9"
-				{ $InputObj | Set-PASDirectoryMapping -UserActivityLogPeriod 10 } | Should Throw
-				$Script:ExternalVersion = "0.0"
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
+
 			}
 
 		}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # version format
-version: 3.3.{build}
+version: 3.4.{build}
 
 environment:
   psgallery_deploy: manual_deploy

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -77,8 +77,6 @@ commands:
         url: /commands/Enable-PASCPMAutoManagement
       - title: "Disable-PASCPMAutoManagement"
         url: /commands/Disable-PASCPMAutoManagement
-      - title: "New-PASGroup"
-        url: /commands/New-PASGroup
 
   - title: "Applications"
     children:
@@ -160,6 +158,8 @@ commands:
         url: /commands/Get-PASPSMRecordingActivity
       - title: "Get-PASPSMRecordingProperty"
         url: /commands/Get-PASPSMRecordingProperty
+      - title: "Test-PASPSMRecording"
+        url: /commands/Test-PASPSMRecording
 
   - title: "Onboarding Rules"
     children:
@@ -271,6 +271,8 @@ commands:
         url: /commands/Add-PASGroupMember
       - title: "Remove-PASGroupMember"
         url: /commands/Remove-PASGroupMember
+      - title: "New-PASGroup"
+        url: /commands/New-PASGroup
 
 # documentation links
 docs:

--- a/docs/collections/_commands/Add-PASDirectory.md
+++ b/docs/collections/_commands/Add-PASDirectory.md
@@ -132,9 +132,8 @@ Membership of the Vault Admins group required.
 
     -------------------------- EXAMPLE 2 --------------------------
 
-    PS C:\>Add-PASDirectory -DirectoryType "MicrosoftADProfile.ini" -BindUsername "bind@domain.com"
-    -BindPassword $pw -DomainName DOMAIN -DomainBaseContext "DC=DOMAIN,DC=COM" -DCList @(@{
-        "Name"="192.168.99.1";"Port"=389;"SSLConnect"=$false},
-        @{"Name"="192.168.99.1";"Port"=389;"SSLConnect"=$false}) -Port 389
+    PS C:\> Add-PASDirectory -DirectoryType "MicrosoftADProfile.ini" -BindUsername "BindUser@domain.com" `
+    -BindPassword $($Creds.Password) -DomainName DOMAIN -DomainBaseContext "DC=domain,DC=com" `
+    -DCList @{"Name"="DC.domain.com";"Port"=636;"SSLConnect"=$true} -SSLConnect $true -Port 636
 
-    (For 10.7+) - Adds the Domain.Com directory to the vault
+    (For 10.7+) - Adds the Domain.Com directory to the vault, configured for LDAPS.

--- a/docs/collections/_commands/Get-PASAccount.md
+++ b/docs/collections/_commands/Get-PASAccount.md
@@ -4,13 +4,12 @@ title: Get-PASAccount
 
 ## SYNOPSIS
 
-Returns details of matching accounts. (Version 10.4 onwards)
-
-Returns information about a single account. (Version 9.3 - 10.3)
+    Returns details of matching accounts. (Version 10.4 onwards)
+    Returns information about a single account. (Version 9.3 - 10.3)
 
 ## SYNTAX
 
-    Get-PASAccount [-search <String>] [-sort <String[]>] [-offset <Int32>] [-limit <Int32>]
+    Get-PASAccount [-search <String>] [-searchType <String>] [-sort <String[]>] [-offset <Int32>] [-limit <Int32>]
     [-filter <String>] [-TimeoutSec <Int32>] [<CommonParameters>]
 
     Get-PASAccount -id <String> [-TimeoutSec <Int32>] [<CommonParameters>]
@@ -19,28 +18,21 @@ Returns information about a single account. (Version 9.3 - 10.3)
 
 ## DESCRIPTION
 
-Version 10.4 onwards:
+    Version 10.4+:
+    This method returns a list of either a specific, or all the accounts in the Vault.
+    Requires the following permission in the Safe: List accounts.
 
-This method returns a list of either a specific, or all the accounts in the Vault.
-
-Requires the following permission in the Safe: List accounts.
-
-Version 9.3 - 10.3:
-
-Returns information about an account. If more than one account meets the search criteria,
-only the first account will be returned (the Count output parameter will display the number
-of accounts that were found).
-
-Only the following users can access this account:
-
-- Users who are members of the Safe where the account is stored
-- Users who have access to this specific account.
-- The user who runs this web service requires the following permission in the Safe:
-- Retrieve account
-
-This method does not display the actual password.
-
-If ten or more accounts are found, the Count Output parameter will show 10.
+    Version 9.3 - 10.3:
+    Returns information about an account. If more than one account meets the search criteria,
+    only the first account will be returned (the Count output parameter will display the number
+    of accounts that were found).
+    Only the following users can access this account:
+        - Users who are members of the Safe where the account is stored
+        - Users who have access to this specific account.
+        - The user who runs this web service requires the following permission in the Safe:
+        - Retrieve account
+    This method does not display the actual password.
+    If ten or more accounts are found, the Count Output parameter will show 10.
 
 ## PARAMETERS
 
@@ -62,8 +54,19 @@ If ten or more accounts are found, the Count Output parameter will show 10.
         Accept pipeline input?       true (ByPropertyName)
         Accept wildcard characters?  false
 
+    -searchType <String>
+        Get accounts that either contain or start with the value specified in the Search parameter.
+
+        Required?                    false
+        Position?                    named
+        Default value
+        Accept pipeline input?       true (ByPropertyName)
+        Accept wildcard characters?  false
+
     -sort <String[]>
-        An account property to sort the results by.
+        Property or properties by which to sort returned accounts,
+        followed by asc (default) or desc to control sort direction.
+        Separate multiple properties with commas, up to a maximum of three properties.
 
         Required?                    false
         Position?                    named
@@ -82,10 +85,8 @@ If ten or more accounts are found, the Count Output parameter will show 10.
 
     -limit <Int32>
         Maximum number of returned accounts. If not specified, the default value is 50.
-        The maximum number that can be specified is 1000. When used together with the
-        Offset parameter,
-        this value determines the number of accounts to return, starting from the first
-        account that is returned.
+        The maximum number that can be specified is 1000. When used together with the Offset parameter,
+        this value determines the number of accounts to return, starting from the first account that is returned.
 
         Required?                    false
         Position?                    named
@@ -95,7 +96,7 @@ If ten or more accounts are found, the Count Output parameter will show 10.
 
     -filter <String>
         A filter for the search.
-        Requires format: "SafeName eq YourSafe"
+        Requires format: "SafeName eq 'YourSafe'"
 
         Required?                    false
         Position?                    named
@@ -116,8 +117,7 @@ If ten or more accounts are found, the Count Output parameter will show 10.
         Accept wildcard characters?  false
 
     -Safe <String>
-        The name of a Safe to search. The search will be carried out only in the Safes
-        in the Vault
+        The name of a Safe to search. The search will be carried out only in the Safes in the Vault
         that the authenticated used is authorized to access.
         Relevant for CyberArk versions earlier than 10.4
 
@@ -159,13 +159,21 @@ If ten or more accounts are found, the Count Output parameter will show 10.
 
     PS C:\>Get-PASAccount -search root -sort name -offset 100 -limit 5
 
-    Returns all accounts matching "root", sorted by AccountName, Search results offset by
-    100 and limited to 5.
+    Returns all accounts matching "root", sorted by AccountName, Search results offset by 100 and limited to 5.
 
 
 
 
     -------------------------- EXAMPLE 3 --------------------------
+
+    PS C:\>Get-PASAccount -search XUser -searchType startswith
+
+    Returns all accounts starting with "XUser".
+
+
+
+
+    -------------------------- EXAMPLE 4 --------------------------
 
     PS C:\>Get-PASAccount -filter "SafeName eq TargetSafe"
 
@@ -174,7 +182,16 @@ If ten or more accounts are found, the Count Output parameter will show 10.
 
 
 
-    -------------------------- EXAMPLE 4 --------------------------
+    -------------------------- EXAMPLE 5 --------------------------
+
+    PS C:\>Get-PASAccount -filter "SafeName eq 'TargetSafe'" -sort "userName desc"
+
+    Returns all accounts found in TargetSafe, sort by username in descending order.
+
+
+
+
+    -------------------------- EXAMPLE 6 --------------------------
 
     PS C:\>Get-PASAccount -Keywords root -Safe UNIX
 
@@ -192,7 +209,7 @@ If ten or more accounts are found, the Count Output parameter will show 10.
 
 
 
-    -------------------------- EXAMPLE 5 --------------------------
+    -------------------------- EXAMPLE 7 --------------------------
 
     PS C:\>Get-PASAccount -Keywords xtest
 

--- a/docs/collections/_commands/New-PASDirectoryMapping.md
+++ b/docs/collections/_commands/New-PASDirectoryMapping.md
@@ -4,25 +4,18 @@ title: New-PASDirectoryMapping
 
 ## SYNOPSIS
 
-Adds a new Directory Mapping for an existing directory
+    Adds a new Directory Mapping for an existing directory
 
 ## SYNTAX
 
-    New-PASDirectoryMapping -DirectoryName <String> -MappingName <String> -LDAPBranch <String>
-    -DomainGroups <String[]> [-VaultGroups <String[]>] [-Location <String>] [-LDAPQuery <String>]
-    [-AddUpdateUsers] [-AddSafes] [-AddNetworkAreas] [-ManageServerFileCategories] [-AuditUsers]
-    [-BackupAllSafes] [-RestoreAllSafes] [-ResetUsersPasswords] [-ActivateUsers]
-    [-UserActivityLogPeriod <Int32>]
-
-    New-PASDirectoryMapping -DirectoryName <String> -MappingName <String> -LDAPBranch <String>
-    -DomainGroups <String[]> [-VaultGroups <String[]>] [-Location <String>] [-LDAPQuery <String>]
-    [-MappingAuthorizations <Int32[]>] [-UserActivityLogPeriod <Int32>]
+    New-PASDirectoryMapping [-DirectoryName] <String> [-MappingName] <String> [-LDAPBranch] <String> [-DomainGroups] <String[]> [[-VaultGroups] <String[]>] [[-Location] <String>] [[-LDAPQuery] <String>]
+    [[-MappingAuthorizations] {AddUpdateUsers | AddSafes | AddNetworkAreas | ManageServerFileCategories | AuditUsers | BackupAllSafes | RestoreAllSafes | ResetUsersPasswords | ActivateUsers}]
+    [[-UserActivityLogPeriod] <Int32>] [-WhatIf] [-Confirm] [<CommonParameters>]
 
 ## DESCRIPTION
 
-Adds an LDAP directory to the Vault.
-
-Membership of the Vault Admins group required.
+    Adds a directory mapping.
+    Membership of the Vault Admins group required.
 
 ## PARAMETERS
 
@@ -30,7 +23,7 @@ Membership of the Vault Admins group required.
         The name of the directory the mapping is for.
 
         Required?                    true
-        Position?                    named
+        Position?                    1
         Default value
         Accept pipeline input?       true (ByPropertyName)
         Accept wildcard characters?  false
@@ -39,7 +32,7 @@ Membership of the Vault Admins group required.
         The name of the PAS role that will be created.
 
         Required?                    true
-        Position?                    named
+        Position?                    2
         Default value
         Accept pipeline input?       true (ByPropertyName)
         Accept wildcard characters?  false
@@ -48,26 +41,26 @@ Membership of the Vault Admins group required.
         The LDAP branch that will be used for external directory queries
 
         Required?                    true
-        Position?                    named
+        Position?                    3
         Default value
         Accept pipeline input?       true (ByPropertyName)
         Accept wildcard characters?  false
 
     -DomainGroups <String[]>
-        Users who belong to these LDAP groups will be automatically assigned to the relevant roles
-        in the PAS system.
+        Users who belong to these LDAP groups will be automatically assigned to the relevant roles in the PAS system.
 
         Required?                    true
-        Position?                    named
+        Position?                    4
         Default value
         Accept pipeline input?       true (ByPropertyName)
         Accept wildcard characters?  false
 
     -VaultGroups <String[]>
         A list of Vault groups that a mapped user will be added to.
+        Requires CyberArk version 10.7+
 
         Required?                    false
-        Position?                    named
+        Position?                    5
         Default value
         Accept pipeline input?       true (ByPropertyName)
         Accept wildcard characters?  false
@@ -75,113 +68,33 @@ Membership of the Vault Admins group required.
     -Location <String>
         The path of the Vault location that mapped users are added under.
         This value cannot be updated.
+        Requires CyberArk version 10.7+
 
         Required?                    false
-        Position?                    named
+        Position?                    6
         Default value
         Accept pipeline input?       true (ByPropertyName)
         Accept wildcard characters?  false
 
     -LDAPQuery <String>
         Match LDAP query results to mapping
+        Requires CyberArk version 10.7+
 
         Required?                    false
-        Position?                    named
+        Position?                    7
         Default value
         Accept pipeline input?       true (ByPropertyName)
         Accept wildcard characters?  false
 
-    -MappingAuthorizations <Int32[]>
-        The integer flag representation of the security attributes and authorizations that will be
-        applied when an LDAP User Account is created in the Vault.
+    -MappingAuthorizations
+        Specify authorizations that will be applied when an LDAP User Account is created in the Vault.
         To apply specific authorizations to a mapping, the user must have the same authorizations.
-        Possible authorizations: AddSafes, AuditUsers, AddUpdateUsers, ResetUsersPasswords,
-        ActivateUsers, AddNetworkAreas, ManageServerFileCategories, BackupAllSafes, RestoreAllSafes.
+        Possible authorizations: AddSafes, AuditUsers, AddUpdateUsers, ResetUsersPasswords, ActivateUsers,
+        AddNetworkAreas, ManageServerFileCategories, BackupAllSafes, RestoreAllSafes.
 
         Required?                    false
-        Position?                    named
+        Position?                    8
         Default value
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
-
-    -AddUpdateUsers [<SwitchParameter>]
-        Specify switch to add the AddUpdateUsers authorization to the directory mapping
-
-        Required?                    false
-        Position?                    named
-        Default value                False
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
-
-    -AddSafes [<SwitchParameter>]
-        Specify switch to add the AddSafes authorization to the directory mapping
-
-        Required?                    false
-        Position?                    named
-        Default value                False
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
-
-    -AddNetworkAreas [<SwitchParameter>]
-        Specify switch to add the AddNetworkAreas authorization to the directory mapping
-
-        Required?                    false
-        Position?                    named
-        Default value                False
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
-
-    -ManageServerFileCategories [<SwitchParameter>]
-        Specify switch to add the ManageServerFileCategories authorization to the directory mapping
-
-        Required?                    false
-        Position?                    named
-        Default value                False
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
-
-    -AuditUsers [<SwitchParameter>]
-        Specify switch to add the AuditUsers authorization to the directory mapping
-
-        Required?                    false
-        Position?                    named
-        Default value                False
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
-
-    -BackupAllSafes [<SwitchParameter>]
-        Specify switch to add the BackupAllSafes authorization to the directory mapping
-
-        Required?                    false
-        Position?                    named
-        Default value                False
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
-
-    -RestoreAllSafes [<SwitchParameter>]
-        Specify switch to add the RestoreAllSafes authorization to the directory mapping
-
-        Required?                    false
-        Position?                    named
-        Default value                False
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
-
-    -ResetUsersPasswords [<SwitchParameter>]
-        Specify switch to add the ResetUsersPasswords authorization to the directory mapping
-
-        Required?                    false
-        Position?                    named
-        Default value                False
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
-
-    -ActivateUsers [<SwitchParameter>]
-        Specify switch to add the ActivateUsers authorization to the directory mapping
-
-        Required?                    false
-        Position?                    named
-        Default value                False
         Accept pipeline input?       true (ByPropertyName)
         Accept wildcard characters?  false
 
@@ -190,7 +103,7 @@ Membership of the Vault Admins group required.
         Requires CyberArk version 10.10+
 
         Required?                    false
-        Position?                    named
+        Position?                    9
         Default value                0
         Accept pipeline input?       true (ByPropertyName)
         Accept wildcard characters?  false
@@ -215,14 +128,13 @@ Membership of the Vault Admins group required.
         This cmdlet supports the common parameters: Verbose, Debug,
         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
         OutBuffer, PipelineVariable, and OutVariable. For more information, see
-        about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).## EXAMPLES
+        about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).
 
 ## EXAMPLES
 
     -------------------------- EXAMPLE 1 --------------------------
 
-    PS C:\>New-PASDirectoryMapping -DirectoryName "domain.com" -LDAPBranch "DC=DOMAIN,DC=COM"
-    -DomainGroups ADGroup -MappingName Map3 -RestoreAllSafes -BackupAllSafes
+    PS C:\>New-PASDirectoryMapping -DirectoryName "domain.com" -LDAPBranch "DC=DOMAIN,DC=COM" -DomainGroups ADGroup -MappingName Map3 -MappingAuthorizations RestoreAllSafes, BackupAllSafes
 
     Creates a new  LDAP directory mapping in the Vault with the following authorizations:
     BackupAllSafes, RestoreAllSafes
@@ -232,8 +144,7 @@ Membership of the Vault Admins group required.
 
     -------------------------- EXAMPLE 2 --------------------------
 
-    PS C:\>New-PASDirectoryMapping -DirectoryName "domain.com" -LDAPBranch "DC=DOMAIN,DC=COM"
-    -DomainGroups ADGroup -MappingName Map2 -MappingAuthorizations 1536
+    PS C:\>New-PASDirectoryMapping -DirectoryName "domain.com" -LDAPBranch "DC=DOMAIN,DC=COM" -DomainGroups ADGroup -MappingName Map2 -MappingAuthorizations BackupAllSafes, RestoreAllSafes
 
     Creates a new  LDAP directory mapping in the Vault with the following authorizations:
     BackupAllSafes, RestoreAllSafes
@@ -243,8 +154,7 @@ Membership of the Vault Admins group required.
 
     -------------------------- EXAMPLE 3 --------------------------
 
-    PS C:\>New-PASDirectoryMapping -DirectoryName "domain.com" -LDAPBranch "DC=DOMAIN,DC=COM"
-    -DomainGroups ADGroup -MappingName Map1 -MappingAuthorizations 1,3,512
+    PS C:\>New-PASDirectoryMapping -DirectoryName "domain.com" -LDAPBranch "DC=DOMAIN,DC=COM" -DomainGroups ADGroup -MappingName Map1 -MappingAuthorizations AddUpdateUsers, AddSafes, BackupAllSafes
 
     Creates a new  LDAP directory mapping in the Vault with the following authorizations:
     AddUpdateUsers, AddSafes, BackupAllSafes

--- a/docs/collections/_commands/Set-PASDirectoryMapping.md
+++ b/docs/collections/_commands/Set-PASDirectoryMapping.md
@@ -4,22 +4,18 @@ title: Set-PASDirectoryMapping
 
 ## SYNOPSIS
 
-Adds a new Directory Mapping for an existing directory
+    Updates an existing Directory Mapping for a directory
 
 ## SYNTAX
 
-    Set-PASDirectoryMapping -DirectoryName <String> -MappingID <String> -MappingName <String> -LDAPBranch <String> [-DomainGroups <String[]>] [-VaultGroups
-    <String[]>] [-Location <String>] [-LDAPQuery <String>] [-MappingAuthorizations <Int32[]>] [-UserActivityLogPeriod <Int32>] [-WhatIf] [-Confirm]
-    [<CommonParameters>]
-
-    Set-PASDirectoryMapping -DirectoryName <String> -MappingID <String> -MappingName <String> -LDAPBranch <String> [-DomainGroups <String[]>] [-VaultGroups
-    <String[]>] [-Location <String>] [-LDAPQuery <String>] [-AddUpdateUsers] [-AddSafes] [-AddNetworkAreas] [-ManageServerFileCategories] [-AuditUsers]
-    [-BackupAllSafes] [-RestoreAllSafes] [-ResetUsersPasswords] [-ActivateUsers] [-UserActivityLogPeriod <Int32>] [-WhatIf] [-Confirm] [<CommonParameters>]
+    Set-PASDirectoryMapping [-DirectoryName] <String> [-MappingID] <String> [-MappingName] <String> [-LDAPBranch] <String> [[-DomainGroups] <String[]>] [[-VaultGroups] <String[]>] [[-Location] <String>]
+    [[-LDAPQuery] <String>] [[-MappingAuthorizations] {AddUpdateUsers | AddSafes | AddNetworkAreas | ManageServerFileCategories | AuditUsers | BackupAllSafes | RestoreAllSafes | ResetUsersPasswords |
+    ActivateUsers}] [[-UserActivityLogPeriod] <Int32>] [-WhatIf] [-Confirm] [<CommonParameters>]
 
 ## DESCRIPTION
 
-Adds an LDAP directory to the Vault.
-Membership of the Vault Admins group required.
+    Updates a  directory mapping.
+    Membership of the Vault Admins group required.
 
 ## PARAMETERS
 
@@ -27,7 +23,7 @@ Membership of the Vault Admins group required.
         The name of the directory the mapping is for.
 
         Required?                    true
-        Position?                    named
+        Position?                    1
         Default value
         Accept pipeline input?       true (ByPropertyName)
         Accept wildcard characters?  false
@@ -36,7 +32,7 @@ Membership of the Vault Admins group required.
         The ID of the Directory Mapping to Update
 
         Required?                    true
-        Position?                    named
+        Position?                    2
         Default value
         Accept pipeline input?       true (ByPropertyName)
         Accept wildcard characters?  false
@@ -45,7 +41,7 @@ Membership of the Vault Admins group required.
         The name of the PAS role that will be created.
 
         Required?                    true
-        Position?                    named
+        Position?                    3
         Default value
         Accept pipeline input?       true (ByPropertyName)
         Accept wildcard characters?  false
@@ -54,7 +50,7 @@ Membership of the Vault Admins group required.
         The LDAP branch that will be used for external directory queries
 
         Required?                    true
-        Position?                    named
+        Position?                    4
         Default value
         Accept pipeline input?       true (ByPropertyName)
         Accept wildcard characters?  false
@@ -63,7 +59,7 @@ Membership of the Vault Admins group required.
         Users who belong to these LDAP groups will be automatically assigned to the relevant roles in the PAS system.
 
         Required?                    false
-        Position?                    named
+        Position?                    5
         Default value
         Accept pipeline input?       true (ByPropertyName)
         Accept wildcard characters?  false
@@ -72,7 +68,7 @@ Membership of the Vault Admins group required.
         A list of Vault groups that a mapped user will be added to.
 
         Required?                    false
-        Position?                    named
+        Position?                    6
         Default value
         Accept pipeline input?       true (ByPropertyName)
         Accept wildcard characters?  false
@@ -82,7 +78,7 @@ Membership of the Vault Admins group required.
         This value cannot be updated.
 
         Required?                    false
-        Position?                    named
+        Position?                    7
         Default value
         Accept pipeline input?       true (ByPropertyName)
         Accept wildcard characters?  false
@@ -91,103 +87,21 @@ Membership of the Vault Admins group required.
         Match LDAP query results to mapping
 
         Required?                    false
-        Position?                    named
+        Position?                    8
         Default value
         Accept pipeline input?       true (ByPropertyName)
         Accept wildcard characters?  false
 
-    -MappingAuthorizations <Int32[]>
-        The integer flag representation of the security attributes and authorizations that will be applied when an
-        LDAP User Account is created in the Vault.
+    -MappingAuthorizations
+        Specify authorizations that will be applied when an LDAP User Account is created in the Vault.
         To apply specific authorizations to a mapping, the user must have the same authorizations.
-        Possible authorizations: AddSafes, AuditUsers, AddUpdateUsers, ResetUsersPasswords, ActivateUsers, AddNetworkAreas,
-        ManageServerFileCategories, BackupAllSafes, RestoreAllSafes.
+        Possible authorizations: AddSafes, AuditUsers, AddUpdateUsers, ResetUsersPasswords, ActivateUsers,
+        AddNetworkAreas, ManageServerFileCategories, BackupAllSafes, RestoreAllSafes.
 
         Required?                    false
-        Position?                    named
+        Position?                    9
         Default value
         Accept pipeline input?       false
-        Accept wildcard characters?  false
-
-    -AddUpdateUsers [<SwitchParameter>]
-        Specify switch to add the AddUpdateUsers authorization to the directory mapping
-
-        Required?                    false
-        Position?                    named
-        Default value                False
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
-
-    -AddSafes [<SwitchParameter>]
-        Specify switch to add the AddSafes authorization to the directory mapping
-
-        Required?                    false
-        Position?                    named
-        Default value                False
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
-
-    -AddNetworkAreas [<SwitchParameter>]
-        Specify switch to add the AddNetworkAreas authorization to the directory mapping
-
-        Required?                    false
-        Position?                    named
-        Default value                False
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
-
-    -ManageServerFileCategories [<SwitchParameter>]
-        Specify switch to add the ManageServerFileCategories authorization to the directory mapping
-
-        Required?                    false
-        Position?                    named
-        Default value                False
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
-
-    -AuditUsers [<SwitchParameter>]
-        Specify switch to add the AuditUsers authorization to the directory mapping
-
-        Required?                    false
-        Position?                    named
-        Default value                False
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
-
-    -BackupAllSafes [<SwitchParameter>]
-        Specify switch to add the BackupAllSafes authorization to the directory mapping
-
-        Required?                    false
-        Position?                    named
-        Default value                False
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
-
-    -RestoreAllSafes [<SwitchParameter>]
-        Specify switch to add the RestoreAllSafes authorization to the directory mapping
-
-        Required?                    false
-        Position?                    named
-        Default value                False
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
-
-    -ResetUsersPasswords [<SwitchParameter>]
-        Specify switch to add the ResetUsersPasswords authorization to the directory mapping
-
-        Required?                    false
-        Position?                    named
-        Default value                False
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
-
-    -ActivateUsers [<SwitchParameter>]
-        Specify switch to add the ActivateUsers authorization to the directory mapping
-
-        Required?                    false
-        Position?                    named
-        Default value                False
-        Accept pipeline input?       true (ByPropertyName)
         Accept wildcard characters?  false
 
     -UserActivityLogPeriod <Int32>
@@ -195,7 +109,7 @@ Membership of the Vault Admins group required.
         Requires CyberArk version 10.10+
 
         Required?                    false
-        Position?                    named
+        Position?                    10
         Default value                0
         Accept pipeline input?       true (ByPropertyName)
         Accept wildcard characters?  false
@@ -228,20 +142,24 @@ Membership of the Vault Admins group required.
 
     PS C:\>Get-PASDirectoryMapping -DirectoryName $Directory -MappingID $ID |
 
-    Set-PASDirectoryMapping -DirectoryName $Directory -AddUpdateUsers -AuditUsers
+    Set-PASDirectoryMapping -DirectoryName $Directory -MappingAuthorizations AddUpdateUsers, AuditUsers
 
     Configures the AddUpdateUsers & AuditUsers authorisations on the mapping.
 
 
     -------------------------- EXAMPLE 2 --------------------------
 
-    PS C:\>Set-PASDirectoryMapping -DirectoryName $DirectoryName -MappingID $MappingID -MappingName $MappingName -LDAPBranch $LDAPBranch -AddUpdateUsers -ActivateUsers -ResetUsersPasswords
+    PS C:\>Set-PASDirectoryMapping -DirectoryName $DirectoryName -MappingID $MappingID -MappingName $MappingName -LDAPBranch $LDAPBranch `
+
+    -MappingAuthorizations AddUpdateUsers, ActivateUsers & ResetUsersPasswords
 
     Sets AddUpdateUsers, ActivateUsers & ResetUsersPasswords authorisations on the directory mapping
 
 
     -------------------------- EXAMPLE 3 --------------------------
 
-    PS C:\>Set-PASDirectoryMapping -DirectoryName $DirectoryName -MappingID $MappingID -MappingName $MappingName -LDAPBranch $LDAPBranch -UserActivityLogPeriod 365
+    PS C:\>Set-PASDirectoryMapping -DirectoryName $DirectoryName -MappingID $MappingID -MappingName $MappingName -LDAPBranch $LDAPBranch `
+
+    -UserActivityLogPeriod 365
 
     Sets UserActivityLogPeriod for the mapping to 365

--- a/docs/collections/_commands/Test-PASPSMRecording.md
+++ b/docs/collections/_commands/Test-PASPSMRecording.md
@@ -1,0 +1,43 @@
+---
+title: Test-PASPSMRecording
+---
+
+## SYNOPSIS
+
+    Determine if a PSM Session / Recording is valid
+
+## SYNTAX
+
+    Test-PASPSMRecording [-SessionID] <String> [<CommonParameters>]
+
+## DESCRIPTION
+
+    Determines if a provided PSM Session / Recording is valid.
+    Returns $True if valid.
+
+## PARAMETERS
+
+    -SessionID <String>
+        Unique ID of the recorded PSM session
+
+        Required?                    true
+        Position?                    1
+        Default value
+        Accept pipeline input?       true (ByPropertyName)
+        Accept wildcard characters?  false
+
+    <CommonParameters>
+        This cmdlet supports the common parameters: Verbose, Debug,
+        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
+        OutBuffer, PipelineVariable, and OutVariable. For more information, see
+        about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).
+
+## EXAMPLES
+
+        Minimum CyberArk Version 11.2
+
+    -------------------------- EXAMPLE 1 --------------------------
+
+    PS C:\>Test-PASPSMRecording -SessionID 334_3
+
+    Tests validity of recorded PSM Session File

--- a/docs/collections/_docs/10-compatibility.md
+++ b/docs/collections/_docs/10-compatibility.md
@@ -2,7 +2,7 @@
 title: "Compatibility"
 permalink: /docs/compatibility/
 excerpt: "Module Compatibility"
-last_modified_at: 2019-09-11T01:33:52-00:00
+last_modified_at: 2021-21-014T01:33:52-00:00
 toc: false
 ---
 
@@ -63,7 +63,7 @@ If you are using version 9.7+, and the function being invoked requires version 9
 [`Get-PASOnboardingRule`][Get-PASOnboardingRule]                                         |**9.7**                                             |Gets automatic on-boarding rules
 [`New-PASOnboardingRule`][New-PASOnboardingRule]                                         |**9.7** ([Notes](#new-pasonboardingrule))           |Adds a new on-boarding rule
 [`Remove-PASOnboardingRule`][Remove-PASOnboardingRule]                                   |**9.7**                                             |Deletes an automatic on-boarding rule
-[`Get-PASPlatform`][Get-PASPlatform]                                                     |**9.10**                                            |Retrieves details of a specified platform.
+[`Get-PASPlatform`][Get-PASPlatform]                                                     |**9.10** ([Notes](#get-pasplatform))                |Retrieves details of a specified platform.
 [`Import-PASPlatform`][Import-PASPlatform]                                               |**10.2**                                            |Import a new platform
 [`Export-PASPlatform`][Export-PASPlatform]                                               |**10.4**                                            |Export a  platform
 [`Add-PASPolicyACL`][Add-PASPolicyACL]                                                   |**9.0**                                             |Adds a new privileged command rule
@@ -93,8 +93,8 @@ If you are using version 9.7+, and the function being invoked requires version 9
 [`Get-PASUserLoginInfo`][Get-PASUserLoginInfo]                                           | **10.4**                                           |Returns login details of the current user
 [`Get-PASUser`][Get-PASUser]                                                             | **9.7** ([Notes](#get-pasuser))                    |Returns details of a user
 [`New-PASUser`][New-PASUser]                                                             | **9.7** ([Notes](#new-pasuser))                    |Creates a new user
-[`Remove-PASUser`][Remove-PASUser]                                                       | **9.7**                                            |Deletes a user
-[`Set-PASUser`][Set-PASUser]                                                             | **9.7**                                            |Updates a user
+[`Remove-PASUser`][Remove-PASUser]                                                       | **9.7** ([Notes](#remove-pasuser))                 |Deletes a user
+[`Set-PASUser`][Set-PASUser]                                                             | **9.7** ([Notes](#set-pasuser))                    |Updates a user
 [`Unblock-PASUser`][Unblock-PASUser]                                                     | **9.7** ([Notes](#unblock-pasuser))                |Activates a suspended user
 [`Get-PASDirectory`][Get-PASDirectory]                                                   | **10.4** ([Notes](#get-pasdirectory))              |Get configured LDAP directories
 [`Add-PASDirectory`][Add-PASDirectory]                                                   | **10.4** ([Notes](#add-pasdirectory))              |Add a new LDAP directory
@@ -108,7 +108,7 @@ If you are using version 9.7+, and the function being invoked requires version 9
 [`Get-PASGroup`][Get-PASGroup]                                                           | **10.5**                                           |Return group information
 [`Remove-PASGroupMember`][Remove-PASGroupMember]                                         | **10.5**                                           |Remove group members
 [`Set-PASOnboardingRule`][Set-PASOnboardingRule]                                         | **10.5**                                           |Update Onboarding Rules
-[`Add-PASDiscoveredAccount`][Add-PASDiscoveredAccount]                                   | **10.5**                                           |Add discovered accounts to the Accounts Feed
+[`Add-PASDiscoveredAccount`][Add-PASDiscoveredAccount]                                   | **10.5** ([Notes](#add-pasdiscoveredaccount))      |Add discovered accounts to the Accounts Feed
 [`Connect-PASPSMSession`][Connect-PASPSMSession]                                         | **10.5**                                           |Get required parameters to connect to a PSM Session
 [`Get-PASPSMSessionActivity`][Get-PASPSMSessionActivity]                                 | **10.6**                                           |Get activity details from an active PSM Session.
 [`Get-PASPSMSessionProperty`][Get-PASPSMSessionProperty]                                 | **10.6**                                           |Get property details from an active PSM Session.
@@ -122,6 +122,12 @@ If you are using version 9.7+, and the function being invoked requires version 9
 [`Find-PASSafe`][Find-PASSafe]                                                           | **10.1**                                           |List or Search Safes by name.
 [`Set-PASDirectoryMappingOrder`][Set-PASDirectoryMappingOrder]                           | **10.10**                                          |Reorder Directory Mappings
 [`Set-PASUserPassword`][Set-PASUserPassword]                                             | **10.10**                                          |Reset a User's Password
+[`New-PASGroup`][New-PASGroup]                                                           | **11.1**                                           |Create a new CyberArk group
+[`Get-PASPlatformSafe`][Get-PASPlatformSafe]                                             | **11.1**                                           |List details for all platforms
+[`Remove-PASDirectoryMapping`][Remove-PASDirectoryMapping]                               | **11.1**                                           |Deletes a Directory Mapping
+[`Enable-PASCPMAutoManagement`][Enable-PASCPMAutoManagement]                             | **10.4**                                           |Enables Automatic CPM Managment for an account
+[`Disable-PASCPMAutoManagement`][Disable-PASCPMAutoManagement]                           | **10.4**                                           |Disables Automatic CPM Managment for an account
+[`Test-PASPSMRecording`][Test-PASPSMRecording]                                           | **11.2**                                           |Determine validity of PSM Session Recording
 
 [New-PASSession]:/commands/New-PASSession
 [Close-PASSession]:/commands/Close-PASSession
@@ -222,6 +228,12 @@ If you are using version 9.7+, and the function being invoked requires version 9
 [Invoke-PASCPMOperation]:/commands/Invoke-PASCPMOperation
 [Set-PASDirectoryMappingOrder]:/commands/Set-PASDirectoryMappingOrder
 [Set-PASUserPassword]:/commands/Set-PASUserPassword
+[Disable-PASCPMAutoManagement]:/commands/Disable-PASCPMAutoManagement.ps1
+[Enable-PASCPMAutoManagement]:/commands/Enable-PASCPMAutoManagement.ps1
+[Remove-PASDirectoryMapping]:/commands/Remove-PASDirectoryMapping.ps1
+[Get-PASPlatformSafe]:/commands/Get-PASPlatformSafe.ps1
+[New-PASGroup]:/commands/New-PASGroup.ps1
+[Test-PASPSMRecording]:/commands/Test-PASPSMRecording.ps1
 
 ## Notes
 
@@ -332,7 +344,7 @@ If you are using version 9.7+, and the function being invoked requires version 9
 ### `*-PASRequest`*
 
 - The functions related to requests (`Approve-PASRequest`, `Deny-PASRequest`, `Get-PASRequest`, `Get-PASRequestDetail`, `New-PASRequest` & `Remove-PASRequest`), are documented as supported from version 9.10.
-  - `psPAS` user reports observer that these functions may also work in version 9.9.
+  - Reports received from `psPAS` users, observing that these functions also work in version 9.9.
 
 ### Add-PASGroupMember
 
@@ -393,3 +405,27 @@ If you are using version 9.7+, and the function being invoked requires version 9
 - Version 10.10 introduced a new API endpoint.
   - Supports:
     - `UserActivityLogPeriod`.
+
+### Add-PASDiscoveredAccount
+
+- Version 10.8 introduced a new API endpoint.
+  - Supports:
+    - Account Dependancy & AWS specific parameters
+
+### Get-PASPlatform
+
+- Version 11.1 introduced a new API endpoint.
+  - Supports:
+    - New options for finding platforms
+
+### Remove-PASUser
+
+- Version 11.1 introduced a new API endpoint.
+  - Supports:
+    - Delete User by ID
+
+### Set-PASUser
+
+- Version 11.1 introduced a new API endpoint.
+  - Supports:
+    - Additional parameters for updating users.

--- a/docs/collections/_docs/20-search.md
+++ b/docs/collections/_docs/20-search.md
@@ -44,12 +44,12 @@ Get-PASUser -Search xap
 
 ID  UserName    Source UserType ComponentUser Location
 --  --------    ------ -------- ------------ - --------
-657 xApprover_A LDAP   EPVUser  False         \VR\VirtualReal\Users
-658 xApprover_1 LDAP   EPVUser  False         \VR\VirtualReal\Users
-659 xApprover_B LDAP   EPVUser  False         \VR\VirtualReal\Users
-660 xApprover_2 LDAP   EPVUser  False         \VR\VirtualReal\Users
-661 xApprover_C LDAP   EPVUser  False         \VR\VirtualReal\Users
-662 xApprover_3 LDAP   EPVUser  False         \VR\VirtualReal\Users
+657 xApprover_A LDAP   EPVUser  False         \SomeLocation\Users
+658 xApprover_1 LDAP   EPVUser  False         \SomeLocation\Users
+659 xApprover_B LDAP   EPVUser  False         \SomeLocation\Users
+660 xApprover_2 LDAP   EPVUser  False         \SomeLocation\Users
+661 xApprover_C LDAP   EPVUser  False         \SomeLocation\Users
+662 xApprover_3 LDAP   EPVUser  False         \SomeLocation\Users
 ````
 
 ## Accounts

--- a/docs/collections/_pages/about.md
+++ b/docs/collections/_pages/about.md
@@ -3,14 +3,14 @@ title: "About psPAS"
 layout: single
 permalink: /about/
 excerpt: "All about psPAS"
-last_modified_at: 2019-09-01T01:33:52-00:00
+last_modified_at: 2020-21-01T01:33:52-00:00
 toc: true
 author_profile: true
 header:
   image: /assets/images/shop_banner_symbol.png
 ---
 
-Initially released in 2017, psPAS contains almost 100 commands for the CyberArk REST API.
+Initially released in 2017, psPAS contains over 100 commands for the CyberArk REST API.
 
 The module is designed to be compatible with CyberArk from Version 9 onwards, providing CyberArk users with an accessible resource for automating simple day to day administration tasks as well as more complex requirements.
 

--- a/psPAS/Functions/AccountACL/Add-PASAccountACL.ps1
+++ b/psPAS/Functions/AccountACL/Add-PASAccountACL.ps1
@@ -1,4 +1,4 @@
-﻿function Add-PASAccountACL {
+function Add-PASAccountACL {
 	<#
 .SYNOPSIS
 Adds a new privileged command rule to an account.
@@ -35,6 +35,9 @@ Add-PASAccountACL -AccountPolicyID UNIXSSH -AccountAddress ServerA.domain.com -A
         -Command 'for /l %a in (0,0,0) do xyz' -CommandGroup $false -PermissionType Deny -UserName TestUser
 
 This will add a new Privileged Command Rule to root for user TestUser
+
+.LINK
+https://pspas.pspete.dev/commands/Add-PASAccountACL
 #>
 	[CmdletBinding()]
 	param(

--- a/psPAS/Functions/AccountACL/Get-PASAccountACL.ps1
+++ b/psPAS/Functions/AccountACL/Get-PASAccountACL.ps1
@@ -13,7 +13,7 @@ The PolicyID associated with account.
 The address of the account whose privileged commands will be listed.
 
 .PARAMETER AccountUserName
-The name of the account’s user.
+The name of the account�s user.
 
 .EXAMPLE
 Get-PASAccount root | Get-PASAccountACL
@@ -34,6 +34,9 @@ Should accept pipeline objects from other *-PASAccount functions
 Outputs Object of Custom Type psPAS.CyberArk.Vault.ACL
 Output format is defined via psPAS.Format.ps1xml.
 To force all output to be shown, pipe to Select-Object *
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASAccountACL
 #>
 	[CmdletBinding()]
 	param(
@@ -61,7 +64,7 @@ To force all output to be shown, pipe to Select-Object *
 		[string]$AccountUserName
 	)
 
-	BEGIN {}#begin
+	BEGIN { }#begin
 
 	PROCESS {
 
@@ -77,7 +80,7 @@ To force all output to be shown, pipe to Select-Object *
 		#Send request to Web Service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession #DevSkim: ignore DS104456
 
-		if($result) {
+		if ($result) {
 
 			$result.ListAccountPrivilegedCommandsResult |
 
@@ -87,6 +90,6 @@ To force all output to be shown, pipe to Select-Object *
 
 	}#process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/AccountACL/Remove-PASAccountACL.ps1
+++ b/psPAS/Functions/AccountACL/Remove-PASAccountACL.ps1
@@ -1,4 +1,4 @@
-﻿function Remove-PASAccountACL {
+function Remove-PASAccountACL {
 	<#
 .SYNOPSIS
 Deletes privileged commands rule from an account
@@ -32,8 +32,8 @@ Removes matching Privileged Account Rule from account.
 All parameters can be piped by property name
 Should accept pipeline objects from Get-PASAccountACL function
 
-.OUTPUTS
-None
+.LINK
+https://pspas.pspete.dev/commands/Remove-PASAccountACL
 #>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
@@ -66,7 +66,7 @@ None
 		[string]$Id
 	)
 
-	BEGIN {}#begin
+	BEGIN { }#begin
 
 	PROCESS {
 
@@ -80,9 +80,9 @@ None
                     Get-EscapedString)/PrivilegedCommands/$Id"
 
 		#Request Body
-		$Body = @{}
+		$Body = @{ }
 
-		if($PSCmdlet.ShouldProcess("$AccountAddress|$AccountUserName|$AccountPolicyId",
+		if ($PSCmdlet.ShouldProcess("$AccountAddress|$AccountUserName|$AccountPolicyId",
 				"Delete Privileged Command '$Id'")) {
 
 			#Send Request to Web Service
@@ -92,6 +92,6 @@ None
 
 	}#process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/AccountGroups/Add-PASAccountGroupMember.ps1
+++ b/psPAS/Functions/AccountGroups/Add-PASAccountGroupMember.ps1
@@ -1,4 +1,4 @@
-﻿function Add-PASAccountGroupMember {
+function Add-PASAccountGroupMember {
 	<#
 .SYNOPSIS
 Adds an account as a member of an account group.
@@ -31,6 +31,9 @@ None
 
 .NOTES
 Minimum version 9.9.5
+
+.LINK
+https://pspas.pspete.dev/commands/Add-PASAccountGroupMember
 #>
 	[CmdletBinding()]
 	param(

--- a/psPAS/Functions/AccountGroups/Get-PASAccountGroup.ps1
+++ b/psPAS/Functions/AccountGroups/Get-PASAccountGroup.ps1
@@ -1,4 +1,4 @@
-﻿function Get-PASAccountGroup {
+function Get-PASAccountGroup {
 	<#
 .SYNOPSIS
 Returns all the account groups in a specific Safe.
@@ -33,6 +33,9 @@ To force all output to be shown, pipe to Select-Object *
 
 .NOTES
 Minimum CyberArk version 9.10
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASAccountGroup
 #>
 	[CmdletBinding()]
 	param(

--- a/psPAS/Functions/AccountGroups/Get-PASAccountGroupMember.ps1
+++ b/psPAS/Functions/AccountGroups/Get-PASAccountGroupMember.ps1
@@ -1,4 +1,4 @@
-﻿function Get-PASAccountGroupMember {
+function Get-PASAccountGroupMember {
 	<#
 .SYNOPSIS
 Returns all the members of a specific account group.
@@ -30,6 +30,9 @@ To force all output to be shown, pipe to Select-Object *
 
 .NOTES
 Minimum CyberArk version 9.10
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASAccountGroupMember
 #>
 	[CmdletBinding()]
 	param(
@@ -54,7 +57,7 @@ Minimum CyberArk version 9.10
 		#send request to PAS web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
 
-		if($result) {
+		if ($result) {
 
 			$result | Add-ObjectDetail -typename psPAS.CyberArk.Vault.Account.Group.Member
 
@@ -62,6 +65,6 @@ Minimum CyberArk version 9.10
 
 	}#process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/AccountGroups/New-PASAccountGroup.ps1
+++ b/psPAS/Functions/AccountGroups/New-PASAccountGroup.ps1
@@ -1,4 +1,4 @@
-﻿function New-PASAccountGroup {
+function New-PASAccountGroup {
 	<#
 .SYNOPSIS
 Adds a new account group to the Vault
@@ -34,6 +34,9 @@ None
 
 .NOTES
 Minimum version 9.9.5
+
+.LINK
+https://pspas.pspete.dev/commands/New-PASAccountGroup
 #>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(

--- a/psPAS/Functions/AccountGroups/Remove-PASAccountGroupMember.ps1
+++ b/psPAS/Functions/AccountGroups/Remove-PASAccountGroupMember.ps1
@@ -1,4 +1,4 @@
-﻿function Remove-PASAccountGroupMember {
+function Remove-PASAccountGroupMember {
 	<#
 .SYNOPSIS
 Deletes a member of an account group.
@@ -31,6 +31,9 @@ None
 
 .NOTES
 Minimum CyberArk version 9.10
+
+.LINK
+https://pspas.pspete.dev/commands/Remove-PASAccountGroupMember
 #>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
@@ -58,7 +61,7 @@ Minimum CyberArk version 9.10
 		#Create URL for Request
 		$URI = "$Script:BaseURI/API/AccountGroups/$GroupID/Members/$AccountID"
 
-		if($PSCmdlet.ShouldProcess($AccountID, "Delete Member from Account Group $($GroupID)")) {
+		if ($PSCmdlet.ShouldProcess($AccountID, "Delete Member from Account Group $($GroupID)")) {
 
 			#send request to PAS web service
 			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
@@ -67,6 +70,6 @@ Minimum CyberArk version 9.10
 
 	}#process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/Accounts/Add-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Add-PASAccount.ps1
@@ -9,7 +9,7 @@ Adds a new privileged account to the Vault.
 Parameters are processed to create request object from passed parameters in the required format.
 
 .PARAMETER name
-The name of the account.
+The name�of the account.
 A version 10.4 onward specific parameter
 
 .PARAMETER secretType
@@ -126,6 +126,9 @@ All parameters can be piped by property name
 .OUTPUTS
 None for v9
 v10.4 outputs th details of the created account.
+
+.LINK
+https://pspas.pspete.dev/commands/Add-PASAccount
 #>
 	[CmdletBinding()]
 	param(

--- a/psPAS/Functions/Accounts/Add-PASDiscoveredAccount.ps1
+++ b/psPAS/Functions/Accounts/Add-PASDiscoveredAccount.ps1
@@ -9,7 +9,7 @@ as a pending account to the Accounts Feed.
 Users can identify privileged accounts and determine which are on-boarded to the vault.
 
 .PARAMETER userName
-The name of the account user.
+The name�of the account user.
 
 .PARAMETER address
 The name or address of the machine where the account is located.
@@ -154,7 +154,8 @@ Adds or updates matching pending account with defined dependancies.
 .INPUTS
 All parameters can be piped by property name
 
-.OUTPUTS
+.LINK
+https://pspas.pspete.dev/commands/Add-PASDiscoveredAccount
 #>
 	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '', Justification = "Username not used for authentication")]
 	[CmdletBinding(DefaultParameterSetName = "Windows")]
@@ -388,7 +389,7 @@ All parameters can be piped by property name
 	PROCESS {
 
 		if ($PSCmdlet.ParameterSetName -match "^108_") {
-			
+
 			#v10.8 required for AWS & Dependancies
 			Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $RequiredVersion
 

--- a/psPAS/Functions/Accounts/Add-PASPendingAccount.ps1
+++ b/psPAS/Functions/Accounts/Add-PASPendingAccount.ps1
@@ -1,4 +1,4 @@
-﻿function Add-PASPendingAccount {
+function Add-PASPendingAccount {
 	<#
 .SYNOPSIS
 Adds discovered account or SSH key as a pending account in the accounts feed.
@@ -87,8 +87,8 @@ Adds matching discovered account as pending account.
 .INPUTS
 All parameters can be piped by property name
 
-.OUTPUTS
-None
+.LINK
+https://pspas.pspete.dev/commands/Add-PASPendingAccount
 #>
 	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '', Justification = "Username not used for authentication")]
 	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', 'LastPasswordSet', Justification = "Parameter does not hold password")]
@@ -228,7 +228,7 @@ None
 		[string]$MachineOSFamily
 	)
 
-	BEGIN {}#begin
+	BEGIN { }#begin
 
 	PROCESS {
 
@@ -238,7 +238,7 @@ None
 		#Get all parameters that will be sent in the request
 		$boundParameters = $PSBoundParameters | Get-PASParameter
 
-		If($PSBoundParameters.ContainsKey("AccountDiscoveryDate")) {
+		If ($PSBoundParameters.ContainsKey("AccountDiscoveryDate")) {
 
 			#Convert ExpiryDate to string in Required format
 			$Date = (Get-Date $AccountDiscoveryDate.ToUniversalTime() -Format "yyyy-MM-ddTHH:mm:ssZ").ToString()
@@ -262,5 +262,5 @@ None
 
 	}#process
 
-	END {}#end
+	END { }#end
 }

--- a/psPAS/Functions/Accounts/Disable-PASCPMAutoManagement.ps1
+++ b/psPAS/Functions/Accounts/Disable-PASCPMAutoManagement.ps1
@@ -1,10 +1,10 @@
-﻿function Disable-PASCPMAutoManagement {
+function Disable-PASCPMAutoManagement {
 	<#
 .SYNOPSIS
 Disables an account for Automatic CPM Management.
 
 .DESCRIPTION
-Disables an account for CPM management by setting automaticManagementEnabled to $false, 
+Disables an account for CPM management by setting automaticManagementEnabled to $false,
 and optionally sets a value for manualManagementReason.
 
 .PARAMETER AccountID
@@ -26,6 +26,8 @@ Sets automaticManagementEnabled to $false & sets manualManagementReason on accou
 .NOTES
 Applicable to and requires 10.4+
 
+.LINK
+https://pspas.pspete.dev/commands/Disable-PASCPMAutoManagement
 #>
 	[CmdletBinding()]
 	param(
@@ -45,11 +47,11 @@ Applicable to and requires 10.4+
 
 	)
 
-	BEGIN { 
+	BEGIN {
 
 		$MinimumVersion = [System.Version]"10.4"
 
-		$ops = @(
+		$ops = [Collections.Generic.List[Object]]@(
 			@{
 				"path"  = "/secretManagement/automaticManagementEnabled"
 				"op"    = "replace"
@@ -64,12 +66,12 @@ Applicable to and requires 10.4+
 		Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $MinimumVersion
 
 		if ($PSCmdlet.ParameterSetName -eq "manualManagementReason") {
-			
-			$ops += @{
-				"path"  = "/secretManagement/manualManagementReason"
-				"op"    = "replace"
-				"value" = $Reason
-			}
+
+			$null = $ops.Add(@{
+					"path"  = "/secretManagement/manualManagementReason"
+					"op"    = "replace"
+					"value" = $Reason
+				})
 		}
 
 		Set-PASAccount -AccountID $AccountID -operations $ops

--- a/psPAS/Functions/Accounts/Enable-PASCPMAutoManagement.ps1
+++ b/psPAS/Functions/Accounts/Enable-PASCPMAutoManagement.ps1
@@ -1,10 +1,10 @@
-﻿function Enable-PASCPMAutoManagement {
-<#
+function Enable-PASCPMAutoManagement {
+	<#
 .SYNOPSIS
 Enables an account for Automatic CPM Management.
 
 .DESCRIPTION
-Enables an account for CPM management by setting automaticManagementEnabled to $true, 
+Enables an account for CPM management by setting automaticManagementEnabled to $true,
 and clearing any value set for manualManagementReason.
 
 Attempting to set automaticManagementEnabled to $true without clearing manualManagementReason
@@ -24,6 +24,8 @@ on account with ID 543_2
 .NOTES
 Applicable to and requires 10.4+
 
+.LINK
+https://pspas.pspete.dev/commands/Enable-PASCPMAutoManagement
 #>
 	[CmdletBinding()]
 	param(
@@ -36,11 +38,11 @@ Applicable to and requires 10.4+
 
 	)
 
-	BEGIN { 
+	BEGIN {
 
 		$MinimumVersion = [System.Version]"10.4"
 
-		$ops = @(
+		$ops = [Collections.Generic.List[Object]]@(
 			@{
 				"path"  = "/secretManagement/automaticManagementEnabled"
 				"op"    = "replace"

--- a/psPAS/Functions/Accounts/Get-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccount.ps1
@@ -297,6 +297,7 @@ https://pspas.pspete.dev/commands/Get-PASAccount
 			#Version 10.4 individual account process
 			If ($PSCmdlet.ParameterSetName -eq "v10ByID") {
 
+				#return expected single result
 				$return = $result
 
 			}
@@ -307,8 +308,11 @@ https://pspas.pspete.dev/commands/Get-PASAccount
 				#Version 10.4 query process
 				If ($PSCmdlet.ParameterSetName -eq "v10ByQuery") {
 
-					#get results
-					$AccountList = [Collections.Generic.List[Object]]::New(($result | Select-Object -ExpandProperty value))
+					#to store list of query results
+					$AccountList = [Collections.Generic.List[Object]]@()
+
+					#add resultst to list
+					$null = $AccountList.Add($result.value)
 
 					#iterate any nextLinks
 					$NextLink = $result.nextLink
@@ -316,9 +320,10 @@ https://pspas.pspete.dev/commands/Get-PASAccount
 						$URI = "$Script:BaseURI/$NextLink"
 						$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession -TimeoutSec $TimeoutSec
 						$NextLink = $result.nextLink
-						$null = $AccountList.AddRange(($result | Select-Object -ExpandProperty value))
+						$null = $AccountList.AddRange(($result.value))
 					}
 
+					#return list
 					$return = $AccountList
 
 				}

--- a/psPAS/Functions/Accounts/Get-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccount.ps1
@@ -1,11 +1,11 @@
-﻿function Get-PASAccount {
+function Get-PASAccount {
 	<#
 .SYNOPSIS
 Returns details of matching accounts. (Version 10.4 onwards)
 Returns information about a single account. (Version 9.3 - 10.3)
 
 .DESCRIPTION
-Version 10.4 onwards:
+Version 10.4+:
 This method returns a list of either a specific, or all the accounts in the Vault.
 Requires the following permission in the Safe: List accounts.
 
@@ -27,8 +27,13 @@ A specific account ID to return details for.
 .PARAMETER search
 The search term or keywords.
 
+.PARAMETER searchType
+Get accounts that either contain or start with the value specified in the Search parameter.
+
 .PARAMETER sort
-An account property to sort the results by.
+Property or properties by which to sort returned accounts,
+followed by asc (default) or desc to control sort direction.
+Separate multiple properties with commas, up to a maximum of three properties.
 
 .PARAMETER offset
 An offset for the search results (to discard the first x results for instance).
@@ -40,7 +45,7 @@ this value determines the number of accounts to return, starting from the first 
 
 .PARAMETER filter
 A filter for the search.
-Requires format: "SafeName eq YourSafe"
+Requires format: "SafeName eq 'YourSafe'"
 
 .PARAMETER Keywords
 Keyword to search for.
@@ -69,9 +74,19 @@ Get-PASAccount -search root -sort name -offset 100 -limit 5
 Returns all accounts matching "root", sorted by AccountName, Search results offset by 100 and limited to 5.
 
 .EXAMPLE
+Get-PASAccount -search XUser -searchType startswith
+
+Returns all accounts starting with "XUser".
+
+.EXAMPLE
 Get-PASAccount -filter "SafeName eq TargetSafe"
 
 Returns all accounts found in TargetSafe
+
+.EXAMPLE
+Get-PASAccount -filter "SafeName eq 'TargetSafe'" -sort "userName desc"
+
+Returns all accounts found in TargetSafe, sort by username in descending order.
 
 .EXAMPLE
 Get-PASAccount -Keywords root -Safe UNIX
@@ -121,7 +136,13 @@ To force all output to be shown, pipe to Select-Object *
 
 .NOTES
 New functionality added in version 10.4, limited functionality before this version.
-As of psPAS v2.5.1+, the use of 'limit' and 'offset' parameters is discouraged - nextLink functionality was added#>
+As of psPAS v2.5.1+, the use of 'limit' and 'offset' parameters is discouraged - nextLink functionality was added
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASAccount
+
+#>
+
 	[CmdletBinding(DefaultParameterSetName = "v10ByQuery")]
 	param(
 		[parameter(
@@ -138,6 +159,14 @@ As of psPAS v2.5.1+, the use of 'limit' and 'offset' parameters is discouraged -
 			ParameterSetName = "v10ByQuery"
 		)]
 		[string]$search,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "v10ByQuery"
+		)]
+		[ValidateSet("startswith", "contains")]
+		[string]$searchType,
 
 		[parameter(
 			Mandatory = $false,
@@ -194,6 +223,7 @@ As of psPAS v2.5.1+, the use of 'limit' and 'offset' parameters is discouraged -
 
 	BEGIN {
 		$MinimumVersion = [System.Version]"10.4"
+		$RequiredVersion = [System.Version]"11.2"
 	}#begin
 
 	PROCESS {
@@ -211,8 +241,19 @@ As of psPAS v2.5.1+, the use of 'limit' and 'offset' parameters is discouraged -
 		#Version 10.4 process
 		If ($PSCmdlet.ParameterSetName -match "v10") {
 
-			#check minimum version
-			Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $MinimumVersion
+			#check version
+			if ($PSBoundParameters.ContainsKey("searchType")) {
+
+				#check required version
+				Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $RequiredVersion
+
+			}
+			Else {
+
+				#check minimum version
+				Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $MinimumVersion
+
+			}
 
 			#assign new type name
 			$typeName = "psPAS.CyberArk.Vault.Account.V10"
@@ -267,8 +308,7 @@ As of psPAS v2.5.1+, the use of 'limit' and 'offset' parameters is discouraged -
 				If ($PSCmdlet.ParameterSetName -eq "v10ByQuery") {
 
 					#get results
-					$AccountArray = @()
-					$AccountArray += ($result | Select-Object value).value
+					$AccountList = [Collections.Generic.List[Object]]::New(($result | Select-Object -ExpandProperty value))
 
 					#iterate any nextLinks
 					$NextLink = $result.nextLink
@@ -276,10 +316,10 @@ As of psPAS v2.5.1+, the use of 'limit' and 'offset' parameters is discouraged -
 						$URI = "$Script:BaseURI/$NextLink"
 						$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession -TimeoutSec $TimeoutSec
 						$NextLink = $result.nextLink
-						$AccountArray += ($result | Select-Object value).value
+						$null = $AccountList.AddRange(($result | Select-Object -ExpandProperty value))
 					}
 
-					$return = $AccountArray
+					$return = $AccountList
 
 				}
 
@@ -303,7 +343,7 @@ As of psPAS v2.5.1+, the use of 'limit' and 'offset' parameters is discouraged -
 					#Get internal properties from found account
 					$InternalProperties = ($account | Select-Object -ExpandProperty InternalProperties)
 
-					$InternalProps = New-object -TypeName psobject
+					$InternalProps = New-Object -TypeName psobject
 
 					#For every account property
 					For ($int = 0; $int -lt $InternalProperties.length; $int++) {

--- a/psPAS/Functions/Accounts/Get-PASAccountActivity.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccountActivity.ps1
@@ -1,4 +1,4 @@
-﻿function Get-PASAccountActivity {
+function Get-PASAccountActivity {
 	<#
 .SYNOPSIS
 Returns activities for an account.
@@ -32,7 +32,9 @@ Outputs Object of Custom Type psPAS.CyberArk.Vault.Account.Activity
 Output format is defined via psPAS.Format.ps1xml.
 To force all output to be shown, pipe to Select-Object *
 
-.NOTES#>
+.LINK
+https://pspas.pspete.dev/commands/Get-PASAccountActivity
+#>
 	[CmdletBinding()]
 	param(
 		[parameter(

--- a/psPAS/Functions/Accounts/Get-PASAccountPassword.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccountPassword.ps1
@@ -1,4 +1,4 @@
-﻿function Get-PASAccountPassword {
+function Get-PASAccountPassword {
 	<#
 .SYNOPSIS
 Returns password for an account.
@@ -87,7 +87,11 @@ To force all output to be shown, pipe to Select-Object *
 
 .NOTES
 Minimum API version is 9.7 for password retrieval only.
-From version 10.1 onwards both passwords and ssh keys can be retrieved.#>
+From version 10.1 onwards both passwords and ssh keys can be retrieved.
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASAccountPassword
+#>
 	[CmdletBinding(DefaultParameterSetName = "v10")]
 	param(
 		[parameter(
@@ -217,13 +221,13 @@ From version 10.1 onwards both passwords and ssh keys can be retrieved.#>
 
 			}
 			elseif ($PSCmdlet.ParameterSetName -eq "v10") {
-				
+
 				#Unescape returned string and remove enclosing quotes.
 				$result = $([System.Text.RegularExpressions.Regex]::Unescape($result) -replace '^"|"$', '')
 
 			}
-			
-			
+
+
 			[PSCustomObject] @{"Password" = $result } |
 
 			Add-ObjectDetail -typename psPAS.CyberArk.Vault.Credential

--- a/psPAS/Functions/Accounts/Invoke-PASCPMOperation.ps1
+++ b/psPAS/Functions/Accounts/Invoke-PASCPMOperation.ps1
@@ -97,6 +97,8 @@ Invoke-PASCPMOperation -AccountID $ID -ReconcileTask
 
 Marks an account for immediate reconcile
 
+.LINK
+https://pspas.pspete.dev/commands/Invoke-PASCPMOperation
 #>
 
 	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', 'ChangeCredsForGroup', Justification = "Parameter does not hold password")]

--- a/psPAS/Functions/Accounts/Remove-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Remove-PASAccount.ps1
@@ -1,4 +1,4 @@
-﻿function Remove-PASAccount {
+function Remove-PASAccount {
 	<#
 .SYNOPSIS
 Deletes an account
@@ -23,8 +23,9 @@ Deletes the account with AccountID of 19_1
 .INPUTS
 All parameters can be piped by propertyname
 
-.OUTPUTS
-None
+
+.LINK
+https://pspas.pspete.dev/commands/Remove-PASAccount
 #>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(

--- a/psPAS/Functions/Accounts/Request-PASAdHocAccess.ps1
+++ b/psPAS/Functions/Accounts/Request-PASAdHocAccess.ps1
@@ -1,4 +1,4 @@
-﻿function Request-PASAdHocAccess {
+function Request-PASAdHocAccess {
 	<#
 .SYNOPSIS
 Requests access to a target Windows machine
@@ -18,8 +18,9 @@ Requests "ad hoc" access on the server for which the account with id 36_3 is a l
 .INPUTS
 All parameters can be piped by propertyname
 
-.OUTPUTS
-None
+
+.LINK
+https://pspas.pspete.dev/commands/Request-PASAdHocAccess
 #>
 	[CmdletBinding()]
 	param(
@@ -49,5 +50,5 @@ None
 
 	}#process
 
-	END {}#end
+	END { }#end
 }

--- a/psPAS/Functions/Accounts/Set-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Set-PASAccount.ps1
@@ -1,4 +1,4 @@
-﻿function Set-PASAccount {
+function Set-PASAccount {
 	<#
 .SYNOPSIS
 Updates an existing accounts details.
@@ -126,6 +126,9 @@ Accounts that do not have a policy ID cannot be updated.
 To update account properties, "Update password properties" permission is required.
 To rename accounts, "Rename accounts" permission is required.
 To move accounts to a different folder, Move accounts/folders permission is required.
+
+.LINK
+https://pspas.pspete.dev/commands/Set-PASAccount
 #>
 	[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = "V10SingleOp")]
 	param(

--- a/psPAS/Functions/Accounts/Unlock-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Unlock-PASAccount.ps1
@@ -1,33 +1,35 @@
 function Unlock-PASAccount {
 	<#
-	.SYNOPSIS
-	Checks in an exclusive account in to the Vault.
+.SYNOPSIS
+Checks in an exclusive account in to the Vault.
 
-	.DESCRIPTION
-	Checks in an account, locked due to an exclusive account policy, to the Vault.
-	If the account is managed automatically by the CPM, after it is checked in,the password is changed immediately.
-	If the account is managed manually, a notification is sent to a user who is authorised to change the password.
-	The account is checked in automatically after it has been changed.
-	Requires Initiate CPM password management operations on the Safe where the account is stored.
+.DESCRIPTION
+Checks in an account, locked due to an exclusive account policy, to the Vault.
+If the account is managed automatically by the CPM, after it is checked in,the password is changed immediately.
+If the account is managed manually, a notification is sent to a user who is authorised to change the password.
+The account is checked in automatically after it has been changed.
+Requires Initiate CPM password management operations on the Safe where the account is stored.
 
-	.PARAMETER AccountID
-	The unique ID  of the account.
-	This is retrieved by the Get-PASAccount function.
+.PARAMETER AccountID
+The unique ID  of the account.
+This is retrieved by the Get-PASAccount function.
 
-	.EXAMPLE
-	Unlock-PASAccount -AccountID 21_3
+.EXAMPLE
+Unlock-PASAccount -AccountID 21_3
 
-	Will check-in exclusive access account with ID of "21_3"
+Will check-in exclusive access account with ID of "21_3"
 
-	.EXAMPLE
-	Get-PASAccount xAccount | Unlock-PASAccount
+.EXAMPLE
+Get-PASAccount xAccount | Unlock-PASAccount
 
-	Will check-in exclusive access account xAccount
+Will check-in exclusive access account xAccount
 
-	.NOTES
-	Minimum CyberArk version 9.10
+.NOTES
+Minimum CyberArk version 9.10
 
-	#>
+.LINK
+https://pspas.pspete.dev/commands/Unlock-PASAccount
+#>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
 		[parameter(

--- a/psPAS/Functions/Applications/Add-PASApplication.ps1
+++ b/psPAS/Functions/Applications/Add-PASApplication.ps1
@@ -1,4 +1,4 @@
-﻿function Add-PASApplication {
+function Add-PASApplication {
 	<#
 .SYNOPSIS
 Adds a new application to the Vault
@@ -58,8 +58,9 @@ Will add a new application called "NewApp", in the root location, accessible fro
 .INPUTS
 All parameters can be piped by property name
 
-.OUTPUTS
-None
+
+.LINK
+https://pspas.pspete.dev/commands/Add-PASApplication
 #>
 	[CmdletBinding()]
 	param(

--- a/psPAS/Functions/Applications/Add-PASApplicationAuthenticationMethod.ps1
+++ b/psPAS/Functions/Applications/Add-PASApplicationAuthenticationMethod.ps1
@@ -1,4 +1,4 @@
-﻿function Add-PASApplicationAuthenticationMethod {
+function Add-PASApplicationAuthenticationMethod {
     <#
 .SYNOPSIS
 Adds an authentication method to an application.
@@ -59,6 +59,9 @@ None
 Function uses dynamicparameters.
 Dynamic Parameters IsFolder, AllowInternalScripts & Comment do
 not accept input from the pipeline.
+
+.LINK
+https://pspas.pspete.dev/commands/Add-PASApplicationAuthenticationMethod
 #>
     [CmdletBinding()]
     param(
@@ -90,7 +93,7 @@ not accept input from the pipeline.
         $Dictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
 
         #Add dynamic parameters to $dictionary
-        if($AuthType -eq "path") {
+        if ($AuthType -eq "path") {
 
             #parameters only relevant to path authentication
             New-DynamicParam -Name IsFolder -DPDictionary $Dictionary -Type boolean
@@ -98,7 +101,7 @@ not accept input from the pipeline.
 
         }
 
-        if(($AuthType -eq "hash") -or ($AuthType -eq "certificateserialnumber")) {
+        if (($AuthType -eq "hash") -or ($AuthType -eq "certificateserialnumber")) {
 
             #add comment parmater
             New-DynamicParam -Name Comment -DPDictionary $Dictionary
@@ -110,7 +113,7 @@ not accept input from the pipeline.
 
     }
 
-    BEGIN {}#begin
+    BEGIN { }#begin
 
     PROCESS {
 
@@ -128,6 +131,6 @@ not accept input from the pipeline.
 
     }#process
 
-    END {}#end
+    END { }#end
 
 }

--- a/psPAS/Functions/Applications/Get-PASApplication.ps1
+++ b/psPAS/Functions/Applications/Get-PASApplication.ps1
@@ -1,4 +1,4 @@
-﻿function Get-PASApplication {
+function Get-PASApplication {
 	<#
 .SYNOPSIS
 Returns details of applications in the Vault
@@ -59,6 +59,9 @@ Should accept pipeline objects from other *-PASApplication* functions
 Outputs Object of Custom Type psPAS.CyberArk.Vault.Application
 Output format is defined via psPAS.Format.ps1xml.
 To force all output to be shown, pipe to Select-Object *
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASApplication
 #>
 	[CmdletBinding(DefaultParameterSetName = 'byQuery')]
 	param(

--- a/psPAS/Functions/Applications/Get-PASApplicationAuthenticationMethod.ps1
+++ b/psPAS/Functions/Applications/Get-PASApplicationAuthenticationMethod.ps1
@@ -1,4 +1,4 @@
-﻿function Get-PASApplicationAuthenticationMethod {
+function Get-PASApplicationAuthenticationMethod {
 	<#
 .SYNOPSIS
 Returns information about all of the authentication methods of a specific application.
@@ -23,6 +23,9 @@ Should accept pipeline objects from other *-PASApplication* functions
 Outputs Object of Custom Type psPAS.CyberArk.Vault.Application
 Output format is defined via psPAS.Format.ps1xml.
 To force all output to be shown, pipe to Select-Object *
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASApplicationAuthenticationMethod
 #>
 	[CmdletBinding()]
 	param(

--- a/psPAS/Functions/Applications/Remove-PASApplication.ps1
+++ b/psPAS/Functions/Applications/Remove-PASApplication.ps1
@@ -1,4 +1,4 @@
-﻿function Remove-PASApplication {
+function Remove-PASApplication {
 	<#
 .SYNOPSIS
 Deletes an application
@@ -19,8 +19,8 @@ Deletes application "NewApp"
 All parameters can be piped by property name
 Should accept pipeline objects from other *-PASApplication* functions
 
-.OUTPUTS
-None
+.LINK
+https://pspas.pspete.dev/commands/Remove-PASApplication
 #>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
@@ -32,7 +32,7 @@ None
 		[string]$AppID
 	)
 
-	BEGIN {}#begin
+	BEGIN { }#begin
 
 	PROCESS {
 
@@ -41,7 +41,7 @@ None
 
             Get-EscapedString)/"
 
-		if($PSCmdlet.ShouldProcess($AppID, "Delete Application")) {
+		if ($PSCmdlet.ShouldProcess($AppID, "Delete Application")) {
 
 			#Send Request
 			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
@@ -50,6 +50,6 @@ None
 
 	}#process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/Applications/Remove-PASApplicationAuthenticationMethod.ps1
+++ b/psPAS/Functions/Applications/Remove-PASApplicationAuthenticationMethod.ps1
@@ -1,4 +1,4 @@
-﻿function Remove-PASApplicationAuthenticationMethod {
+function Remove-PASApplicationAuthenticationMethod {
 	<#
 .SYNOPSIS
 Deletes an authentication method from an application
@@ -27,8 +27,8 @@ Deletes all authentication methods from "NewApp"
 All parameters can be piped by property name
 Should accept pipeline objects from other *-PASApplication* functions
 
-.OUTPUTS
-None
+.LINK
+https://pspas.pspete.dev/commands/Remove-PASApplicationAuthenticationMethod
 #>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(

--- a/psPAS/Functions/Authentication/Add-PASPublicSSHKey.ps1
+++ b/psPAS/Functions/Authentication/Add-PASPublicSSHKey.ps1
@@ -10,10 +10,10 @@ to authenticate to the Vault through PSMP using a corresponding private SSH key.
 The "Reset User Passwords" Permission is required in the vault to manage public SSH keys.
 The user account used to add the key MUST be in the same Vault Location or higher
 then the user whose public SSH keys are added.
-A user cannot manage their own public SSH keys.
+A user cannot manage their own public SSH�keys.
 
 .PARAMETER UserName
-The username of the Vault user whose public SSH keys will be added
+The username of the Vault user whose public SSH�keys will be added
 A username cannot contain te follwing characters: "%", "&", "+" or ".".
 
 .PARAMETER PublicSSHKey
@@ -28,6 +28,8 @@ Add-PASPublicSSHKey -UserName keyUser -PublicSSHKey AAAAB3NzaC1kc3MAAACBAJ3hB5SA
 
 Adds SSH Key to vault user keyUser
 
+.LINK
+https://pspas.pspete.dev/commands/Add-PASPublicSSHKey
 #>
 	[CmdletBinding()]
 	param(
@@ -35,19 +37,19 @@ Adds SSH Key to vault user keyUser
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateScript( {$_ -notmatch ".*(%|\&|\+|\.).*"})]
+		[ValidateScript( { $_ -notmatch ".*(%|\&|\+|\.).*" })]
 		[string]$UserName,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateScript( {$_ -notmatch "`n"})]
+		[ValidateScript( { $_ -notmatch "`n" })]
 		[string]$PublicSSHKey
 
 	)
 
-	BEGIN {}#begin
+	BEGIN { }#begin
 
 	PROCESS {
 
@@ -66,13 +68,13 @@ Adds SSH Key to vault user keyUser
 		#send request to webservice
 		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
 
-		if($result) {
+		if ($result) {
 
 			$result.AddUserAuthorizedKeyResult |
 
 			Add-ObjectDetail -typename psPAS.CyberArk.Vault.PublicSSHKey -PropertyToAdd @{
 
-				"UserName"     = $UserName
+				"UserName" = $UserName
 
 			}
 
@@ -80,5 +82,5 @@ Adds SSH Key to vault user keyUser
 
 	}#process
 
-	END {}#end
+	END { }#end
 }

--- a/psPAS/Functions/Authentication/Close-PASSession.ps1
+++ b/psPAS/Functions/Authentication/Close-PASSession.ps1
@@ -1,42 +1,44 @@
-﻿function Close-PASSession {
+function Close-PASSession {
 	<#
-	.SYNOPSIS
-	Logoff from CyberArk Vault.
+.SYNOPSIS
+Logoff from CyberArk Vault.
 
-	.DESCRIPTION
-	Performs Logoff and removes the Vault session.
+.DESCRIPTION
+Performs Logoff and removes the Vault session.
 
-	.PARAMETER UseClassicAPI
-	Specify the UseClassicAPI switch to send the logoff request via the Classic (v9) API endpoint.
-	Relevant for CyberArk versions earlier than 10.4
+.PARAMETER UseClassicAPI
+Specify the UseClassicAPI switch to send the logoff request via the Classic (v9) API endpoint.
+Relevant for CyberArk versions earlier than 10.4
 
-	.PARAMETER SharedAuthentication
-	Specify the SharedAuthentication switch to logoff from a shared authentication session
+.PARAMETER SharedAuthentication
+Specify the SharedAuthentication switch to logoff from a shared authentication session
 
-	.PARAMETER SAMLAuthentication
-	Specify the SAMLAuthentication switch to logoff from a session authenticated to with SAML
+.PARAMETER SAMLAuthentication
+Specify the SAMLAuthentication switch to logoff from a session authenticated to with SAML
 
-	.EXAMPLE
-	Close-PASSession
+.EXAMPLE
+Close-PASSession
 
-	Logs off from the session related to the authorisation token.
+Logs off from the session related to the authorisation token.
 
-	.EXAMPLE
-	Close-PASSession -SAMLAuthentication
+.EXAMPLE
+Close-PASSession -SAMLAuthentication
 
-	Logs off from the session related to the authorisation token using the SAML Authentication API endpoint.
+Logs off from the session related to the authorisation token using the SAML Authentication API endpoint.
 
-	.EXAMPLE
-	Close-PASSession -SharedAuthentication
+.EXAMPLE
+Close-PASSession -SharedAuthentication
 
-	Logs off from the session related to the authorisation token using the Shared Authentication API endpoint.
+Logs off from the session related to the authorisation token using the Shared Authentication API endpoint.
 
-	.EXAMPLE
-	Close-PASSession -UseClassicAPI
+.EXAMPLE
+Close-PASSession -UseClassicAPI
 
-	Logs off from the session related to the authorisation token using the Classic API endpoint.
+Logs off from the session related to the authorisation token using the Classic API endpoint.
 
-	#>
+.LINK
+https://pspas.pspete.dev/commands/Close-PASSession
+#>
 	[CmdletBinding(DefaultParameterSetName = "V10")]
 	param(
 

--- a/psPAS/Functions/Authentication/Get-PASPublicSSHKey.ps1
+++ b/psPAS/Functions/Authentication/Get-PASPublicSSHKey.ps1
@@ -4,14 +4,14 @@
 Retrieves a user's SSH Keys.
 
 .DESCRIPTION
-Retrieves all public SSH keys that are authorized for a specific user.
+Retrieves all public SSH�keys that are authorized for a specific user.
 The "Reset User Passwords" Vault permission is required to query public SSH Keys.
 The authenticated user who runs the function must be in the same Vault
 Location or higher as the user whose public SSH keys are retrieved.
-A user cannot manage their own public SSH keys.
+A user cannot manage their own public SSH�keys.
 
 .PARAMETER UserName
-The username of the Vault user whose public SSH keys will be added
+The username of the Vault user whose public SSH�keys will be added
 A username cannot contain te follwing characters: "%", "&", "+" or ".".
 
 .EXAMPLE
@@ -25,6 +25,8 @@ user1    415161FE8F2B408BB76BC244258C3697 ACABB3NzaC1kc3MAAACBAJ3hA.............
 user1    B6DCA4D54B2E93380F42DDCDB23EE52A AgreatNzaC1kc3MAAACBAJ3hB...............
 user1    D6374740D11A5F45992D80D80E97387A PHil0soPh3rkc3MAAACBAJ3hC...............
 
+.LINK
+https://pspas.pspete.dev/commands/Get-PASPublicSSHKey
 #>
 	[CmdletBinding()]
 	param(
@@ -32,12 +34,12 @@ user1    D6374740D11A5F45992D80D80E97387A PHil0soPh3rkc3MAAACBAJ3hC.............
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateScript( {$_ -notmatch ".*(%|\&|\+|\.).*"})]
+		[ValidateScript( { $_ -notmatch ".*(%|\&|\+|\.).*" })]
 		[string]$UserName
 
 	)
 
-	BEGIN {}#begin
+	BEGIN { }#begin
 
 	PROCESS {
 
@@ -49,13 +51,13 @@ user1    D6374740D11A5F45992D80D80E97387A PHil0soPh3rkc3MAAACBAJ3hC.............
 		#Send request to web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
 
-		if($result) {
+		if ($result) {
 
 			$result.GetUserAuthorizedKeysResult |
 
 			Add-ObjectDetail -typename psPAS.CyberArk.Vault.PublicSSHKey -PropertyToAdd @{
 
-				"UserName"     = $UserName
+				"UserName" = $UserName
 
 			}
 
@@ -63,6 +65,6 @@ user1    D6374740D11A5F45992D80D80E97387A PHil0soPh3rkc3MAAACBAJ3hC.............
 
 	}#process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/Authentication/Get-PASSession.ps1
+++ b/psPAS/Functions/Authentication/Get-PASSession.ps1
@@ -1,36 +1,38 @@
-﻿function Get-PASSession {
+function Get-PASSession {
 	<#
-	.SYNOPSIS
-	Returns information related to the authenticated session
+.SYNOPSIS
+Returns information related to the authenticated session
 
-	.DESCRIPTION
-	For the current session, returns data from the module scope:
-	- Username relating to the session.
-	- BaseURI: URL value used for sending requests to the API.
-	- ExternalVersion: PAS version information.
-	- Websession: Contains Authorization Header, Cookie & Certificate data related to the current session.
+.DESCRIPTION
+For the current session, returns data from the module scope:
+- Username relating to the session.
+- BaseURI: URL value used for sending requests to the API.
+- ExternalVersion: PAS version information.
+- Websession: Contains Authorization Header, Cookie & Certificate data related to the current session.
 
-	The session information can be saved a variable accessible outside of the module scope for use in requests outside of psPAS.
+The session information can be saved a variable accessible outside of the module scope for use in requests outside of psPAS.
 
-	.EXAMPLE
-	Show current session related information
+.EXAMPLE
+Show current session related information
 
-	Get-PASSession
+Get-PASSession
 
-	.EXAMPLE
-	Save current session related information
+.EXAMPLE
+Save current session related information
 
-	$session = Get-PASSession
+$session = Get-PASSession
 
-	.EXAMPLE
-	Use session information for Invoke-RestMethod command
+.EXAMPLE
+Use session information for Invoke-RestMethod command
 
-	$session = Get-PASSession
+$session = Get-PASSession
 
-	Invoke-RestMethod
-	Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $session.WebSession
+Invoke-RestMethod
+Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $session.WebSession
 
-	#>
+.LINK
+https://pspas.pspete.dev/commands/Get-PASSession
+#>
 	[CmdletBinding()]
 	param( )
 

--- a/psPAS/Functions/Authentication/New-PASSession.ps1
+++ b/psPAS/Functions/Authentication/New-PASSession.ps1
@@ -1,175 +1,178 @@
-﻿function New-PASSession {
+function New-PASSession {
 	<#
-	.SYNOPSIS
-	Authenticates a user to CyberArk Vault/API.
+.SYNOPSIS
+Authenticates a user to CyberArk Vault/API.
 
-	.DESCRIPTION
-	Authenticates a user to a CyberArk Vault and stores an authentication token and a webrequest session object
-	which are used in subsequent calls to the API.
-	In addition, this method allows you to set a new password.
-	Will attempt authentication against the V10 API by default.
-	For older CyberArk versions, specify the -UseClassicAPI switch parameter to force use of the V9 API endpoint.
-	Windows authentication is only supported (from CyberArk 10.4+).
-	Authenticate using CyberArk, LDAP, RADIUS, SAML or Shared authentication (From CyberArk version 9.7+),
-	For CyberArk version older than 9.7:
-		Only CyberArk Authentication method is supported.
-		newPassword Parameter is not supported.
-		useRadiusAuthentication Parameter is not supported.
-		connectionNumber Parameter is not supported.
+.DESCRIPTION
+Authenticates a user to a CyberArk Vault and stores an authentication token and a webrequest session object
+which are used in subsequent calls to the API.
+In addition, this method allows you to set a new password.
+Will attempt authentication against the V10 API by default.
+For older CyberArk versions, specify the -UseClassicAPI switch parameter to force use of the V9 API endpoint.
+Windows authentication is only supported (from CyberArk 10.4+).
+Authenticate using CyberArk, LDAP, RADIUS, SAML or Shared authentication (From CyberArk version 9.7+),
+For CyberArk version older than 9.7:
+	Only CyberArk Authentication method is supported.
+	newPassword Parameter is not supported.
+	useRadiusAuthentication Parameter is not supported.
+	connectionNumber Parameter is not supported.
 
-	.PARAMETER Credential
-	A Valid PSCredential object.
+.PARAMETER Credential
+A Valid PSCredential object.
 
-	.PARAMETER UseClassicAPI
-	Specify the UseClassicAPI to send the authentication request via the Classic (v9) API endpoint.
-	Relevant for CyberArk versions earlier than 10.4
+.PARAMETER UseClassicAPI
+Specify the UseClassicAPI to send the authentication request via the Classic (v9) API endpoint.
+Relevant for CyberArk versions earlier than 10.4
 
-	.PARAMETER newPassword
-	Optional parameter, enables you to change a CyberArk users password.
-	Must be supplied as a SecureString (Not Plain Text).
+.PARAMETER newPassword
+Optional parameter, enables you to change a CyberArk users password.
+Must be supplied as a SecureString (Not Plain Text).
 
-	.PARAMETER SAMLToken
-	SAML token that identifies the session, encoded in BASE 64.
+.PARAMETER SAMLToken
+SAML token that identifies the session, encoded in BASE 64.
 
-	.PARAMETER UseSharedAuthentication
-	Specify the UseSharedAuthentication switch to use the Shared Authentication API endpoint to logon
+.PARAMETER UseSharedAuthentication
+Specify the UseSharedAuthentication switch to use the Shared Authentication API endpoint to logon
 
-	.PARAMETER useRadiusAuthentication
-	Whether or not users will be authenticated via a RADIUS server.
+.PARAMETER useRadiusAuthentication
+Whether or not users will be authenticated via a RADIUS server.
 
-	.PARAMETER type
-	When using the version 10 API endpoint, specify the type of authentication to use.
-	Valid values are CyberArk, LDAP, Windows or RADIUS
-	Windows is only a valid option for version 10.4 onward.
+.PARAMETER type
+When using the version 10 API endpoint, specify the type of authentication to use.
+Valid values are CyberArk, LDAP, Windows or RADIUS
+Windows is only a valid option for version 10.4 onward.
 
-	.PARAMETER OTP
-	One Time Passcode for RADIUS authentication.
+.PARAMETER OTP
+One Time Passcode for RADIUS authentication.
 
-	.PARAMETER OTPMode
-	Specify if OTP is to be sent in 'Append' (appended to the password) or 'Challenge' mode (sent in response to RADIUS Challenge).
+.PARAMETER OTPMode
+Specify if OTP is to be sent in 'Append' (appended to the password) or 'Challenge' mode (sent in response to RADIUS Challenge).
 
-	.PARAMETER OTPDelimiter
-	The character to use as a delimiter when appending the OTP to the password. Defaults to comma ",".
+.PARAMETER OTPDelimiter
+The character to use as a delimiter when appending the OTP to the password. Defaults to comma ",".
 
-	.PARAMETER RadiusChallenge
-	Specify if Radius challenge is satisfied by 'OTP' or 'Password'.
-	If "OTP" (Default), Password will be sent first, with OTP as the challenge response.
-	If "Password", then OTP value will be sent first, and Password will be sent as the challenge response.
+.PARAMETER RadiusChallenge
+Specify if Radius challenge is satisfied by 'OTP' or 'Password'.
+If "OTP" (Default), Password will be sent first, with OTP as the challenge response.
+If "Password", then OTP value will be sent first, and Password will be sent as the challenge response.
 
-	.PARAMETER connectionNumber
-	In order to allow more than one connection for the same user simultaneously, each request
-	should be sent with different 'connectionNumber'.
-	Valid values: 1-100
+.PARAMETER connectionNumber
+In order to allow more than one connection for the same user simultaneously, each request
+should be sent with different 'connectionNumber'.
+Valid values: 1-100
 
-	.PARAMETER SkipVersionCheck
-	If the SkipVersionCheck switch is specified, Get-PASServer will not be called after
-	successfully authenticating. Get-PASServer is not supported before version 9.7.
+.PARAMETER SkipVersionCheck
+If the SkipVersionCheck switch is specified, Get-PASServer will not be called after
+successfully authenticating. Get-PASServer is not supported before version 9.7.
 
-	.PARAMETER BaseURI
-	A string containing the base web address to send te request to.
-	Pass the portion the PVWA HTTP address.
-	Do not include "/PasswordVault/"
+.PARAMETER BaseURI
+A string containing the base web address to send te request to.
+Pass the portion the PVWA HTTP address.
+Do not include "/PasswordVault/"
 
-	.PARAMETER PVWAAppName
-	The name of the CyberArk PVWA Virtual Directory.
-	Defaults to PasswordVault
+.PARAMETER PVWAAppName
+The name of the CyberArk PVWA Virtual Directory.
+Defaults to PasswordVault
 
-	.PARAMETER UseDefaultCredentials
-	See Invoke-WebRequest
-	Uses the credentials of the current user to send the web request
+.PARAMETER UseDefaultCredentials
+See Invoke-WebRequest
+Uses the credentials of the current user to send the web request
 
-	.PARAMETER Certificate
-	See Invoke-WebRequest
-	Specifies the client certificate that is used for a secure web request. 
-	Enter a variable that contains a certificate or a command or expression that gets the certificate.
+.PARAMETER Certificate
+See Invoke-WebRequest
+Specifies the client certificate that is used for a secure web request.
+Enter a variable that contains a certificate or a command or expression that gets the certificate.
 
-	.PARAMETER CertificateThumbprint
-	See Invoke-WebRequest
-	The thumbprint of the certificate to use for client certificate authentication.
+.PARAMETER CertificateThumbprint
+See Invoke-WebRequest
+The thumbprint of the certificate to use for client certificate authentication.
 
-	.PARAMETER SkipCertificateCheck
-	Skips certificate validation checks.
-	Using this parameter is not secure and is not recommended.
-	This switch is only intended to be used against known hosts using a self-signed certificate for testing purposes.
-	Use at your own risk.
+.PARAMETER SkipCertificateCheck
+Skips certificate validation checks.
+Using this parameter is not secure and is not recommended.
+This switch is only intended to be used against known hosts using a self-signed certificate for testing purposes.
+Use at your own risk.
 
-	.EXAMPLE
-	New-PASSession -Credential $cred -BaseURI https://PVWA -type LDAP
+.EXAMPLE
+New-PASSession -Credential $cred -BaseURI https://PVWA -type LDAP
 
-	Logon to Version 10 with LDAP credential
+Logon to Version 10 with LDAP credential
 
-	.EXAMPLE
-	New-PASSession -Credential $cred -BaseURI https://PVWA -type CyberArk
+.EXAMPLE
+New-PASSession -Credential $cred -BaseURI https://PVWA -type CyberArk
 
-	Logon to Version 10 with CyberArk credential
+Logon to Version 10 with CyberArk credential
 
-	.EXAMPLE
-	New-PASSession -BaseURI https://PVWA -UseDefaultCredentials
+.EXAMPLE
+New-PASSession -BaseURI https://PVWA -UseDefaultCredentials
 
-	Logon to Version 10 with Windows Integrated Authentication
+Logon to Version 10 with Windows Integrated Authentication
 
-	.EXAMPLE
-	New-PASSession -Credential $cred -BaseURI https://PVWA -UseClassicAPI
+.EXAMPLE
+New-PASSession -Credential $cred -BaseURI https://PVWA -UseClassicAPI
 
-	Logon to Version 9 with credential
-	Request would be sent to PVWA URL https://PVWA/PasswordVault/
+Logon to Version 9 with credential
+Request would be sent to PVWA URL https://PVWA/PasswordVault/
 
-	.EXAMPLE
-	New-PASSession -Credential $cred -BaseURI https://PVWA -PVWAAppName CustomVault -UseClassicAPI
+.EXAMPLE
+New-PASSession -Credential $cred -BaseURI https://PVWA -PVWAAppName CustomVault -UseClassicAPI
 
-	Logon to Version 9 where PVWA Virtual Directory has non-default name
-	Request would be sent to PVWA URL https://PVWA/CustomVault/
+Logon to Version 9 where PVWA Virtual Directory has non-default name
+Request would be sent to PVWA URL https://PVWA/CustomVault/
 
-	.EXAMPLE
-	New-PASSession -UseSharedAuthentication -BaseURI https://PVWA.domain.com
+.EXAMPLE
+New-PASSession -UseSharedAuthentication -BaseURI https://PVWA.domain.com
 
-	Gets authorisation token by authenticating to a CyberArk Vault using shared authentication.
+Gets authorisation token by authenticating to a CyberArk Vault using shared authentication.
 
-	.EXAMPLE
-	New-PASSession -SAMLToken $SAMLToken -BaseURI https://PVWA.domain.com
+.EXAMPLE
+New-PASSession -SAMLToken $SAMLToken -BaseURI https://PVWA.domain.com
 
-	Authenticates to a CyberArk Vault using SAML authentication.
+Authenticates to a CyberArk Vault using SAML authentication.
 
-	.EXAMPLE
-	New-PASSession -Credential $cred -BaseURI https://PVWA -type RADIUS
+.EXAMPLE
+New-PASSession -Credential $cred -BaseURI https://PVWA -type RADIUS
 
-	Logon to Version 10 using RADIUS
+Logon to Version 10 using RADIUS
 
-	.EXAMPLE
-	New-PASSession -Credential $cred -BaseURI https://PVWA -useRadiusAuthentication $True
+.EXAMPLE
+New-PASSession -Credential $cred -BaseURI https://PVWA -useRadiusAuthentication $True
 
-	Logon using RADIUS via the Classic API
+Logon using RADIUS via the Classic API
 
-	.EXAMPLE
-	New-PASSession -Credential $cred -BaseURI https://PVWA -type RADIUS -OTP 123456 -OTPMode Challenge
+.EXAMPLE
+New-PASSession -Credential $cred -BaseURI https://PVWA -type RADIUS -OTP 123456 -OTPMode Challenge
 
-	Logon to Version 10 using RADIUS (Challenge) & OTP (Response)
+Logon to Version 10 using RADIUS (Challenge) & OTP (Response)
 
-	.EXAMPLE
-	New-PASSession -Credential $cred -BaseURI https://PVWA -UseClassicAPI -useRadiusAuthentication $True -OTP 123456 -OTPMode Append
+.EXAMPLE
+New-PASSession -Credential $cred -BaseURI https://PVWA -UseClassicAPI -useRadiusAuthentication $True -OTP 123456 -OTPMode Append
 
-	Logon using RADIUS & OTP (Append Mode) via the Classic API
+Logon using RADIUS & OTP (Append Mode) via the Classic API
 
-	.EXAMPLE
-	New-PASSession -Credential $cred -BaseURI https://PVWA -type RADIUS -OTP push -OTPMode Append
+.EXAMPLE
+New-PASSession -Credential $cred -BaseURI https://PVWA -type RADIUS -OTP push -OTPMode Append
 
-	Logon to Version 10 using RADIUS & Push Authentication (works with DUO 2FA)
+Logon to Version 10 using RADIUS & Push Authentication (works with DUO 2FA)
 
-	.EXAMPLE
-	New-PASSession -UseSharedAuthentication -BaseURI https://pvwa.some.co -CertificateThumbprint 0e194289c57e666115109d6e2800c24fb7db6edb
+.EXAMPLE
+New-PASSession -UseSharedAuthentication -BaseURI https://pvwa.some.co -CertificateThumbprint 0e194289c57e666115109d6e2800c24fb7db6edb
 
-	If authentication via certificates is configured, provide CertificateThumbprint details.
+If authentication via certificates is configured, provide CertificateThumbprint details.
 
-	.EXAMPLE
-	New-PASSession -Credential $cred -BaseURI $url -SkipCertificateCheck
+.EXAMPLE
+New-PASSession -Credential $cred -BaseURI $url -SkipCertificateCheck
 
-	Skip SSL Certificate validation for the session.
+Skip SSL Certificate validation for the session.
 
-	.EXAMPLE
-	New-PASSession -Credential $cred -BaseURI https://PVWA -type LDAP -Certificate $Certificate
+.EXAMPLE
+New-PASSession -Credential $cred -BaseURI https://PVWA -type LDAP -Certificate $Certificate
 
-	Logon to Version 10 with LDAP credential & Client Certificate
-	#>
+Logon to Version 10 with LDAP credential & Client Certificate
+
+.LINK
+https://pspas.pspete.dev/commands/New-PASSession
+#>
 	[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = "v10")]
 	param(
 		[parameter(
@@ -371,7 +374,7 @@
 			ValueFromPipelinebyPropertyName = $false
 		)]
 		[X509Certificate]$Certificate,
-		
+
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipeline = $false,

--- a/psPAS/Functions/Authentication/Remove-PASPublicSSHKey.ps1
+++ b/psPAS/Functions/Authentication/Remove-PASPublicSSHKey.ps1
@@ -10,10 +10,10 @@ using a corresponding private SSH key.
 "Reset Users Passwords" Vault permission is required.
 The authenticated user who runs this function must be in the same Vault
 Location or higher as the user whose public SSH keys are deleted.
-A user cannot manage their own public SSH keys.
+A user cannot manage their own public SSH�keys.
 
 .PARAMETER UserName
-The username of the Vault user whose public SSH keys will be added
+The username of the Vault user whose public SSH�keys will be added
 A username cannot contain te follwing characters: "%", "&", "+" or ".".
 
 .PARAMETER KeyID
@@ -24,6 +24,8 @@ Remove-PASPublicSSHKey -UserName Splitter -KeyID 415161FE8F2B408BB76BC244258C369
 
 Deletes specified ssh key from vault user "Splitter"
 
+.LINK
+https://pspas.pspete.dev/commands/Remove-PASPublicSSHKey
 #>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
@@ -31,7 +33,7 @@ Deletes specified ssh key from vault user "Splitter"
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateScript( {$_ -notmatch ".*(%|\&|\+|\.).*"})]
+		[ValidateScript( { $_ -notmatch ".*(%|\&|\+|\.).*" })]
 		[string]$UserName,
 
 		[parameter(
@@ -42,7 +44,7 @@ Deletes specified ssh key from vault user "Splitter"
 
 	)
 
-	BEGIN {}#begin
+	BEGIN { }#begin
 
 	PROCESS {
 
@@ -51,7 +53,7 @@ Deletes specified ssh key from vault user "Splitter"
 
             Get-EscapedString)/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys/$KeyID"
 
-		if($PSCmdlet.ShouldProcess($KeyID, "Delete Public SSH Key")) {
+		if ($PSCmdlet.ShouldProcess($KeyID, "Delete Public SSH Key")) {
 
 			#Send Request to web service
 			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
@@ -60,5 +62,5 @@ Deletes specified ssh key from vault user "Splitter"
 
 	}#process
 
-	END {}#end
+	END { }#end
 }

--- a/psPAS/Functions/Authentication/Use-PASSession.ps1
+++ b/psPAS/Functions/Authentication/Use-PASSession.ps1
@@ -1,31 +1,33 @@
-﻿function Use-PASSession {
+function Use-PASSession {
 	<#
-	.SYNOPSIS
-	Sets module scope variables allowing saved session information to be used for future requests.
+.SYNOPSIS
+Sets module scope variables allowing saved session information to be used for future requests.
 
-	.DESCRIPTION
-	Use session data (BaseURI, ExternalVersion, WebSession (containing Authorization Header)) for future requests.
-	psPAS uses variables in the Module scope to provide required values to all module functions, use this function to
-	set the required values in the module scope, using session information returned from `Get-PASSession`.
+.DESCRIPTION
+Use session data (BaseURI, ExternalVersion, WebSession (containing Authorization Header)) for future requests.
+psPAS uses variables in the Module scope to provide required values to all module functions, use this function to
+set the required values in the module scope, using session information returned from `Get-PASSession`.
 
-	.PARAMETER Session
-	An object containing psPAS session data, as returned from Get-PASSession
+.PARAMETER Session
+An object containing psPAS session data, as returned from Get-PASSession
 
-	.EXAMPLE
-	Use Saved Session Data for future requests
+.EXAMPLE
+Use Saved Session Data for future requests
 
-	Use-PASSession -Session $Session
+Use-PASSession -Session $Session
 
-	.EXAMPLE
-	Save current session, switch to using different session details, switch back to original session.
+.EXAMPLE
+Save current session, switch to using different session details, switch back to original session.
 
-	$CurrentSession = Get-PASSession
+$CurrentSession = Get-PASSession
 
-	Use-PASSession -Session $OtherSession
-	...
-	Use-PASSession -Session $CurrentSession
+Use-PASSession -Session $OtherSession
+...
+Use-PASSession -Session $CurrentSession
 
-	#>
+.LINK
+https://pspas.pspete.dev/commands/Use-PASSession
+#>
 	[CmdletBinding()]
 	param(
 		[parameter(

--- a/psPAS/Functions/Connections/Get-PASPSMConnectionParameter.ps1
+++ b/psPAS/Functions/Connections/Get-PASPSMConnectionParameter.ps1
@@ -59,6 +59,9 @@ Outputs RDP file for Direct Connection via PSM using account with ID in $ID
 Minimum CyberArk Version 9.10
 PSMGW connections require 10.2
 Ad-Hoc connections require 10.5
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASPSMConnectionParameter
 #>
 	[CmdletBinding()]
 	param(
@@ -208,7 +211,8 @@ Ad-Hoc connections require 10.5
 			#Create body of request
 			$body = $PSBoundParameters | Get-PASParameter -ParametersToRemove AccountID, ConnectionMethod | ConvertTo-Json
 
-		} elseif ($PSCmdlet.ParameterSetName -eq "AdHocConnect") {
+		}
+		elseif ($PSCmdlet.ParameterSetName -eq "AdHocConnect") {
 
 			Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $AdHocVersion
 
@@ -247,7 +251,8 @@ Ad-Hoc connections require 10.5
 				#RDP accept "application/json" response
 				$Accept = "application/octet-stream"
 
-			} elseif ($PSBoundParameters["ConnectionMethod"] -eq "PSMGW") {
+			}
+			elseif ($PSBoundParameters["ConnectionMethod"] -eq "PSMGW") {
 
 				Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $RequiredVersion
 
@@ -271,7 +276,8 @@ Ad-Hoc connections require 10.5
 				#Return PSM GW URL Details
 				$result
 
-			} Else {
+			}
+			Else {
 
 				#Save the RDP file to disk
 				Out-PASFile -InputObject $result -Path $Path

--- a/psPAS/Functions/Connections/Import-PASConnectionComponent.ps1
+++ b/psPAS/Functions/Connections/Import-PASConnectionComponent.ps1
@@ -1,24 +1,26 @@
 function Import-PASConnectionComponent {
 	<#
-	.SYNOPSIS
-	Import a new connection component.
+.SYNOPSIS
+Import a new connection component.
 
-	.DESCRIPTION
-	Allows administrators to import a new connection component, such as those available to download from the
-	CyberArk Marketplace.
+.DESCRIPTION
+Allows administrators to import a new connection component, such as those available to download from the
+CyberArk Marketplace.
 
-	.PARAMETER ImportFile
-	The zip file that contains the connection component.
+.PARAMETER ImportFile
+The zip file that contains the connection component.
 
-	.EXAMPLE
-	Import-PASConnectionComponent -ImportFile ConnectionComponent.zip
+.EXAMPLE
+Import-PASConnectionComponent -ImportFile ConnectionComponent.zip
 
-	Imports ConnectionComponent.zip Connection Component
+Imports ConnectionComponent.zip Connection Component
 
-	.NOTES
-	Minimum CyberArk version 10.3
+.NOTES
+Minimum CyberArk version 10.3
 
-	#>
+.LINK
+https://pspas.pspete.dev/commands/Import-PASConnectionComponent
+#>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
 		[parameter(

--- a/psPAS/Functions/EventSecurity/Add-PASPTARule.ps1
+++ b/psPAS/Functions/EventSecurity/Add-PASPTARule.ps1
@@ -1,42 +1,45 @@
 Function Add-PASPTARule {
 	<#
-	.SYNOPSIS
-	Adds a new Risky Activity rule to PTA
+.SYNOPSIS
+Adds a new Risky Activity rule to PTA
 
-	.DESCRIPTION
-	Adds a new Risky Activity rule in the PTA server configuration.
+.DESCRIPTION
+Adds a new Risky Activity rule in the PTA server configuration.
 
-	.PARAMETER category
-	The Category of the risky activity
-	Valid values: SSH, WINDOWS, SCP, KEYSTROKES or SQL
+.PARAMETER category
+The Category of the risky activity
+Valid values: SSH, WINDOWS, SCP, KEYSTROKES or SQL
 
-	.PARAMETER regex
-	Risky activity in regex form.
-	Must support all characters (including "/" and escaping characters)
+.PARAMETER regex
+Risky activity in regex form.
+Must support all characters (including "/" and escaping characters)
 
-	.PARAMETER score
-	Activity score.
-	Number must be between 1 and 100
+.PARAMETER score
+Activity score.
+Number must be between 1 and 100
 
-	.PARAMETER description
-	Activity description.
-	The field is mandatory but can be empty
+.PARAMETER description
+Activity description.
+The field is mandatory but can be empty
 
-	.PARAMETER response
-	Automatic response to be executed
-	Valid Values: NONE, TERMINATE or SUSPEND
+.PARAMETER response
+Automatic response to be executed
+Valid Values: NONE, TERMINATE or SUSPEND
 
-	.PARAMETER active
-	Indicate if the rule should be active or disbaled
+.PARAMETER active
+Indicate if the rule should be active or disbaled
 
-	.EXAMPLE
+.EXAMPLE
 Add-PASPTARule -category KEYSTROKES -regex '(*.)risky command(.*)' -score 60 -description "Example Rule" -response NONE -active $true
 
-	Adds a new rule to PTA
+Adds a new rule to PTA
 
-	.NOTES
-	Minimum Version CyberArk 10.4
-	#>
+.NOTES
+Minimum Version CyberArk 10.4
+
+.LINK
+https://pspas.pspete.dev/commands/Add-PASPTARule
+#>
 	[CmdletBinding()]
 	param(
 		[parameter(
@@ -103,7 +106,7 @@ Add-PASPTARule -category KEYSTROKES -regex '(*.)risky command(.*)' -score 60 -de
 		#send request to PAS web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
 
-		if($result) {
+		if ($result) {
 
 			#Return Results
 			$result | Add-ObjectDetail -typename "psPAS.CyberArk.Vault.PTA.Rule"
@@ -112,5 +115,5 @@ Add-PASPTARule -category KEYSTROKES -regex '(*.)risky command(.*)' -score 60 -de
 
 	}#process
 
-	END {}#end
+	END { }#end
 }

--- a/psPAS/Functions/EventSecurity/Get-PASPTAEvent.ps1
+++ b/psPAS/Functions/EventSecurity/Get-PASPTAEvent.ps1
@@ -1,22 +1,25 @@
 Function Get-PASPTAEvent {
 	<#
-	.SYNOPSIS
-	Returns PTA security events
+.SYNOPSIS
+Returns PTA security events
 
-	.DESCRIPTION
-	Returns PTA security events
+.DESCRIPTION
+Returns PTA security events
 
-	.PARAMETER lastUpdatedEventDate
-	Parameter description
+.PARAMETER lastUpdatedEventDate
+Parameter description
 
-	.EXAMPLE
+.EXAMPLE
 Get-PASPTAEvent
 
-	Returns all PTA security events
+Returns all PTA security events
 
-	.NOTES
-	Minimum Version CyberArk 10.3
-	#>
+.NOTES
+Minimum Version CyberArk 10.3
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASPTAEvent
+#>
 	[CmdletBinding()]
 	param(
 		[parameter(

--- a/psPAS/Functions/EventSecurity/Get-PASPTARemediation.ps1
+++ b/psPAS/Functions/EventSecurity/Get-PASPTARemediation.ps1
@@ -1,19 +1,22 @@
 Function Get-PASPTARemediation {
 	<#
-	.SYNOPSIS
-	Returns automatic remediation settings from PTA
+.SYNOPSIS
+Returns automatic remediation settings from PTA
 
-	.DESCRIPTION
-	Returns automatic remediation settings configured in PTA
+.DESCRIPTION
+Returns automatic remediation settings configured in PTA
 
-	.EXAMPLE
+.EXAMPLE
 Get-PASPTARemediation
 
-	Returns all automatic remediation settings from PTA
+Returns all automatic remediation settings from PTA
 
-	.NOTES
-	Minimum Version CyberArk 10.4
-	#>
+.NOTES
+Minimum Version CyberArk 10.4
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASPTARemediation
+#>
 	[CmdletBinding()]
 	param(	)
 
@@ -31,7 +34,7 @@ Get-PASPTARemediation
 		#Send request to web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
 
-		If($result) {
+		If ($result) {
 
 			#Return Results
 			$result.automaticRemediation |
@@ -42,5 +45,5 @@ Get-PASPTARemediation
 
 	}#process
 
-	END {}#end
+	END { }#end
 }

--- a/psPAS/Functions/EventSecurity/Get-PASPTARule.ps1
+++ b/psPAS/Functions/EventSecurity/Get-PASPTARule.ps1
@@ -1,19 +1,22 @@
 Function Get-PASPTARule {
 	<#
-	.SYNOPSIS
-	Returns risky activities rules from PTA
+.SYNOPSIS
+Returns risky activities rules from PTA
 
-	.DESCRIPTION
-	Returns risky activities rules configured in PTA
+.DESCRIPTION
+Returns risky activities rules configured in PTA
 
-	.EXAMPLE
+.EXAMPLE
 Get-PASPTARule
 
-	Returns all risky activities rules from PTA
+Returns all risky activities rules from PTA
 
-	.NOTES
-	Minimum Version CyberArk 10.4
-	#>
+.NOTES
+Minimum Version CyberArk 10.4
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASPTARule
+#>
 	[CmdletBinding()]
 	param(	)
 
@@ -31,7 +34,7 @@ Get-PASPTARule
 		#Send request to web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
 
-		If($result) {
+		If ($result) {
 
 			#Return Results
 			$result.riskyActivities |
@@ -42,5 +45,5 @@ Get-PASPTARule
 
 	}#process
 
-	END {}#end
+	END { }#end
 }

--- a/psPAS/Functions/EventSecurity/Set-PASPTARemediation.ps1
+++ b/psPAS/Functions/EventSecurity/Set-PASPTARemediation.ps1
@@ -1,35 +1,38 @@
 Function Set-PASPTARemediation {
 	<#
-	.SYNOPSIS
-	Updates automatic remediation settings in PTA
+.SYNOPSIS
+Updates automatic remediation settings in PTA
 
-	.DESCRIPTION
-	Updates automatic remediation settings configured in PTA
+.DESCRIPTION
+Updates automatic remediation settings configured in PTA
 
-	.PARAMETER changePassword_SuspectedCredentialsTheft
-	Indicate if Change Password on Suspected Credential Theft the command is active
+.PARAMETER changePassword_SuspectedCredentialsTheft
+Indicate if Change Password on Suspected Credential Theft the command is active
 
-	.PARAMETER changePassword_OverPassTheHash
-	Indicate if the Change Password on Over Pass The Hash command is active
+.PARAMETER changePassword_OverPassTheHash
+Indicate if the Change Password on Over Pass The Hash command is active
 
-	.PARAMETER reconcilePassword_SuspectedPasswordChange
-	Indicate if the Reconcile Password on Suspected Password Change command is active
+.PARAMETER reconcilePassword_SuspectedPasswordChange
+Indicate if the Reconcile Password on Suspected Password Change command is active
 
-	.PARAMETER pendAccount_UnmanagedPrivilegedAccount
-	Indicate if the Add Unmanaged Accounts to Pending Accounts command is active
+.PARAMETER pendAccount_UnmanagedPrivilegedAccount
+Indicate if the Add Unmanaged Accounts to Pending Accounts command is active
 
-	.EXAMPLE
+.EXAMPLE
 Set-PASPTARemediation -changePassword_SuspectedCredentialsTheft $true
 
-	Enables the "Change password on Suspected Credentials Theft" rule.
-	.EXAMPLE
+Enables the "Change password on Suspected Credentials Theft" rule.
+.EXAMPLE
 Set-PASPTARemediation -reconcilePassword_SuspectedPasswordChange $false
 
-	Disables the "reconcile on suspected password change" rule.
+Disables the "reconcile on suspected password change" rule.
 
-	.NOTES
-	Minimum Version CyberArk 10.4
-	#>
+.NOTES
+Minimum Version CyberArk 10.4
+
+.LINK
+https://pspas.pspete.dev/commands/Set-PASPTARemediation
+#>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
 		[parameter(
@@ -78,12 +81,12 @@ Set-PASPTARemediation -reconcilePassword_SuspectedPasswordChange $false
 		#Create body of request
 		$body = $boundParameters | ConvertTo-Json
 
-		if($PSCmdlet.ShouldProcess("PTA", "Update Automatic Remediation Config")) {
+		if ($PSCmdlet.ShouldProcess("PTA", "Update Automatic Remediation Config")) {
 
 			#send request to PAS web service
 			$result = Invoke-PASRestMethod -Uri $URI -Method PATCH -Body $Body -WebSession $Script:WebSession
 
-			if($result) {
+			if ($result) {
 
 				#Return Results
 				$result.automaticRemediation | Add-ObjectDetail -typename "psPAS.CyberArk.Vault.PTA.Remediation"
@@ -94,6 +97,6 @@ Set-PASPTARemediation -reconcilePassword_SuspectedPasswordChange $false
 
 	}#process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/EventSecurity/Set-PASPTARule.ps1
+++ b/psPAS/Functions/EventSecurity/Set-PASPTARule.ps1
@@ -1,45 +1,48 @@
 Function Set-PASPTARule {
 	<#
-	.SYNOPSIS
-	Updates an existing Risky Activity rule to PTA
+.SYNOPSIS
+Updates an existing Risky Activity rule to PTA
 
-	.DESCRIPTION
-	Updates an existing Risky Activity rule in the PTA server configuration.
+.DESCRIPTION
+Updates an existing Risky Activity rule in the PTA server configuration.
 
-	.PARAMETER id
-	The unique ID of the rule.
+.PARAMETER id
+The unique ID of the rule.
 
-	.PARAMETER category
-	The Category of the risky activity
-	Valid values: SSH, WINDOWS, SCP, KEYSTROKES or SQL
+.PARAMETER category
+The Category of the risky activity
+Valid values: SSH, WINDOWS, SCP, KEYSTROKES or SQL
 
-	.PARAMETER regex
-	Risky activity in regex form.
-	Must support all characters (including "/" and escaping characters)
+.PARAMETER regex
+Risky activity in regex form.
+Must support all characters (including "/" and escaping characters)
 
-	.PARAMETER score
-	Activity score.
-	Number must be between 1 and 100
+.PARAMETER score
+Activity score.
+Number must be between 1 and 100
 
-	.PARAMETER description
-	Activity description.
-	The field is mandatory but can be empty
+.PARAMETER description
+Activity description.
+The field is mandatory but can be empty
 
-	.PARAMETER response
-	Automatic response to be executed
-	Valid Values: NONE, TERMINATE or SUSPEND
+.PARAMETER response
+Automatic response to be executed
+Valid Values: NONE, TERMINATE or SUSPEND
 
-	.PARAMETER active
-	Indicate if the rule should be active or disbaled
+.PARAMETER active
+Indicate if the rule should be active or disbaled
 
-	.EXAMPLE
+.EXAMPLE
 Set-PASPTARule -id 66 -category KEYSTROKES -regex '(*.)risky cmd(.*)' -score 65 -description "Updated Rule" -response SUSPEND -active $true
 
-	Updates rule 66 in PTA
+Updates rule 66 in PTA
 
-	.NOTES
-	Minimum Version CyberArk 10.4
-	#>
+.NOTES
+Minimum Version CyberArk 10.4
+
+.LINK
+https://pspas.pspete.dev/commands/Set-PASPTARule
+#>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
 		[parameter(
@@ -109,7 +112,7 @@ Set-PASPTARule -id 66 -category KEYSTROKES -regex '(*.)risky cmd(.*)' -score 65 
 		#Create body of request
 		$body = $boundParameters | ConvertTo-Json
 
-		if($PSCmdlet.ShouldProcess($id, "Update Risky Activity Rule")) {
+		if ($PSCmdlet.ShouldProcess($id, "Update Risky Activity Rule")) {
 
 			#send request to PAS web service
 			Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body -WebSession $Script:WebSession
@@ -118,5 +121,5 @@ Set-PASPTARule -id 66 -category KEYSTROKES -regex '(*.)risky cmd(.*)' -score 65 
 
 	}#process
 
-	END {}#end
+	END { }#end
 }

--- a/psPAS/Functions/LDAPDirectories/Add-PASDirectory.ps1
+++ b/psPAS/Functions/LDAPDirectories/Add-PASDirectory.ps1
@@ -1,4 +1,4 @@
-﻿function Add-PASDirectory {
+function Add-PASDirectory {
 	<#
 .SYNOPSIS
 Adds an LDAP directory to the Vault
@@ -44,16 +44,19 @@ Add-PASDirectory -DirectoryType "MicrosoftADProfile.ini" -HostAddresses "192.168
 Adds the Domain.Com directory to the vault
 
 .EXAMPLE
-Add-PASDirectory -DirectoryType "MicrosoftADProfile.ini" -BindUsername "bind@domain.com" -BindPassword $pw -DomainName DOMAIN `
--DomainBaseContext "DC=DOMAIN,DC=COM" -DCList @(@{"Name"="192.168.99.1";"Port"=389;"SSLConnect"=$false},@{"Name"="192.168.99.1";"Port"=389;"SSLConnect"=$false}) -Port 389
+Add-PASDirectory -DirectoryType "MicrosoftADProfile.ini" -BindUsername "BindUser@domain.com" -BindPassword $($Creds.Password) -DomainName DOMAIN `
+-DomainBaseContext "DC=domain,DC=com" -DCList @{"Name"="DC.domain.com";"Port"=636;"SSLConnect"=$true} -SSLConnect $true -Port 636
 
-(For 10.7+) - Adds the Domain.Com directory to the vault
+(For 10.7+) - Adds the Domain.Com directory to the vault, configured for LDAPS.
 
 .INPUTS
 All parameters can be piped to the function by propertyname
 
 .OUTPUTS
 LDAP Directory Details
+
+.LINK
+https://pspas.pspete.dev/commands/Add-PASDirectory
 #>
 	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlaintextForPassword', '', Justification = "It's a path to password object")]
 	[CmdletBinding()]
@@ -128,7 +131,8 @@ LDAP Directory Details
 
 			Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $RequiredVersion
 
-		} Elseif ($PSCmdlet.ParameterSetName -eq "v10_4") {
+		}
+		Elseif ($PSCmdlet.ParameterSetName -eq "v10_4") {
 
 			Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $MinimumVersion
 

--- a/psPAS/Functions/LDAPDirectories/Get-PASDirectory.ps1
+++ b/psPAS/Functions/LDAPDirectories/Get-PASDirectory.ps1
@@ -1,4 +1,4 @@
-﻿function Get-PASDirectory {
+function Get-PASDirectory {
 	<#
 .SYNOPSIS
 Get LDAP directories configured in the Vault
@@ -22,6 +22,9 @@ WebSession & BaseURI can be piped to the function by propertyname
 
 .OUTPUTS
 LDAP Directory Details
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASDirectory
 #>
 	[CmdletBinding()]
 	param(
@@ -56,7 +59,8 @@ LDAP Directory Details
 
 			$type = "psPAS.CyberArk.Vault.Directory.Extended"
 
-		} Else { $type = "psPAS.CyberArk.Vault.Directory" }
+		}
+		Else { $type = "psPAS.CyberArk.Vault.Directory" }
 
 		#send request to web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession

--- a/psPAS/Functions/LDAPDirectories/Get-PASDirectoryMapping.ps1
+++ b/psPAS/Functions/LDAPDirectories/Get-PASDirectoryMapping.ps1
@@ -1,4 +1,4 @@
-﻿function Get-PASDirectoryMapping {
+function Get-PASDirectoryMapping {
 	<#
 .SYNOPSIS
 Get directory mappings configured for a directory
@@ -28,6 +28,9 @@ WebSession & BaseURI can be piped to the function by propertyname
 
 .OUTPUTS
 LDAP Directory Mapping Details
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASDirectoryMapping
 #>
 	[CmdletBinding(DefaultParameterSetName = "All")]
 	param(
@@ -64,7 +67,7 @@ LDAP Directory Mapping Details
 		#Create URL for request
 		$URI = "$Script:BaseURI/api/Configuration/LDAP/Directories/$DirectoryName/Mappings"
 
-		if($PSCmdlet.ParameterSetName -eq "Mapping") {
+		if ($PSCmdlet.ParameterSetName -eq "Mapping") {
 
 			#Update URL for request
 			$URI = "$URI/$MappingID"
@@ -74,7 +77,7 @@ LDAP Directory Mapping Details
 		#send request to web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
 
-		If($result) {
+		If ($result) {
 
 			#Return Results
 			$result |
@@ -85,5 +88,5 @@ LDAP Directory Mapping Details
 
 	}#process
 
-	END {}#end
+	END { }#end
 }

--- a/psPAS/Functions/LDAPDirectories/New-PASDirectoryMapping.ps1
+++ b/psPAS/Functions/LDAPDirectories/New-PASDirectoryMapping.ps1
@@ -1,10 +1,10 @@
-﻿function New-PASDirectoryMapping {
+function New-PASDirectoryMapping {
 	<#
 .SYNOPSIS
 Adds a new Directory Mapping for an existing directory
 
 .DESCRIPTION
-Adds an LDAP directory to the Vault.
+Adds a directory mapping.
 Membership of the Vault Admins group required.
 
 .PARAMETER DirectoryName
@@ -33,57 +33,29 @@ Match LDAP query results to mapping
 Requires CyberArk version 10.7+
 
 .PARAMETER MappingAuthorizations
-The integer flag representation of the security attributes and authorizations that will be applied when an
-LDAP User Account is created in the Vault.
+Specify authorizations that will be applied when an LDAP User Account is created in the Vault.
 To apply specific authorizations to a mapping, the user must have the same authorizations.
-Possible authorizations: AddSafes, AuditUsers, AddUpdateUsers, ResetUsersPasswords, ActivateUsers, AddNetworkAreas,
-ManageServerFileCategories, BackupAllSafes, RestoreAllSafes.
-
-.PARAMETER AddUpdateUsers
-Specify switch to add the AddUpdateUsers authorization to the directory mapping
-
-.PARAMETER AddSafes
-Specify switch to add the AddSafes authorization to the directory mapping
-
-.PARAMETER AddNetworkAreas
-Specify switch to add the AddNetworkAreas authorization to the directory mapping
-
-.PARAMETER ManageServerFileCategories
-Specify switch to add the ManageServerFileCategories authorization to the directory mapping
-
-.PARAMETER AuditUsers
-Specify switch to add the AuditUsers authorization to the directory mapping
-
-.PARAMETER BackupAllSafes
-Specify switch to add the BackupAllSafes authorization to the directory mapping
-
-.PARAMETER RestoreAllSafes
-Specify switch to add the RestoreAllSafes authorization to the directory mapping
-
-.PARAMETER ResetUsersPasswords
-Specify switch to add the ResetUsersPasswords authorization to the directory mapping
-
-.PARAMETER ActivateUsers
-Specify switch to add the ActivateUsers authorization to the directory mapping
+Possible authorizations: AddSafes, AuditUsers, AddUpdateUsers, ResetUsersPasswords, ActivateUsers,
+AddNetworkAreas, ManageServerFileCategories, BackupAllSafes, RestoreAllSafes.
 
 .PARAMETER UserActivityLogPeriod
 Retention period in days for user activity logs
 Requires CyberArk version 10.10+
 
 .EXAMPLE
-New-PASDirectoryMapping -DirectoryName "domain.com" -LDAPBranch "DC=DOMAIN,DC=COM" -DomainGroups ADGroup -MappingName Map3 -RestoreAllSafes -BackupAllSafes
+New-PASDirectoryMapping -DirectoryName "domain.com" -LDAPBranch "DC=DOMAIN,DC=COM" -DomainGroups ADGroup -MappingName Map3 -MappingAuthorizations RestoreAllSafes, BackupAllSafes
 
 Creates a new  LDAP directory mapping in the Vault with the following authorizations:
 BackupAllSafes, RestoreAllSafes
 
 .EXAMPLE
-New-PASDirectoryMapping -DirectoryName "domain.com" -LDAPBranch "DC=DOMAIN,DC=COM" -DomainGroups ADGroup -MappingName Map2 -MappingAuthorizations 1536
+New-PASDirectoryMapping -DirectoryName "domain.com" -LDAPBranch "DC=DOMAIN,DC=COM" -DomainGroups ADGroup -MappingName Map2 -MappingAuthorizations BackupAllSafes, RestoreAllSafes
 
 Creates a new  LDAP directory mapping in the Vault with the following authorizations:
 BackupAllSafes, RestoreAllSafes
 
 .EXAMPLE
-New-PASDirectoryMapping -DirectoryName "domain.com" -LDAPBranch "DC=DOMAIN,DC=COM" -DomainGroups ADGroup -MappingName Map1 -MappingAuthorizations 1,3,512
+New-PASDirectoryMapping -DirectoryName "domain.com" -LDAPBranch "DC=DOMAIN,DC=COM" -DomainGroups ADGroup -MappingName Map1 -MappingAuthorizations AddUpdateUsers, AddSafes, BackupAllSafes
 
 Creates a new  LDAP directory mapping in the Vault with the following authorizations:
 AddUpdateUsers, AddSafes, BackupAllSafes
@@ -91,9 +63,11 @@ AddUpdateUsers, AddSafes, BackupAllSafes
 .INPUTS
 All parameters can be piped to the function by propertyname
 
-.OUTPUTS
+
+.LINK
+https://pspas.pspete.dev/commands/New-PASDirectoryMapping
 #>
-	[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = "AuthNames")]
+	[CmdletBinding(SupportsShouldProcess)]
 	param(
 		[parameter(
 			Mandatory = $true,
@@ -140,75 +114,9 @@ All parameters can be piped to the function by propertyname
 
 		[parameter(
 			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AuthFlags"
+			ValueFromPipelinebyPropertyName = $true
 		)]
-		[int[]]$MappingAuthorizations,
-
-
-		[parameter(
-			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AuthNames"
-		)]
-		[switch]$AddUpdateUsers,
-
-		[parameter(
-			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AuthNames"
-		)]
-		[switch]$AddSafes,
-
-		[parameter(
-			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AuthNames"
-		)]
-		[switch]$AddNetworkAreas,
-
-		[parameter(
-			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AuthNames"
-		)]
-		[switch]$ManageServerFileCategories,
-
-		[parameter(
-			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AuthNames"
-		)]
-		[switch]$AuditUsers,
-
-		[parameter(
-			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AuthNames"
-		)]
-		[switch]$BackupAllSafes,
-
-		[parameter(
-			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AuthNames"
-		)]
-
-		[switch]$RestoreAllSafes,
-
-		[parameter(
-			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AuthNames"
-		)]
-		[switch]$ResetUsersPasswords,
-
-		[parameter(
-			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AuthNames"
-		)]
-		[switch]$ActivateUsers,
+		[Authorizations]$MappingAuthorizations,
 
 		[parameter(
 			Mandatory = $false,
@@ -220,90 +128,70 @@ All parameters can be piped to the function by propertyname
 	)
 
 	BEGIN {
+
 		$MinimumVersion = [System.Version]"10.4"
 		$RequiredVersion = [System.Version]"10.7"
 		$NeededVersion = [System.Version]"10.10"
-
-		#Enum Flag values for Mapping Authorizations
-		[Flags()]enum Authorizations{
-			AddUpdateUsers = 1
-			AddSafes = 2
-			AddNetworkAreas = 4
-			ManageServerFileCategories = 16
-			AuditUsers = 32
-			BackupAllSafes = 512
-			RestoreAllSafes = 1024
-			ResetUsersPasswords = 8388608
-			ActivateUsers = 16777216
-		}
 
 	}#begin
 
 	PROCESS {
 
+		#Get request parameters
+		$boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove DirectoryName, MappingAuthorizations
+
 		#Ensure minimum required version is being used.
-		if ($PSBoundParameters.ContainsKey("UserActivityLogPeriod")) {
+		switch ($PSBoundParameters.Keys) {
 
-			#v10.10
-			Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $NeededVersion
+			'MappingAuthorizations' {
 
-		} Elseif ($PSBoundParameters.keys -match "VaultGroups|Location|LDAPQuery") {
+				#Transform MappingAuthorizations
+				$boundParameters.Add("MappingAuthorizations", [array][int]$MappingAuthorizations)
+				Continue
 
-			#v10.7
-			Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $RequiredVersion
+			}
 
-		} Else {
+			'UserActivityLogPeriod' {
 
-			#v10.4
-			Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $MinimumVersion
+				#v10.10
+				Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $NeededVersion
+				Continue
+
+			}
+
+			{ $_ -match "VaultGroups|Location|LDAPQuery" } {
+
+				#v10.7
+				Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $RequiredVersion
+				Continue
+
+			}
+
+			Default {
+
+				#v10.4
+				Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $MinimumVersion
+
+			}
 
 		}
 
 		#Create URL for request
 		$URI = "$Script:BaseURI/api/Configuration/LDAP/Directories/$DirectoryName/Mappings"
 
-		#Get request parameters
-		$boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove DirectoryName, AddUpdateUsers,
-		AddSafes, AddNetworkAreas, ManageServerFileCategories, AuditUsers, BackupAllSafes, RestoreAllSafes,
-		ResetUsersPasswords, ActivateUsers
-
-		#If individual authorisations have been specified
-		if ($PSCmdlet.ParameterSetName -match "^AuthNames") {
-
-			[array]$Authorizations = @()
-
-			#For each bound parameter
-			$PSBoundParameters.keys | ForEach-Object {
-
-				#where parameter name is defined in the Authorizations Enum
-				if ([enum]::IsDefined([Authorizations], "$_")) {
-
-					#Add enum name to array
-					$Authorizations = $Authorizations + $_
-
-				}
-			}
-
-			If ($Authorizations.count -gt 0) {
-
-				#Add enum integer flag as array to MappingAuthorizations request parameter
-				$boundParameters["MappingAuthorizations"] = [array][int][Authorizations]$Authorizations
-
-			}
-
-		}
-
 		$body = $boundParameters | ConvertTo-Json
 
-		#send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+		if ($PSCmdlet.ShouldProcess($MappingName, "Create Directory Mapping")) {
 
-		If ($result) {
+			#send request to web service
+			$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
 
-			#Return Results
-			$result |
+			If ($result) {
 
-			Add-ObjectDetail -typename psPAS.CyberArk.Vault.Directory.Mapping
+				#Return Results
+				$result | Add-ObjectDetail -typename psPAS.CyberArk.Vault.Directory.Mapping
+
+			}
 
 		}
 

--- a/psPAS/Functions/LDAPDirectories/Remove-PASDirectory.ps1
+++ b/psPAS/Functions/LDAPDirectories/Remove-PASDirectory.ps1
@@ -1,4 +1,4 @@
-﻿function Remove-PASDirectory {
+function Remove-PASDirectory {
 	<#
 .SYNOPSIS
 Removes an LDAP directory configured in the Vault
@@ -20,6 +20,9 @@ WebSession & BaseURI can be piped to the function by propertyname
 
 .OUTPUTS
 LDAP Directory Details
+
+.LINK
+https://pspas.pspete.dev/commands/Remove-PASDirectory
 #>
 	[CmdletBinding(SupportsShouldProcess = $true)]
 	param(
@@ -43,7 +46,7 @@ LDAP Directory Details
 		#Create URL for request
 		$URI = "$Script:BaseURI/api/Configuration/LDAP/Directories/$id"
 
-		if($PSCmdlet.ShouldProcess($id, "Delete Directory")) {
+		if ($PSCmdlet.ShouldProcess($id, "Delete Directory")) {
 
 			#send request to web service
 			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession

--- a/psPAS/Functions/LDAPDirectories/Remove-PASDirectoryMapping.ps1
+++ b/psPAS/Functions/LDAPDirectories/Remove-PASDirectoryMapping.ps1
@@ -1,4 +1,4 @@
-﻿function Remove-PASDirectoryMapping {
+function Remove-PASDirectoryMapping {
 	<#
 .SYNOPSIS
 Removes a configured directory mapping from the Vault
@@ -23,6 +23,9 @@ WebSession & BaseURI can be piped to the function by propertyname
 
 .OUTPUTS
 LDAP Directory Details
+
+.LINK
+https://pspas.pspete.dev/commands/Remove-PASDirectoryMapping
 #>
 	[CmdletBinding(SupportsShouldProcess = $true)]
 	param(

--- a/psPAS/Functions/LDAPDirectories/Set-PASDirectoryMapping.ps1
+++ b/psPAS/Functions/LDAPDirectories/Set-PASDirectoryMapping.ps1
@@ -1,10 +1,10 @@
-﻿function Set-PASDirectoryMapping {
+function Set-PASDirectoryMapping {
 	<#
 .SYNOPSIS
-Adds a new Directory Mapping for an existing directory
+Updates an existing Directory Mapping for a directory
 
 .DESCRIPTION
-Adds an LDAP directory to the Vault.
+Updates a  directory mapping.
 Membership of the Vault Admins group required.
 
 .PARAMETER DirectoryName
@@ -33,52 +33,24 @@ This value cannot be updated.
 Match LDAP query results to mapping
 
 .PARAMETER MappingAuthorizations
-The integer flag representation of the security attributes and authorizations that will be applied when an
-LDAP User Account is created in the Vault.
+Specify authorizations that will be applied when an LDAP User Account is created in the Vault.
 To apply specific authorizations to a mapping, the user must have the same authorizations.
-Possible authorizations: AddSafes, AuditUsers, AddUpdateUsers, ResetUsersPasswords, ActivateUsers, AddNetworkAreas,
-ManageServerFileCategories, BackupAllSafes, RestoreAllSafes.
-
-.PARAMETER AddUpdateUsers
-Specify switch to add the AddUpdateUsers authorization to the directory mapping
-
-.PARAMETER AddSafes
-Specify switch to add the AddSafes authorization to the directory mapping
-
-.PARAMETER AddNetworkAreas
-Specify switch to add the AddNetworkAreas authorization to the directory mapping
-
-.PARAMETER ManageServerFileCategories
-Specify switch to add the ManageServerFileCategories authorization to the directory mapping
-
-.PARAMETER AuditUsers
-Specify switch to add the AuditUsers authorization to the directory mapping
-
-.PARAMETER BackupAllSafes
-Specify switch to add the BackupAllSafes authorization to the directory mapping
-
-.PARAMETER RestoreAllSafes
-Specify switch to add the RestoreAllSafes authorization to the directory mapping
-
-.PARAMETER ResetUsersPasswords
-Specify switch to add the ResetUsersPasswords authorization to the directory mapping
-
-.PARAMETER ActivateUsers
-Specify switch to add the ActivateUsers authorization to the directory mapping
+Possible authorizations: AddSafes, AuditUsers, AddUpdateUsers, ResetUsersPasswords, ActivateUsers,
+AddNetworkAreas, ManageServerFileCategories, BackupAllSafes, RestoreAllSafes.
 
 .PARAMETER UserActivityLogPeriod
 Retention period in days for user activity logs
 Requires CyberArk version 10.10+
 
 .EXAMPLE
-Get-PASDirectoryMapping -DirectoryName $Directory -MappingID $ID | 
-Set-PASDirectoryMapping -DirectoryName $Directory -AddUpdateUsers -AuditUsers
+Get-PASDirectoryMapping -DirectoryName $Directory -MappingID $ID |
+Set-PASDirectoryMapping -DirectoryName $Directory -MappingAuthorizations AddUpdateUsers, AuditUsers
 
 Configures the AddUpdateUsers & AuditUsers authorisations on the mapping.
 
 .EXAMPLE
 Set-PASDirectoryMapping -DirectoryName $DirectoryName -MappingID $MappingID -MappingName $MappingName -LDAPBranch $LDAPBranch `
--AddUpdateUsers -ActivateUsers -ResetUsersPasswords
+-MappingAuthorizations AddUpdateUsers, ActivateUsers & ResetUsersPasswords
 
 Sets AddUpdateUsers, ActivateUsers & ResetUsersPasswords authorisations on the directory mapping
 
@@ -86,14 +58,15 @@ Sets AddUpdateUsers, ActivateUsers & ResetUsersPasswords authorisations on the d
 Set-PASDirectoryMapping -DirectoryName $DirectoryName -MappingID $MappingID -MappingName $MappingName -LDAPBranch $LDAPBranch `
 -UserActivityLogPeriod 365
 
-Sets UserActivityLogPeriod for the mapping to 365 
+Sets UserActivityLogPeriod for the mapping to 365
 
 .INPUTS
 All parameters can be piped to the function by propertyname
 
-.OUTPUTS
+.LINK
+https://pspas.pspete.dev/commands/Set-PASDirectoryMapping
 #>
-	[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = "AuthFlags")]
+	[CmdletBinding(SupportsShouldProcess)]
 	param(
 		[parameter(
 			Mandatory = $true,
@@ -146,73 +119,9 @@ All parameters can be piped to the function by propertyname
 
 		[parameter(
 			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $false,
-			ParameterSetName = "AuthFlags"
+			ValueFromPipelinebyPropertyName = $false
 		)]
-		[int[]]$MappingAuthorizations,
-
-		[parameter(
-			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AuthNames"
-		)]
-		[switch]$AddUpdateUsers,
-
-		[parameter(
-			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AuthNames"
-		)]
-		[switch]$AddSafes,
-
-		[parameter(
-			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AuthNames"
-		)]
-		[switch]$AddNetworkAreas,
-
-		[parameter(
-			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AuthNames"
-		)]
-		[switch]$ManageServerFileCategories,
-
-		[parameter(
-			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AuthNames"
-		)]
-		[switch]$AuditUsers,
-
-		[parameter(
-			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AuthNames"
-		)]
-		[switch]$BackupAllSafes,
-
-		[parameter(
-			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AuthNames"
-		)]
-		[switch]$RestoreAllSafes,
-
-		[parameter(
-			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AuthNames"
-		)]
-		[switch]$ResetUsersPasswords,
-
-		[parameter(
-			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AuthNames"
-		)]
-		[switch]$ActivateUsers,
+		[Authorizations]$MappingAuthorizations,
 
 		[parameter(
 			Mandatory = $false,
@@ -224,73 +133,47 @@ All parameters can be piped to the function by propertyname
 	)
 
 	BEGIN {
+
 		$MinimumVersion = [System.Version]"10.7"
 		$RequiredVersion = [System.Version]"10.10"
-
-		#Enum Flag values for Mapping Authorizations
-		[Flags()]enum Authorizations{
-			AddUpdateUsers = 1
-			AddSafes = 2
-			AddNetworkAreas = 4
-			ManageServerFileCategories = 16
-			AuditUsers = 32
-			BackupAllSafes = 512
-			RestoreAllSafes = 1024
-			ResetUsersPasswords = 8388608
-			ActivateUsers = 16777216
-		}
 
 	}#begin
 
 	PROCESS {
 
+		#Get request parameters
+		$boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove DirectoryName, MappingID, MappingAuthorizations
+
 		#Ensure minimum required version is being used.
-		if ($PSBoundParameters.ContainsKey("UserActivityLogPeriod")) {
+		switch ($PSBoundParameters.Keys) {
 
-			#10.10 Functionality
-			Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $RequiredVersion
+			'MappingAuthorizations' {
 
-		}
-		Else {
+				#Transform MappingAuthorizations
+				$boundParameters.Add("MappingAuthorizations", [array][int]$MappingAuthorizations)
+				Continue
 
-			#10.7 functionality
-			Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $MinimumVersion
+			}
+
+			'UserActivityLogPeriod' {
+
+				#v10.10
+				Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $RequiredVersion
+				Continue
+
+			}
+
+			Default {
+
+				#10.7 functionality
+				Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $MinimumVersion
+
+			}
 
 		}
 
 		#Create URL for request
 		$URI = "$Script:BaseURI/api/Configuration/LDAP/Directories/$DirectoryName/Mappings/$MappingID"
-
-		#Get request parameters
-		$boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove DirectoryName, MappingID,
-		AddUpdateUsers, AddSafes, AddNetworkAreas, ManageServerFileCategories, AuditUsers, BackupAllSafes,
-		RestoreAllSafes, ResetUsersPasswords, ActivateUsers
-
-		#If individual authorisations have been specified
-		if ($PSCmdlet.ParameterSetName -match "^AuthNames") {
-
-			[array]$Authorizations = @()
-
-			#For each bound parameter
-			$PSBoundParameters.keys | ForEach-Object {
-
-				#where parameter name is defined in the Authorizations Enum
-				if ([enum]::IsDefined([Authorizations], "$_")) {
-
-					#Add enum name to array
-					$Authorizations = $Authorizations + $_
-
-				}
-			}
-
-			If ($Authorizations.count -gt 0) {
-
-				#Add enum integer flag as array to MappingAuthorizations request parameter
-				$boundParameters["MappingAuthorizations"] = [array][int][Authorizations]$Authorizations
-
-			}
-
-		}
 
 		$body = $boundParameters | ConvertTo-Json
 
@@ -302,9 +185,7 @@ All parameters can be piped to the function by propertyname
 			If ($result) {
 
 				#Return Results
-				$result |
-
-				Add-ObjectDetail -typename psPAS.CyberArk.Vault.Directory.Mapping
+				$result | Add-ObjectDetail -typename psPAS.CyberArk.Vault.Directory.Mapping
 
 			}
 

--- a/psPAS/Functions/LDAPDirectories/Set-PASDirectoryMappingOrder.ps1
+++ b/psPAS/Functions/LDAPDirectories/Set-PASDirectoryMappingOrder.ps1
@@ -1,25 +1,28 @@
-﻿function Set-PASDirectoryMappingOrder {
+function Set-PASDirectoryMappingOrder {
 	<#
-	.SYNOPSIS
-	Changes the order of directory mappings for a directory
+.SYNOPSIS
+Changes the order of directory mappings for a directory
 
-	.DESCRIPTION
-	Updates the order of all a directories mappings.
+.DESCRIPTION
+Updates the order of all a directories mappings.
 
-	Requires membership of Vault Admins group  & "Audit users", "Add/Update users" & "Manage Directory mappings" authorizations.
-	Minimum version 10.10
+Requires membership of Vault Admins group  & "Audit users", "Add/Update users" & "Manage Directory mappings" authorizations.
+Minimum version 10.10
 
-	.PARAMETER DirectoryName
-	The name of the directory
+.PARAMETER DirectoryName
+The name of the directory
 
-	.PARAMETER MappingsOrder
-	The MappingID of each directory mapping, in the order they should be applied.
+.PARAMETER MappingsOrder
+The MappingID of each directory mapping, in the order they should be applied.
 
-	.EXAMPLE
-	Set-PASDirectoryMappingOrder -DirectoryName "DOMAIN.COM" -MappingsOrder 39,43,41,669,668,667
+.EXAMPLE
+Set-PASDirectoryMappingOrder -DirectoryName "DOMAIN.COM" -MappingsOrder 39,43,41,669,668,667
 
-	Sets the order of the directory mappings for directory "DOMAIN.COM"
-	#>
+Sets the order of the directory mappings for directory "DOMAIN.COM"
+
+.LINK
+https://pspas.pspete.dev/commands/Set-PASDirectoryMappingOrder
+#>
 
 	[CmdletBinding(SupportsShouldProcess)]
 	param(

--- a/psPAS/Functions/Monitoring/Connect-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Connect-PASPSMSession.ps1
@@ -22,12 +22,11 @@ Connect-PASPSMSession -LiveSessionId $SessionUUID -ConnectionMethod PSMGW
 
 Returns parameters to connect to Live PSM Session via HTML5 GW.
 
-.INPUTS
-
-.OUTPUTS
-
 .NOTES
 Minimum CyberArk Version 10.5
+
+.LINK
+https://pspas.pspete.dev/commands/Connect-PASPSMSession
 #>
 	[CmdletBinding()]
 	param(
@@ -68,7 +67,8 @@ Minimum CyberArk Version 10.5
 				#RDP accept "application/json" response
 				$Accept = "application/json"
 
-			} elseif ($PSBoundParameters["ConnectionMethod"] -eq "PSMGW") {
+			}
+			elseif ($PSBoundParameters["ConnectionMethod"] -eq "PSMGW") {
 
 				#PSMGW accept * / * response
 				$Accept = "* / *"

--- a/psPAS/Functions/Monitoring/Export-PASPSMRecording.ps1
+++ b/psPAS/Functions/Monitoring/Export-PASPSMRecording.ps1
@@ -1,25 +1,28 @@
 function Export-PASPSMRecording {
 	<#
-	.SYNOPSIS
-	Saves a PSM Recording
+.SYNOPSIS
+Saves a PSM Recording
 
-	.DESCRIPTION
-	Saves a specific recorded session to a file
+.DESCRIPTION
+Saves a specific recorded session to a file
 
-	.PARAMETER RecordingID
-	Unique ID of the recorded PSM session
+.PARAMETER RecordingID
+Unique ID of the recorded PSM session
 
-	.PARAMETER Path
-	The folder to export the PSM recording to.
+.PARAMETER Path
+The folder to export the PSM recording to.
 
-	.EXAMPLE
-	Export-PASPSMRecording -RecordingID 123_45 -path C:\PSMRecording.avi
+.EXAMPLE
+Export-PASPSMRecording -RecordingID 123_45 -path C:\PSMRecording.avi
 
-	Saves PSM Recording with Id 123_45 to C:\PSMRecording.avi
+Saves PSM Recording with Id 123_45 to C:\PSMRecording.avi
 
-	.NOTES
-	Minimum CyberArk Version 10.6
-	#>
+.NOTES
+Minimum CyberArk Version 10.6
+
+.LINK
+https://pspas.pspete.dev/commands/Export-PASPSMRecording
+#>
 	[CmdletBinding()]
 	param(
 		[parameter(

--- a/psPAS/Functions/Monitoring/Get-PASPSMRecording.ps1
+++ b/psPAS/Functions/Monitoring/Get-PASPSMRecording.ps1
@@ -65,6 +65,9 @@ To force all output to be shown, pipe to Select-Object *
 
 .NOTES
 Minimum CyberArk Version 9.10
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASPSMRecording
 #>
 	[CmdletBinding(DefaultParameterSetName = "byQuery")]
 	param(

--- a/psPAS/Functions/Monitoring/Get-PASPSMRecordingActivity.ps1
+++ b/psPAS/Functions/Monitoring/Get-PASPSMRecordingActivity.ps1
@@ -23,6 +23,9 @@ To force all output to be shown, pipe to Select-Object *
 
 .NOTES
 Minimum CyberArk Version 10.6
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASPSMRecordingActivity
 #>
 	[CmdletBinding()]
 	param(
@@ -48,7 +51,7 @@ Minimum CyberArk Version 10.6
 		#send request to PAS web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
 
-		If($result) {
+		If ($result) {
 
 			#Return Results
 			$result.Activities |
@@ -59,6 +62,6 @@ Minimum CyberArk Version 10.6
 
 	}
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/Monitoring/Get-PASPSMRecordingProperty.ps1
+++ b/psPAS/Functions/Monitoring/Get-PASPSMRecordingProperty.ps1
@@ -23,6 +23,9 @@ To force all output to be shown, pipe to Select-Object *
 
 .NOTES
 Minimum CyberArk Version 10.6
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASPSMRecordingProperty
 #>
 	[CmdletBinding()]
 	param(
@@ -48,7 +51,7 @@ Minimum CyberArk Version 10.6
 		#send request to PAS web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
 
-		If($result) {
+		If ($result) {
 
 			#Return Results
 			$result |
@@ -59,6 +62,6 @@ Minimum CyberArk Version 10.6
 
 	}
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/Monitoring/Get-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Get-PASPSMSession.ps1
@@ -71,6 +71,9 @@ To force all output to be shown, pipe to Select-Object *
 .NOTES
 Minimum CyberArk Version 9.10
 For querying sessions by ID, Required CyberArk Version is 10.6
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASPSMSession
 #>
 	[CmdletBinding(DefaultParameterSetName = "byQuery")]
 	param(

--- a/psPAS/Functions/Monitoring/Get-PASPSMSessionActivity.ps1
+++ b/psPAS/Functions/Monitoring/Get-PASPSMSessionActivity.ps1
@@ -23,6 +23,9 @@ To force all output to be shown, pipe to Select-Object *
 
 .NOTES
 Minimum CyberArk Version 10.6
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASPSMSessionActivity
 #>
 	[CmdletBinding()]
 	param(
@@ -48,7 +51,7 @@ Minimum CyberArk Version 10.6
 		#send request to PAS web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
 
-		If($result) {
+		If ($result) {
 
 			#Return Results
 			$result.Activities |
@@ -59,6 +62,6 @@ Minimum CyberArk Version 10.6
 
 	}
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/Monitoring/Get-PASPSMSessionProperty.ps1
+++ b/psPAS/Functions/Monitoring/Get-PASPSMSessionProperty.ps1
@@ -23,6 +23,9 @@ To force all output to be shown, pipe to Select-Object *
 
 .NOTES
 Minimum CyberArk Version 10.6
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASPSMSessionProperty
 #>
 	[CmdletBinding()]
 	param(
@@ -48,7 +51,7 @@ Minimum CyberArk Version 10.6
 		#send request to PAS web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
 
-		If($result) {
+		If ($result) {
 
 			#Return Results
 			$result |
@@ -59,6 +62,6 @@ Minimum CyberArk Version 10.6
 
 	}
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/Monitoring/Resume-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Resume-PASPSMSession.ps1
@@ -18,11 +18,11 @@ Terminates Live PSM Session identified by the session UUID.
 .INPUTS
 All parameters can be piped by property name
 
-.OUTPUTS
-None
-
 .NOTES
 Minimum CyberArk Version 10.2
+
+.LINK
+https://pspas.pspete.dev/commands/Resume-PASPSMSession
 #>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
@@ -46,7 +46,7 @@ Minimum CyberArk Version 10.2
 		#Create URL for Request
 		$URI = "$Script:BaseURI/api/LiveSessions/$($LiveSessionId | Get-EscapedString)/Resume"
 
-		if($PSCmdlet.ShouldProcess($LiveSessionId, "Resume PSM Session")) {
+		if ($PSCmdlet.ShouldProcess($LiveSessionId, "Resume PSM Session")) {
 
 			#send request to PAS web service
 			Invoke-PASRestMethod -Uri $URI -Method POST -WebSession $Script:WebSession
@@ -55,6 +55,6 @@ Minimum CyberArk Version 10.2
 
 	} #process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/Monitoring/Stop-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Stop-PASPSMSession.ps1
@@ -17,11 +17,11 @@ Terminates Live PSM Session identified by the session UUID.
 .INPUTS
 All parameters can be piped by property name
 
-.OUTPUTS
-None
-
 .NOTES
 Minimum CyberArk Version 10.1
+
+.LINK
+https://pspas.pspete.dev/commands/Stop-PASPSMSession
 #>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
@@ -45,7 +45,7 @@ Minimum CyberArk Version 10.1
 		#Create URL for Request
 		$URI = "$Script:BaseURI/api/LiveSessions/$($LiveSessionId | Get-EscapedString)/Terminate"
 
-		if($PSCmdlet.ShouldProcess($LiveSessionId, "Terminate PSM Session")) {
+		if ($PSCmdlet.ShouldProcess($LiveSessionId, "Terminate PSM Session")) {
 
 			#send request to PAS web service
 			Invoke-PASRestMethod -Uri $URI -Method POST -WebSession $Script:WebSession
@@ -54,6 +54,6 @@ Minimum CyberArk Version 10.1
 
 	} #process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/Monitoring/Suspend-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Suspend-PASPSMSession.ps1
@@ -23,6 +23,9 @@ None
 
 .NOTES
 Minimum CyberArk Version 10.2
+
+.LINK
+https://pspas.pspete.dev/commands/Suspend-PASPSMSession
 #>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
@@ -46,7 +49,7 @@ Minimum CyberArk Version 10.2
 		#Create URL for Request
 		$URI = "$Script:BaseURI/api/LiveSessions/$($LiveSessionId | Get-EscapedString)/Suspend"
 
-		if($PSCmdlet.ShouldProcess($LiveSessionId, "Suspend PSM Session")) {
+		if ($PSCmdlet.ShouldProcess($LiveSessionId, "Suspend PSM Session")) {
 
 			#send request to PAS web service
 			Invoke-PASRestMethod -Uri $URI -Method POST -WebSession $Script:WebSession
@@ -55,6 +58,6 @@ Minimum CyberArk Version 10.2
 
 	} #process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/Monitoring/Test-PASPSMRecording.ps1
+++ b/psPAS/Functions/Monitoring/Test-PASPSMRecording.ps1
@@ -1,0 +1,51 @@
+function Test-PASPSMRecording {
+	<#
+.SYNOPSIS
+Determine if a PSM Session / Recording is valid
+
+.DESCRIPTION
+Determines if a provided PSM Session / Recording is valid.
+Returns $True if valid.
+
+.PARAMETER SessionID
+Unique ID of the recorded PSM session
+
+.EXAMPLE
+Test-PASPSMRecording -SessionID 334_3
+
+Tests validity of recorded PSM Session File
+
+.NOTES
+Minimum CyberArk Version 11.2
+
+.LINK
+https://pspas.pspete.dev/commands/Test-PASPSMRecording
+#>
+	[CmdletBinding()]
+	param(
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$SessionID
+	)
+
+	BEGIN {
+		$MinimumVersion = [System.Version]"11.2"
+	}#begin
+
+	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $MinimumVersion
+
+		#Create URL for Request
+		$URI = "$Script:BaseURI/API/Recordings/$SessionID/valid"
+
+		#send request to PAS web service
+		Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+
+	} #process
+
+	END { }#end
+
+}

--- a/psPAS/Functions/OnboardingRules/Get-PASOnboardingRule.ps1
+++ b/psPAS/Functions/OnboardingRules/Get-PASOnboardingRule.ps1
@@ -1,4 +1,4 @@
-﻿function Get-PASOnboardingRule {
+function Get-PASOnboardingRule {
 	<#
 .SYNOPSIS
 Gets all automatic on-boarding rules
@@ -31,8 +31,8 @@ Outputs Object of Custom Type psPAS.CyberArk.Vault.OnboardingRule
 Output format is defined via psPAS.Format.ps1xml.
 To force all output to be shown, pipe to Select-Object *
 
-.NOTES
-Not Tested
+.LINK
+https://pspas.pspete.dev/commands/Get-PASOnboardingRule
 #>
 	[CmdletBinding()]
 	param(

--- a/psPAS/Functions/OnboardingRules/New-PASOnboardingRule.ps1
+++ b/psPAS/Functions/OnboardingRules/New-PASOnboardingRule.ps1
@@ -90,10 +90,13 @@ To force all output to be shown, pipe to Select-Object *
 
 .NOTES
 Before running:
-Create the Safe and the reconcile account according to the rule’s definition.
+Create the Safe and the reconcile account according to the rule�s definition.
 Associate the reconcile account with the platform that is defined in the rule.
 Make sure that the user whose credentials will be used for this session is a member of
 the Safe specified in the TargetSafeName parameter with the Add accounts permission.
+
+.LINK
+https://pspas.pspete.dev/commands/New-PASOnboardingRule
 #>
 	[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = "post_V10_2")]
 	param(
@@ -225,7 +228,7 @@ the Safe specified in the TargetSafeName parameter with the Add accounts permiss
 		$body = $PSBoundParameters | Get-PASParameter | ConvertTo-Json
 
 		#Get Values for ShouldProcess Message
-		If($PSCmdlet.ParameterSetName -eq "post_V10_2") {
+		If ($PSCmdlet.ParameterSetName -eq "post_V10_2") {
 
 			Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $RequiredVersion
 
@@ -233,7 +236,8 @@ the Safe specified in the TargetSafeName parameter with the Add accounts permiss
 			$SafeName = $TargetSafeName
 			$PlatformID = $TargetPlatformId
 
-		} ElseIf($PSCmdlet.ParameterSetName -eq "pre_V10_2") {
+		}
+		ElseIf ($PSCmdlet.ParameterSetName -eq "pre_V10_2") {
 
 			Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $MinimumVersion
 
@@ -243,12 +247,12 @@ the Safe specified in the TargetSafeName parameter with the Add accounts permiss
 
 		}
 
-		if($PSCmdlet.ShouldProcess($SafeName, "Add On-Boarding Rule Using '$PlatformID'")) {
+		if ($PSCmdlet.ShouldProcess($SafeName, "Add On-Boarding Rule Using '$PlatformID'")) {
 
 			#send request to web service
 			$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
 
-			if($result) {
+			if ($result) {
 
 				$result | Add-ObjectDetail -typename psPAS.CyberArk.Vault.OnboardingRule
 
@@ -258,6 +262,6 @@ the Safe specified in the TargetSafeName parameter with the Add accounts permiss
 
 	}#process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/OnboardingRules/Remove-PASOnboardingRule.ps1
+++ b/psPAS/Functions/OnboardingRules/Remove-PASOnboardingRule.ps1
@@ -1,4 +1,4 @@
-﻿function Remove-PASOnboardingRule {
+function Remove-PASOnboardingRule {
 	<#
 .SYNOPSIS
 Deletes an automatic on-boarding rule
@@ -19,8 +19,8 @@ Removes specified on-boarding rule.
 .INPUTS
 All parameters can be piped by property name
 
-.OUTPUTS
-None
+.LINK
+https://pspas.pspete.dev/commands/Remove-PASOnboardingRule
 #>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
@@ -31,7 +31,7 @@ None
 		[string]$RuleID
 	)
 
-	BEGIN {}#begin
+	BEGIN { }#begin
 
 	PROCESS {
 
@@ -40,7 +40,7 @@ None
 
             Get-EscapedString)"
 
-		if($PSCmdlet.ShouldProcess($RuleID, "Delete On-boarding Rule")) {
+		if ($PSCmdlet.ShouldProcess($RuleID, "Delete On-boarding Rule")) {
 
 			#Send request to web service
 			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
@@ -49,5 +49,5 @@ None
 
 	}#process
 
-	END {}#end
+	END { }#end
 }

--- a/psPAS/Functions/OnboardingRules/Set-PASOnboardingRule.ps1
+++ b/psPAS/Functions/OnboardingRules/Set-PASOnboardingRule.ps1
@@ -1,4 +1,4 @@
-﻿function Set-PASOnboardingRule {
+function Set-PASOnboardingRule {
 	<#
 .SYNOPSIS
 Updates an automatic onboarding rule.
@@ -66,6 +66,9 @@ To force all output to be shown, pipe to Select-Object *
 
 .NOTES
 Minimum Version: 10.5
+
+.LINK
+https://pspas.pspete.dev/commands/Set-PASOnboardingRule
 #>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
@@ -173,12 +176,12 @@ Minimum Version: 10.5
 		#create request body
 		$body = $PSBoundParameters | Get-PASParameter -ParametersToRemove Id | ConvertTo-Json
 
-		if($PSCmdlet.ShouldProcess($TargetPlatformId, "Update On-Boarding Rule $ID")) {
+		if ($PSCmdlet.ShouldProcess($TargetPlatformId, "Update On-Boarding Rule $ID")) {
 
 			#send request to web service
 			$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body -WebSession $Script:WebSession
 
-			if($result) {
+			if ($result) {
 
 				$result | Add-ObjectDetail -typename psPAS.CyberArk.Vault.OnboardingRule
 
@@ -188,6 +191,6 @@ Minimum Version: 10.5
 
 	}#process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/Platforms/Export-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Export-PASPlatform.ps1
@@ -1,27 +1,29 @@
 function Export-PASPlatform {
 	<#
-	.SYNOPSIS
-	Export a platform
+.SYNOPSIS
+Export a platform
 
-	.DESCRIPTION
-	Export a platform to a zip file in order to import it to a different Vault environment.
-	Vault Admin group membership required.
+.DESCRIPTION
+Export a platform to a zip file in order to import it to a different Vault environment.
+Vault Admin group membership required.
 
-	.PARAMETER PlatformID
-	The name of the platform.
+.PARAMETER PlatformID
+The name of the platform.
 
-	.PARAMETER Path
-	The folder to export the platform configuration to.
+.PARAMETER Path
+The folder to export the platform configuration to.
 
-	.EXAMPLE
-	Export-PASPlatform -PlatformID YourPlatform -Path C:\Platform.zip
+.EXAMPLE
+Export-PASPlatform -PlatformID YourPlatform -Path C:\Platform.zip
 
-	Exports UnixSSH to Platform.zip platform package.
+Exports UnixSSH to Platform.zip platform package.
 
-	.NOTES
-	Minimum CyberArk version 10.4
+.NOTES
+Minimum CyberArk version 10.4
 
-	#>
+.LINK
+https://pspas.pspete.dev/commands/Export-PASPlatform
+#>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
 		[parameter(

--- a/psPAS/Functions/Platforms/Get-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Get-PASPlatform.ps1
@@ -1,56 +1,59 @@
 function Get-PASPlatform {
 	<#
-	.SYNOPSIS
-	Retrieves details of Vault platforms.
+.SYNOPSIS
+Retrieves details of Vault platforms.
 
-	.DESCRIPTION
-	Request platform configuration information from the Vault.
-	
-	11.1+ can return details of all platforms.
-	Filters can be used to retrieve a subset of the platforms
+.DESCRIPTION
+Request platform configuration information from the Vault.
 
-	For 9.10+, the "PlatformID" parameter must be used to retrieve details of a single 
-	specified platform from the Vault.
+11.1+ can return details of all platforms.
+Filters can be used to retrieve a subset of the platforms
 
-	The output contained under the "Details" property differs depending 
-	on which method (9.10+ or 11.1+) is used. 
+For 9.10+, the "PlatformID" parameter must be used to retrieve details of a single
+specified platform from the Vault.
 
-	.PARAMETER Active
-	Filter active/inactive platforms
+The output contained under the "Details" property differs depending
+on which method (9.10+ or 11.1+) is used.
 
-	.PARAMETER PlatformType
-	Filter regular/group platforms
+.PARAMETER Active
+Filter active/inactive platforms
 
-	.PARAMETER Search
-	Filter platform by search pattern
+.PARAMETER PlatformType
+Filter regular/group platforms
 
-	.PARAMETER PlatformID
-	The unique ID/Name of the platform.
+.PARAMETER Search
+Filter platform by search pattern
 
-	.EXAMPLE
-	Get-PASPlatform
+.PARAMETER PlatformID
+The unique ID/Name of the platform.
 
-	Return details of all platforms
+.EXAMPLE
+Get-PASPlatform
 
-	.EXAMPLE
-	Get-PASPlatform -Active $true
+Return details of all platforms
 
-	Get all active platforms
+.EXAMPLE
+Get-PASPlatform -Active $true
 
-	.EXAMPLE
-	Get-PASPlatform -Active $true -Search "WIN_"
+Get all active platforms
 
-	Get active platforms matching search string "WIN_"
+.EXAMPLE
+Get-PASPlatform -Active $true -Search "WIN_"
 
-	.EXAMPLE
-	Get-PASPlatform -PlatformID "CyberArk"
+Get active platforms matching search string "WIN_"
 
-	Get details of specific platform CyberArk
+.EXAMPLE
+Get-PASPlatform -PlatformID "CyberArk"
 
-	.NOTES
-	Minimum CyberArk version 9.10
-	CyberArk version 11.1 required for Active, PlatformType & Search paramters.
-	#>
+Get details of specific platform CyberArk
+
+.NOTES
+Minimum CyberArk version 9.10
+CyberArk version 11.1 required for Active, PlatformType & Search paramters.
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASPlatform
+#>
 
 	[CmdletBinding(DefaultParameterSetName = "11_1")]
 	param(
@@ -131,7 +134,7 @@ function Get-PASPlatform {
 			#11.1 returns result under "platforms" property
 			If ($result.Platforms) {
 
-				$result = $result | Select-Object -ExpandProperty Platforms | 
+				$result = $result | Select-Object -ExpandProperty Platforms |
 				Select-Object @{ Name = 'PlatformID'; Expression = { $_.general.id } }, @{ Name = 'Active'; Expression = { $_.general.active } }, @{ Name = 'Details'; Expression = { [pscustomobject]@{
 							"General"                   = $_.general
 							"properties"                = $_.properties
@@ -139,9 +142,9 @@ function Get-PASPlatform {
 							"credentialsManagement"     = $_.credentialsManagement
 							"sessionManagement"         = $_.sessionManagement
 							"privilegedAccessWorkflows" = $_.privilegedAccessWorkflows
-						} 
-					} 
-    			}
+						}
+					}
+				}
 
 			}
 

--- a/psPAS/Functions/Platforms/Get-PASPlatformSafe.ps1
+++ b/psPAS/Functions/Platforms/Get-PASPlatformSafe.ps1
@@ -1,20 +1,23 @@
 function Get-PASPlatformSafe {
 	<#
-	.SYNOPSIS
-	Get safes by platform id
-	
-	.DESCRIPTION
-	Returns all safes for a given platform ID
+.SYNOPSIS
+Get safes by platform id
 
-	.PARAMETER PlatformID
-	The unique ID/Name of the platform.
+.DESCRIPTION
+Returns all safes for a given platform ID
 
-	.EXAMPLE
-	Get-PASPlatformSafe -PlatformID WINDOMAIN
+.PARAMETER PlatformID
+The unique ID/Name of the platform.
 
-	.NOTES
-	Minimum CyberArk version 11.1
-	#>
+.EXAMPLE
+Get-PASPlatformSafe -PlatformID WINDOMAIN
+
+.NOTES
+Minimum CyberArk version 11.1
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASPlatformSafe
+#>
 
 	[CmdletBinding()]
 	param(
@@ -30,12 +33,12 @@ function Get-PASPlatformSafe {
 	}#begin
 
 	PROCESS {
-		
+
 		Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $MinimumVersion
 
 		#Create request URL
 		$URI = "$Script:BaseURI/API/Platforms/$($PlatformID | Get-EscapedString)/Safes"
-			
+
 		#Send request to web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
 

--- a/psPAS/Functions/Platforms/Import-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Import-PASPlatform.ps1
@@ -1,23 +1,25 @@
 function Import-PASPlatform {
 	<#
-	.SYNOPSIS
-	Import a new platform
+.SYNOPSIS
+Import a new platform
 
-	.DESCRIPTION
-	Import a new CPM platform.
+.DESCRIPTION
+Import a new CPM platform.
 
-	.PARAMETER ImportFile
-	The zip file that contains the platform.
+.PARAMETER ImportFile
+The zip file that contains the platform.
 
-	.EXAMPLE
-	Import-PASPlatform -ImportFile CustomApp.zip
+.EXAMPLE
+Import-PASPlatform -ImportFile CustomApp.zip
 
-	Imports CustomApp.zip Platform package
+Imports CustomApp.zip Platform package
 
-	.NOTES
-	Minimum CyberArk version 10.2
+.NOTES
+Minimum CyberArk version 10.2
 
-	#>
+.LINK
+https://pspas.pspete.dev/commands/Import-PASPlatform
+#>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
 		[parameter(

--- a/psPAS/Functions/PolicyACL/Add-PASPolicyACL.ps1
+++ b/psPAS/Functions/PolicyACL/Add-PASPolicyACL.ps1
@@ -1,4 +1,4 @@
-﻿function Add-PASPolicyACL {
+function Add-PASPolicyACL {
 	<#
 .SYNOPSIS
 Adds a new privileged command rule
@@ -37,6 +37,9 @@ All parameters can be piped by property name
 Outputs Object of Custom Type psPAS.CyberArk.Vault.ACL
 Output format is defined via psPAS.Format.ps1xml.
 To force all output to be shown, pipe to Select-Object *
+
+.LINK
+https://pspas.pspete.dev/commands/Add-PASPolicyACL
 #>
 	[CmdletBinding()]
 	param(
@@ -82,7 +85,7 @@ To force all output to be shown, pipe to Select-Object *
 		[string]$UserName
 	)
 
-	BEGIN {}#begin
+	BEGIN { }#begin
 
 	PROCESS {
 
@@ -101,7 +104,7 @@ To force all output to be shown, pipe to Select-Object *
 		#Send request to web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body -WebSession $Script:WebSession
 
-		if($result) {
+		if ($result) {
 
 			$result.AddPolicyPrivilegedCommandResult |
 
@@ -111,6 +114,6 @@ To force all output to be shown, pipe to Select-Object *
 
 	}#process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/PolicyACL/Get-PASPolicyACL.ps1
+++ b/psPAS/Functions/PolicyACL/Get-PASPolicyACL.ps1
@@ -1,4 +1,4 @@
-﻿function Get-PASPolicyACL {
+function Get-PASPolicyACL {
 	<#
 .SYNOPSIS
 Lists OPM Rules for a policy
@@ -22,6 +22,9 @@ All parameters can be piped by property name
 Outputs Object of Custom Type psPAS.CyberArk.Vault.ACL
 Output format is defined via psPAS.Format.ps1xml.
 To force all output to be shown, pipe to Select-Object *
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASPolicyACL
 #>
 	[CmdletBinding()]
 	param(
@@ -34,7 +37,7 @@ To force all output to be shown, pipe to Select-Object *
 
 	)
 
-	BEGIN {}#begin
+	BEGIN { }#begin
 
 	PROCESS {
 
@@ -46,7 +49,7 @@ To force all output to be shown, pipe to Select-Object *
 		#Send Request to web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
 
-		if($result) {
+		if ($result) {
 
 			$result.ListPolicyPrivilegedCommandsResult |
 
@@ -56,6 +59,6 @@ To force all output to be shown, pipe to Select-Object *
 
 	}#process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/PolicyACL/Remove-PASPolicyACL.ps1
+++ b/psPAS/Functions/PolicyACL/Remove-PASPolicyACL.ps1
@@ -1,4 +1,4 @@
-﻿function Remove-PASPolicyACL {
+function Remove-PASPolicyACL {
 	<#
 .SYNOPSIS
 Delete all privileged commands on policy
@@ -20,8 +20,8 @@ Deletes Rule with ID of 13 from UNIXSSH platform.
 .INPUTS
 All parameters can be piped by property name
 
-.OUTPUTS
-None
+.LINK
+https://pspas.pspete.dev/commands/Remove-PASPolicyACL
 #>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
@@ -40,7 +40,7 @@ None
 
 	)
 
-	BEGIN {}#begin
+	BEGIN { }#begin
 
 	PROCESS {
 
@@ -51,7 +51,7 @@ None
 
                 Get-EscapedString)"
 
-		if($PSCmdlet.ShouldProcess($PolicyID, "Delete Rule $Id")) {
+		if ($PSCmdlet.ShouldProcess($PolicyID, "Delete Rule $Id")) {
 
 			#send request to web service
 			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
@@ -60,6 +60,6 @@ None
 
 	}#process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/Requests/Approve-PASRequest.ps1
+++ b/psPAS/Functions/Requests/Approve-PASRequest.ps1
@@ -26,6 +26,9 @@ None
 
 .NOTES
 Minimum CyberArk Version 9.10
+
+.LINK
+https://pspas.pspete.dev/commands/Approve-PASRequest
 #>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
@@ -57,15 +60,15 @@ Minimum CyberArk Version 9.10
 		#Create body of request
 		$body = $PSBoundParameters | Get-PASParameter -ParametersToRemove RequestId | ConvertTo-Json
 
-	if($PSCmdlet.ShouldProcess($RequestId, "Confirm Request for Account Access")) {
+		if ($PSCmdlet.ShouldProcess($RequestId, "Confirm Request for Account Access")) {
 
-		#send request to PAS web service
-		Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+			#send request to PAS web service
+			Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
 
-	}
+		}
 
-}#process
+	}#process
 
-END { }#end
+	END { }#end
 
 }

--- a/psPAS/Functions/Requests/Deny-PASRequest.ps1
+++ b/psPAS/Functions/Requests/Deny-PASRequest.ps1
@@ -26,6 +26,9 @@ None
 
 .NOTES
 Minimum CyberArk Version 9.10
+
+.LINK
+https://pspas.pspete.dev/commands/Deny-PASRequest
 #>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
@@ -57,15 +60,15 @@ Minimum CyberArk Version 9.10
 		#Create body of request
 		$body = $PSBoundParameters | Get-PASParameter -ParametersToRemove RequestId | ConvertTo-Json
 
-	if($PSCmdlet.ShouldProcess($RequestId, "Reject Request for Account Access")) {
+		if ($PSCmdlet.ShouldProcess($RequestId, "Reject Request for Account Access")) {
 
-		#send request to PAS web service
-		Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+			#send request to PAS web service
+			Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
 
-	}
+		}
 
-}#process
+	}#process
 
-END { }#end
+	END { }#end
 
 }

--- a/psPAS/Functions/Requests/Get-PASRequest.ps1
+++ b/psPAS/Functions/Requests/Get-PASRequest.ps1
@@ -35,6 +35,9 @@ To force all output to be shown, pipe to Select-Object *
 
 .NOTES
 Minimum CyberArk Version 9.10
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASRequest
 #>
 	[CmdletBinding()]
 	param(

--- a/psPAS/Functions/Requests/Get-PASRequestDetail.ps1
+++ b/psPAS/Functions/Requests/Get-PASRequestDetail.ps1
@@ -33,6 +33,9 @@ To force all output to be shown, pipe to Select-Object *
 
 .NOTES
 Minimum CyberArk Version 9.10
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASRequestDetail
 #>
 	[CmdletBinding()]
 	param(

--- a/psPAS/Functions/Requests/New-PASRequest.ps1
+++ b/psPAS/Functions/Requests/New-PASRequest.ps1
@@ -52,6 +52,9 @@ Creates a new request for access to account with ID in $ID
 
 .NOTES
 Minimum CyberArk Version 9.10
+
+.LINK
+https://pspas.pspete.dev/commands/New-PASRequest
 #>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(

--- a/psPAS/Functions/Requests/Remove-PASRequest.ps1
+++ b/psPAS/Functions/Requests/Remove-PASRequest.ps1
@@ -1,4 +1,4 @@
-﻿function Remove-PASRequest {
+function Remove-PASRequest {
 	<#
 .SYNOPSIS
 Deletes a request from the Vault
@@ -19,8 +19,8 @@ Deletes Request <ID>
 .INPUTS
 All parameters can be piped by property name
 
-.OUTPUTS
-None
+.LINK
+https://pspas.pspete.dev/commands/Remove-PASRequest
 #>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
@@ -43,7 +43,7 @@ None
 		#Create URL for request
 		$URI = "$Script:BaseURI/API/MyRequests/$($RequestID)"
 
-		if($PSCmdlet.ShouldProcess($RequestID, "Delete Request")) {
+		if ($PSCmdlet.ShouldProcess($RequestID, "Delete Request")) {
 
 			#Send request to web service
 			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession

--- a/psPAS/Functions/SafeMembers/Add-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Add-PASSafeMember.ps1
@@ -1,4 +1,4 @@
-﻿function Add-PASSafeMember {
+function Add-PASSafeMember {
 	<#
 .SYNOPSIS
 Adds a Safe Member to safe
@@ -153,6 +153,9 @@ All parameters can be piped by property name
 Outputs Object of Custom Type psPAS.CyberArk.Vault.Safe.Member.Extended
 Output format is defined via psPAS.Format.ps1xml.
 To force all output to be shown, pipe to Select-Object *
+
+.LINK
+https://pspas.pspete.dev/commands/Add-PASSafeMember
 #>
 	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'keysToRemove', Justification = "False Positive")]
 	[CmdletBinding()]
@@ -337,7 +340,7 @@ To force all output to be shown, pipe to Select-Object *
 		$permissions = @{ }
 
 		#array for parameter names which will do not appear in the top-tier of the JSON object
-		[array]$keysToRemove += "SafeName"
+		$keysToRemove = [Collections.Generic.List[String]]@('SafeName')
 
 	}#begin
 
@@ -368,7 +371,7 @@ To force all output to be shown, pipe to Select-Object *
 			$permissions[$_] = $boundParameters[$_]
 
 			#Add parameter name to array
-			$keysToRemove += $_
+			$null = $keysToRemove.Add($_)
 
 		}
 
@@ -377,6 +380,7 @@ To force all output to be shown, pipe to Select-Object *
 
 		#Create required request object
 		$body = @{
+
 			"member" = $boundParameters |
 
 			Get-PASParameter -ParametersToRemove $keysToRemove

--- a/psPAS/Functions/SafeMembers/Get-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Get-PASSafeMember.ps1
@@ -30,7 +30,7 @@ Manage Safe Members							ManageSafeMembers
 Validate Safe Content						ValidateSafeContent
 Backup Safe								BackupSafe
 Access Safe without confirmation					<NOT RETURNED>
-Authorize account requests (level1, level2)				<NOT RETURNED>
+Authorize account requests�(level1, level2)				<NOT RETURNED>
 
 If a Safe Member Name is provided, the full permissions of the member on the Safe will be returned:
 
@@ -83,6 +83,9 @@ contains SafeName in the output
 Outputs Object of Custom Type psPAS.CyberArk.Vault.Safe.Member
 Output format is defined via psPAS.Format.ps1xml.
 To force all output to be shown, pipe to Select-Object *
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASSafeMember
 #>
 	[CmdletBinding()]
 	param(

--- a/psPAS/Functions/SafeMembers/Remove-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Remove-PASSafeMember.ps1
@@ -1,4 +1,4 @@
-﻿function Remove-PASSafeMember {
+function Remove-PASSafeMember {
 	<#
 .SYNOPSIS
 Removes a member from a safe
@@ -22,8 +22,8 @@ Removes TargetUser as safe member from TargetSafe
 .INPUTS
 All parameters can be piped by property name
 
-.OUTPUTS
-None
+.LINK
+https://pspas.pspete.dev/commands/Remove-PASSafeMember
 #>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
@@ -43,7 +43,7 @@ None
 		[string]$MemberName
 	)
 
-	BEGIN {}#begin
+	BEGIN { }#begin
 
 	PROCESS {
 
@@ -54,7 +54,7 @@ None
 
                 Get-EscapedString)"
 
-		if($PSCmdlet.ShouldProcess($SafeName, "Remove Safe Member '$MemberName'")) {
+		if ($PSCmdlet.ShouldProcess($SafeName, "Remove Safe Member '$MemberName'")) {
 
 			#Send Delete request to web service
 			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
@@ -63,6 +63,6 @@ None
 
 	}#process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/SafeMembers/Set-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Set-PASSafeMember.ps1
@@ -1,4 +1,4 @@
-﻿function Set-PASSafeMember {
+function Set-PASSafeMember {
 	<#
 .SYNOPSIS
 Updates a Safe Member
@@ -105,6 +105,9 @@ member on safe.
 Set-PASSafeMember -SafeName TargetSafe -MemberName TargetUser -AddAccounts $true
 
 Updates TargetUser's permissions as safe member on TargetSafe to include "Add Accounts"
+
+.LINK
+https://pspas.pspete.dev/commands/Set-PASSafeMember
 #>
 	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'keysToRemove', Justification = "False Positive")]
 	[CmdletBinding(SupportsShouldProcess)]
@@ -269,7 +272,7 @@ Updates TargetUser's permissions as safe member on TargetSafe to include "Add Ac
 		$permissions = @{ }
 
 		#Create array of keys to remove from top level of required JSON structure.
-		[array]$keysToRemove += "SafeName", "MemberName"
+		$keysToRemove = [Collections.Generic.List[String]]@('SafeName', 'MemberName')
 
 	}#begin
 
@@ -302,7 +305,7 @@ Updates TargetUser's permissions as safe member on TargetSafe to include "Add Ac
 			$permissions[$_] = $boundParameters[$_]
 
 			#non-base parameter name
-			$keysToRemove += $_
+			$null = $keysToRemove.Add($_)
 
 		}
 

--- a/psPAS/Functions/Safes/Add-PASSafe.ps1
+++ b/psPAS/Functions/Safes/Add-PASSafe.ps1
@@ -1,4 +1,4 @@
-﻿function Add-PASSafe {
+function Add-PASSafe {
 	<#
 .SYNOPSIS
 Adds a new safe to the Vault
@@ -52,6 +52,9 @@ All parameters can be piped by property name
 Outputs Object of Custom Type psPAS.CyberArk.Vault.Safe
 Output format is defined via psPAS.Format.ps1xml.
 To force all output to be shown, pipe to Select-Object *
+
+.LINK
+https://pspas.pspete.dev/commands/Add-PASSafe
 #>
 	[CmdletBinding()]
 	param(
@@ -60,7 +63,7 @@ To force all output to be shown, pipe to Select-Object *
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateNotNullOrEmpty()]
-		[ValidateScript( {$_ -notmatch ".*(\\|\/|:|\*|<|>|`"|\.|\||^\s).*"})]
+		[ValidateScript( { $_ -notmatch ".*(\\|\/|:|\*|<|>|`"|\.|\||^\s).*" })]
 		[ValidateLength(0, 28)]
 		[string]$SafeName,
 
@@ -100,7 +103,7 @@ To force all output to be shown, pipe to Select-Object *
 		[int]$NumberOfDaysRetention
 	)
 
-	BEGIN {}#begin
+	BEGIN { }#begin
 
 	PROCESS {
 
@@ -119,7 +122,7 @@ To force all output to be shown, pipe to Select-Object *
 		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
 
 
-		if($result) {
+		if ($result) {
 
 			$result.AddSafeResult | Add-ObjectDetail -typename psPAS.CyberArk.Vault.Safe
 
@@ -127,6 +130,6 @@ To force all output to be shown, pipe to Select-Object *
 
 	}#process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/Safes/Get-PASSafe.ps1
+++ b/psPAS/Functions/Safes/Get-PASSafe.ps1
@@ -1,4 +1,4 @@
-﻿function Get-PASSafe {
+function Get-PASSafe {
 	<#
 .SYNOPSIS
 Returns safe details from the vault.
@@ -20,11 +20,13 @@ If SafeName or query are not specified, FindAll is the default behaviour.
 See Invoke-WebRequest
 Specify a timeout value in seconds
 
-
 .EXAMPLE
 Get-PASSafe -SafeName SAFE1
 
 Returns details of "Safe1"
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASSafe
 #>
 	[CmdletBinding(DefaultParameterSetName = "byAll")]
 	param(

--- a/psPAS/Functions/Safes/Remove-PASSafe.ps1
+++ b/psPAS/Functions/Safes/Remove-PASSafe.ps1
@@ -1,4 +1,4 @@
-﻿function Remove-PASSafe {
+function Remove-PASSafe {
 	<#
 .SYNOPSIS
 Deletes a safe from the Vault
@@ -19,9 +19,8 @@ Deletes "OLD_Safe"
 .INPUTS
 All parameters can be piped by property name
 
-.OUTPUTS
-None
-
+.LINK
+https://pspas.pspete.dev/commands/Remove-PASSafe
 #>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
@@ -34,7 +33,7 @@ None
 
 	)
 
-	BEGIN {}#begin
+	BEGIN { }#begin
 
 	PROCESS {
 
@@ -43,7 +42,7 @@ None
 
             Get-EscapedString)"
 
-		if($PSCmdlet.ShouldProcess($SafeName, "Delete Safe")) {
+		if ($PSCmdlet.ShouldProcess($SafeName, "Delete Safe")) {
 
 			#Send request to web service
 			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
@@ -52,5 +51,5 @@ None
 
 	}#process
 
-	END {}#end
+	END { }#end
 }

--- a/psPAS/Functions/Safes/Set-PASSafe.ps1
+++ b/psPAS/Functions/Safes/Set-PASSafe.ps1
@@ -1,4 +1,4 @@
-﻿function Set-PASSafe {
+function Set-PASSafe {
 	<#
 .SYNOPSIS
 Updates a safe in the Vault
@@ -45,6 +45,9 @@ Specify either this parameter or NumberOfVersionsRetention
 Set-PASSafe -SafeName SAFE -Description "New-Description" -NumberOfVersionsRetention 10
 
 Updates description and version retention on SAFE
+
+.LINK
+https://pspas.pspete.dev/commands/Set-PASSafe
 #>
 	[CmdletBinding(SupportsShouldProcess,
 		DefaultParameterSetName = "Update")]

--- a/psPAS/Functions/ServerWebServices/Get-PASSafeShareLogo.ps1
+++ b/psPAS/Functions/ServerWebServices/Get-PASSafeShareLogo.ps1
@@ -1,4 +1,4 @@
-﻿function Get-PASSafeShareLogo {
+function Get-PASSafeShareLogo {
 	<#
 .SYNOPSIS
 Returns details of configured SafeShare Logo
@@ -17,10 +17,11 @@ Retrieves Safe Share Logo
 .INPUTS
 WebSession & BaseURI can be piped to the function by propertyname
 
-.OUTPUTS
-
 .NOTES
 SafeShare no longer available from CyberArk
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASSafeShareLogo
 #>
 	[CmdletBinding()]
 	param(
@@ -31,7 +32,7 @@ SafeShare no longer available from CyberArk
 		[String]$ImageType
 	)
 
-	BEGIN {}#begin
+	BEGIN { }#begin
 
 	PROCESS {
 
@@ -42,7 +43,7 @@ SafeShare no longer available from CyberArk
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
 
 
-		if($result) {
+		if ($result) {
 
 			$result
 
@@ -50,5 +51,5 @@ SafeShare no longer available from CyberArk
 
 	}#process
 
-	END {}#end
+	END { }#end
 }

--- a/psPAS/Functions/ServerWebServices/Get-PASServer.ps1
+++ b/psPAS/Functions/ServerWebServices/Get-PASServer.ps1
@@ -1,20 +1,21 @@
-﻿function Get-PASServer {
+function Get-PASServer {
 	<#
-	.SYNOPSIS
-	Returns details of the Web Service Server
+.SYNOPSIS
+Returns details of the Web Service Server
 
-	.DESCRIPTION
-	Returns information on Server.
-	Returns the name of the Vault configured in the ServerDisplayName configuration parameter
-	Appears to need Vault administrator rights
+.DESCRIPTION
+Returns information on Server.
+Returns the name of the Vault configured in the ServerDisplayName configuration parameter
+Appears to need Vault administrator rights
 
-	.EXAMPLE
-	Get-PASServer
+.EXAMPLE
+Get-PASServer
 
-	Displays CyberArk Server information
-	#>
+Displays CyberArk Server information
 
-
+.LINK
+https://pspas.pspete.dev/commands/Get-PASServer
+#>
 	[CmdletBinding()]
 	param(	)
 

--- a/psPAS/Functions/ServerWebServices/Get-PASServerWebService.ps1
+++ b/psPAS/Functions/ServerWebServices/Get-PASServerWebService.ps1
@@ -1,4 +1,4 @@
-﻿function Get-PASServerWebService {
+function Get-PASServerWebService {
 	<#
 .SYNOPSIS
 Returns details of the Web Service
@@ -29,6 +29,9 @@ WebSession & BaseURI can be piped to the function by propertyname
 .OUTPUTS
 Webservice Details
 ServerName, ServerID, ApplicationName & Available Authentication Methods
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASServerWebService
 #>
 	[CmdletBinding()]
 	param(
@@ -51,7 +54,7 @@ ServerName, ServerID, ApplicationName & Available Authentication Methods
 		[string]$PVWAAppName = "PasswordVault"
 	)
 
-	BEGIN {}#begin
+	BEGIN { }#begin
 
 	PROCESS {
 
@@ -61,7 +64,7 @@ ServerName, ServerID, ApplicationName & Available Authentication Methods
 		#send request to web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
 
-		if($result) {
+		if ($result) {
 
 			#return results
 			$result | Select-Object ServerName, ServerId, ApplicationName , AuthenticationMethods
@@ -70,5 +73,5 @@ ServerName, ServerID, ApplicationName & Available Authentication Methods
 
 	}#process
 
-	END {}#end
+	END { }#end
 }

--- a/psPAS/Functions/SystemHealth/Get-PASComponentDetail.ps1
+++ b/psPAS/Functions/SystemHealth/Get-PASComponentDetail.ps1
@@ -32,6 +32,9 @@ All parameters can be piped to the function by propertyname
 
 .NOTES
 Requires minimum version of CyberArk 10.1.
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASComponentDetail
 #>
 	[CmdletBinding()]
 	param(
@@ -59,7 +62,7 @@ Requires minimum version of CyberArk 10.1.
 		#send request to web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
 
-		if($result) {
+		if ($result) {
 
 			#output returned data
 			$result | Select-Object -ExpandProperty ComponentsDetails
@@ -68,5 +71,5 @@ Requires minimum version of CyberArk 10.1.
 
 	}#process
 
-	END {}#end
+	END { }#end
 }

--- a/psPAS/Functions/SystemHealth/Get-PASComponentSummary.ps1
+++ b/psPAS/Functions/SystemHealth/Get-PASComponentSummary.ps1
@@ -19,6 +19,9 @@ All parameters can be piped to the function by propertyname
 
 .NOTES
 Requires minimum version of CyberArk 10.1.
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASComponentSummary
 #>
 	[CmdletBinding()]
 	param(
@@ -39,7 +42,7 @@ Requires minimum version of CyberArk 10.1.
 		#send request to web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
 
-		if($result) {
+		if ($result) {
 
 			$result | Select-Object -ExpandProperty Components
 
@@ -52,5 +55,5 @@ Requires minimum version of CyberArk 10.1.
 
 	}#process
 
-	END {}#end
+	END { }#end
 }

--- a/psPAS/Functions/User/Add-PASGroupMember.ps1
+++ b/psPAS/Functions/User/Add-PASGroupMember.ps1
@@ -1,4 +1,4 @@
-﻿function Add-PASGroupMember {
+function Add-PASGroupMember {
 	<#
 .SYNOPSIS
 Adds a vault user as a group member
@@ -42,8 +42,8 @@ Adds TargetUser to PVWAMonitor group
 .INPUTS
 All parameters can be piped by property name
 
-.OUTPUTS
-None
+.LINK
+https://pspas.pspete.dev/commands/Add-PASGroupMember
 #>
 	[CmdletBinding(DefaultParameterSetName = "post_10_6")]
 	param(

--- a/psPAS/Functions/User/Get-PASGroup.ps1
+++ b/psPAS/Functions/User/Get-PASGroup.ps1
@@ -1,4 +1,4 @@
-﻿function Get-PASGroup {
+function Get-PASGroup {
 	<#
 .SYNOPSIS
 List groups from the vault
@@ -49,6 +49,9 @@ psPAS.CyberArk.Vault.Group Object
 
 .NOTES
 Minimum Version 10.5
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASGroup
 #>
 	[CmdletBinding()]
 	param(
@@ -93,7 +96,7 @@ Minimum Version 10.5
 		#send request to web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
 
-		if($result) {
+		if ($result) {
 
 			$result.value | Add-ObjectDetail -typename psPAS.CyberArk.Vault.Group
 
@@ -101,6 +104,6 @@ Minimum Version 10.5
 
 	}#process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/User/Get-PASLoggedOnUser.ps1
+++ b/psPAS/Functions/User/Get-PASLoggedOnUser.ps1
@@ -1,4 +1,4 @@
-﻿function Get-PASLoggedOnUser {
+function Get-PASLoggedOnUser {
 	<#
 .SYNOPSIS
 Returns details of the logged on user
@@ -11,6 +11,8 @@ Get-PASLoggedOnUser
 
 Returns information on the currently authenticated user.
 
+.LINK
+https://pspas.pspete.dev/commands/Get-PASLoggedOnUser
 #>
 	[CmdletBinding()]
 	param(

--- a/psPAS/Functions/User/Get-PASUser.ps1
+++ b/psPAS/Functions/User/Get-PASUser.ps1
@@ -1,4 +1,4 @@
-﻿function Get-PASUser {
+function Get-PASUser {
 	<#
 .SYNOPSIS
 Returns details of a user
@@ -44,6 +44,9 @@ Returns information for all matching Users
 Get-PASUser -UserName Target_User
 
 Displays information on Target_User
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASUser
 #>
 	[CmdletBinding(DefaultParameterSetName = "10_9")]
 	param(
@@ -102,7 +105,8 @@ Displays information on Target_User
 
 			$URI = "$URI/$id"
 
-		} ElseIf ($PSCmdlet.ParameterSetName -eq "10_9") {
+		}
+		ElseIf ($PSCmdlet.ParameterSetName -eq "10_9") {
 
 			Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $MinimumVersion
 
@@ -145,7 +149,8 @@ Displays information on Target_User
 
 				$result | Add-ObjectDetail -typename psPAS.CyberArk.Vault.User.Extended
 
-			} ElseIf ($PSCmdlet.ParameterSetName -eq "legacy") {
+			}
+			ElseIf ($PSCmdlet.ParameterSetName -eq "legacy") {
 
 				$result | Add-ObjectDetail -typename psPAS.CyberArk.Vault.User
 

--- a/psPAS/Functions/User/Get-PASUser.ps1
+++ b/psPAS/Functions/User/Get-PASUser.ps1
@@ -105,6 +105,8 @@ https://pspas.pspete.dev/commands/Get-PASUser
 
 			$URI = "$URI/$id"
 
+			$TypeName = "psPAS.CyberArk.Vault.User.Extended"
+
 		}
 		ElseIf ($PSCmdlet.ParameterSetName -eq "10_9") {
 
@@ -123,6 +125,8 @@ https://pspas.pspete.dev/commands/Get-PASUser
 			#Build URL from base URL
 			$URI = "$URI`?$queryString"
 
+			$TypeName = "psPAS.CyberArk.Vault.User.Extended"
+
 		}
 
 		ElseIf ($PSCmdlet.ParameterSetName -eq "legacy") {
@@ -130,34 +134,26 @@ https://pspas.pspete.dev/commands/Get-PASUser
 			#Create URL for request
 			$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)"
 
+			$TypeName = "psPAS.CyberArk.Vault.User"
+
 		}
 
 		#send request to web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
 
-		#Handle V10 return
-		if ($result.Users) {
+		#Handle return
+		If ($result) {
 
-			$result.Users | Add-ObjectDetail -typename psPAS.CyberArk.Vault.User.Extended
+			#Handle V10 list return
+			If ($result.Users) {
 
-		}
-
-		#Handle legacy return
-		ElseIf ($result) {
-
-			If ($PSCmdlet.ParameterSetName -eq "10_10") {
-
-				$result | Add-ObjectDetail -typename psPAS.CyberArk.Vault.User.Extended
-
-			}
-			ElseIf ($PSCmdlet.ParameterSetName -eq "legacy") {
-
-				$result | Add-ObjectDetail -typename psPAS.CyberArk.Vault.User
+				$result = $result.Users
 
 			}
 
-		}
+			$result | Add-ObjectDetail -typename $TypeName
 
+		}
 
 	}#process
 

--- a/psPAS/Functions/User/Get-PASUserLoginInfo.ps1
+++ b/psPAS/Functions/User/Get-PASUserLoginInfo.ps1
@@ -1,4 +1,4 @@
-﻿function Get-PASUserLoginInfo {
+function Get-PASUserLoginInfo {
 	<#
 .SYNOPSIS
 Get Login information for the current user
@@ -16,6 +16,9 @@ WebSession & BaseURI can be piped to the function by propertyname
 
 .OUTPUTS
 Last successful & failed logon times for the current user
+
+.LINK
+https://pspas.pspete.dev/commands/Get-PASUserLoginInfo
 #>
 	[CmdletBinding()]
 	param(	)
@@ -34,7 +37,7 @@ Last successful & failed logon times for the current user
 		#send request to web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
 
-		If($result) {
+		If ($result) {
 
 			#Return Results
 			$result |
@@ -45,6 +48,6 @@ Last successful & failed logon times for the current user
 
 	}#process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/User/New-PASGroup.ps1
+++ b/psPAS/Functions/User/New-PASGroup.ps1
@@ -1,4 +1,4 @@
-﻿function New-PASGroup {
+function New-PASGroup {
 	<#
 .SYNOPSIS
 Creates a vault group.
@@ -37,6 +37,9 @@ psPAS.CyberArk.Vault.Group Object
 
 .NOTES
 Minimum Version 11.1
+
+.LINK
+https://pspas.pspete.dev/commands/New-PASGroup
 #>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(

--- a/psPAS/Functions/User/New-PASUser.ps1
+++ b/psPAS/Functions/User/New-PASUser.ps1
@@ -45,16 +45,16 @@ Requires CyberArk version 10.9+
 The user permissions in the vault.
 To grant authorization to a user, the same authorization must be held by the account logged on to the API.
 Valid values:
-• AddSafes
-• AuditUsers
-• AddUpdateUsers
-• ResetUsersPasswords
-• ActivateUsers
-• AddNetworkAreas
-• ManageDirectoryMapping
-• ManageServerFileCategories
-• BackupAllSafes
-• RestoreAllSafes
+� AddSafes
+� AuditUsers
+� AddUpdateUsers
+� ResetUsersPasswords
+� ActivateUsers
+� AddNetworkAreas
+� ManageDirectoryMapping
+� ManageServerFileCategories
+� BackupAllSafes
+� RestoreAllSafes
 Requires CyberArk version 10.9+
 
 .PARAMETER ChangePassOnNextLogon
@@ -214,6 +214,9 @@ All parameters can be piped by property name
 Outputs Object of Custom Type psPAS.CyberArk.Vault.User
 Output format is defined via psPAS.Format.ps1xml.
 To force all output to be shown, pipe to Select-Object *
+
+.LINK
+https://pspas.pspete.dev/commands/New-PASUser
 #>
 	[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = "10_9")]
 	param(

--- a/psPAS/Functions/User/Remove-PASGroupMember.ps1
+++ b/psPAS/Functions/User/Remove-PASGroupMember.ps1
@@ -1,4 +1,4 @@
-﻿function Remove-PASGroupMember {
+function Remove-PASGroupMember {
 	<#
 .SYNOPSIS
 Removes a vault user from a group
@@ -20,8 +20,8 @@ Removes TargetUser from group
 .INPUTS
 All parameters can be piped by property name
 
-.OUTPUTS
-None
+.LINK
+https://pspas.pspete.dev/commands/Remove-PASGroupMember
 #>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
@@ -51,7 +51,7 @@ None
 		#Create URL for request
 		$URI = "$Script:BaseURI/API/UserGroups/$GroupID/members/$Member"
 
-		if($PSCmdlet.ShouldProcess($GroupID, "Remove Group Member $Member")) {
+		if ($PSCmdlet.ShouldProcess($GroupID, "Remove Group Member $Member")) {
 
 			#send request to web service
 			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
@@ -60,6 +60,6 @@ None
 
 	}#process
 
-	END {}#end
+	END { }#end
 
 }

--- a/psPAS/Functions/User/Remove-PASUser.ps1
+++ b/psPAS/Functions/User/Remove-PASUser.ps1
@@ -1,4 +1,4 @@
-﻿function Remove-PASUser {
+function Remove-PASUser {
 	<#
 .SYNOPSIS
 Deletes a vault user
@@ -26,12 +26,12 @@ Deletes vault user "This_User"
 .INPUTS
 All parameters can be piped by property name
 
-.OUTPUTS
-None
+.LINK
+https://pspas.pspete.dev/commands/Remove-PASUser
 #>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
-		
+
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,

--- a/psPAS/Functions/User/Set-PASUser.ps1
+++ b/psPAS/Functions/User/Set-PASUser.ps1
@@ -55,16 +55,16 @@ Requires CyberArk version 11.1+
 The user permissions in the vault.
 To grant authorization to a user, the same authorization must be held by the account logged on to the API.
 Valid values:
-• AddSafes
-• AuditUsers
-• AddUpdateUsers
-• ResetUsersPasswords
-• ActivateUsers
-• AddNetworkAreas
-• ManageDirectoryMapping
-• ManageServerFileCategories
-• BackupAllSafes
-• RestoreAllSafes
+� AddSafes
+� AuditUsers
+� AddUpdateUsers
+� ResetUsersPasswords
+� ActivateUsers
+� AddNetworkAreas
+� ManageDirectoryMapping
+� ManageServerFileCategories
+� BackupAllSafes
+� RestoreAllSafes
 Requires CyberArk version 11.1+
 
 .PARAMETER ChangePassOnNextLogon
@@ -206,6 +206,9 @@ Specify the UseClassicAPI to force usage the Classic (v9) API endpoint.
 set-pasuser -UserName Bill -Disabled $true
 
 Disables vault user Bill
+
+.LINK
+https://pspas.pspete.dev/commands/Set-PASUser
 #>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
@@ -236,7 +239,7 @@ Disables vault user Bill
 			ParameterSetName = "11_1"
 		)]
 		[parameter(
-			Mandatory = $true,
+			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = "legacy"
 		)]
@@ -655,7 +658,7 @@ Disables vault user Bill
 			If ($businessAddress.keys -gt 0) {
 
 				$boundParameters["businessAddress"] = $businessAddress
-		
+
 			}
 
 			$boundParameters.keys | Where-Object { $internetParams -contains $_ } | ForEach-Object {
@@ -668,7 +671,7 @@ Disables vault user Bill
 			If ($internet.keys -gt 0) {
 
 				$boundParameters["internet"] = $internet
-		
+
 			}
 
 			$boundParameters.keys | Where-Object { $phonesParams -contains $_ } | ForEach-Object {
@@ -682,7 +685,7 @@ Disables vault user Bill
 			If ($phones.keys -gt 0) {
 
 				$boundParameters["phones"] = $phones
-		
+
 			}
 
 			$boundParameters.keys | Where-Object { $personalDetailsParams -contains $_ } | ForEach-Object {
@@ -695,7 +698,7 @@ Disables vault user Bill
 			If ($personalDetails.keys -gt 0) {
 
 				$boundParameters["personalDetails"] = $personalDetails
-		
+
 			}
 
 			#Construct Request Body

--- a/psPAS/Functions/User/Set-PASUserPassword.ps1
+++ b/psPAS/Functions/User/Set-PASUserPassword.ps1
@@ -1,23 +1,26 @@
-﻿function Set-PASUserPassword {
+function Set-PASUserPassword {
 	<#
-	.SYNOPSIS
-	Updates a vault user
+.SYNOPSIS
+Updates a vault user
 
-	.DESCRIPTION
-	Updates an existing user in the vault
+.DESCRIPTION
+Updates an existing user in the vault
 
-	.PARAMETER id
-	The name of the user to update in the vault
+.PARAMETER id
+The name of the user to update in the vault
 
-	.PARAMETER NewPassword
-	The password to set on the account.
-	Must meet the password complexity requirements
+.PARAMETER NewPassword
+The password to set on the account.
+Must meet the password complexity requirements
 
-	.EXAMPLE
-	Set-PASUserPassword -id 123 -NewPassword $SecureString
+.EXAMPLE
+Set-PASUserPassword -id 123 -NewPassword $SecureString
 
-	Resets password on account with id 123
-	#>
+Resets password on account with id 123
+
+.LINK
+https://pspas.pspete.dev/commands/Set-PASUserPassword
+#>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
 		[parameter(

--- a/psPAS/Functions/User/Unblock-PASUser.ps1
+++ b/psPAS/Functions/User/Unblock-PASUser.ps1
@@ -1,4 +1,4 @@
-﻿function Unblock-PASUser {
+function Unblock-PASUser {
 	<#
 .SYNOPSIS
 Activates a suspended user
@@ -26,6 +26,8 @@ Unblock-PASUser -id 666
 
 Activates suspended vault user with id 666, using the API from 10.10+
 
+.LINK
+https://pspas.pspete.dev/commands/Unblock-PASUser
 #>
 	[CmdletBinding(DefaultParameterSetName = "10_10")]
 	param(
@@ -70,7 +72,8 @@ Activates suspended vault user with id 666, using the API from 10.10+
 			$Request["URI"] = "$Script:BaseURI/api/Users/$id/Activate"
 			$Request["Method"] = "POST"
 
-		} ElseIf ($PSCmdlet.ParameterSetName -eq "ClassicAPI") {
+		}
+		ElseIf ($PSCmdlet.ParameterSetName -eq "ClassicAPI") {
 
 			#Create request
 			$Request["URI"] = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)"

--- a/psPAS/Private/Get-PASParameter.ps1
+++ b/psPAS/Private/Get-PASParameter.ps1
@@ -19,14 +19,6 @@ Accepts an array of any additional parameter keys which should be removed from t
 object. Specifying additional parameter names/keys here means that the default value assigned
 to the BaseParameters parameter will remain unchanged.
 
-.PARAMETER BaseParameters
-This is the default list of parameter names/keys which will be removed from the passed object.
-Contains all standard parameters associated with PowerShell advanced functions, as well as
-additional parameter names related to the CyberArk REST API but which are never included in a
-JSON object sent to the API (URL for instance).
-For normal operation, there is no need to pass anything for the BaseParameters parameter.
-The default value should be used.
-
 .EXAMPLE
 $PSBoundParameters | Get-PASParameter
 
@@ -39,6 +31,7 @@ $PSBoundParameters object
 .OUTPUTS
 Hashtable/$PSBoundParameters object, with defined parameters removed.
 #>
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'FilteredParameters', Justification = "False Positive")]
 	[CmdletBinding()]
 	[OutputType('System.Collections.Hashtable')]
 	param(
@@ -50,56 +43,39 @@ Hashtable/$PSBoundParameters object, with defined parameters removed.
 
 		[parameter(
 			Mandatory = $false)]
-		[array]$ParametersToRemove = @(),
+		[array]$ParametersToRemove = @()
 
-		[parameter(
-			Mandatory = $false)]
-		[array]$BaseParameters = @("Debug",
-			"ErrorAction",
-			"ErrorVariable",
-			"OutVariable",
-			"OutBuffer",
-			"PipelineVariable",
-			"Verbose",
-			"WarningAction",
-			"WarningVariable",
-			"WhatIf",
-			"Confirm",
-			"SessionVariable",
-			"InformationAction",
-			"InformationVariable",
-			"UseTransaction",
-			"UseClassicAPI")
 	)
 
 	BEGIN {
 
-
+		$BaseParameters = [Collections.Generic.List[String]]@(
+			[System.Management.Automation.PSCmdlet]::CommonParameters +
+			[System.Management.Automation.PSCmdlet]::OptionalCommonParameters +
+			"SessionVariable" +
+			"UseClassicAPI"
+		)
 
 	}#begin
 
 	PROCESS {
 
-		#Combine base parameters and any additional parameters to remove
-		($BaseParameters + $ParametersToRemove) |
+		$Parameters.Keys | ForEach-Object {
 
-		ForEach-Object {
+			$FilteredParameters = @{ }
 
-			If ($Parameters.Contains($_)) {
+		} {
 
-				#remove specified parameters from passed values
-				$Parameters.Remove($_)
+			if (($BaseParameters + $ParametersToRemove) -notcontains $PSItem) {
+
+				$FilteredParameters.Add($PSItem, $Parameters[$PSItem])
 
 			}
 
-		}
+		} { $FilteredParameters }
 
 	}#process
 
-	END {
+	END { }#end
 
-		#Return Object
-		$Parameters
-
-	}#end
 }

--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -253,16 +253,16 @@
 
 						#API Error Message
 						$ErrorMessage = "[$StatusCode] $($Response.ErrorMessage)"
-						
+
 						#API Error Code
 						$ErrorID = $Response.ErrorCode
-						
+
 						#Inner error details are present
 						if ($Response.Details) {
-							
+
 							#Join Inner Error Text to Error Message
 							$ErrorMessage = $ErrorMessage, $(($Response.Details | Select-Object -ExpandProperty ErrorMessage) -join ", ") -join ": "
-							
+
 							#Join Inner Error Codes to ErrorID
 							$ErrorID = $ErrorID, $(($Response.Details | Select-Object -ExpandProperty ErrorCode) -join ",") -join ","
 

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -13,10 +13,10 @@
 	Author            = 'Pete Maan'
 
 	# Company or vendor of this module
-	# CompanyName = ''
+	CompanyName = 'PSPETE LTD'
 
 	# Copyright statement for this module
-	Copyright         = '(c) 2019 Pete Maan. All rights reserved.'
+	Copyright         = '(c) 2020 PSPETE LTD. All rights reserved.'
 
 	# Description of the functionality provided by this module
 	Description       = 'Module for CyberArk Privileged Access Security Web Service REST API'
@@ -180,7 +180,8 @@
 		'New-PASGroup',
 		'Get-PASPlatformSafe',
 		'Remove-PASDirectoryMapping',
-		'Disable-PASCPMAutoManagement'
+		'Disable-PASCPMAutoManagement',
+		'Test-PASPSMRecording'
 	)
 
 	# AliasesToExport   = @( )
@@ -203,7 +204,7 @@
 			IconUri    = 'https://pspas.pspete.dev/assets/images/symbol.png'
 
 			# ReleaseNotes of this module
-			# ReleaseNotes = ''
+			ReleaseNotes = 'https://github.com/pspete/psPAS/blob/master/CHANGELOG.md'
 
 		} # End of PSData hashtable
 

--- a/psPAS/psPAS.psm1
+++ b/psPAS/psPAS.psm1
@@ -16,6 +16,19 @@ param(
 
 )
 
+#Enum Flag values for Directory Mapping Authorizations
+[Flags()]enum Authorizations{
+	AddUpdateUsers = 1
+	AddSafes = 2
+	AddNetworkAreas = 4
+	ManageServerFileCategories = 16
+	AuditUsers = 32
+	BackupAllSafes = 512
+	RestoreAllSafes = 1024
+	ResetUsersPasswords = 8388608
+	ActivateUsers = 16777216
+}
+
 #Get function files
 Get-ChildItem $PSScriptRoot\ -Recurse -Filter "*.ps1" -Exclude "*.ps1xml" |
 

--- a/psPAS/xml/psPAS.CyberArk.Vault.User.Formats.ps1xml
+++ b/psPAS/xml/psPAS.CyberArk.Vault.User.Formats.ps1xml
@@ -41,7 +41,9 @@
 								<PropertyName>enableUser</PropertyName>
 							</TableColumnItem>
 							<TableColumnItem>
-								<ScriptBlock>(get-date 1/1/1970).addseconds($_.expiryDate)</ScriptBlock>
+								<ScriptBlock>
+									If($_.expiryDate -gt 0){get-date 1/1/1970).addseconds($_.expiryDate)}
+								</ScriptBlock>
 							</TableColumnItem>
 							<TableColumnItem>
 								<PropertyName>Location</PropertyName>
@@ -86,14 +88,14 @@
 							</ListItem>
 							<ListItem>
 								<Label>lastSuccessfulLoginDate</Label>
-								<ScriptBlock>(get-date 1/1/1970).addseconds($_.lastSuccessfulLoginDate)</ScriptBlock>
+								<ScriptBlock>If($_.lastSuccessfulLoginDate -gt 0){get-date 1/1/1970).addseconds($_.lastSuccessfulLoginDate)}</ScriptBlock>
 							</ListItem>
 							<ListItem>
 								<PropertyName>EnableUser</PropertyName>
 							</ListItem>
 							<ListItem>
 								<Label>ExpiryDate</Label>
-								<ScriptBlock>(get-date 1/1/1970).addseconds($_.ExpiryDate)</ScriptBlock>
+								<ScriptBlock>If($_.expiryDate -gt 0){get-date 1/1/1970).addseconds($_.expiryDate)}</ScriptBlock>
 							</ListItem>
 							<ListItem>
 								<PropertyName>PasswordNeverExpires</PropertyName>
@@ -246,7 +248,7 @@
 					<TableRowEntry>
 						<TableColumnItems>
 							<TableColumnItem>
-								<ScriptBlock>(get-date 1/1/1970).addseconds($_.LastSuccessLoginTime)</ScriptBlock>
+								<ScriptBlock>If($_.LastSuccessLoginTime -gt 0){get-date 1/1/1970).addseconds($_.LastSuccessLoginTime)}</ScriptBlock>
 							</TableColumnItem>
 							<TableColumnItem>
 								<PropertyName>LastSuccessLoginIP</PropertyName>
@@ -255,7 +257,7 @@
 								<PropertyName>FailedLogins</PropertyName>
 							</TableColumnItem>
 							<TableColumnItem>
-								<ScriptBlock>(get-date 1/1/1970).addseconds($_.LastFailLoginTime)</ScriptBlock>
+								<ScriptBlock>If($_.LastFailLoginTime -gt 0){get-date 1/1/1970).addseconds($_.LastFailLoginTime)}</ScriptBlock>
 							</TableColumnItem>
 							<TableColumnItem>
 								<PropertyName>LastFailLoginIP</PropertyName>
@@ -276,7 +278,7 @@
 						<ListItems>
 							<ListItem>
 								<Label>LastSuccessLoginTime</Label>
-								<ScriptBlock>(get-date 1/1/1970).addseconds($_.LastSuccessLoginTime)</ScriptBlock>
+								<ScriptBlock>If($_.LastSuccessLoginTime -gt 0){get-date 1/1/1970).addseconds($_.LastSuccessLoginTime)}</ScriptBlock>
 							</ListItem>
 							<ListItem>
 								<PropertyName>LastSuccessLoginIP</PropertyName>
@@ -286,7 +288,7 @@
 							</ListItem>
 							<ListItem>
 								<Label>LastFailLoginTime</Label>
-								<ScriptBlock>(get-date 1/1/1970).addseconds($_.LastFailLoginTime)</ScriptBlock>
+								<ScriptBlock>If($_.LastFailLoginTime -gt 0){get-date 1/1/1970).addseconds($_.LastFailLoginTime)}</ScriptBlock>
 							</ListItem>
 							<ListItem>
 								<PropertyName>LastFailLoginIP</PropertyName>

--- a/psPAS/xml/psPAS.CyberArk.Vault.User.Formats.ps1xml
+++ b/psPAS/xml/psPAS.CyberArk.Vault.User.Formats.ps1xml
@@ -14,6 +14,10 @@
 					<TableColumnHeader />
 					<TableColumnHeader />
 					<TableColumnHeader />
+					<TableColumnHeader>
+						<Label>ExpiryDate</Label>
+					</TableColumnHeader>
+					<TableColumnHeader />
 				</TableHeaders>
 				<TableRowEntries>
 					<TableRowEntry>
@@ -31,7 +35,13 @@
 								<PropertyName>UserType</PropertyName>
 							</TableColumnItem>
 							<TableColumnItem>
-								<PropertyName>ComponentUser</PropertyName>
+								<PropertyName>Suspended</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<PropertyName>enableUser</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<ScriptBlock>(get-date 1/1/1970).addseconds($_.expiryDate)</ScriptBlock>
 							</TableColumnItem>
 							<TableColumnItem>
 								<PropertyName>Location</PropertyName>
@@ -75,10 +85,15 @@
 								<PropertyName>Suspended</PropertyName>
 							</ListItem>
 							<ListItem>
+								<Label>lastSuccessfulLoginDate</Label>
+								<ScriptBlock>(get-date 1/1/1970).addseconds($_.lastSuccessfulLoginDate)</ScriptBlock>
+							</ListItem>
+							<ListItem>
 								<PropertyName>EnableUser</PropertyName>
 							</ListItem>
 							<ListItem>
-								<PropertyName>ExpiryDate</PropertyName>
+								<Label>ExpiryDate</Label>
+								<ScriptBlock>(get-date 1/1/1970).addseconds($_.ExpiryDate)</ScriptBlock>
 							</ListItem>
 							<ListItem>
 								<PropertyName>PasswordNeverExpires</PropertyName>
@@ -122,6 +137,7 @@
 			</ViewSelectedBy>
 			<TableControl>
 				<TableHeaders>
+				<TableColumnHeader />
 					<TableColumnHeader />
 					<TableColumnHeader />
 					<TableColumnHeader />
@@ -134,6 +150,9 @@
 					<TableRowEntry>
 						<TableColumnItems>
 							<TableColumnItem>
+								<PropertyName>ID</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
 								<PropertyName>UserName</PropertyName>
 							</TableColumnItem>
 							<TableColumnItem>
@@ -143,16 +162,16 @@
 								<PropertyName>UserTypeName</PropertyName>
 							</TableColumnItem>
 							<TableColumnItem>
-								<PropertyName>AgentUser</PropertyName>
-							</TableColumnItem>
-							<TableColumnItem>
-								<PropertyName>Expired</PropertyName>
+								<PropertyName>Suspended</PropertyName>
 							</TableColumnItem>
 							<TableColumnItem>
 								<PropertyName>Disabled</PropertyName>
 							</TableColumnItem>
 							<TableColumnItem>
-								<PropertyName>Suspended</PropertyName>
+								<PropertyName>ExpiryDate</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<PropertyName>Location</PropertyName>
 							</TableColumnItem>
 						</TableColumnItems>
 					</TableRowEntry>
@@ -188,6 +207,9 @@
 							</ListItem>
 							<ListItem>
 								<PropertyName>Expired</PropertyName>
+							</ListItem>
+							<ListItem>
+								<PropertyName>ExpiryDate</PropertyName>
 							</ListItem>
 							<ListItem>
 								<PropertyName>Disabled</PropertyName>

--- a/psPAS/xml/psPAS.CyberArk.Vault.User.Formats.ps1xml
+++ b/psPAS/xml/psPAS.CyberArk.Vault.User.Formats.ps1xml
@@ -42,7 +42,7 @@
 							</TableColumnItem>
 							<TableColumnItem>
 								<ScriptBlock>
-									If($_.expiryDate -gt 0){get-date 1/1/1970).addseconds($_.expiryDate)}
+									If($_.expiryDate -gt 0){(get-date 1/1/1970).addseconds($_.expiryDate)}
 								</ScriptBlock>
 							</TableColumnItem>
 							<TableColumnItem>
@@ -88,14 +88,14 @@
 							</ListItem>
 							<ListItem>
 								<Label>lastSuccessfulLoginDate</Label>
-								<ScriptBlock>If($_.lastSuccessfulLoginDate -gt 0){get-date 1/1/1970).addseconds($_.lastSuccessfulLoginDate)}</ScriptBlock>
+								<ScriptBlock>If($_.lastSuccessfulLoginDate -gt 0){(get-date 1/1/1970).addseconds($_.lastSuccessfulLoginDate)}</ScriptBlock>
 							</ListItem>
 							<ListItem>
 								<PropertyName>EnableUser</PropertyName>
 							</ListItem>
 							<ListItem>
 								<Label>ExpiryDate</Label>
-								<ScriptBlock>If($_.expiryDate -gt 0){get-date 1/1/1970).addseconds($_.expiryDate)}</ScriptBlock>
+								<ScriptBlock>If($_.expiryDate -gt 0){(get-date 1/1/1970).addseconds($_.expiryDate)}</ScriptBlock>
 							</ListItem>
 							<ListItem>
 								<PropertyName>PasswordNeverExpires</PropertyName>
@@ -248,7 +248,7 @@
 					<TableRowEntry>
 						<TableColumnItems>
 							<TableColumnItem>
-								<ScriptBlock>If($_.LastSuccessLoginTime -gt 0){get-date 1/1/1970).addseconds($_.LastSuccessLoginTime)}</ScriptBlock>
+								<ScriptBlock>If($_.LastSuccessLoginTime -gt 0){(get-date 1/1/1970).addseconds($_.LastSuccessLoginTime)}</ScriptBlock>
 							</TableColumnItem>
 							<TableColumnItem>
 								<PropertyName>LastSuccessLoginIP</PropertyName>
@@ -257,7 +257,7 @@
 								<PropertyName>FailedLogins</PropertyName>
 							</TableColumnItem>
 							<TableColumnItem>
-								<ScriptBlock>If($_.LastFailLoginTime -gt 0){get-date 1/1/1970).addseconds($_.LastFailLoginTime)}</ScriptBlock>
+								<ScriptBlock>If($_.LastFailLoginTime -gt 0){(get-date 1/1/1970).addseconds($_.LastFailLoginTime)}</ScriptBlock>
 							</TableColumnItem>
 							<TableColumnItem>
 								<PropertyName>LastFailLoginIP</PropertyName>
@@ -278,7 +278,7 @@
 						<ListItems>
 							<ListItem>
 								<Label>LastSuccessLoginTime</Label>
-								<ScriptBlock>If($_.LastSuccessLoginTime -gt 0){get-date 1/1/1970).addseconds($_.LastSuccessLoginTime)}</ScriptBlock>
+								<ScriptBlock>If($_.LastSuccessLoginTime -gt 0){(get-date 1/1/1970).addseconds($_.LastSuccessLoginTime)}</ScriptBlock>
 							</ListItem>
 							<ListItem>
 								<PropertyName>LastSuccessLoginIP</PropertyName>
@@ -288,7 +288,7 @@
 							</ListItem>
 							<ListItem>
 								<Label>LastFailLoginTime</Label>
-								<ScriptBlock>If($_.LastFailLoginTime -gt 0){get-date 1/1/1970).addseconds($_.LastFailLoginTime)}</ScriptBlock>
+								<ScriptBlock>If($_.LastFailLoginTime -gt 0){(get-date 1/1/1970).addseconds($_.LastFailLoginTime)}</ScriptBlock>
 							</ListItem>
 							<ListItem>
 								<PropertyName>LastFailLoginIP</PropertyName>


### PR DESCRIPTION
### Module update to cover CyberArk 11.2 API features

- **Breaking Changes**
  - Parameters Changed: `New-PASDirectoryMapping` & `Set-PASDirectoryMapping`
    - Functions updated to use enum flag for mapping authorization options
    - `MappingAuthorizations`
      - Parameter now accepts string values representing the authorizations to configure for the mapping instead of an integer representation of them.
    - The following parameters are no longer accepted by the functions, the string values must now be provided to the `MappingAuthorizations` parameter instead:
      - `AddUpdateUsers`
      - `AddSafes`
      - `AddNetworkAreas`
      - `ManageServerFileCategories`
      - `AuditUsers`
      - `BackupAllSafes`
      - `RestoreAllSafes`
      - `ResetUsersPasswords`
      - `ActivateUsers`

- New Function
  - Added `Test-PASPSMRecording`
    - New in 11.2

- Fixes & Other Updates
  - Update `Get-PASAccount` to accept `searchType` parameter. Relevant to 11.2+.
  - Fixed incorrectly declared mandatory parameter in `Set-PASUser`
    - No longer required to set new password on user update.
  - Update `psPAS.CyberArk.Vault.User.Formats`
    - Include expiry & last logon date in friendly format.
    - New table format for displaying user information returned from API requests.
  - Performance related updates to internal module mechanics.
  - All functions help text updated to include link to function documentation on https://pspas.pspete.dev
  - Corrections & updates to documentation on https://pspas.pspete.dev