### PR TITLE
`*-PASSafeMember` Permission Output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 - Continued development to encompass any capability updates released for the CyberArk API.
 - psPAS v4.0...
 
+## 3.6.xx
+
+- **Breaking Changes**
+  - `Get-PASSafeMember`, `Add-PASSafeMember` & `Set-PASSafeMember`: Output Changed
+    - "Permission" property of returned object now contains a nested property=value pair for each permission instead of an array containing only the name of the assigned permissions.
+
 ## 3.5.8 (April 2nd 2020)
 
 - Changes minimum required PowerShell version to 5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - **Breaking Changes**
   - `Get-PASSafeMember`, `Add-PASSafeMember` & `Set-PASSafeMember`: Output Changed
     - "Permission" property of returned object now contains a nested property=value pair for each permission instead of an array containing only the name of the assigned permissions.
+    - Existing scripts which rely on the legacy array value of the `Permissions` property when working with the `*-PASSafeMember` functions must either be updated to work with the new output or use an earlier compatible psPAS version.
 
 ## 3.5.8 (April 2nd 2020)
 

--- a/Tests/Add-PASSafeMember.Tests.ps1
+++ b/Tests/Add-PASSafeMember.Tests.ps1
@@ -68,6 +68,10 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 						[pscustomobject]@{
 							"Key"   = "AnotherFalseKey"
 							"Value" = $false
+						},
+						[pscustomobject]@{
+							"Key"   = "IntegerKey"
+							"Value" = 1
 						}
 
 
@@ -195,9 +199,30 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has expected number of nested properties" {
+			It "has expected number of nested permission properties" {
 
-				($response.permissions).count | Should -Be 4
+				($response.permissions | Get-Member -MemberType NoteProperty).count | Should -Be 7
+
+			}
+
+			It "has expected boolean false property value" {
+
+				$response.permissions.FalseKey | Should -Be $False
+
+
+			}
+
+			It "has expected boolean true property value" {
+
+
+				$response.permissions.TrueKey | Should -Be $True
+
+			}
+
+			It "has expected integer property value" {
+
+
+				$response.permissions.IntegerKey | Should -Be 1
 
 			}
 

--- a/Tests/Add-PASSafeMember.Tests.ps1
+++ b/Tests/Add-PASSafeMember.Tests.ps1
@@ -68,10 +68,6 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 						[pscustomobject]@{
 							"Key"   = "AnotherFalseKey"
 							"Value" = $false
-						},
-						[pscustomobject]@{
-							"Key"   = "IntegerKey"
-							"Value" = 1
 						}
 
 
@@ -199,30 +195,9 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has expected number of nested permission properties" {
+			It "has expected number of nested properties" {
 
-				($response.permissions | Get-Member -MemberType NoteProperty).count | Should -Be 7
-
-			}
-
-			It "has expected boolean false property value" {
-
-				$response.permissions.FalseKey | Should -Be $False
-
-
-			}
-
-			It "has expected boolean true property value" {
-
-
-				$response.permissions.TrueKey | Should -Be $True
-
-			}
-
-			It "has expected integer property value" {
-
-
-				$response.permissions.IntegerKey | Should -Be 1
+				($response.permissions).count | Should -Be 4
 
 			}
 

--- a/Tests/Get-PASSafeMember.Tests.ps1
+++ b/Tests/Get-PASSafeMember.Tests.ps1
@@ -128,6 +128,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 								"FalseKey"        = $false
 								"AnotherKey"      = $true
 								"AnotherFalseKey" = $false
+								"IntegerKey" 	  = 1
 							}
 						}
 					}
@@ -155,9 +156,30 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has expected number of nested array elements" {
+			It "has expected number of nested permission properties"{
 
-				($response.permissions).count | Should -Be 3
+				($response.permissions | Get-Member -MemberType NoteProperty).count | Should -Be 6
+
+			}
+
+			It "has expected boolean false property value"{
+
+				$response.permissions.FalseKey | Should -Be $False
+
+
+			}
+
+			It "has expected boolean true property value" {
+
+
+				$response.permissions.Key1 | Should -Be $True
+
+			}
+
+			It "has expected integer property value" {
+
+
+				$response.permissions.IntegerKey | Should -Be 1
 
 			}
 

