### PR TITLE
ADD SAML Authentication

### DIFF
--- a/Tests/Get-PASSAMLResponse.Tests.ps1
+++ b/Tests/Get-PASSAMLResponse.Tests.ps1
@@ -1,0 +1,94 @@
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
+
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
+
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+		if ( -not (Get-Module -Name $ModuleName -All)) {
+
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+		}
+
+	}
+
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+		BeforeEach{
+
+			Mock Invoke-WebRequest -MockWith {
+
+				[pscustomobject]@{
+
+					"Links"       = [pscustomobject]@{
+
+						"href" = "https://SomeLink/"
+
+					}
+
+					"InputFields" = @(
+
+						[pscustomobject]@{
+
+							"Name"  = "SAMLResponse"
+							"Value" = "IamSAMLiAM"
+
+						}
+
+					)
+
+				}
+
+			}
+
+			$response = Get-PASSAMLResponse -URL "https://pvwa.somecompany.com/PasswordVault"
+
+		}
+
+		Context "Standard Operation" {
+
+			It "sends expected requests" {
+
+				Assert-MockCalled Invoke-WebRequest -Times 2 -Exactly -Scope It
+
+			}
+
+			It "returns expected response" {
+
+				$response | Should -Be "IamSAMLiAM"
+
+			}
+
+			It "throws expected error"{
+
+				Mock Invoke-WebRequest -MockWith {
+
+					Throw "Some Error"
+
+				}
+
+				{Get-PASSAMLResponse -URL "https://pvwa.somecompany.com/PasswordVault"} | Should -Throw "Failed to get SAMLResponse"
+
+			}
+
+		}
+
+	}
+
+}

--- a/psPAS/Private/Get-PASSAMLResponse.ps1
+++ b/psPAS/Private/Get-PASSAMLResponse.ps1
@@ -1,0 +1,43 @@
+Function Get-PASSAMLResponse {
+<#
+.SYNOPSIS
+Get SAML Token for PAS SAML Auth
+
+.DESCRIPTION
+Get SAML Token from pvwa webresponse
+
+.PARAMETER URL
+The PVWA URL
+
+.EXAMPLE
+Get-PASSAMLResponse -URL "https://pvwa.somecompany.com/PasswordVault"
+
+.NOTES
+https://gist.github.com/infamousjoeg/b44faa299ec3de65bdd1d3b8474b0649
+#>
+	[CmdletBinding()]
+	param(
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipeline = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		$URL
+	)
+
+	Try {
+
+		$WebResponse = Invoke-WebRequest -Uri "$URL/auth/saml/" -MaximumRedirection 0 -ErrorAction SilentlyContinue -UseBasicParsing
+
+		$SAMLResponse = Invoke-WebRequest -Uri ($WebResponse.links.href) -MaximumRedirection 1 -UseDefaultCredentials -UseBasicParsing
+
+		If ($SAMLResponse.InputFields[0].name -eq "SAMLResponse") {
+			$SAMLResponse.InputFields[0].value
+		}
+		Else { Throw }
+
+	}
+
+	Catch { Throw "Failed to get SAMLResponse" }
+
+}


### PR DESCRIPTION
## Summary

Adds SAML Auth support introduced to the api in 11.4.
- added new parameter `SAMLAuth`.

Adds new Private function `Get-PASSAMLResponse`, based on [this gist](https://gist.github.com/infamousjoeg/b44faa299ec3de65bdd1d3b8474b0649), which is designed to get the required saml response before attempting authentication.

## Test Plan

Pester tests created based on expected output and logic flow
