### PR TITLE
Issue 272

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 - Fixes
   - `Set-PASUser`
     - Corrects issue where an incorrectly formed json body was being sent with the request if using the parameters introduced in psPAS 3.3.88.
+  - `Add-PASSafeMember` & `Set-PASSafeMember`
+    - Update ensures json body of request is always sent with the permission properties statically ordered.
 
 ## 3.5.8 (April 2nd 2020)
 

--- a/psPAS/Functions/SafeMembers/Add-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Add-PASSafeMember.ps1
@@ -333,11 +333,32 @@ https://pspas.pspete.dev/commands/Add-PASSafeMember
 
 	BEGIN {
 
-		#Set base Parameters the exist at the top level of required JSON object
-		$baseParameters = @("MemberName", "SearchIn", "MembershipExpirationDate", "SafeName")
-
 		#Create empty hashtable to hold permission related parameters
-		$permissions = @{ }
+		$Permissions = [ordered]@{ }
+
+		$OrderedPermisions = [ordered]@{
+			UseAccounts                            = $false
+			RetrieveAccounts                       = $false
+			ListAccounts                           = $false
+			AddAccounts                            = $false
+			UpdateAccountContent                   = $false
+			UpdateAccountProperties                = $false
+			InitiateCPMAccountManagementOperations = $false
+			SpecifyNextAccountContent              = $false
+			RenameAccounts                         = $false
+			DeleteAccounts                         = $false
+			UnlockAccounts                         = $false
+			ManageSafe                             = $false
+			ManageSafeMembers                      = $false
+			BackupSafe                             = $false
+			ViewAuditLog                           = $false
+			ViewSafeMembers                        = $false
+			RequestsAuthorizationLevel             = 0
+			AccessWithoutConfirmation              = $false
+			CreateFolders                          = $false
+			DeleteFolders                          = $false
+			MoveAccountsAndFolders                 = $false
+		}
 
 		#array for parameter names which will do not appear in the top-tier of the JSON object
 		$keysToRemove = [Collections.Generic.List[String]]@('SafeName')
@@ -364,19 +385,24 @@ https://pspas.pspete.dev/commands/Add-PASSafeMember
 
 		}
 
-		#For every passed permission ("Non-Base") parameter
-		$boundParameters.keys | Where-Object { $baseParameters -notcontains $_ } | ForEach-Object {
+		#For each Member Permission parameter
+		$OrderedPermisions.keys | ForEach-Object {
 
-			#Add Key=Value pair to permissions hashtable
-			$permissions[$_] = $boundParameters[$_]
+			#include permission in request
+			If ($boundParameters.ContainsKey($PSItem)) {
 
-			#Add parameter name to array
-			$null = $keysToRemove.Add($_)
+				#Add to hash table in key/value pair
+				$Permissions.Add($PSItem, $boundParameters[$PSItem])
+
+				#permission parameter name
+				$null = $keysToRemove.Add($PSItem)
+
+			}
 
 		}
 
 		#add all required permissions  as value to "Permissions" key
-		$boundParameters["Permissions"] = @($permissions.getenumerator() | ForEach-Object { $_ })
+		$boundParameters["Permissions"] = @($Permissions.getenumerator() | ForEach-Object { $PSItem })
 
 		#Create required request object
 		$body = @{


### PR DESCRIPTION
<!-- _A similar PR may already be submitted.
Please search existing `Pull Requests` before creating one._

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.  -->

## Summary

Ensures json body of request created by `Add-PASSafeMember` & `Set-PASSafeMember` always has the permission properties statically ordered.

The JSON properties are expected to be in a certain order. i.e. AddAccounts should appear before UpdateAccountProperties.
 
<!-- Example: When "Amended logic in function _X_ to achieve _Y_", explain why it is necessary to have a way to do _Y_. -->

## Test Plan

All pester tests pass, functionality remains.

## Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes. -->
Fixes #272 

<!--
## Code formatting

 See the `CONTRIBUTING` guide.

_Ensure your code adheres to the project's PowerShell Styleguide_
-->