### PR TITLE
Windows + RADIUS Auth

### DIFF
--- a/Tests/New-PASSession.Tests.ps1
+++ b/Tests/New-PASSession.Tests.ps1
@@ -559,6 +559,26 @@ Describe $FunctionName {
 
 			}
 
+			It "throws if RADIUS challenge fails" {
+
+				Mock -CommandName Invoke-PASRestMethod {Throw $errorRecord} -ParameterFilter { $Uri -eq "https://P_URI/PasswordVault/api/Auth/RADIUS/Logon" }
+
+				{ $Credentials | New-PASSession -BaseURI "https://P_URI" -type Windows -OTP 123456 -OTPMode Challenge } | Should throw
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "https://P_URI/PasswordVault/api/Auth/Windows/Logon"
+
+				} -Times 1 -Exactly -Scope It
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "https://P_URI/PasswordVault/api/Auth/RADIUS/Logon"
+
+				} -Times 2 -Exactly -Scope It
+
+			}
+
 		}
 
 	}

--- a/docs/collections/_commands/New-PASSession.md
+++ b/docs/collections/_commands/New-PASSession.md
@@ -13,30 +13,30 @@ Authenticates a user to CyberArk Vault/API.
     [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
 
     New-PASSession -Credential <PSCredential> -UseClassicAPI -useRadiusAuthentication <Boolean> [-OTP <String>]
-    [-OTPMode <String>] [-OTPDelimiter <String>] [-RadiusChallenge <String>] [-connectionNumber <Int32>] -BaseURI
-    <String> [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate <X509Certificate>] [-CertificateThumbprint
-    <String>] [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
+    [-OTPMode <String>] [-OTPDelimiter <String>] [-RadiusChallenge <String>] [-connectionNumber <Int32>]
+    -BaseURI <String> [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate <X509Certificate>]
+    [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf][-Confirm] [<CommonParameters>]
 
     New-PASSession -Credential <PSCredential> -UseClassicAPI [-newPassword <SecureString>] [-connectionNumber <Int32>]
-    -BaseURI <String> [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate <X509Certificate>]
-    [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
+     -BaseURI <String> [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate <X509Certificate>]
+     [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
 
-    New-PASSession -Credential <PSCredential> [-type <String>] [-OTP <String>] [-OTPMode <String>] [-OTPDelimiter
-    <String>] [-RadiusChallenge <String>] -BaseURI <String> [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate
-    <X509Certificate>] [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf] [-Confirm]
-    [<CommonParameters>]
+    New-PASSession -Credential <PSCredential> [-type <String>] [-OTP <String>] [-OTPMode <String>]
+    [-OTPDelimiter <String>] [-RadiusChallenge <String>] -BaseURI <String> [-PVWAAppName <String>]
+    [-SkipVersionCheck] [-Certificate <X509Certificate>] [-CertificateThumbprint <String>] [-SkipCertificateCheck]
+    [-WhatIf] [-Confirm] [<CommonParameters>]
 
-    New-PASSession -SAMLToken <String> -BaseURI <String> [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate
-    <X509Certificate>] [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf] [-Confirm]
-    [<CommonParameters>]
+    New-PASSession -SAMLToken <String> -BaseURI <String> [-PVWAAppName <String>] [-SkipVersionCheck]
+    [-Certificate <X509Certificate>] [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf]
+    [-Confirm] [<CommonParameters>]
 
     New-PASSession -UseSharedAuthentication -BaseURI <String> [-PVWAAppName <String>] [-SkipVersionCheck]
-    [-Certificate <X509Certificate>] [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf] [-Confirm]
-    [<CommonParameters>]
+    [-Certificate <X509Certificate>] [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf]
+    [-Confirm] [<CommonParameters>]
 
     New-PASSession [-UseDefaultCredentials] -BaseURI <String> [-PVWAAppName <String>] [-SkipVersionCheck]
-    [-Certificate <X509Certificate>] [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf] [-Confirm]
-    [<CommonParameters>]
+    [-Certificate <X509Certificate>] [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf]
+    [-Confirm] [<CommonParameters>]
 
 ## DESCRIPTION
 
@@ -48,11 +48,10 @@ For older CyberArk versions, specify the -UseClassicAPI switch parameter to forc
 Windows authentication is only supported (from CyberArk 10.4+).
 Authenticate using CyberArk, LDAP, RADIUS, SAML or Shared authentication (From CyberArk version 9.7+),
 For CyberArk version older than 9.7:
-
-- Only CyberArk Authentication method is supported.
-- newPassword Parameter is not supported.
-- useRadiusAuthentication Parameter is not supported.
-- connectionNumber Parameter is not supported.
+    Only CyberArk Authentication method is supported.
+    newPassword Parameter is not supported.
+    useRadiusAuthentication Parameter is not supported.
+    connectionNumber Parameter is not supported.
 
 ## PARAMETERS
 
@@ -125,6 +124,8 @@ For CyberArk version older than 9.7:
 
     -OTP <String>
         One Time Passcode for RADIUS authentication.
+        To provide an OTP value after the initial RADIUS authentication,
+        specify a value of 'passcode' to get prompted for the OTP to use.
 
         Required?                    false
         Position?                    named
@@ -133,8 +134,8 @@ For CyberArk version older than 9.7:
         Accept wildcard characters?  false
 
     -OTPMode <String>
-        Specify if OTP is to be sent in 'Append' (appended to the password) or 'Challenge' mode (sent in response to
-        RADIUS Challenge).
+        Specify if OTP is to be sent in 'Append' (appended to the password) or 'Challenge' mode
+        (sent in response to RADIUS Challenge).
 
         Required?                    false
         Position?                    named
@@ -143,7 +144,8 @@ For CyberArk version older than 9.7:
         Accept wildcard characters?  false
 
     -OTPDelimiter <String>
-        The character to use as a delimiter when appending the OTP to the password. Defaults to comma ",".
+        The character to use as a delimiter when appending the OTP to the password.
+        Defaults to comma ",".
 
         Required?                    false
         Position?                    named
@@ -154,7 +156,8 @@ For CyberArk version older than 9.7:
     -RadiusChallenge <String>
         Specify if Radius challenge is satisfied by 'OTP' or 'Password'.
         If "OTP" (Default), Password will be sent first, with OTP as the challenge response.
-        If "Password", then OTP value will be sent first, and Password will be sent as the challenge response.
+        If "Password", then OTP value will be sent first, and Password will be sent as
+        the challenge response.
 
         Required?                    false
         Position?                    named
@@ -173,8 +176,8 @@ For CyberArk version older than 9.7:
         Accept wildcard characters?  false
 
     -connectionNumber <Int32>
-        In order to allow more than one connection for the same user simultaneously, each request
-        should be sent with different 'connectionNumber'.
+        In order to allow more than one connection for the same user simultaneously,
+        each request should be sent with different 'connectionNumber'.
         Valid values: 1-100
 
         Required?                    false
@@ -217,7 +220,8 @@ For CyberArk version older than 9.7:
     -Certificate <X509Certificate>
         See Invoke-WebRequest
         Specifies the client certificate that is used for a secure web request.
-        Enter a variable that contains a certificate or a command or expression that gets the certificate.
+        Enter a variable that contains a certificate or a command or expression
+        that gets the certificate.
 
         Required?                    false
         Position?                    named
@@ -238,8 +242,8 @@ For CyberArk version older than 9.7:
     -SkipCertificateCheck [<SwitchParameter>]
         Skips certificate validation checks.
         Using this parameter is not secure and is not recommended.
-        This switch is only intended to be used against known hosts using a self-signed certificate for testing
-        purposes.
+        This switch is only intended to be used against known hosts using a self-signed
+        certificate for testing purposes.
         Use at your own risk.
 
         Required?                    false
@@ -366,8 +370,7 @@ For CyberArk version older than 9.7:
 
     -------------------------- EXAMPLE 11 --------------------------
 
-    PS > New-PASSession -Credential $cred -BaseURI https://PVWA -UseClassicAPI -useRadiusAuthentication $True -OTP
-    123456 -OTPMode Append
+    PS > New-PASSession -Credential $cred -BaseURI https://PVWA -UseClassicAPI -useRadiusAuthentication $True -OTP 123456 -OTPMode Append
 
     Logon using RADIUS & OTP (Append Mode) via the Classic API
 
@@ -385,8 +388,7 @@ For CyberArk version older than 9.7:
 
     -------------------------- EXAMPLE 13 --------------------------
 
-    PS > New-PASSession -UseSharedAuthentication -BaseURI https://pvwa.some.co -CertificateThumbprint
-    0e194289c57e666115109d6e2800c24fb7db6edb
+    PS > New-PASSession -UseSharedAuthentication -BaseURI https://pvwa.some.co -CertificateThumbprint 0e194289c57e666115109d6e2800c24fb7db6edb
 
     If authentication via certificates is configured, provide CertificateThumbprint details.
 
@@ -407,3 +409,21 @@ For CyberArk version older than 9.7:
     PS > New-PASSession -Credential $cred -BaseURI https://PVWA -type LDAP -Certificate $Certificate
 
     Logon to Version 10 with LDAP credential & Client Certificate
+
+
+
+
+    -------------------------- EXAMPLE 16 --------------------------
+
+    PS > New-PASSession -Credential $cred -BaseURI https://PVWA -type Windows -OTP 123456 -OTPMode Challenge
+
+    Perform initial Windows authentication and satisfy secondary RADIUS challenge
+
+
+
+
+    -------------------------- EXAMPLE 17 --------------------------
+
+    PS > New-PASSession -Credential $cred -BaseURI https://PVWA -type Windows -OTP passcode -OTPMode Challenge
+
+    Perform initial authentication and then get prompted to supply OTP value for  RADIUS challenge.

--- a/psPAS/Functions/Authentication/New-PASSession.ps1
+++ b/psPAS/Functions/Authentication/New-PASSession.ps1
@@ -44,6 +44,7 @@ Windows is only a valid option for version 10.4 onward.
 
 .PARAMETER OTP
 One Time Passcode for RADIUS authentication.
+To provide an OTP value after the initial RADIUS authentication, specify a value of 'passcode' to get prompted for the OTP to use.
 
 .PARAMETER OTPMode
 Specify if OTP is to be sent in 'Append' (appended to the password) or 'Challenge' mode (sent in response to RADIUS Challenge).
@@ -169,6 +170,16 @@ Skip SSL Certificate validation for the session.
 New-PASSession -Credential $cred -BaseURI https://PVWA -type LDAP -Certificate $Certificate
 
 Logon to Version 10 with LDAP credential & Client Certificate
+
+.EXAMPLE
+New-PASSession -Credential $cred -BaseURI https://PVWA -type Windows -OTP 123456 -OTPMode Challenge
+
+Perform initial Windows authentication and satisfy secondary RADIUS challenge
+
+.EXAMPLE
+New-PASSession -Credential $cred -BaseURI https://PVWA -type Windows -OTP passcode -OTPMode Challenge
+
+Perform initial authentication and then get prompted to supply OTP value for  RADIUS challenge.
 
 .LINK
 https://pspas.pspete.dev/commands/New-PASSession
@@ -401,30 +412,35 @@ https://pspas.pspete.dev/commands/New-PASSession
 		$LogonRequest["SessionVariable"] = "PASSession"
 		$LogonRequest["UseDefaultCredentials"] = $UseDefaultCredentials.IsPresent
 		$LogonRequest["SkipCertificateCheck"] = $SkipCertificateCheck.IsPresent
-		If ($CertificateThumbprint) {
-			$LogonRequest["CertificateThumbprint"] = $CertificateThumbprint
+
+		If ($PSBoundParameters["type"] -eq "Windows") {
+
+			$LogonRequest["Credential"] = $Credential
+
 		}
+
+		If ($CertificateThumbprint) {
+
+			$LogonRequest["CertificateThumbprint"] = $CertificateThumbprint
+
+		}
+
 		If ($Certificate) {
+
 			$LogonRequest["Certificate"] = $Certificate
+
 		}
 
 		Switch -Wildcard ($PSCmdlet.ParameterSetName) {
 
-			"v10" {
+			"v10*" {
 
 				$LogonRequest["Uri"] = "$baseURI/$PVWAAppName/api/Auth/$type/Logon"
 				break
 
 			}
 
-			"v10Radius" {
-
-				$LogonRequest["Uri"] = "$baseURI/$PVWAAppName/api/Auth/RADIUS/Logon"
-				break
-
-			}
-
-			"integrated" {
+			"integrated*" {
 
 				$LogonRequest["Uri"] = "$baseURI/$PVWAAppName/api/Auth/Windows/Logon"  #hardcode Windows for integrated auth
 				break
@@ -458,11 +474,11 @@ https://pspas.pspete.dev/commands/New-PASSession
 
 	PROCESS {
 
-		#Get request parameters
-		$boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove Credential, SkipVersionCheck, SkipCertificateCheck,
-		UseDefaultCredentials, CertificateThumbprint, BaseURI, PVWAAppName, OTP, type, OTPMode, OTPDelimiter, RadiusChallenge, Certificate
-
 		If (($PSCmdlet.ParameterSetName -match "^v9*") -or ($PSCmdlet.ParameterSetName -match "^v10*") ) {
+
+			#Get request parameters
+			$boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove Credential, SkipVersionCheck, SkipCertificateCheck,
+			UseDefaultCredentials, CertificateThumbprint, BaseURI, PVWAAppName, OTP, type, OTPMode, OTPDelimiter, RadiusChallenge, Certificate
 
 			#Add user name from credential object
 			$boundParameters["username"] = $($Credential.UserName)
@@ -534,6 +550,29 @@ https://pspas.pspete.dev/commands/New-PASSession
 				#Send Logon Request
 				$PASSession = Invoke-PASRestMethod @LogonRequest
 
+				If($null -ne $PASSession.UserName){
+
+					#$PASSession is expected to be a string value
+					#For IIS Windows auth:
+					#An object with a username property can be returned if a secondary authentication is required
+
+					If ($PSCmdlet.ParameterSetName -match "Radius$") {
+
+						#If RADIUS parameters are specified
+						#Prepare RADIUS auth request
+						$LogonRequest["Uri"] = "$baseURI/$PVWAAppName/api/Auth/RADIUS/Logon"
+
+						#Use WebSession from initial request
+						$LogonRequest.Remove("SessionVariable")
+						$LogonRequest["WebSession"] = $Script:WebSession
+
+						#Submit initial RADIUS auth request
+						$PASSession = Invoke-PASRestMethod @LogonRequest
+
+					}
+
+				}
+
 			}
 			catch {
 
@@ -549,6 +588,12 @@ https://pspas.pspete.dev/commands/New-PASSession
 					If (($PSCmdlet.ParameterSetName -match "Radius$") -and ($PSBoundParameters["OTPMode"] -eq "Challenge")) {
 
 						If ($PSBoundParameters.ContainsKey("OTP")) {
+
+							If ($OTP -match "passcode") {
+
+								$OTP = $(Read-Host -Prompt "Enter OTP")
+
+							}
 
 							#$OTP as RADIUS response
 							#If $RadiusChallenge = Password, $OTP will be password value
@@ -587,6 +632,12 @@ https://pspas.pspete.dev/commands/New-PASSession
 
 				#If Logon Result
 				If ($PASSession) {
+
+					If ($null -ne $PASSession.UserName) {
+
+						throw "No Session Token for user $($PASSession.UserName)"
+
+					}
 
 					#Version 10
 					If ($PASSession.length -ge 180) {

--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -38,6 +38,10 @@
 	See Invoke-WebRequest
 	Used for Integrated Auth
 
+	.PARAMETER Credential
+	See Invoke-WebRequest
+	Used for Integrated Auth
+
 	.PARAMETER TimeoutSec
 	See Invoke-WebRequest
 	Specify a timeout value in seconds
@@ -88,6 +92,9 @@
 
 		[Parameter(Mandatory = $false)]
 		[switch]$UseDefaultCredentials,
+
+		[Parameter(Mandatory = $false)]
+		[pscredential]$Credential,
 
 		[Parameter(Mandatory = $false)]
 		[int]$TimeoutSec,


### PR DESCRIPTION
<!-- _A similar PR may already be submitted.
Please search existing `Pull Requests` before creating one._

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.  -->

## Summary

Adds capability for Windows + RADIUS authentication.

This PR implements the following **features**:

- Passes `$Credential` value onto `Invoke-WebRequest` for Windows authentication, in addition to including in the JSON body.
- If initial IIS Windows authentication succeeds but does not return an authentication token, and if radius parameters are specified, submits the username & password, and subsequently the OTP to respond to any radius challenge.
- Adds prompt for OTP, after initial RADIUS authentication, if the value of the `$OTP` parameter is `passcode`.
- Adds condition to throw error if Windows authentication succeeds but does not result in a CyberArk authentication token being returned.

## Test Plan

Pester tests updated & passing

## Closes issues

Closes #245 

<!--
## Code formatting

 See the `CONTRIBUTING` guide.

_Ensure your code adheres to the project's PowerShell Styleguide_
-->