### PR TITLE
Added -RequiresPVWAIISAuthentication & OTP prompt

### DIFF
--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -99,7 +99,10 @@
 		[string]$CertificateThumbprint,
 
 		[Parameter(Mandatory = $false)]
-		[switch]$SkipCertificateCheck
+		[switch]$SkipCertificateCheck,
+
+		[ValidateNotNullOrEmpty()]
+		[PSCredential]$Credential
 	)
 
 	Begin {


### PR DESCRIPTION
Added -RequiresPVWAIISAuthentication to support the usecase where PVWA web access requires windows authentication before any login method can be used (except CyberArk login).
Some OTP solutions send the token via SMS. This means that the token is not known the moment the request is sent. Input prompt is needed to enter the token and a new webservice request to send it to CyberArk.

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes. -->
Fixes #245 

Closes #245 
