### PR TITLE
Version Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 - Continued development to encompass any capability updates released for the CyberArk API.
 - psPAS v4.0...
 
+## 3.5.8 (April 2nd 2020)
+
+- Changes minimum required PowerShell version to 5.1
+- Updates + Fixes
+  - Marginal performance improvement by suppressing progress bar for `Invoke-WebRequest`.
+  - `Add-PASAccount`
+    - Fixed bug where mandatory username parameter is not sent in the request body when using the classic API.
+  - `Get-PASDirectoryMapping`
+    - include MappingID in default table output
+  - `Get-PASSafeMember`
+    - Updated help text to clarify `MemberName` parameter and expected failure conditions due to request method (`PUT` instead of `GET`)
+
 ## 3.5.0 (March 15th 2020)
 
 ### Module update to cover CyberArk 11.3

--- a/Tests/Add-PASAccount.Tests.ps1
+++ b/Tests/Add-PASAccount.Tests.ps1
@@ -179,7 +179,7 @@ Describe $FunctionName {
 				$InputObj | Add-PASAccount
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-					($Body | ConvertFrom-Json | Select-Object -ExpandProperty Account | Get-Member -MemberType NoteProperty).length -eq 10
+					($Body | ConvertFrom-Json | Select-Object -ExpandProperty Account | Get-Member -MemberType NoteProperty).length -eq 11
 				} -Times 1 -Exactly -Scope It
 			}
 

--- a/docs/collections/_commands/Get-PASSafeMember.md
+++ b/docs/collections/_commands/Get-PASSafeMember.md
@@ -82,7 +82,9 @@ If a Safe Member Name is provided, the full permissions of the member on the Saf
 
     -MemberName <String>
         Specify the name of a safe member to return their safe permissions in full.
-        You cannot report on the permissions of the user authenticated to the API.
+        An empty PUT request (update) is sent to retrieve full safe permissions for a user, as such:
+        - You cannot report on the permissions of the user authenticated to the API.
+        - Reporting on the permissions of the Quota Owner is expected to fail.
 
         Required?                    false
         Position?                    named

--- a/psPAS/Functions/Accounts/Add-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Add-PASAccount.ps1
@@ -429,11 +429,11 @@ https://pspas.pspete.dev/commands/Add-PASAccount
 			}
 
 			#Process for required formatting - fix V10 specific parameter names
+			$boundParameters.remove("SafeName")
+			$boundParameters.remove("userName")
 			$boundParameters["safe"] = $SafeName
 			$boundParameters["username"] = $userName
 
-			$boundParameters.remove("SafeName")
-			$boundParameters.remove("userName")
 			#declare empty hashtable to hold "non-base" parameters
 			$properties = @{ }
 

--- a/psPAS/Functions/SafeMembers/Get-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Get-PASSafeMember.ps1
@@ -62,7 +62,9 @@ The name of the safe to get the members of
 
 .PARAMETER MemberName
 Specify the name of a safe member to return their safe permissions in full.
-You cannot report on the permissions of the user authenticated to the API.
+An empty PUT request (update) is sent to retrieve full safe permissions for a user, as such:
+- You cannot report on the permissions of the user authenticated to the API.
+- Reporting on the permissions of the Quota Owner is expected to fail.
 
 .EXAMPLE
 Get-PASSafeMember -SafeName Target_Safe

--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -112,6 +112,7 @@
 	Begin {
 
 		#Set defaults for all function calls
+		$ProgressPreference = 'SilentlyContinue'
 		$PSBoundParameters.Add("ContentType", 'application/json')
 		$PSBoundParameters.Add("UseBasicParsing", $true)
 

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -22,7 +22,7 @@
 	Description       = 'Module for CyberArk Privileged Access Security Web Service REST API'
 
 	# Minimum version of the Windows PowerShell engine required by this module
-	PowerShellVersion = '5.0'
+	PowerShellVersion = '5.1'
 
 	# Name of the Windows PowerShell host required by this module
 	# PowerShellHostName = ''

--- a/psPAS/xml/psPAS.CyberArk.Vault.Directory.Formats.ps1xml
+++ b/psPAS/xml/psPAS.CyberArk.Vault.Directory.Formats.ps1xml
@@ -156,12 +156,19 @@
 					<TableColumnHeader />
 					<TableColumnHeader />
 					<TableColumnHeader />
+					<TableColumnHeader />
 				</TableHeaders>
 				<TableRowEntries>
 					<TableRowEntry>
 						<TableColumnItems>
 							<TableColumnItem>
+								<PropertyName>MappingID</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
 								<PropertyName>MappingName</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<PropertyName>DirectoryMappingOrder</PropertyName>
 							</TableColumnItem>
 							<TableColumnItem>
 								<PropertyName>LDAPBranch</PropertyName>
@@ -172,9 +179,7 @@
 							<TableColumnItem>
 								<PropertyName>MappingAuthorizations</PropertyName>
 							</TableColumnItem>
-							<TableColumnItem>
-								<PropertyName>DirectoryMappingOrder</PropertyName>
-							</TableColumnItem>
+
 						</TableColumnItems>
 					</TableRowEntry>
 				</TableRowEntries>


### PR DESCRIPTION
## Summary

- Changes minimum required PowerShell version to 5.1
- Marginal performance improvement by suppressing progress bar for `Invoke-WebRequest`.
- `Add-PASAccount`
  - Fixed bug where mandatory username parameter is not sent in the request body when using the classic API.
- `Get-PASDirectoryMapping`
  - include MappingID in default table output
- `Get-PASSafeMember`
  - Updated help text to clarify `MemberName` parameter and expected failure conditions due to request method (`PUT` instead of `GET`)

## Closes issues

Closes #253 
Closes #257 
Closes #258 

<!--
## Code formatting

 See the `CONTRIBUTING` guide.

_Ensure your code adheres to the project's PowerShell Styleguide_
-->