### PR TITLE
UPDATE Add-PASAccount

### DIFF
--- a/Tests/Add-PASAccount.Tests.ps1
+++ b/Tests/Add-PASAccount.Tests.ps1
@@ -179,7 +179,7 @@ Describe $FunctionName {
 				$InputObj | Add-PASAccount
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-					($Body | ConvertFrom-Json | Select-Object -ExpandProperty Account | Get-Member -MemberType NoteProperty).length -eq 10
+					($Body | ConvertFrom-Json | Select-Object -ExpandProperty Account | Get-Member -MemberType NoteProperty).length -eq 11
 				} -Times 1 -Exactly -Scope It
 			}
 

--- a/psPAS/Functions/Accounts/Add-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Add-PASAccount.ps1
@@ -429,11 +429,11 @@ https://pspas.pspete.dev/commands/Add-PASAccount
 			}
 
 			#Process for required formatting - fix V10 specific parameter names
+			$boundParameters.remove("SafeName")
+			$boundParameters.remove("userName")
 			$boundParameters["safe"] = $SafeName
 			$boundParameters["username"] = $userName
 
-			$boundParameters.remove("SafeName")
-			$boundParameters.remove("userName")
 			#declare empty hashtable to hold "non-base" parameters
 			$properties = @{ }
 


### PR DESCRIPTION

## Summary

Fixes bug where mandatory username parameter is not sent in the request body when using the classic API.