--- a/Tests/Set-PASSafeMember.Tests.ps1
+++ b/Tests/Set-PASSafeMember.Tests.ps1
@@ -40,7 +40,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 			[PSCustomObject]@{
 				"member" = [PSCustomObject]@{
 					"MembershipExpirationDate" = "31/12/2018"
-					"Permissions"              = @(
+					"Permissions" = @(
 						[pscustomobject]@{
 							"Key"   = "Key1"
 							"Value" = $true
@@ -65,7 +65,10 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 							"Key"   = "AnotherFalseKey"
 							"Value" = $false
 						}
-
+						[pscustomobject]@{
+							"Key"   = "IntegerKey"
+							"Value" = 1
+						}
 
 					)
 				}
@@ -92,7 +95,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 			"BackupSafe"                             = $false
 			"ViewAuditLog"                           = $true
 			"ViewSafeMembers"                        = $true
-			"RequestsAuthorizationLevel"             = 0
+			"RequestsAuthorizationLevel"             = 1
 			"AccessWithoutConfirmation"              = $false
 			"CreateFolders"                          = $false
 			"DeleteFolders"                          = $false
@@ -190,9 +193,30 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has expected number of nested array elements" {
+			It "has expected number of nested permission properties" {
 
-				($response.permissions).count | Should -Be 4
+				($response.permissions | Get-Member -MemberType NoteProperty).count | Should -Be 7
+
+			}
+
+			It "has expected boolean false property value" {
+
+				$response.permissions.FalseKey | Should -Be $False
+
+
+			}
+
+			It "has expected boolean true property value" {
+
+
+				$response.permissions.TrueKey | Should -Be $True
+
+			}
+
+			It "has expected integer property value" {
+
+
+				$response.permissions.IntegerKey | Should -Be 1
 
 			}
 

--- a/Tests/Set-PASSafeMember.Tests.ps1
+++ b/Tests/Set-PASSafeMember.Tests.ps1
@@ -64,6 +64,10 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 						[pscustomobject]@{
 							"Key"   = "AnotherFalseKey"
 							"Value" = $false
+						},
+						[pscustomobject]@{
+							"Key"   = "IntegerKey"
+							"Value" = 1
 						}
 
 
@@ -92,7 +96,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 			"BackupSafe"                             = $false
 			"ViewAuditLog"                           = $true
 			"ViewSafeMembers"                        = $true
-			"RequestsAuthorizationLevel"             = 0
+			"RequestsAuthorizationLevel"             = 1
 			"AccessWithoutConfirmation"              = $false
 			"CreateFolders"                          = $false
 			"DeleteFolders"                          = $false
@@ -190,9 +194,30 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has expected number of nested array elements" {
+			It "has expected number of nested permission properties" {
 
-				($response.permissions).count | Should -Be 4
+				($response.permissions | Get-Member -MemberType NoteProperty).count | Should -Be 7
+
+			}
+
+			It "has expected boolean false property value" {
+
+				$response.permissions.FalseKey | Should -Be $False
+
+
+			}
+
+			It "has expected boolean true property value" {
+
+
+				$response.permissions.TrueKey | Should -Be $True
+
+			}
+
+			It "has expected integer property value" {
+
+
+				$response.permissions.IntegerKey | Should -Be 1
 
 			}
 

--- a/Tests/Set-PASSafeMember.Tests.ps1
+++ b/Tests/Set-PASSafeMember.Tests.ps1
@@ -64,10 +64,6 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 						[pscustomobject]@{
 							"Key"   = "AnotherFalseKey"
 							"Value" = $false
-						},
-						[pscustomobject]@{
-							"Key"   = "IntegerKey"
-							"Value" = 1
 						}
 
 
@@ -96,7 +92,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 			"BackupSafe"                             = $false
 			"ViewAuditLog"                           = $true
 			"ViewSafeMembers"                        = $true
-			"RequestsAuthorizationLevel"             = 1
+			"RequestsAuthorizationLevel"             = 0
 			"AccessWithoutConfirmation"              = $false
 			"CreateFolders"                          = $false
 			"DeleteFolders"                          = $false
@@ -194,30 +190,9 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has expected number of nested permission properties" {
+			It "has expected number of nested array elements" {
 
-				($response.permissions | Get-Member -MemberType NoteProperty).count | Should -Be 7
-
-			}
-
-			It "has expected boolean false property value" {
-
-				$response.permissions.FalseKey | Should -Be $False
-
-
-			}
-
-			It "has expected boolean true property value" {
-
-
-				$response.permissions.TrueKey | Should -Be $True
-
-			}
-
-			It "has expected integer property value" {
-
-
-				$response.permissions.IntegerKey | Should -Be 1
+				($response.permissions).count | Should -Be 4
 
 			}
 

--- a/psPAS/Functions/SafeMembers/Add-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Add-PASSafeMember.ps1
@@ -394,12 +394,23 @@ https://pspas.pspete.dev/commands/Add-PASSafeMember
 
 		if ($result) {
 
+			$MemberPermissions = [PSCustomObject]@{ }
+
+			$result.member.Permissions | ForEach-Object {
+
+				$MemberPermissions |
+					Add-Member -MemberType NoteProperty -Name $($PSItem |
+						Select-Object -ExpandProperty key) -Value $($PSItem |
+							Select-Object -ExpandProperty value)
+
+			}
+
 			#format output
 			$result.member | Select-Object MemberName, MembershipExpirationDate, SearchIn,
 
 			@{Name = "Permissions"; "Expression" = {
 
-					$_.Permissions | Where-Object { $_.value } | Select-Object -ExpandProperty key }
+					$MemberPermissions }
 
 			} | Add-ObjectDetail -typename psPAS.CyberArk.Vault.Safe.Member.Extended -PropertyToAdd @{
 

--- a/psPAS/Functions/SafeMembers/Add-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Add-PASSafeMember.ps1
@@ -394,23 +394,12 @@ https://pspas.pspete.dev/commands/Add-PASSafeMember
 
 		if ($result) {
 
-			$MemberPermissions = [PSCustomObject]@{}
-
-			$result.member.Permissions | ForEach-Object {
-
-				$MemberPermissions |
-					Add-Member -MemberType NoteProperty -Name $($PSItem |
-						Select-Object -ExpandProperty key) -Value $($PSItem |
-							Select-Object -ExpandProperty value)
-
-			}
-
 			#format output
 			$result.member | Select-Object MemberName, MembershipExpirationDate, SearchIn,
 
 			@{Name = "Permissions"; "Expression" = {
 
-					$MemberPermissions }
+					$_.Permissions | Where-Object { $_.value } | Select-Object -ExpandProperty key }
 
 			} | Add-ObjectDetail -typename psPAS.CyberArk.Vault.Safe.Member.Extended -PropertyToAdd @{
 

--- a/psPAS/Functions/SafeMembers/Add-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Add-PASSafeMember.ps1
@@ -394,12 +394,23 @@ https://pspas.pspete.dev/commands/Add-PASSafeMember
 
 		if ($result) {
 
+			$MemberPermissions = [PSCustomObject]@{}
+
+			$result.member.Permissions | ForEach-Object {
+
+				$MemberPermissions |
+					Add-Member -MemberType NoteProperty -Name $($PSItem |
+						Select-Object -ExpandProperty key) -Value $($PSItem |
+							Select-Object -ExpandProperty value)
+
+			}
+
 			#format output
 			$result.member | Select-Object MemberName, MembershipExpirationDate, SearchIn,
 
 			@{Name = "Permissions"; "Expression" = {
 
-					$_.Permissions | Where-Object { $_.value } | Select-Object -ExpandProperty key }
+					$MemberPermissions }
 
 			} | Add-ObjectDetail -typename psPAS.CyberArk.Vault.Safe.Member.Extended -PropertyToAdd @{
 

--- a/psPAS/Functions/SafeMembers/Get-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Get-PASSafeMember.ps1
@@ -150,12 +150,7 @@ https://pspas.pspete.dev/commands/Get-PASSafeMember
 				$MemberPermissions = [PSCustomObject]@{}
 
 				$result.member.Permissions | ForEach-Object {
-
-					$MemberPermissions |
-						Add-Member -MemberType NoteProperty -Name $($PSItem |
-							Select-Object -ExpandProperty key) -Value $($PSItem |
-								Select-Object -ExpandProperty value)
-
+					$MemberPermissions | Add-Member -MemberType NoteProperty -Name $($PSItem | Select-Object -ExpandProperty key) -Value $($PSItem | Select-Object -ExpandProperty value)
 				}
 
 				#format output

--- a/psPAS/Functions/SafeMembers/Get-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Get-PASSafeMember.ps1
@@ -9,53 +9,53 @@ View Safe Members permission is required.
 
 When querying all members of a safe, the permissions are reported as per the following table:
 
-List accounts							ListContent
+List accounts							    ListContent
 Retrieve accounts							Retrieve
-Add accounts (includes update properties)				Add
+Add accounts (includes update properties)	Add
 Update account content						Update
-Update account properties						UpdateMetadata
-Rename accounts							Rename
-Delete accounts							Delete
-View Audit log							ViewAudit
+Update account properties					UpdateMetadata
+Rename accounts							    Rename
+Delete accounts							    Delete
+View Audit log							    ViewAudit
 View Safe Members							ViewMembers
-Use accounts							RestrictedRetrieve
-Initiate CPM account management operations				<NOT RETURNED>
-Specify next account content					<NOT RETURNED>
-Create folders							AddRenameFolder
-Delete folders							DeleteFolder
-Unlock accounts							Unlock
+Use accounts								RestrictedRetrieve
+Initiate CPM account management operations	<NOT RETURNED>
+Specify next account content			    <NOT RETURNED>
+Create folders							    AddRenameFolder
+Delete folders							    DeleteFolder
+Unlock accounts							    Unlock
 Move accounts/folders						MoveFilesAndFolders
-Manage Safe								ManageSafe
+Manage Safe								    ManageSafe
 Manage Safe Members							ManageSafeMembers
 Validate Safe Content						ValidateSafeContent
-Backup Safe								BackupSafe
-Access Safe without confirmation					<NOT RETURNED>
-Authorize account requests�(level1, level2)				<NOT RETURNED>
+Backup Safe								    BackupSafe
+Access Safe without confirmation			<NOT RETURNED>
+Authorize account requests�(level1, level2)	<NOT RETURNED>
 
 If a Safe Member Name is provided, the full permissions of the member on the Safe will be returned:
 
-List accounts							ListAccounts
+List accounts							    ListAccounts
 Retrieve accounts							RetrieveAccounts
-Add accounts (includes update properties)				AddAccounts
+Add accounts (includes update properties)	AddAccounts
 Update account content						UpdateAccountContent
-Update account properties						UpdateAccountProperties
-Rename accounts							RenameAccounts
-Delete accounts							DeleteAccounts
-View Audit log							ViewAuditLog
+Update account properties					UpdateAccountProperties
+Rename accounts							    RenameAccounts
+Delete accounts							    DeleteAccounts
+View Audit log							    ViewAuditLog
 View Safe Members							ViewSafeMembers
-Use accounts							UseAccounts
-Initiate CPM account management operations				InitiateCPMAccountManagementOperations
-Specify next account content					SpecifyNextAccountContent
-Create folders							CreateFolders
-Delete folders							DeleteFolder
-Unlock accounts							UnlockAccounts
+Use accounts							    UseAccounts
+Initiate CPM account management operations	InitiateCPMAccountManagementOperations
+Specify next account content				SpecifyNextAccountContent
+Create folders							    CreateFolders
+Delete folders							    DeleteFolder
+Unlock accounts							    UnlockAccounts
 Move accounts/folders						MoveAccountsAndFolders
-Manage Safe								ManageSafe
+Manage Safe								    ManageSafe
 Manage Safe Members							ManageSafeMembers
 Validate Safe Content						<NOT RETURNED>
-Backup Safe								BackupSafe
-Access Safe without confirmation					AccessWithoutConfirmation
-Authorize account requests (level1, level2)				RequestsAuthorizationLevel
+Backup Safe								    BackupSafe
+Access Safe without confirmation			AccessWithoutConfirmation
+Authorize account requests (level1, level2)	RequestsAuthorizationLevel
 
 .PARAMETER SafeName
 The name of the safe to get the members of
@@ -147,6 +147,12 @@ https://pspas.pspete.dev/commands/Get-PASSafeMember
 
 			if ($PSCmdlet.ParameterSetName -eq "MemberPermissions") {
 
+				$MemberPermissions = [PSCustomObject]@{}
+
+				$result.member.Permissions | ForEach-Object {
+					$MemberPermissions | Add-Member -MemberType NoteProperty -Name $($PSItem | Select-Object -ExpandProperty key) -Value $($PSItem | Select-Object -ExpandProperty value)
+				}
+
 				#format output
 				$Output = $result.member | Select-Object MembershipExpirationDate,
 
@@ -158,7 +164,7 @@ https://pspas.pspete.dev/commands/Get-PASSafeMember
 
 				@{Name = "Permissions"; "Expression" = {
 
-						$_.Permissions | Where-Object { $_.value } | Select-Object -ExpandProperty key }
+						$MemberPermissions }
 
 				}
 
@@ -167,13 +173,7 @@ https://pspas.pspete.dev/commands/Get-PASSafeMember
 			Else {
 
 				#output
-				$Output = $result.members | Select-Object UserName, @{Name = "Permissions"; "Expression" = {
-
-						($_.Permissions).psobject.properties | Where-Object { $_.Value -eq $true } |
-
-						Select-Object -ExpandProperty Name }
-
-				}
+				$Output = $result.members | Select-Object UserName, Permissions
 
 			}
 

--- a/psPAS/Functions/SafeMembers/Get-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Get-PASSafeMember.ps1
@@ -150,7 +150,12 @@ https://pspas.pspete.dev/commands/Get-PASSafeMember
 				$MemberPermissions = [PSCustomObject]@{}
 
 				$result.member.Permissions | ForEach-Object {
-					$MemberPermissions | Add-Member -MemberType NoteProperty -Name $($PSItem | Select-Object -ExpandProperty key) -Value $($PSItem | Select-Object -ExpandProperty value)
+
+					$MemberPermissions |
+						Add-Member -MemberType NoteProperty -Name $($PSItem |
+							Select-Object -ExpandProperty key) -Value $($PSItem |
+								Select-Object -ExpandProperty value)
+
 				}
 
 				#format output

--- a/psPAS/Functions/SafeMembers/Set-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Set-PASSafeMember.ps1
@@ -329,12 +329,23 @@ https://pspas.pspete.dev/commands/Set-PASSafeMember
 
 			if ($result) {
 
+				$MemberPermissions = [PSCustomObject]@{ }
+
+				$result.member.Permissions | ForEach-Object {
+
+					$MemberPermissions |
+						Add-Member -MemberType NoteProperty -Name $($PSItem |
+							Select-Object -ExpandProperty key) -Value $($PSItem |
+								Select-Object -ExpandProperty value)
+
+				}
+
 				#format output
 				$result.member | Select-Object MembershipExpirationDate,
 
 				@{Name = "Permissions"; "Expression" = {
 
-						$_.Permissions | Where-Object { $_.value } | Select-Object -ExpandProperty key }
+						$MemberPermissions }
 
 				} | Add-ObjectDetail -typename psPAS.CyberArk.Vault.Safe.Member -PropertyToAdd @{
 


### PR DESCRIPTION
<!-- _A similar PR may already be submitted.
Please search existing `Pull Requests` before creating one._

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.  -->

## Summary

Changes `Permissions` output of:
- `Get-PASSafeMember`
- `Set-PASSafeMember`
- `Add-PASSafeMember`

This PR fixes the following bug:

When added, set or queried, both the name & value of safe permissions is now returned as a nested property under `Permissions`.
Previously, only the name of any permissions configured with a value of `$true` was returned, contained as an array of the `Permissions` property.
Update allows integer value of `RequestsAuthorizationLevel` permission to be returned.

## Test Plan

Pester tests updated to check that expected `boolean` or `int` permission property values 

## Related issues

#275 

<!--
## Code formatting

 See the `CONTRIBUTING` guide.

_Ensure your code adheres to the project's PowerShell Styleguide_
-->