### PR TITLE
New Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,23 @@
 
 ## 3.6.xx
 
+### Module update to cover CyberArk 11.4 API features
+
 - **Breaking Changes**
   - `Get-PASSafeMember`, `Add-PASSafeMember` & `Set-PASSafeMember`: Output Changed
     - "Permission" property of returned object now contains a nested property=value pair for each permission instead of an array containing only the name of the assigned permissions.
     - Existing scripts which rely on the legacy array value of the `Permissions` property when working with the `*-PASSafeMember` functions must either be updated to work with the new output or use an earlier compatible psPAS version.
+
+- New Function
+  - Added `Set-PASPTAEvent`
+    - Appeared in 11.3
+    - Set status of PTA events
+
+- Updated Functions
+  - `New-PASSession`
+    - Adds support for updated saml auth updated in 11.4
+  - `Get-PASPTAEvent`
+    - Adds newly documented parameters for 11.4 and updates request format for filtering events
 
 ## 3.5.8 (April 2nd 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
   - `Get-PASPTAEvent`
     - Adds newly documented parameters for 11.4 and updates request format for filtering events
 
+- Fixes
+  - `Set-PASUser`
+    - Corrects issue where an incorrectly formed json body was being sent with the request if using the parameters introduced in psPAS 3.3.88.
+
 ## 3.5.8 (April 2nd 2020)
 
 - Changes minimum required PowerShell version to 5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 - Fixes
   - `Set-PASUser`
     - Corrects issue where an incorrectly formed json body was being sent with the request if using the parameters introduced in psPAS 3.3.88.
+  - `Add-PASSafeMember` & `Set-PASSafeMember`
+    - Update ensures json body of request is always sent with the permission properties statically ordered.
 
 ## 3.5.8 (April 2nd 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 - Continued development to encompass any capability updates released for the CyberArk API.
 - psPAS v4.0...
 
+## 3.6.xx
+
+- **Breaking Changes**
+  - `Get-PASSafeMember`, `Add-PASSafeMember` & `Set-PASSafeMember`: Output Changed
+    - "Permission" property of returned object now contains a nested property=value pair for each permission instead of an array containing only the name of the assigned permissions.
+    - Existing scripts which rely on the legacy array value of the `Permissions` property when working with the `*-PASSafeMember` functions must either be updated to work with the new output or use an earlier compatible psPAS version.
+
 ## 3.5.8 (April 2nd 2020)
 
 - Changes minimum required PowerShell version to 5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## Planned Updates
 
-- Continued development to encompass any capability updates released for the CyberArk API.
-- psPAS v4.0...
+- Update for PAS 11.5
+- Continued development to encompass any new documented features of the CyberArk API.
+- psPAS v5.0...
 
-## 3.6.xx
+## **4.0.0** (July 1st 2020)
 
 ### Module update to cover CyberArk 11.4 API features
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Use PowerShell to manage CyberArk via the Web Services REST API.
 
-Contains all published methods of the API up to CyberArk v11.3.
+Contains all published methods of the API up to CyberArk v11.4.
 
 Docs: [https://pspas.pspete.dev](https://pspas.pspete.dev)
 
@@ -188,7 +188,7 @@ Get-PASSafeMember -SafeName 3_TestSafe_028_XYJ -MemberName ACC-G-3_TestSafe_028_
 
 UserName                     SafeName           Permissions
 --------                     --------           -----------
-ACC-G-3_TestSafe_028_XYJ-Usr 3_TestSafe_028_XYJ {UseAccounts, RetrieveAccounts, ListAccounts, ViewAuditLog…}
+ACC-G-3_TestSafe_028_XYJ-Usr 3_TestSafe_028_XYJ @{Add=True; AddRenameFolder=True; BackupSafe=True...}
 ````
 
 ##### Users
@@ -321,7 +321,7 @@ Add-PASSafeMember -SafeName NewSafe -MemberName NewMember -UseAccounts $false -L
 
 MemberName SearchIn SafeName Permissions
 ---------- -------- -------- -----------
-NewMember  vault    NewSafe  {ListAccounts, ViewAuditLog, ViewSafeMembers}
+NewMember  vault    NewSafe  @{Add=True; AddRenameFolder=True; BackupSafe=True...}
 ````
 
 ##### Update Accounts
@@ -432,12 +432,12 @@ Where-Object{ Get-PASGroup -search $_.UserName -filter 'groupType eq Directory' 
 
 UserName                     SafeName           Permissions
 --------                     --------           -----------
-ACC-G-1_TestSafe_049_JXW-Usr 1_TestSafe_049_JXW {ListContent, RestrictedRetrieve, Retrieve, ViewAudit…}
-ACC-G-1_TestSafe_049_JXW-Adm 1_TestSafe_049_JXW {ListContent, RestrictedRetrieve, Retrieve, Unlock…}
-ACC-G-2_TestSafe_049_JXW-Usr 2_TestSafe_049_JXW {ListContent, RestrictedRetrieve, Retrieve, ViewAudit…}
-ACC-G-2_TestSafe_049_JXW-Adm 2_TestSafe_049_JXW {ListContent, RestrictedRetrieve, Retrieve, Unlock…}
-ACC-G-3_TestSafe_049_JXW-Usr 3_TestSafe_049_JXW {ListContent, RestrictedRetrieve, Retrieve, ViewAudit…}
-ACC-G-3_TestSafe_049_JXW-Adm 3_TestSafe_049_JXW {ListContent, RestrictedRetrieve, Retrieve, Unlock…}
+ACC-G-1_TestSafe_049_JXW-Usr 1_TestSafe_049_JXW @{Add=True; AddRenameFolder=True; BackupSafe=True...}
+ACC-G-1_TestSafe_049_JXW-Adm 1_TestSafe_049_JXW @{Add=True; AddRenameFolder=True; BackupSafe=True...}
+ACC-G-2_TestSafe_049_JXW-Usr 2_TestSafe_049_JXW @{Add=True; AddRenameFolder=True; BackupSafe=True...}
+ACC-G-2_TestSafe_049_JXW-Adm 2_TestSafe_049_JXW @{Add=True; AddRenameFolder=True; BackupSafe=True...}
+ACC-G-3_TestSafe_049_JXW-Usr 3_TestSafe_049_JXW @{Add=True; AddRenameFolder=True; BackupSafe=True...}
+ACC-G-3_TestSafe_049_JXW-Adm 3_TestSafe_049_JXW @{Add=True; AddRenameFolder=True; BackupSafe=True...}
 ````
 
 - Multiple `psPAS` commands can be used together, along with standard PowerShell CmdLets:
@@ -451,20 +451,20 @@ Add-PASGroupMember -GroupName PVWAMonitor
 Get-PASAccount -id 330_5 | Get-PASSafe | Get-PASSafeMember
 
 UserName             SafeName    Permissions
---------             --------    -----------
-Master               ApproveTest {Add, AddRenameFolder, BackupSafe, Delete...}
-Batch                ApproveTest {Add, AddRenameFolder, BackupSafe, Delete...}
-Backup Users         ApproveTest BackupSafe
-Auditors             ApproveTest {ListContent, ViewAudit, ViewMembers}
-Operators            ApproveTest {AddRenameFolder, DeleteFolder, ManageSafe, MoveFilesAndFolders...}
-DR Users             ApproveTest BackupSafe
-Notification Engines ApproveTest {ListContent, ViewAudit, ViewMembers}
-PVWAGWAccounts       ApproveTest {ListContent, ViewAudit, ViewMembers}
-PasswordManager      ApproveTest {Add, AddRenameFolder, Delete, DeleteFolder...}
-SafeAdmin            ApproveTest {Add, AddRenameFolder, BackupSafe, Delete...}
-SafeAdmin1           ApproveTest {Add, AddRenameFolder, BackupSafe, Delete...}
-zApprover_1          ApproveTest {ListContent, ViewAudit, ViewMembers}
-xReq                 ApproveTest {ListContent, RestrictedRetrieve, Retrieve, ViewAudit...}
+--------             --------    ---------- -
+Master               ApproveTest @{Add=True; AddRenameFolder=True; BackupSafe=True...}
+Batch                ApproveTest @{Add=True; AddRenameFolder=True; BackupSafe=True...}
+Backup Users         ApproveTest @{Add=False; AddRenameFolder=False; BackupSafe=True...}
+Auditors             ApproveTest @{Add=False; AddRenameFolder=False; BackupSafe=False...}
+Operators            ApproveTest @{Add=True; AddRenameFolder=True; BackupSafe=True...}
+DR Users             ApproveTest @{Add=False; AddRenameFolder=False; BackupSafe=True...}
+Notification Engines ApproveTest @{Add=False; AddRenameFolder=False; BackupSafe=False...}
+PVWAGWAccounts       ApproveTest @{Add=False; AddRenameFolder=False; BackupSafe=False...}
+PasswordManager      ApproveTest @{Add=False; AddRenameFolder=True; BackupSafe=False...}
+SafeAdmin            ApproveTest @{Add=True; AddRenameFolder=True; BackupSafe=True...}
+SafeAdmin1           ApproveTest @{Add=True; AddRenameFolder=True; BackupSafe=True...}
+zApprover_1          ApproveTest @{Add=False; AddRenameFolder=False; BackupSafe=False...}
+xReq                 ApproveTest @{Add=False; AddRenameFolder=False; BackupSafe=False...}
 ````
 
 ### Advanced Examples
@@ -586,13 +586,13 @@ $Role1 | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn Vault
 
 MemberName SearchIn SafeName Permissions
 ---------- -------- -------- -----------
-User23     Vault    NewSafe  {UseAccounts, RetrieveAccounts, ListAccounts}
+User23     Vault    NewSafe  @{Add=False; AddRenameFolder=False; BackupSafe=False...}
 
 $Role2 | Add-PASSafeMember -SafeName NewSafe -MemberName SafeAdmin1 -SearchIn Vault
 
 MemberName SearchIn SafeName Permissions
 ---------- -------- -------- -----------
-SafeAdmin1 Vault    NewSafe  {ListAccounts, AddAccounts, UpdateAccountContent, UpdateAccountProperties…}
+SafeAdmin1 Vault    NewSafe  @{Add=True; AddRenameFolder=True; BackupSafe=True...}
 ````
 
 ![psPAS](docs/assets/images/shop_banner_symbol.png)
@@ -822,7 +822,8 @@ Check the output of `Get-Help` for the `psPAS` functions for further details of 
 [`Add-PASDirectory`][Add-PASDirectory]                                                   |**10.4**            |Add a new LDAP directory
 [`New-PASDirectoryMapping`][New-PASDirectoryMapping]                                     |**10.4**            |Create a new LDAP directory mapping
 [`Add-PASPTARule`][Add-PASPTARule]                                                       |**10.4**            |Add a new Risky Commandrule to PTA
-[`Get-PASPTAEvent`][Get-PASPTAEvent]                                                     |**10.3**            |Get security eventsfrom PTA
+[`Get-PASPTAEvent`][Get-PASPTAEvent]                                                     |**10.3**            |Get security events from PTA
+[`Set-PASPTAEvent`][Set-PASPTAEvent]                                                     |**11.3**            |Set PTA security event status
 [`Get-PASPTARemediation`][Get-PASPTARemediation]                                         |**10.4**            |Get automatic response config from PTA
 [`Get-PASPTARule`][Get-PASPTARule]                                                       |**10.4**            |List Risky Command rules from PTA
 [`Set-PASPTARemediation`][Set-PASPTARemediation]                                         |**10.4**            |Update automaticresponse config in PTA
@@ -838,8 +839,8 @@ Check the output of `Get-Help` for the `psPAS` functions for further details of 
 [`Get-PASPSMRecordingProperty`][Get-PASPSMRecordingProperty]                             |**10.6**            |Get property details from a PSM Recording.
 [`Export-PASPSMRecording`][Export-PASPSMRecording]                                       |**10.6**            |Save PSM Session Recording to a file.
 [`Request-PASAdHocAccess`][Request-PASAdHocAccess]                                       |**10.6**            |Request temporary access to a server.
-[`Get-PASDirectoryMapping`][Get-PASDirectoryMapping]                                     |**10.7**            |Get details of configureddirectory mappings.
-[`Set-PASDirectoryMapping`][Set-PASDirectoryMapping]                                     |**10.7**            |Update a configureddirectory mapping.
+[`Get-PASDirectoryMapping`][Get-PASDirectoryMapping]                                     |**10.7**            |Get details of configured directory mappings.
+[`Set-PASDirectoryMapping`][Set-PASDirectoryMapping]                                     |**10.7**            |Update a configured directory mapping.
 [`Remove-PASDirectory`][Remove-PASDirectory]                                             |**10.7**            |Delete a directory configuration.
 [`Find-PASSafe`][Find-PASSafe]                                                           |**10.1**            |List or Search Safes by name.
 [`Set-PASDirectoryMappingOrder`][Set-PASDirectoryMappingOrder]                           |**10.10**           |Reorder Directory Mappings
@@ -847,8 +848,8 @@ Check the output of `Get-Help` for the `psPAS` functions for further details of 
 [`New-PASGroup`][New-PASGroup]                                                           |**11.1**            |Create a new CyberArk group
 [`Get-PASPlatformSafe`][Get-PASPlatformSafe]                                             |**11.1**            |List details for all platforms
 [`Remove-PASDirectoryMapping`][Remove-PASDirectoryMapping]                               |**11.1**            |Deletes a Directory Mapping
-[`Enable-PASCPMAutoManagement`][Enable-PASCPMAutoManagement]                             |**10.4**            |Enables Automatic CPM Managment for an account
-[`Disable-PASCPMAutoManagement`][Disable-PASCPMAutoManagement]                           |**10.4**            |Disables Automatic CPM Managment for an account
+[`Enable-PASCPMAutoManagement`][Enable-PASCPMAutoManagement]                             |**10.4**            |Enables Automatic CPM Management for an account
+[`Disable-PASCPMAutoManagement`][Disable-PASCPMAutoManagement]                           |**10.4**            |Disables Automatic CPM Management for an account
 [`Test-PASPSMRecording`][Test-PASPSMRecording]                                           | **11.2**           |Determine validity of PSM Session Recording
 
 [New-PASSession]:/psPAS/Functions/Authentication/New-PASSession.ps1
@@ -928,6 +929,7 @@ Check the output of `Get-Help` for the `psPAS` functions for further details of 
 [New-PASDirectoryMapping]:/psPAS/Functions/LDAPDirectories/New-PASDirectoryMapping.ps1
 [Add-PASPTARule]:/psPAS/Functions/EventSecurity/Add-PASPTARule.ps1
 [Get-PASPTAEvent]:/psPAS/Functions/EventSecurity/Get-PASPTAEvent.ps1
+[Set-PASPTAEvent]:/psPAS/Functions/EventSecurity/Set-PASPTAEvent.ps1
 [Get-PASPTARemediation]:/psPAS/Functions/EventSecurity/Get-PASPTARemediation.ps1
 [Get-PASPTARule]:/psPAS/Functions/EventSecurity/Get-PASPTARule.ps1
 [Set-PASPTARemediation]:/psPAS/Functions/EventSecurity/Set-PASPTARemediation.ps1

--- a/Tests/Add-PASAccount.Tests.ps1
+++ b/Tests/Add-PASAccount.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Mandatory Parameters" {
 
@@ -46,33 +43,33 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Add-PASAccount).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Add-PASAccount).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 			It "specifies parameter userName as mandatory for ParameterSet V9" {
 
-				(Get-Command Add-PASAccount).Parameters["UserName"].ParameterSets["V9"].IsMandatory | Should be $true
+				(Get-Command Add-PASAccount).Parameters["UserName"].ParameterSets["V9"].IsMandatory | Should -Be $true
 
 			}
 			It "specifies parameter SafeName as mandatory for ParameterSet V9" {
 
-				(Get-Command Add-PASAccount).Parameters["SafeName"].ParameterSets["V9"].IsMandatory | Should be $true
+				(Get-Command Add-PASAccount).Parameters["SafeName"].ParameterSets["V9"].IsMandatory | Should -Be $true
 
 			}
 			It "specifies parameter SafeName as mandatory for ParameterSet V10" {
 
-				(Get-Command Add-PASAccount).Parameters["SafeName"].ParameterSets["V10"].IsMandatory | Should be $true
+				(Get-Command Add-PASAccount).Parameters["SafeName"].ParameterSets["V10"].IsMandatory | Should -Be $true
 
 			}
 			It "specifies parameter platformID as mandatory for ParameterSet V9" {
 
-				(Get-Command Add-PASAccount).Parameters["platformID"].ParameterSets["V9"].IsMandatory | Should be $true
+				(Get-Command Add-PASAccount).Parameters["platformID"].ParameterSets["V9"].IsMandatory | Should -Be $true
 
 			}
 			It "specifies parameter platformID as mandatory for ParameterSet V10" {
 
-				(Get-Command Add-PASAccount).Parameters["platformID"].ParameterSets["V10"].IsMandatory | Should be $true
+				(Get-Command Add-PASAccount).Parameters["platformID"].ParameterSets["V10"].IsMandatory | Should -Be $true
 
 			}
 
@@ -241,7 +238,7 @@ Describe $FunctionName {
 			It "throws error if version requirement not met" {
 
 				$Script:ExternalVersion = "1.0"
-				{ $InputObjV10 | Add-PASAccount } | Should Throw
+				{ $InputObjV10 | Add-PASAccount } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 
 			}
@@ -299,13 +296,13 @@ Describe $FunctionName {
 					"ExtraPass3Safe"        = "SomeSafe"
 				}
 				$response = $InputObj | Add-PASAccount
-				$response | Should BeNullOrEmpty
+				$response | Should -BeNullOrEmpty
 
 			}
 
 			it "provides output - V10 ParameterSet" {
 				$response = $InputObj | Add-PASAccount
-				$response | Should Not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
@@ -317,14 +314,16 @@ Describe $FunctionName {
 					}
 				}
 				$response = $InputObj | Add-PASAccount
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Account.V10
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Account.V10
 
 			}
 
 
 
 		}
-
+#>
 	}
+
+
 
 }

--- a/Tests/Add-PASAccountACL.Tests.ps1
+++ b/Tests/Add-PASAccountACL.Tests.ps1
@@ -1,44 +1,43 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
+		BeforeEach{
 
-		Mock Invoke-PASRestMethod -MockWith {
+			Mock Invoke-PASRestMethod -MockWith {
 			[pscustomobject]@{"AddAccountPrivilegedCommandResult" = [pscustomobject]@{"some" = "thing" } }
 
 		}
@@ -46,6 +45,10 @@ Describe $FunctionName {
 		$InputObj = [pscustomobject]@{
 			"AccountPolicyID" = "UNIXSSH"
 			"AccountAddress"  = "ServerA.domain.com"
+		}
+
+		$response = $InputObj | Add-PASAccountACL -AccountUserName "root" -Command 'some command' -CommandGroup $false -PermissionType Deny -UserName "TestUser"
+
 		}
 
 		Context "Mandatory Parameters" {
@@ -63,19 +66,17 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Add-PASAccountACL).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Add-PASAccountACL).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Add-PASAccountACL -AccountUserName "root" -Command 'some command' -CommandGroup $false -PermissionType Deny -UserName "TestUser"
-
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -85,13 +86,13 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Account/ServerA.domain.com|root|UNIXSSH/PrivilegedCommands"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PUT' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PUT' } -Times 1 -Exactly -Scope It
 
 			}
 
@@ -103,13 +104,13 @@ Describe $FunctionName {
 
 					($Script:RequestBody) -ne $null
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "has a request body with expected number of properties" {
 
-				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 4
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 4
 
 			}
 
@@ -119,19 +120,19 @@ Describe $FunctionName {
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 1
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.ACL.Account
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.ACL.Account
 
 			}
 

--- a/Tests/Add-PASAccountGroupMember.Tests.ps1
+++ b/Tests/Add-PASAccountGroupMember.Tests.ps1
@@ -1,51 +1,53 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
-
-}
-
-BeforeAll {
-
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
-
-}
-
-AfterAll {
-
-	$Script:RequestBody = $null
-
-}
-
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
-
-		Mock Invoke-PASRestMethod -MockWith {
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
 		}
 
-		$InputObj = [pscustomobject]@{
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-			"AccountID" = "99_9"
-			"GroupID"   = "88_8"
+	}
+
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+		BeforeEach{
+			Mock Invoke-PASRestMethod -MockWith {
+
+			}
+
+			$InputObj = [pscustomobject]@{
+
+				"AccountID" = "99_9"
+				"GroupID"   = "88_8"
+
+			}
+
+			$response = $InputObj | Add-PASAccountGroupMember
 
 		}
 
@@ -58,19 +60,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Add-PASAccountGroupMember).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Add-PASAccountGroupMember).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Add-PASAccountGroupMember
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -80,13 +82,13 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/API/AccountGroups/88_8/Members"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
@@ -98,20 +100,20 @@ Describe $FunctionName {
 
 					($Script:RequestBody) -ne $null
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "has a request body with expected number of properties" {
 
-				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 1
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
 			}
 
 			It "throws error if version requirement not met" {
 $Script:ExternalVersion = "1.0"
 				$Script:ExternalVersion = "1.0"
-				{ $InputObj | Add-PASAccountGroupMember } | Should Throw
+				{ $InputObj | Add-PASAccountGroupMember } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 
@@ -121,7 +123,7 @@ $Script:ExternalVersion = "1.0"
 
 			it "provides no output" {
 
-				$response | Should BeNullOrEmpty
+				$response | Should -BeNullOrEmpty
 
 			}
 

--- a/Tests/Add-PASApplicationAuthenticationMethod.Tests.ps1
+++ b/Tests/Add-PASApplicationAuthenticationMethod.Tests.ps1
@@ -1,43 +1,41 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 
 		}
@@ -47,7 +45,7 @@ Describe $FunctionName {
 			"AppID"        = "SomeApplication"
 
 		}
-
+}
 		Context "Mandatory Parameters" {
 
 			$Parameters = @{Parameter = 'AppID'},
@@ -61,17 +59,13 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Add-PASApplicationAuthenticationMethod).Parameters["$Parameter"].Attributes.Mandatory | Select-Object -Unique |  Should Be $true
+				(Get-Command Add-PASApplicationAuthenticationMethod).Parameters["$Parameter"].Attributes.Mandatory | Select-Object -Unique |  Should -Be $true
 
 			}
 
 		}
 
 		Context "Input" {
-
-			BeforeEach{
-
-			}
 
 			It "sends request" {
 				$InputObj | Add-PASApplicationAuthenticationMethod -path "SomePath" -IsFolder $true -AllowInternalScripts $true
@@ -191,7 +185,7 @@ Describe $FunctionName {
 
 				$response = $InputObj | Add-PASApplicationAuthenticationMethod -path "SomePath"  -IsFolder $true -AllowInternalScripts $true
 
-				$response | Should BeNullOrEmpty
+				$response | Should -BeNullOrEmpty
 
 			}
 

--- a/Tests/Add-PASDirectory.Tests.ps1
+++ b/Tests/Add-PASDirectory.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Mandatory Parameters" {
 
@@ -49,7 +46,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Add-PASDirectory).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Add-PASDirectory).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
@@ -112,14 +109,14 @@ Describe $FunctionName {
 
 			It "has a request body with expected number of properties" {
 
-				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 6
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 6
 
 			}
 
 			It "throws error if version requirement not met" {
 $Script:ExternalVersion = "1.0"
 				$Script:ExternalVersion = "1.0"
-				{ $InputObj | Add-PASDirectory } | Should Throw
+				{ $InputObj | Add-PASDirectory } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 
@@ -148,19 +145,19 @@ $Script:ExternalVersion = "1.0"
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 2
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Directory.Extended
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Directory.Extended
 
 			}
 

--- a/Tests/Add-PASDiscoveredAccount.Tests.ps1
+++ b/Tests/Add-PASDiscoveredAccount.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Mandatory Parameters" {
 
@@ -50,7 +47,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Add-PASDiscoveredAccount ).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Add-PASDiscoveredAccount ).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
@@ -123,7 +120,7 @@ Describe $FunctionName {
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "1.2"
 
-				{ $InputObj | Add-PASDiscoveredAccount } | Should throw
+				{ $InputObj | Add-PASDiscoveredAccount } | Should -Throw
 
 				$Script:ExternalVersion = "0.0"
 
@@ -201,7 +198,7 @@ Describe $FunctionName {
 
 			it "provides output" {
 				$response = $InputObj | Add-PASDiscoveredAccount
-				$response | Should Not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 

--- a/Tests/Add-PASGroupMember.Tests.ps1
+++ b/Tests/Add-PASGroupMember.Tests.ps1
@@ -1,43 +1,41 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 			Write-Output "Added"
 		}
@@ -55,7 +53,7 @@ Describe $FunctionName {
 			"groupId"    = "1234"
 
 		}
-
+}
 		Context "Mandatory Parameters" {
 
 			$Parameters = @{Parameter = 'GroupName' },
@@ -65,13 +63,11 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Add-PASGroupMember).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Add-PASGroupMember).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
-
-		#$response = $InputObj | Add-PASGroupMember
 
 		Context "Input" {
 
@@ -139,7 +135,7 @@ Describe $FunctionName {
 
 			It "has a request body with expected number of properties" {
 
-				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 1
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
 			}
 
@@ -159,7 +155,7 @@ Describe $FunctionName {
 
 			It "has a request body with expected number of properties - V10" {
 
-				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 3
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 3
 
 			}
 
@@ -168,7 +164,7 @@ $Script:ExternalVersion = "1.0"
 
 				$Script:ExternalVersion = "1.0"
 
-				{ $InputObjV10 | Add-PASGroupMember } | Should Throw
+				{ $InputObjV10 | Add-PASGroupMember } | Should -Throw
 
 				$Script:ExternalVersion = "0.0"
 
@@ -180,7 +176,7 @@ $Script:ExternalVersion = "1.0"
 
 			it "provides output" {
 				$response = $InputObj | Add-PASGroupMember
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 

--- a/Tests/Add-PASPTARule.Tests.ps1
+++ b/Tests/Add-PASPTARule.Tests.ps1
@@ -1,56 +1,62 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
-
-}
-
-BeforeAll {
-
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
-
-}
-
-AfterAll {
-
-	$Script:RequestBody = $null
-
-}
-
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
-
-		Mock Invoke-PASRestMethod -MockWith {
-			[PSCustomObject]@{"addsaferesult" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" } }
-		}
-
-		$InputObj = [pscustomobject]@{
-			"category"    = "KEYSTROKES"
-			"regex"       = "(.*)Some Pattern(.*)"
-			"score"       = 80
-			"description" = "Some String"
-			"response"    = "NONE"
-			"active"      = $true
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
 		}
+
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+	}
+
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+		BeforeEach{
+
+			Mock Invoke-PASRestMethod -MockWith {
+				[PSCustomObject]@{"addsaferesult" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" } }
+				$Script:ExternalVersion = "10.4"
+			}
+
+			$InputObj = [pscustomobject]@{
+				"category"    = "KEYSTROKES"
+				"regex"       = "(.*)Some Pattern(.*)"
+				"score"       = 80
+				"description" = "Some String"
+				"response"    = "NONE"
+				"active"      = $true
+
+			}
+
+			$response = $InputObj | Add-PASPTARule
+
+		}
+
+
 
 		Context "Mandatory Parameters" {
 
@@ -65,19 +71,17 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Add-PASPTARule).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Add-PASPTARule).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Add-PASPTARule
-
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -87,13 +91,13 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/API/pta/API/Settings/RiskyActivity/"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
@@ -105,22 +109,21 @@ Describe $FunctionName {
 
 					($Script:RequestBody) -ne $null
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "has a request body with expected number of properties" {
 
-				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 6
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 6
 
 			}
 
 			It "throws error if version requirement not met" {
-$Script:ExternalVersion = "1.0"
 
 				$Script:ExternalVersion = "1.0"
 
-				{ $InputObj | Add-PASPTARule } | Should Throw
+				{ $InputObj | Add-PASPTARule } | Should -Throw
 
 				$Script:ExternalVersion = "0.0"
 			}
@@ -131,19 +134,19 @@ $Script:ExternalVersion = "1.0"
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 1
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.PTA.Rule
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PTA.Rule
 
 			}
 

--- a/Tests/Add-PASPolicyACL.Tests.ps1
+++ b/Tests/Add-PASPolicyACL.Tests.ps1
@@ -1,51 +1,57 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
-
-}
-
-BeforeAll {
-
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
-
-}
-
-AfterAll {
-
-	$Script:RequestBody = $null
-
-}
-
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
-
-		Mock Invoke-PASRestMethod -MockWith {
-			[pscustomobject]@{"AddPolicyPrivilegedCommandResult" = [pscustomobject]@{"some" = "thing"}}
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
 		}
 
-		$InputObj = [pscustomobject]@{
-"PolicyID"     = "UNIXSSH"
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+	}
+
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+
+		BeforeEach{
+
+			Mock Invoke-PASRestMethod -MockWith {
+				[pscustomobject]@{"AddPolicyPrivilegedCommandResult" = [pscustomobject]@{"some" = "thing" } }
+
+			}
+
+			$InputObj = [pscustomobject]@{
+				"PolicyID" = "UNIXSSH"
+			}
+
+			$response = $InputObj | Add-PASPolicyACL -UserName "root" -Command 'some command' -CommandGroup $false -PermissionType Deny
+
+
 		}
+
 
 		Context "Mandatory Parameters" {
 
@@ -60,19 +66,18 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Add-PASPolicyACL).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Add-PASPolicyACL).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Add-PASPolicyACL -UserName "root" -Command 'some command' -CommandGroup $false -PermissionType Deny
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -82,13 +87,13 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Policy/UNIXSSH/PrivilegedCommands"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'PUT' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'PUT' } -Times 1 -Exactly -Scope It
 
 			}
 
@@ -100,13 +105,13 @@ Describe $FunctionName {
 
 					($Script:RequestBody) -ne $null
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "has a request body with expected number of properties" {
 
-				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 4
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 4
 
 			}
 
@@ -116,19 +121,19 @@ Describe $FunctionName {
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 1
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.ACL.Policy
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.ACL.Policy
 
 			}
 

--- a/Tests/Add-PASPublicSSHKey.Tests.ps1
+++ b/Tests/Add-PASPublicSSHKey.Tests.ps1
@@ -1,51 +1,56 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
-
-}
-
-BeforeAll {
-
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
-
-}
-
-AfterAll {
-
-	$Script:RequestBody = $null
-
-}
-
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
-
-		Mock Invoke-PASRestMethod -MockWith {
-			[PSCustomObject]@{"AddUserAuthorizedKeyResult" = [PSCustomObject]@{"PublicSSHKey" = "SomeSSHKey" } }
-		}
-
-		$InputObj = [pscustomobject]@{
-			"UserName" = "SomeUser"
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
 		}
+
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+	}
+
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+		BeforeEach {
+
+			Mock Invoke-PASRestMethod -MockWith {
+				[PSCustomObject]@{"AddUserAuthorizedKeyResult" = [PSCustomObject]@{"PublicSSHKey" = "SomeSSHKey" } }
+			}
+
+			$InputObj = [pscustomobject]@{
+				"UserName" = "SomeUser"
+
+			}
+
+			$response = $InputObj | Add-PASPublicSSHKey -PublicSSHKey "SomeSSHKey"
+
+		}
+
+
 
 		Context "Mandatory Parameters" {
 
@@ -56,18 +61,18 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Add-PASPublicSSHKey).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Add-PASPublicSSHKey).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Add-PASPublicSSHKey -PublicSSHKey "SomeSSHKey"
+
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -77,13 +82,13 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/SomeUser/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
@@ -95,13 +100,13 @@ Describe $FunctionName {
 
 					($Script:RequestBody.PublicSSHKey) -ne $null
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "has a request body with expected number of properties" {
 
-				($Script:RequestBody.PublicSSHKey).count | Should Be 1
+				($Script:RequestBody.PublicSSHKey).count | Should -Be 1
 
 			}
 
@@ -111,19 +116,19 @@ Describe $FunctionName {
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 2
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.PublicSSHKey
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PublicSSHKey
 
 			}
 
@@ -131,7 +136,7 @@ Describe $FunctionName {
 
 			It "returns expected UserName property in response" {
 
-				$response.UserName | Should Be "SomeUser"
+				$response.UserName | Should -Be "SomeUser"
 
 			}
 

--- a/Tests/Add-PASSafe.Tests.ps1
+++ b/Tests/Add-PASSafe.Tests.ps1
@@ -1,49 +1,52 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
-
-BeforeAll {
-
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
-
-}
-
-AfterAll {
-
-	$Script:RequestBody = $null
-
-}
-
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
-
-		Mock Invoke-PASRestMethod -MockWith {
-			[PSCustomObject]@{"addsaferesult" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2"}}
 		}
 
-		$InputObj = [pscustomobject]@{
-"SafeName"     = "SomeName"
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+	}
+
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+		BeforeEach{
+
+			Mock Invoke-PASRestMethod -MockWith {
+				[PSCustomObject]@{"addsaferesult" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2"}}
+			}
+
+			$InputObj = [pscustomobject]@{
+				"SafeName"     = "SomeName"
+
+			}
+
+			$response = $InputObj | Add-PASSafe -NumberOfDaysRetention 1
 
 		}
 
@@ -55,31 +58,29 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Add-PASSafe).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Add-PASSafe).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 			It "specifies parameter NumberOfVersionsRetention as mandatory for ParameterSet Versions" {
 
-				(Get-Command Add-PASSafe).Parameters["NumberOfVersionsRetention"].ParameterSets["Versions"].IsMandatory | Should be $true
+				(Get-Command Add-PASSafe).Parameters["NumberOfVersionsRetention"].ParameterSets["Versions"].IsMandatory | Should -Be $true
 
 			}
 
 			It "specifies parameter NumberOfDaysRetention as mandatory for ParameterSet Days" {
 
-				(Get-Command Add-PASSafe).Parameters["NumberOfDaysRetention"].ParameterSets["Days"].IsMandatory | Should be $true
+				(Get-Command Add-PASSafe).Parameters["NumberOfDaysRetention"].ParameterSets["Days"].IsMandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Add-PASSafe -NumberOfDaysRetention 1
-
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -89,13 +90,13 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Safes"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
@@ -107,13 +108,13 @@ Describe $FunctionName {
 
 					($Script:RequestBody.safe) -ne $null
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "has a request body with expected number of properties" {
 
-				($Script:RequestBody.safe | Get-Member -MemberType NoteProperty).length | Should Be 2
+				($Script:RequestBody.safe | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
@@ -123,19 +124,19 @@ Describe $FunctionName {
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 2
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Safe
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Safe
 
 			}
 

--- a/Tests/Add-PASSafeMember.Tests.ps1
+++ b/Tests/Add-PASSafeMember.Tests.ps1
@@ -68,6 +68,10 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 						[pscustomobject]@{
 							"Key"   = "AnotherFalseKey"
 							"Value" = $false
+						},
+						[pscustomobject]@{
+							"Key"   = "IntegerKey"
+							"Value" = 1
 						}
 
 
@@ -195,9 +199,30 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has expected number of nested properties" {
+			It "has expected number of nested permission properties" {
 
-				($response.permissions).count | Should -Be 4
+				($response.permissions | Get-Member -MemberType NoteProperty).count | Should -Be 7
+
+			}
+
+			It "has expected boolean false property value" {
+
+				$response.permissions.FalseKey | Should -Be $False
+
+
+			}
+
+			It "has expected boolean true property value" {
+
+
+				$response.permissions.TrueKey | Should -Be $True
+
+			}
+
+			It "has expected integer property value" {
+
+
+				$response.permissions.IntegerKey | Should -Be 1
 
 			}
 

--- a/Tests/Add-PASSafeMember.Tests.ps1
+++ b/Tests/Add-PASSafeMember.Tests.ps1
@@ -1,42 +1,42 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
+
+		BeforeEach{
 
 		Mock Invoke-PASRestMethod -MockWith {
 			[PSCustomObject]@{
@@ -106,6 +106,8 @@ Describe $FunctionName {
 
 		}
 
+			$response = $InputObj | Add-PASSafeMember -MembershipExpirationDate "12/31/18"
+	}
 		Context "Mandatory Parameters" {
 
 			$Parameters = @{Parameter = 'SafeName' },
@@ -115,19 +117,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Add-PASSafeMember).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Add-PASSafeMember).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Add-PASSafeMember -MembershipExpirationDate "12/31/18"
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -137,13 +139,13 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Safes/SomeSafe/Members"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
@@ -155,25 +157,25 @@ Describe $FunctionName {
 
 					($Script:RequestBody.member) -ne $null
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "has a request body with expected number of properties" {
 
-				($Script:RequestBody.member | Get-Member -MemberType NoteProperty).length | Should Be 4
+				($Script:RequestBody.member | Get-Member -MemberType NoteProperty).length | Should -Be 4
 
 			}
 
 			It "has expected number of nested properties" {
 
-				($Script:RequestBody.member.permissions).Count | Should Be 21
+				($Script:RequestBody.member.permissions).Count | Should -Be 21
 
 			}
 
 			It "throws if invalid date pattern specified" {
 
-				{ $InputObj | Add-PASSafeMember -MembershipExpirationDate "31/12/18" } | Should throw
+				{ $InputObj | Add-PASSafeMember -MembershipExpirationDate "31/12/18" } | Should -Throw
 
 			}
 
@@ -183,25 +185,25 @@ Describe $FunctionName {
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 5
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 5
 
 			}
 
 			It "has expected number of nested properties" {
 
-				($response.permissions).count | Should Be 4
+				($response.permissions).count | Should -Be 4
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Safe.Member.Extended
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Safe.Member.Extended
 
 			}
 

--- a/Tests/Approve-PASRequest.Tests.ps1
+++ b/Tests/Approve-PASRequest.Tests.ps1
@@ -1,52 +1,56 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
-
-}
-
-BeforeAll {
-
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
-
-}
-
-AfterAll {
-
-	$Script:RequestBody = $null
-
-}
-
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
-
-		Mock Invoke-PASRestMethod -MockWith {
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
 		}
 
-		$InputObj = [pscustomobject]@{
-			"RequestID" = "24_68"
-			"Reason"    = "Some Reason"
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
+	}
+
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+		BeforeEach{
+			$InputObj = [pscustomobject]@{
+				"RequestID" = "24_68"
+				"Reason"    = "Some Reason"
+
+			}
+
+				Mock Invoke-PASRestMethod -MockWith {
+
+			}
+			$Script:ExternalVersion = "9.10"
+			$response = $InputObj | Approve-PASRequest
 		}
+
+
+
 
 		Context "Mandatory Parameters" {
 
@@ -56,19 +60,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Approve-PASRequest).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Approve-PASRequest).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Approve-PASRequest
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -78,13 +82,13 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/API/IncomingRequests/24_68/Confirm"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
@@ -96,20 +100,20 @@ Describe $FunctionName {
 
 					($Script:RequestBody) -ne $null
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "has a request body with expected number of properties" {
 
-				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 1
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
 			}
 
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "1.0"
-				{ $InputObj | Approve-PASRequest  } | Should Throw
-$Script:ExternalVersion = "0.0"
+				{ $InputObj | Approve-PASRequest  } | Should -Throw
+				$Script:ExternalVersion = "0.0"
 			}
 
 		}
@@ -118,7 +122,7 @@ $Script:ExternalVersion = "0.0"
 
 			it "provides no output" {
 
-				$response | Should BeNullOrEmpty
+				$response | Should -BeNullOrEmpty
 
 			}
 

--- a/Tests/Assert-VersionRequirement.Tests.ps1
+++ b/Tests/Assert-VersionRequirement.Tests.ps1
@@ -1,36 +1,48 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repo Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-Describe $FunctionName {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	InModuleScope $ModuleName {
+	}
+
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context 'Minimum Version Met' {
 
 			It 'returns nothing if version requirment is satisfied' {
-				Assert-VersionRequirement -ExternalVersion "0.2" -RequiredVersion "0.1" | Should BeNullOrEmpty
+				Assert-VersionRequirement -ExternalVersion "0.2" -RequiredVersion "0.1" | Should -BeNullOrEmpty
 			}
 
 			It 'does not throw if version requirment is satisfied' {
-				{Assert-VersionRequirement -ExternalVersion "0.2" -RequiredVersion "0.1"} | Should Not Throw
+				{Assert-VersionRequirement -ExternalVersion "0.2" -RequiredVersion "0.1"} | Should -Not -Throw
 			}
 
 		}
@@ -38,17 +50,18 @@ Describe $FunctionName {
 		Context 'Version Check Skipped' {
 
 			It 'returns nothing if external version is "0.0"' {
-				Assert-VersionRequirement -ExternalVersion "0.0" -RequiredVersion "9.9" | Should BeNullOrEmpty
+				Assert-VersionRequirement -ExternalVersion "0.0" -RequiredVersion "9.9" | Should -BeNullOrEmpty
 			}
 
 			It 'does not throw if external version is "0.0"' {
-				{Assert-VersionRequirement -ExternalVersion "0.0" -RequiredVersion "1.1"} | Should Not Throw
+				{Assert-VersionRequirement -ExternalVersion "0.0" -RequiredVersion "1.1"} | Should -Not -Throw
 			}
 
 		}
 
 		Context 'Minimum Version Not Met' {
 
+			BeforeEach{
 			Mock Get-ParentFunction -MockWith {
 				[PSCustomObject]@{
 					FunctionName     = "SomeFunction"
@@ -56,9 +69,9 @@ Describe $FunctionName {
 				}
 			}
 			Function Test-Failure {Assert-VersionRequirement -ExternalVersion "1.1" -RequiredVersion "2.0"}
-
+}
 			It 'throws error if external version is less than required version' {
-				{Test-Failure} | should Throw
+				{Test-Failure} | Should -Throw
 			}
 
 			It 'throws expected error if no custom parameterset has been used in the parent function' {
@@ -70,7 +83,7 @@ Describe $FunctionName {
 					}
 				}
 
-				{Test-Failure} | should Throw "CyberArk 1.1 does not meet the minimum version requirement of 2.0 for Test-Example (using ParameterSet: __AllParameterSets)"
+				{Test-Failure} | Should -Throw "CyberArk 1.1 does not meet the minimum version requirement of 2.0 for Test-Example (using ParameterSet: __AllParameterSets)"
 			}
 
 			It 'throws expected error if a custom parameterset has been used in the parent function' {
@@ -80,7 +93,7 @@ Describe $FunctionName {
 						ParameterSetName = "SomeParamSet"
 					}
 				}
-				{Test-Failure} | should Throw "CyberArk 1.1 does not meet the minimum version requirement of 2.0 for Test-Example (using ParameterSet: SomeParamSet)"
+				{Test-Failure} | Should -Throw "CyberArk 1.1 does not meet the minimum version requirement of 2.0 for Test-Example (using ParameterSet: SomeParamSet)"
 			}
 		}
 

--- a/Tests/Close-PASSession.Tests.ps1
+++ b/Tests/Close-PASSession.Tests.ps1
@@ -1,58 +1,58 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
-
-}
-
-BeforeAll {
-
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
-
-}
-
-AfterAll {
-
-	$Script:RequestBody = $null
-
-}
-
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
-
-		Mock Invoke-PASRestMethod -MockWith {
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
 		}
 
-		Mock Clear-Variable -MockWith {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+	}
+
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+		BeforeEach{
+				Mock Invoke-PASRestMethod -MockWith {
+
+			}
+
+			Mock Clear-Variable -MockWith {
+
+			}
+
+			$response = Close-PASSession -UseClassicAPI -verbose
 
 		}
-
-		$response = Close-PASSession -UseClassicAPI -verbose
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -62,19 +62,19 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/auth/Cyberark/CyberArkAuthenticationService.svc/Logoff"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
@@ -117,7 +117,7 @@ Describe $FunctionName {
 
 			it "provides no output" {
 
-				$response | Should BeNullOrEmpty
+				$response | Should -BeNullOrEmpty
 
 			}
 

--- a/Tests/Compare-MinimumVersion.Tests.ps1
+++ b/Tests/Compare-MinimumVersion.Tests.ps1
@@ -1,39 +1,51 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repo Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-Describe $FunctionName {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	InModuleScope $ModuleName {
+	}
+
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		It 'returns TRUE if version is greater than minimum version' {
-			Compare-MinimumVersion -Version "9.8.0" -MinimumVersion "8.9.0" | Should Be $true
+			Compare-MinimumVersion -Version "9.8.0" -MinimumVersion "8.9.0" | Should -Be $true
 		}
 
 		It 'returns FALSE if version is less than minimum version' {
-			Compare-MinimumVersion -Version "9.8.0" -MinimumVersion "9.9.0" | Should Be $false
+			Compare-MinimumVersion -Version "9.8.0" -MinimumVersion "9.9.0" | Should -Be $false
 		}
 
 		It 'returns TRUE if version is 0.0' {
 
-			Compare-MinimumVersion -Version "0.0" -MinimumVersion "1.1.0" | Should Be $true
+			Compare-MinimumVersion -Version "0.0" -MinimumVersion "1.1.0" | Should -Be $true
 
 		}
 

--- a/Tests/Connect-PASPSMSession.Tests.ps1
+++ b/Tests/Connect-PASPSMSession.Tests.ps1
@@ -1,41 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-
-}
-
-AfterAll {
-
-	$Script:RequestBody = $null
-
-}
-
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	}
 
 
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Mandatory Parameters" {
 
@@ -46,7 +44,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Connect-PASPSMSession).Parameters["$Parameter"].Attributes.Mandatory | Select-Object -Unique | Should Be $true
+				(Get-Command Connect-PASPSMSession).Parameters["$Parameter"].Attributes.Mandatory | Select-Object -Unique | Should -Be $true
 
 			}
 
@@ -130,7 +128,7 @@ Describe $FunctionName {
 
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "9.8"
-				{ $InputObj | Connect-PASPSMSession -ConnectionMethod RDP } | Should Throw
+				{ $InputObj | Connect-PASPSMSession -ConnectionMethod RDP } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 
@@ -160,19 +158,19 @@ Describe $FunctionName {
 
 			it "provides output" {
 
-				$InputObj | Connect-PASPSMSession | Should not BeNullOrEmpty
+				$InputObj | Connect-PASPSMSession | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($InputObj | Connect-PASPSMSession | Get-Member -MemberType NoteProperty).length | Should Be 3
+				($InputObj | Connect-PASPSMSession | Get-Member -MemberType NoteProperty).length | Should -Be 3
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$InputObj | Connect-PASPSMSession | get-member | select-object -expandproperty typename -Unique | Should Be System.Management.Automation.PSCustomObject
+				$InputObj | Connect-PASPSMSession | get-member | select-object -expandproperty typename -Unique | Should -Be System.Management.Automation.PSCustomObject
 
 			}
 

--- a/Tests/ConvertTo-InsecureString.Tests.ps1
+++ b/Tests/ConvertTo-InsecureString.Tests.ps1
@@ -1,39 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	#$Script:RequestBody = $null
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	#$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Mandatory Parameters" {
 
@@ -43,7 +43,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command ConvertTo-InsecureString).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command ConvertTo-InsecureString).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
@@ -61,7 +61,7 @@ Describe $FunctionName {
 
 			It "converts securestring to plaintext" {
 
-				ConvertTo-InsecureString -SecureString $InputObj.SecureString| Should Be "SomeSecureString"
+				ConvertTo-InsecureString -SecureString $InputObj.SecureString| Should -Be "SomeSecureString"
 
 			}
 

--- a/Tests/Disable-PASCPMAutoManagement.Tests.ps1
+++ b/Tests/Disable-PASCPMAutoManagement.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Mandatory Parameters" {
 
@@ -46,7 +43,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Enable-PASCPMAutoManagement).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Enable-PASCPMAutoManagement).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
@@ -76,7 +73,7 @@ Describe $FunctionName {
 
 				$Script:ExternalVersion = "1.2"
 
-				{ $InputObj | Disable-PASCPMAutoManagement } | Should throw
+				{ $InputObj | Disable-PASCPMAutoManagement } | Should -Throw
 
 				$Script:ExternalVersion = "0.0"
 

--- a/Tests/Enable-PASCPMAutoManagement.Tests.ps1
+++ b/Tests/Enable-PASCPMAutoManagement.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Mandatory Parameters" {
 
@@ -46,7 +43,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Enable-PASCPMAutoManagement).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Enable-PASCPMAutoManagement).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
@@ -74,7 +71,7 @@ Describe $FunctionName {
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "1.2"
 
-				{ $InputObj | Enable-PASCPMAutoManagement } | Should throw
+				{ $InputObj | Enable-PASCPMAutoManagement } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 

--- a/Tests/Export-PASPSMRecording.Tests.ps1
+++ b/Tests/Export-PASPSMRecording.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Mandatory Parameters" {
 
@@ -47,7 +44,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Export-PASPSMRecording).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Export-PASPSMRecording).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
@@ -75,7 +72,7 @@ Describe $FunctionName {
 			}
 
 			It "throws if path is invalid" {
-				{ $InputObj | Export-PASPSMRecording -PlatformID SomePlatform -path A:\test.avi } | Should throw
+				{ $InputObj | Export-PASPSMRecording -PlatformID SomePlatform -path A:\test.avi } | Should -Throw
 			}
 
 			It "throws if InputFile resolves to a file" {
@@ -86,7 +83,7 @@ Describe $FunctionName {
 
 				}
 
-				{ $InputObj | Export-PASPSMRecording -PlatformID SomePlatform -path $pwd } | Should throw
+				{ $InputObj | Export-PASPSMRecording -PlatformID SomePlatform -path $pwd } | Should -Throw
 			}
 
 			It "sends request" {
@@ -120,7 +117,7 @@ Describe $FunctionName {
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "10.5"
 
-				{ $InputObj | Export-PASPSMRecording } | Should throw
+				{ $InputObj | Export-PASPSMRecording } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 

--- a/Tests/Find-PASSafe.Tests.ps1
+++ b/Tests/Find-PASSafe.Tests.ps1
@@ -1,40 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
+	}
 
 
-}
+	AfterAll {
 
-AfterAll {
+		$Script:RequestBody = $null
 
-	$Script:RequestBody = $null
+	}
 
-}
-
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Input" {
 
@@ -94,7 +93,7 @@ Describe $FunctionName {
 
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "1.0"
-				{ Find-PASSafe } | Should Throw
+				{ Find-PASSafe } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 
@@ -146,13 +145,13 @@ Describe $FunctionName {
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 2
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
@@ -173,7 +172,7 @@ Describe $FunctionName {
 
 				$response = Find-PASSafe
 
-				$response.count | Should be 20
+				$response.count | Should -Be 20
 
 			}
 

--- a/Tests/Get-EscapedString.Tests.ps1
+++ b/Tests/Get-EscapedString.Tests.ps1
@@ -1,37 +1,49 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repo Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-Describe $FunctionName {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	InModuleScope $ModuleName {
+	}
+
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		It 'outputs a string' {
 
-			"+ & %" | Get-EscapedString | Should BeOfType System.String
+			"+ & %" | Get-EscapedString | Should -BeOfType System.String
 
 		}
 
 		It 'outputs an escaped string' {
 
-			"+ & %" | Get-EscapedString | Should BeExactly "%2B%20%26%20%25"
+			"+ & %" | Get-EscapedString | Should -BeExactly "%2B%20%26%20%25"
 
 		}
 

--- a/Tests/Get-PASAccount.Tests.ps1
+++ b/Tests/Get-PASAccount.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repo Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Request Input" {
 
@@ -125,7 +122,7 @@ Describe $FunctionName {
 
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "1.0"
-				{ Get-PASAccount -ID "SomeID" } | Should Throw
+				{ Get-PASAccount -ID "SomeID" } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 
@@ -216,7 +213,7 @@ Describe $FunctionName {
 
 			It "provides output - legacy parameterset" {
 				$response = Get-PASAccount -Keywords SomeValue -Safe SomeSafe -WarningAction SilentlyContinue
-				$response | Should not be null
+				$response | Should -Not -Be Null
 
 			}
 
@@ -228,7 +225,7 @@ Describe $FunctionName {
 					}
 				}
 				$response = Get-PASAccount -id "SomeID"
-				$response | Should not be null
+				$response | Should -not -be null
 
 			}
 
@@ -240,7 +237,7 @@ Describe $FunctionName {
 					}
 				}
 				$response = Get-PASAccount -search SomeSearchTerm
-				$response | Should not be null
+				$response | Should -not -be null
 
 			}
 
@@ -269,13 +266,13 @@ Describe $FunctionName {
 
 			It "has output with expected number of properties - legacy parameterset" {
 				$response = Get-PASAccount -Keywords SomeValue -Safe SomeSafe -WarningAction SilentlyContinue
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 11
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 11
 
 			}
 
 			It "outputs object with expected typename - legacy parameterset" {
 				$response = Get-PASAccount -Keywords SomeValue -Safe SomeSafe -WarningAction SilentlyContinue
-				$response | Get-Member | Select-Object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Account
+				$response | Get-Member | Select-Object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Account
 
 			}
 
@@ -287,13 +284,13 @@ Describe $FunctionName {
 					}
 				}
 				$response = Get-PASAccount -search SomeSearch
-				$response | Get-Member | Select-Object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Account.V10
+				$response | Get-Member | Select-Object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Account.V10
 
 			}
 
 			It "writes warning that more than 1 account returned from the search - legacy parameterset" {
 				$response = Get-PASAccount -Keywords SomeValue -Safe SomeSafe -WarningVariable warning -WarningAction SilentlyContinue
-				$warning | Should be "30 matching accounts found. Only the first result will be returned"
+				$warning | Should -Be "30 matching accounts found. Only the first result will be returned"
 
 			}
 

--- a/Tests/Get-PASAccountACL.Tests.ps1
+++ b/Tests/Get-PASAccountACL.Tests.ps1
@@ -1,53 +1,57 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
-
-}
-
-BeforeAll {
-
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
-
-}
-
-AfterAll {
-
-	$Script:RequestBody = $null
-
-}
-
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
-
-		Mock Invoke-PASRestMethod -MockWith {
-			[pscustomobject]@{"ListAccountPrivilegedCommandsResult" = [pscustomobject]@{"some" = "thing"; "other" = "thing"}}
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
 		}
 
-		$InputObj = [pscustomobject]@{
-			"AccountPolicyID" = "UNIXSSH"
-			"AccountAddress"  = "ServerA.domain.com"
-			"AccountUserName" = "root"
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+	}
+
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+		BeforeEach{
+
+			Mock Invoke-PASRestMethod -MockWith {
+				[pscustomobject]@{"ListAccountPrivilegedCommandsResult" = [pscustomobject]@{"some" = "thing"; "other" = "thing" } }
+
+			}
+
+			$InputObj = [pscustomobject]@{
+				"AccountPolicyID" = "UNIXSSH"
+				"AccountAddress"  = "ServerA.domain.com"
+				"AccountUserName" = "root"
+			}
+
+			$response = $InputObj | Get-PASAccountACL
 		}
+
+
 
 		Context "Mandatory Parameters" {
 
@@ -60,19 +64,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Get-PASAccountACL).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Get-PASAccountACL).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Get-PASAccountACL
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -82,19 +86,19 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Account/ServerA.domain.com|root|UNIXSSH/PrivilegedCommands"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
 
 			}
 
@@ -104,19 +108,19 @@ Describe $FunctionName {
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 2
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.ACL.Account
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.ACL.Account
 
 			}
 

--- a/Tests/Get-PASAccountActivity.Tests.ps1
+++ b/Tests/Get-PASAccountActivity.Tests.ps1
@@ -1,55 +1,57 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
-
-BeforeAll {
-
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
-
-}
-
-AfterAll {
-
-	$Script:RequestBody = $null
-
-}
-
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
-
-		Mock Invoke-PASRestMethod -MockWith {
-			[pscustomobject]@{"GetAccountActivitiesResult" = [pscustomobject]@{
-					"prop1" = "val1"
-					"prop2" = "val2"
-					"prop3" = "val3"
-				}
-			}
 		}
 
-		$InputObj = [pscustomobject]@{
-			"AccountID" = "66_6"
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
+	}
+
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+		BeforeEach{
+
+			Mock Invoke-PASRestMethod -MockWith {
+				[pscustomobject]@{"GetAccountActivitiesResult" = [pscustomobject]@{
+						"prop1" = "val1"
+						"prop2" = "val2"
+						"prop3" = "val3"
+					}
+				}
+			}
+
+			$InputObj = [pscustomobject]@{
+				"AccountID" = "66_6"
+
+			}
+
+			$response = $InputObj | Get-PASAccountActivity -verbose
 		}
 
 		Context "Mandatory Parameters" {
@@ -60,19 +62,21 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Get-PASAccountActivity).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Get-PASAccountActivity).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
+
+
 		}
 
-		$response = $InputObj | Get-PASAccountActivity -verbose
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -82,19 +86,19 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Accounts/66_6/Activities"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
@@ -104,19 +108,19 @@ Describe $FunctionName {
 
 			it "provides output" {
 
-				$response | Should not be null
+				$response | Should -not -be null
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 3
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 3
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Account.Activity
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Account.Activity
 
 			}
 

--- a/Tests/Get-PASAccountGroupMember.Tests.ps1
+++ b/Tests/Get-PASAccountGroupMember.Tests.ps1
@@ -1,51 +1,54 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
-
-}
-
-BeforeAll {
-
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
-
-}
-
-AfterAll {
-
-	$Script:RequestBody = $null
-
-}
-
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
-
-		Mock Invoke-PASRestMethod -MockWith {
-			[pscustomobject]@{"Prop1" = "Val1"}
-		}
-
-		$InputObj = [pscustomobject]@{
-"GroupID"      = "32_1"
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
 		}
+
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+	}
+
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+		BeforeEach{
+
+			Mock Invoke-PASRestMethod -MockWith {
+				[pscustomobject]@{"Prop1" = "Val1" }
+			}
+
+			$InputObj = [pscustomobject]@{
+				"GroupID" = "32_1"
+
+			}
+
+			$response = $InputObj | Get-PASAccountGroupMember -verbose
+		}
+
 
 		Context "Mandatory Parameters" {
 
@@ -55,19 +58,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Get-PASAccountGroupMember).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Get-PASAccountGroupMember).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Get-PASAccountGroupMember -verbose
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -77,25 +80,25 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/API/AccountGroups/32_1/Members"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "throws error if version requirement not met" {
 $Script:ExternalVersion = "1.0"
-				{$InputObj | Get-PASAccountGroupMember } | Should Throw
+				{$InputObj | Get-PASAccountGroupMember } | Should -Throw
 $Script:ExternalVersion = "0.0"
 			}
 
@@ -105,19 +108,19 @@ $Script:ExternalVersion = "0.0"
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 1
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Account.Group.Member
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Account.Group.Member
 
 			}
 

--- a/Tests/Get-PASAccountPassword.Tests.ps1
+++ b/Tests/Get-PASAccountPassword.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Standard Operation" {
 

--- a/Tests/Get-PASApplication.Tests.ps1
+++ b/Tests/Get-PASApplication.Tests.ps1
@@ -1,59 +1,62 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
-
-}
-
-BeforeAll {
-
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
-
-}
-
-AfterAll {
-
-	$Script:RequestBody = $null
-
-}
-
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
-
-		Mock Invoke-PASRestMethod -MockWith {
-			[PSCustomObject]@{"application" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" } }
-		}
-
-		$InputObj = [pscustomobject]@{
-			"AppID" = "SomeApplication"
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
 		}
 
-		$response = $InputObj | Get-PASApplication -ExactMatch
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+	}
+
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+		BeforeEach{
+
+			Mock Invoke-PASRestMethod -MockWith {
+				[PSCustomObject]@{"application" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" } }
+			}
+
+			$InputObj = [pscustomobject]@{
+				"AppID" = "SomeApplication"
+
+			}
+
+			$response = $InputObj | Get-PASApplication -ExactMatch
+
+
+		}
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -63,19 +66,19 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Applications/SomeApplication"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
@@ -95,19 +98,19 @@ Describe $FunctionName {
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 2
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Application
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Application
 
 			}
 

--- a/Tests/Get-PASApplicationAuthenticationMethod.Tests.ps1
+++ b/Tests/Get-PASApplicationAuthenticationMethod.Tests.ps1
@@ -1,51 +1,56 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
-
-}
-
-BeforeAll {
-
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
-
-}
-
-AfterAll {
-
-	$Script:RequestBody = $null
-
-}
-
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
-
-		Mock Invoke-PASRestMethod -MockWith {
-			[PSCustomObject]@{"authentication" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2"}}
-		}
-
-		$InputObj = [pscustomobject]@{
-"AppID"        = "SomeApplication"
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
 		}
+
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+	}
+
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+		BeforeEach{
+
+			Mock Invoke-PASRestMethod -MockWith {
+				[PSCustomObject]@{"authentication" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" } }
+			}
+
+			$InputObj = [pscustomobject]@{
+				"AppID" = "SomeApplication"
+
+			}
+
+			$response = $InputObj | Get-PASApplicationAuthenticationMethod
+
+		}
+
+
 
 		Context "Mandatory Parameters" {
 
@@ -55,19 +60,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Get-PASApplicationAuthenticationMethod).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Get-PASApplicationAuthenticationMethod).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Get-PASApplicationAuthenticationMethod
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -77,19 +82,19 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Applications/SomeApplication/Authentications"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
 
 			}
 
@@ -99,19 +104,19 @@ Describe $FunctionName {
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 2
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.ApplicationAuth
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.ApplicationAuth
 
 			}
 

--- a/Tests/Get-PASComponentDetail.Tests.ps1
+++ b/Tests/Get-PASComponentDetail.Tests.ps1
@@ -1,46 +1,49 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
-
-BeforeAll {
-
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
-
-}
-
-AfterAll {
-
-	$Script:RequestBody = $null
-
-}
-
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
-
-		Mock Invoke-PASRestMethod -MockWith {
-			[PSCustomObject]@{"ComponentsDetails" = [PSCustomObject]@{"SomeProp" = "SomValue"; "OtherProp" = "OtherValue" } }
 		}
+
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+	}
+
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+		BeforeEach{
+			Mock Invoke-PASRestMethod -MockWith {
+				[PSCustomObject]@{"ComponentsDetails" = [PSCustomObject]@{"SomeProp" = "SomValue"; "OtherProp" = "OtherValue" }}
+
+		}
+
+			$response = Get-PASComponentDetail -ComponentID PVWA
+	}
+
 
 		Context "Mandatory Parameters" {
 
@@ -50,19 +53,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Get-PASComponentDetail).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Get-PASComponentDetail).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = Get-PASComponentDetail -ComponentID PVWA
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -72,26 +75,26 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/api/ComponentsMonitoringDetails/PVWA"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "throws error if version requirement not met" {
-$Script:ExternalVersion = "1.0"
-				{ Get-PASComponentDetail -ComponentID PVWA  } | Should Throw
-$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = "1.0"
+				{ Get-PASComponentDetail -ComponentID PVWA  } | Should -Throw
+				$Script:ExternalVersion = "0.0"
 			}
 
 		}
@@ -100,13 +103,13 @@ $Script:ExternalVersion = "0.0"
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 2
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 

--- a/Tests/Get-PASComponentSummary.Tests.ps1
+++ b/Tests/Get-PASComponentSummary.Tests.ps1
@@ -1,43 +1,41 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 			[PSCustomObject]@{
 				"Components" = [PSCustomObject]@{"ComponentID" = "SomValue"; "ComponentName" = "OtherValue"; "Role" = "SomValue"; "IP" = "OtherValue"; "IsLoggedOn" = "OtherValue" }
@@ -46,12 +44,12 @@ Describe $FunctionName {
 		}
 
 		$response = Get-PASComponentSummary
-
+}
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -61,25 +59,25 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/api/ComponentsMonitoringSummary"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "throws error if version requirement not met" {
 $Script:ExternalVersion = "1.0"
-				{ Get-PASComponentSummary  } | Should Throw
+				{ Get-PASComponentSummary  } | Should -Throw
 $Script:ExternalVersion = "0.0"
 			}
 

--- a/Tests/Get-PASDirectory.Tests.ps1
+++ b/Tests/Get-PASDirectory.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Input" {
 
@@ -80,7 +77,7 @@ Describe $FunctionName {
 
 			It "throws error if version requirement not met" {
 $Script:ExternalVersion = "1.0"
-				{ Get-PASDirectory  } | Should Throw
+				{ Get-PASDirectory  } | Should -Throw
 $Script:ExternalVersion = "0.0"
 			}
 
@@ -100,19 +97,19 @@ $Script:ExternalVersion = "0.0"
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 2
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Directory.Extended
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Directory.Extended
 
 			}
 
@@ -120,7 +117,7 @@ $Script:ExternalVersion = "0.0"
 
 				$response = Get-PASDirectory
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Directory
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Directory
 
 			}
 

--- a/Tests/Get-PASDirectoryMapping.Tests.ps1
+++ b/Tests/Get-PASDirectoryMapping.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Mandatory Parameters" {
 
@@ -47,7 +44,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Get-PASDirectoryMapping).Parameters["$Parameter"].Attributes.Mandatory | Select-object -Unique | Should Be $true
+				(Get-Command Get-PASDirectoryMapping).Parameters["$Parameter"].Attributes.Mandatory | Select-object -Unique | Should -Be $true
 
 			}
 
@@ -101,7 +98,7 @@ Describe $FunctionName {
 
 			It "throws error if version requirement not met" {
 $Script:ExternalVersion = "1.0"
-				{ $InputObj | Get-PASDirectoryMapping  } | Should Throw
+				{ $InputObj | Get-PASDirectoryMapping  } | Should -Throw
 $Script:ExternalVersion = "0.0"
 			}
 
@@ -128,19 +125,19 @@ $Script:ExternalVersion = "0.0"
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 2
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Directory.Mapping
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Directory.Mapping
 
 			}
 

--- a/Tests/Get-PASGroup.Tests.ps1
+++ b/Tests/Get-PASGroup.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Input" {
 
@@ -87,7 +84,7 @@ Describe $FunctionName {
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "1.2"
 
-				{ Get-PASGroup } | Should throw
+				{ Get-PASGroup } | Should -Throw
 
 				$Script:ExternalVersion = "0.0"
 
@@ -114,13 +111,13 @@ Describe $FunctionName {
 
 			it "provides output" {
 				$response = Get-PASGroup
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 				$response = Get-PASGroup
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 4
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 4
 
 			}
 

--- a/Tests/Get-PASLoggedOnUser.Tests.ps1
+++ b/Tests/Get-PASLoggedOnUser.Tests.ps1
@@ -1,43 +1,41 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 			[PSCustomObject]@{"Detail1" = "Detail"; "Detail2" = "Detail" }
 		}
@@ -45,12 +43,12 @@ Describe $FunctionName {
 
 
 		$response = Get-PASLoggedOnUser
-
+}
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -60,19 +58,19 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/User"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
@@ -82,19 +80,19 @@ Describe $FunctionName {
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 2
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.User
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.User
 
 			}
 

--- a/Tests/Get-PASOnboardingRule.Tests.ps1
+++ b/Tests/Get-PASOnboardingRule.Tests.ps1
@@ -1,43 +1,41 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 			[PSCustomObject]@{"AutomaticOnboardingRules" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" } }
 		}
@@ -49,12 +47,12 @@ Describe $FunctionName {
 		}
 
 		$response = $InputObj | Get-PASOnboardingRule
-
+}
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -64,25 +62,25 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/api/AutomaticOnboardingRules?Names=SomeRule,SomeRule2"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "throws error if version requirement not met" {
 $Script:ExternalVersion = "1.0"
-				{ $InputObj | Get-PASOnboardingRule  } | Should Throw
+				{ $InputObj | Get-PASOnboardingRule  } | Should -Throw
 $Script:ExternalVersion = "0.0"
 			}
 
@@ -92,19 +90,19 @@ $Script:ExternalVersion = "0.0"
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 2
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.OnboardingRule
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.OnboardingRule
 
 			}
 

--- a/Tests/Get-PASPSMConnectionParameter.Tests.ps1
+++ b/Tests/Get-PASPSMConnectionParameter.Tests.ps1
@@ -1,39 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Mandatory Parameters" {
 
@@ -44,7 +44,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Get-PASPSMConnectionParameter).Parameters["$Parameter"].Attributes.Mandatory | Select-Object -Unique | Should Be $true
+				(Get-Command Get-PASPSMConnectionParameter).Parameters["$Parameter"].Attributes.Mandatory | Select-Object -Unique | Should -Be $true
 
 			}
 
@@ -81,7 +81,7 @@ Describe $FunctionName {
 			}
 
 			It "throws if path is invalid" {
-				{ $InputObj | Get-PASPSMConnectionParameter -ConnectionMethod RDP -path A:\test.txt } | Should throw
+				{ $InputObj | Get-PASPSMConnectionParameter -ConnectionMethod RDP -path A:\test.txt } | Should -Throw
 			}
 
 			It "sends request" {
@@ -130,7 +130,7 @@ Describe $FunctionName {
 
 				$InputObj | Get-PASPSMConnectionParameter -ConnectionMethod RDP
 
-				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 1
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
 			}
 
@@ -156,14 +156,14 @@ Describe $FunctionName {
 
 			It "throws error if version requirement not met for RDP connection method" {
 				$Script:ExternalVersion = "9.8"
-				{ $InputObj | Get-PASPSMConnectionParameter -ConnectionMethod RDP } | Should Throw
+				{ $InputObj | Get-PASPSMConnectionParameter -ConnectionMethod RDP } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 
 			It "throws error if version requirement not met for PSMGW connection method" {
 
 				$Script:ExternalVersion = "9.10"
-				{ $InputObj | Get-PASPSMConnectionParameter -ConnectionMethod PSMGW } | Should Throw
+				{ $InputObj | Get-PASPSMConnectionParameter -ConnectionMethod PSMGW } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 
@@ -180,7 +180,7 @@ Describe $FunctionName {
 
 			It "throws error if version requirement not met for AdHocConnect" {
 				$Script:ExternalVersion = "10.4"
-				{ $AdHocObj | Get-PASPSMConnectionParameter -ConnectionMethod PSMGW } | Should Throw
+				{ $AdHocObj | Get-PASPSMConnectionParameter -ConnectionMethod PSMGW } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 

--- a/Tests/Get-PASPSMRecording.Tests.ps1
+++ b/Tests/Get-PASPSMRecording.Tests.ps1
@@ -1,40 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
+	}
 
 
-}
+	AfterAll {
 
-AfterAll {
+		$Script:RequestBody = $null
 
-	$Script:RequestBody = $null
+	}
 
-}
-
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Input" {
 
@@ -96,13 +95,13 @@ Describe $FunctionName {
 
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "1.0"
-				{ $InputObj | Get-PASPSMRecording } | Should Throw
+				{ $InputObj | Get-PASPSMRecording } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 
 			It "throws error if version requirement not met when querying by ID" {
 				$Script:ExternalVersion = "10.5"
-				{ Get-PASPSMRecording -RecordingId SomeID } | Should Throw
+				{ Get-PASPSMRecording -RecordingId SomeID } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 
@@ -126,19 +125,19 @@ Describe $FunctionName {
 			}
 			it "provides output" {
 
-				$InputObj | Get-PASPSMRecording | Should not BeNullOrEmpty
+				$InputObj | Get-PASPSMRecording | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($InputObj | Get-PASPSMRecording | Get-Member -MemberType NoteProperty).length | Should Be 3
+				($InputObj | Get-PASPSMRecording | Get-Member -MemberType NoteProperty).length | Should -Be 3
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$InputObj | Get-PASPSMRecording | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.PSM.Recording
+				$InputObj | Get-PASPSMRecording | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PSM.Recording
 
 			}
 

--- a/Tests/Get-PASPSMRecordingActivity.Tests.ps1
+++ b/Tests/Get-PASPSMRecordingActivity.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Mandatory Parameters" {
 
@@ -46,7 +43,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Get-PASPSMRecordingActivity).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Get-PASPSMRecordingActivity).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
@@ -96,7 +93,7 @@ Describe $FunctionName {
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "10.5"
 
-				{ $InputObj | Get-PASPSMRecordingActivity } | Should throw
+				{ $InputObj | Get-PASPSMRecordingActivity } | Should -Throw
 
 				$Script:ExternalVersion = "0.0"
 
@@ -127,19 +124,19 @@ Describe $FunctionName {
 
 			it "provides output" {
 				$response = $InputObj | Get-PASPSMRecordingActivity
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			it "outputs object with expected typename" {
 				$response = $InputObj | Get-PASPSMRecordingActivity
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.PSM.Recording.Activity
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PSM.Recording.Activity
 
 			}
 
 			It "has output with expected number of properties" {
 				$response = $InputObj | Get-PASPSMRecordingActivity
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 4
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 4
 
 			}
 

--- a/Tests/Get-PASPSMRecordingProperty.Tests.ps1
+++ b/Tests/Get-PASPSMRecordingProperty.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Mandatory Parameters" {
 
@@ -46,7 +43,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Get-PASPSMRecordingProperty).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Get-PASPSMRecordingProperty).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
@@ -96,7 +93,7 @@ Describe $FunctionName {
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "10.5"
 
-				{ $InputObj | Get-PASPSMRecordingProperty } | Should throw
+				{ $InputObj | Get-PASPSMRecordingProperty } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 
@@ -123,19 +120,19 @@ Describe $FunctionName {
 
 			it "provides output" {
 				$response = $InputObj | Get-PASPSMRecordingProperty
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			it "outputs object with expected typename" {
 				$response = $InputObj | Get-PASPSMRecordingProperty
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.PSM.Recording.Property
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PSM.Recording.Property
 
 			}
 
 			It "has output with expected number of properties" {
 				$response = $InputObj | Get-PASPSMRecordingProperty
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 4
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 4
 
 			}
 

--- a/Tests/Get-PASPSMSession.Tests.ps1
+++ b/Tests/Get-PASPSMSession.Tests.ps1
@@ -1,39 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Input" {
 
@@ -97,13 +97,13 @@ Describe $FunctionName {
 
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "1.0"
-				{ $InputObj | Get-PASPSMSession } | Should Throw
+				{ $InputObj | Get-PASPSMSession } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 
 			It "throws error if version requirement not met when querying by ID" {
 				$Script:ExternalVersion = "10.5"
-				{ Get-PASPSMSession -liveSessionId SomeID } | Should Throw
+				{ Get-PASPSMSession -liveSessionId SomeID } | Should -Throw
 
 				$Script:ExternalVersion = "0.0"
 			}
@@ -130,19 +130,19 @@ Describe $FunctionName {
 			}
 			it "provides output" {
 
-				$InputObj | Get-PASPSMSession | Should not BeNullOrEmpty
+				$InputObj | Get-PASPSMSession | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($InputObj | Get-PASPSMSession | Get-Member -MemberType NoteProperty).length | Should Be 3
+				($InputObj | Get-PASPSMSession | Get-Member -MemberType NoteProperty).length | Should -Be 3
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$InputObj | Get-PASPSMSession | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.PSM.Session
+				$InputObj | Get-PASPSMSession | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PSM.Session
 
 			}
 

--- a/Tests/Get-PASPSMSessionActivity.Tests.ps1
+++ b/Tests/Get-PASPSMSessionActivity.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Mandatory Parameters" {
 
@@ -46,7 +43,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Get-PASPSMSessionActivity).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Get-PASPSMSessionActivity).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
@@ -96,7 +93,7 @@ Describe $FunctionName {
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "10.5"
 
-				{ $InputObj | Get-PASPSMSessionActivity } | Should throw
+				{ $InputObj | Get-PASPSMSessionActivity } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 
 			}
@@ -126,19 +123,19 @@ Describe $FunctionName {
 
 			it "provides output" {
 				$response = $InputObj | Get-PASPSMSessionActivity
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			it "outputs object with expected typename" {
 				$response = $InputObj | Get-PASPSMSessionActivity
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.PSM.Session.Activity
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PSM.Session.Activity
 
 			}
 
 			It "has output with expected number of properties" {
 				$response = $InputObj | Get-PASPSMSessionActivity
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 4
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 4
 
 			}
 

--- a/Tests/Get-PASPSMSessionProperty.Tests.ps1
+++ b/Tests/Get-PASPSMSessionProperty.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Mandatory Parameters" {
 
@@ -46,7 +43,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Get-PASPSMSessionProperty).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Get-PASPSMSessionProperty).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
@@ -96,7 +93,7 @@ Describe $FunctionName {
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "10.5"
 
-				{ $InputObj | Get-PASPSMSessionProperty } | Should throw
+				{ $InputObj | Get-PASPSMSessionProperty } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 
 			}
@@ -126,19 +123,19 @@ Describe $FunctionName {
 
 			it "provides output" {
 				$response = $InputObj | Get-PASPSMSessionProperty
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			it "outputs object with expected typename" {
 				$response = $InputObj | Get-PASPSMSessionProperty
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.PSM.Session.Property
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PSM.Session.Property
 
 			}
 
 			It "has output with expected number of properties" {
 				$response = $InputObj | Get-PASPSMSessionProperty
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 4
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 4
 
 			}
 

--- a/Tests/Get-PASPTAEvent.Tests.ps1
+++ b/Tests/Get-PASPTAEvent.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Input" {
 
@@ -96,7 +93,7 @@ Describe $FunctionName {
 
 			It "throws error if version requirement not met" {
 $Script:ExternalVersion = "1.0"
-				{ Get-PASPTAEvent  } | Should Throw
+				{ Get-PASPTAEvent  } | Should -Throw
 $Script:ExternalVersion = "0.0"
 			}
 
@@ -116,19 +113,19 @@ $Script:ExternalVersion = "0.0"
 			}
 			it "provides output" {
 
-				Get-PASPTAEvent -lastUpdatedEventDate 1-1-1979 | Should not BeNullOrEmpty
+				Get-PASPTAEvent -lastUpdatedEventDate 1-1-1979 | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				(Get-PASPTAEvent -lastUpdatedEventDate 1-1-1979 | Get-Member -MemberType NoteProperty).length | Should Be 1
+				(Get-PASPTAEvent -lastUpdatedEventDate 1-1-1979 | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
 			}
 
 			it "outputs object with expected typename" {
 
-				Get-PASPTAEvent -lastUpdatedEventDate 1-1-1979 | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.PTA.Event
+				Get-PASPTAEvent -lastUpdatedEventDate 1-1-1979 | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PTA.Event
 
 			}
 

--- a/Tests/Get-PASPTARule.Tests.ps1
+++ b/Tests/Get-PASPTARule.Tests.ps1
@@ -1,54 +1,51 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
-
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 			[PSCustomObject]@{"riskyActivities" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" } }
 		}
 
 		$response = Get-PASPTARule
-
+}
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -58,13 +55,13 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/API/pta/API/Settings"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
@@ -74,13 +71,13 @@ Describe $FunctionName {
 
 					$Body -eq $null
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "throws error if version requirement not met" {
 $Script:ExternalVersion = "1.0"
-				{ Get-PASPTARule  } | Should Throw
+				{ Get-PASPTARule  } | Should -Throw
 $Script:ExternalVersion = "0.0"
 			}
 
@@ -90,19 +87,19 @@ $Script:ExternalVersion = "0.0"
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 2
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.PTA.Rule
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PTA.Rule
 
 			}
 

--- a/Tests/Get-PASParameter.Tests.ps1
+++ b/Tests/Get-PASParameter.Tests.ps1
@@ -1,60 +1,76 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
-
-}
-
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
-
-		[array]$CommonParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
-		[array]$CommonParameters += [System.Management.Automation.PSCmdlet]::OptionalCommonParameters
-		[hashtable]$InputParams = @{"KeepThis" = "Kept"; "RemoveThis" = "Removed"}
-
-		$CommonParameters | ForEach-Object {$InputParams.Add($_, "something")}
-
-		$ReturnData = $InputParams | Get-PASParameter -ParametersToRemove RemoveThis
-
-		It 'returns a hashtable' {
-
-			$ReturnData | Should BeOfType System.Collections.Hashtable
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
 		}
 
-		$CommonParameters | ForEach-Object {
-
-			It "does not include $_ in return data" {
-
-				$ReturnData[$_] | Should BeNullOrEmpty
-
-			}
-
-		}
-
-		It 'does not return additional specified parameters' {
-			$ReturnData["RemoveThis"] | Should BeNullOrEmpty
-		}
-
-		It 'returns expected value' {
-			$ReturnData["KeepThis"] | Should Be "Kept"
-		}
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
 
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+		Context "General Tests"{
+
+			BeforeEach{
+
+				[array]$CommonParameters = [System.Management.Automation.PSCmdlet]::CommonParameters
+				[array]$CommonParameters += [System.Management.Automation.PSCmdlet]::OptionalCommonParameters
+				[array]$CommonParameters = $CommonParameters | Select-Object -Unique
+				[hashtable]$InputParams = @{"KeepThis" = "Kept"; "RemoveThis" = "Removed" }
+				$CommonParameters | ForEach-Object { $InputParams.Add($PSItem, "something") }
+				$ReturnData = $InputParams | Get-PASParameter -ParametersToRemove RemoveThis
+
+			}
+
+			It 'returns a hashtable' {
+
+				$ReturnData | Should -BeOfType System.Collections.Hashtable
+
+			}
+
+			$CommonParameters | ForEach-Object {
+
+				It "does not include $_ in return data" {
+
+					$ReturnData.keys | Should -Not -Contain $_
+				}
+
+			}
+
+			It 'does not return additional specified parameters' {
+				$ReturnData["RemoveThis"] | Should -BeNullOrEmpty
+			}
+
+			It 'returns expected value' {
+				$ReturnData["KeepThis"] | Should -Be "Kept"
+			}
+
+		}
+	}
 }

--- a/Tests/Get-PASPlatform.Tests.ps1
+++ b/Tests/Get-PASPlatform.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Input - Legacy" {
 
@@ -87,23 +84,23 @@ Describe $FunctionName {
 
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "1.0"
-				{$InputObj | Get-PASPlatform } | Should Throw
+				{$InputObj | Get-PASPlatform } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 
 		}
 
-		Context "Input - 11.1" { 
-			BeforeEach { 
+		Context "Input - 11.1" {
+			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
 
 					[PSCustomObject]@{
 						"Platforms" = [PSCustomObject]@{
-							"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = 123 
-						} 
+							"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = 123
+						}
 					}
-					
+
 				}
 
 				$InputObj = [pscustomobject]@{
@@ -136,7 +133,7 @@ Describe $FunctionName {
 
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "10.0"
-				{ $InputObj | Get-PASPlatform } | Should Throw
+				{ $InputObj | Get-PASPlatform } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 
@@ -149,7 +146,7 @@ Describe $FunctionName {
 				Mock Invoke-PASRestMethod -MockWith {
 
 					[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = 123 }
-					
+
 				}
 
 				$InputObj = [pscustomobject]@{
@@ -163,13 +160,13 @@ Describe $FunctionName {
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties - legacy" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 3
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 3
 
 			}
 
@@ -179,21 +176,21 @@ Describe $FunctionName {
 
 					[PSCustomObject]@{
 						"Platforms" = [PSCustomObject]@{
-							"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = 123 
-						} 
+							"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = 123
+						}
 					}
-					
+
 				}
 
 				$response = Get-PASPlatform -Active $true
-				
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 3
+
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 3
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Platform
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Platform
 
 			}
 

--- a/Tests/Get-PASPolicyACL.Tests.ps1
+++ b/Tests/Get-PASPolicyACL.Tests.ps1
@@ -1,52 +1,52 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 			[pscustomobject]@{"ListPolicyPrivilegedCommandsResult" = [pscustomobject]@{"some" = "thing"; "other" = "thing"}}
 
 		}
 
 		$InputObj = [pscustomobject]@{
-"PolicyID"     = "UNIXSSH"
+		"PolicyID"     = "UNIXSSH"
 		}
+			$response = $InputObj | Get-PASPolicyACL
 
+	}
 		Context "Mandatory Parameters" {
 
 			$Parameters = @{Parameter = 'PolicyId'}
@@ -56,19 +56,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Get-PASPolicyACL).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Get-PASPolicyACL).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Get-PASPolicyACL
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -78,19 +78,19 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Policy/UNIXSSH/PrivilegedCommands"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
 
 			}
 
@@ -100,19 +100,19 @@ Describe $FunctionName {
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 2
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.ACL.Policy
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.ACL.Policy
 
 			}
 

--- a/Tests/Get-PASPublicSSHKey.Tests.ps1
+++ b/Tests/Get-PASPublicSSHKey.Tests.ps1
@@ -1,52 +1,51 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 			[PSCustomObject]@{"GetUserAuthorizedKeysResult" = [PSCustomObject]@{"KeyID" = "SomeID"; "PublicSSHKey" = "SomeKey" } }
 		}
 
 		$InputObj = [pscustomobject]@{
-"UserName" = "SomeUser"
+		"UserName" = "SomeUser"
 
+				}
+					$response = $InputObj | Get-PASPublicSSHKey
 		}
-
 		Context "Mandatory Parameters" {
 
 			$Parameters = @{Parameter = 'UserName' }
@@ -55,19 +54,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Get-PASPublicSSHKey).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Get-PASPublicSSHKey).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Get-PASPublicSSHKey
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -77,19 +76,19 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/SomeUser/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
@@ -99,19 +98,19 @@ Describe $FunctionName {
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 3
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 3
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.PublicSSHKey
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PublicSSHKey
 
 			}
 
@@ -119,7 +118,7 @@ Describe $FunctionName {
 
 			It "returns username property in response" {
 
-				$response.UserName | Should Be SomeUser
+				$response.UserName | Should -Be SomeUser
 
 			}
 

--- a/Tests/Get-PASResponse.Tests.ps1
+++ b/Tests/Get-PASResponse.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Standard Operation" {
 
@@ -76,11 +73,11 @@ Describe $FunctionName {
 
 			It "returns expected number of properties" {
 				$result = Get-PASResponse -APIResponse $JSONResponse
-				($result | Get-Member -MemberType NoteProperty).length | Should Be 4
+				($result | Get-Member -MemberType NoteProperty).length | Should -Be 4
 			}
 
 			It "returns expected text value" {
-				Get-PASResponse -APIResponse $TextResponse | Should Be '"Value"'
+				Get-PASResponse -APIResponse $TextResponse | Should -Be '"Value"'
 			}
 
 			It "throws if HTML received" {
@@ -89,12 +86,12 @@ Describe $FunctionName {
 
 			It "returns expected application-save value" {
 				$result = Get-PASResponse -APIResponse $ApplicationSave
-				$([System.Text.Encoding]::ASCII.GetString($result.Content)) | Should Be "Expected"
+				$([System.Text.Encoding]::ASCII.GetString($result.Content)) | Should -Be "Expected"
 			}
 
 			It "returns expected octet-stream value" {
 				$result = Get-PASResponse -APIResponse $OctetStream
-				$([System.Text.Encoding]::ASCII.GetString($result.Content)) | Should Be "Expected"
+				$([System.Text.Encoding]::ASCII.GetString($result.Content)) | Should -Be "Expected"
 			}
 
 		}

--- a/Tests/Get-PASSAMLResponse.Tests.ps1
+++ b/Tests/Get-PASSAMLResponse.Tests.ps1
@@ -1,0 +1,94 @@
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
+
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
+
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+		if ( -not (Get-Module -Name $ModuleName -All)) {
+
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+		}
+
+	}
+
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+		BeforeEach{
+
+			Mock Invoke-WebRequest -MockWith {
+
+				[pscustomobject]@{
+
+					"Links"       = [pscustomobject]@{
+
+						"href" = "https://SomeLink/"
+
+					}
+
+					"InputFields" = @(
+
+						[pscustomobject]@{
+
+							"Name"  = "SAMLResponse"
+							"Value" = "IamSAMLiAM"
+
+						}
+
+					)
+
+				}
+
+			}
+
+			$response = Get-PASSAMLResponse -URL "https://pvwa.somecompany.com/PasswordVault"
+
+		}
+
+		Context "Standard Operation" {
+
+			It "sends expected requests" {
+
+				Assert-MockCalled Invoke-WebRequest -Times 2 -Exactly -Scope It
+
+			}
+
+			It "returns expected response" {
+
+				$response | Should -Be "IamSAMLiAM"
+
+			}
+
+			It "throws expected error"{
+
+				Mock Invoke-WebRequest -MockWith {
+
+					Throw "Some Error"
+
+				}
+
+				{Get-PASSAMLResponse -URL "https://pvwa.somecompany.com/PasswordVault"} | Should -Throw "Failed to get SAMLResponse"
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASSafe.Tests.ps1
+++ b/Tests/Get-PASSafe.Tests.ps1
@@ -1,43 +1,41 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 			[PSCustomObject]@{
 				"SearchSafesResult" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
@@ -45,14 +43,14 @@ Describe $FunctionName {
 				"GetSafeResult"     = [PSCustomObject]@{"Prop5" = "Val5"; "Prop6" = "Val6"; "Prop7" = "Val7"; "Prop8" = "Val8" }
 			}
 		}
-
+}
 		Context "Input - byAll ParameterSet" {
-
+			BeforeEach{
 			Get-PASSafe -FindAll
-
+}
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Context
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -62,31 +60,31 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Safes"
 
-				} -Times 1 -Exactly -Scope Context
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope Context
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope Context
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
 		}
 
 		Context "Input - byName ParameterSet" {
-
+			BeforeEach{
 			Get-PASSafe -SafeName SomeSafe
-
+}
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Context
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -96,31 +94,31 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Safes/SomeSafe"
 
-				} -Times 1 -Exactly -Scope Context
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope Context
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope Context
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
 		}
 
 		Context "Input - byQuery ParameterSet" {
-
+			BeforeEach{
 			Get-PASSafe -query "SomeSafe"
-
+}
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Context
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -130,43 +128,43 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Safes?query=SomeSafe"
 
-				} -Times 1 -Exactly -Scope Context
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope Context
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope Context
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
 		}
 
 		Context "Output - byAll ParameterSet" {
-
+			BeforeEach{
 			$response = Get-PASSafe -FindAll
-
+}
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 3
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 3
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Safe
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Safe
 
 			}
 
@@ -175,24 +173,24 @@ Describe $FunctionName {
 		}
 
 		Context "Output - byName ParameterSet" {
-
+			BeforeEach{
 			$response = Get-PASSafe -SafeName SomeSafe
-
+}
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 4
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 4
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Safe
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Safe
 
 			}
 
@@ -201,24 +199,24 @@ Describe $FunctionName {
 		}
 
 		Context "Output - byQuery ParameterSet" {
-
+			BeforeEach{
 			$response = Get-PASSafe -query "SomeSafe"
-
+}
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 2
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Safe
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Safe
 
 			}
 

--- a/Tests/Get-PASSafeMember.Tests.ps1
+++ b/Tests/Get-PASSafeMember.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Mandatory Parameters" {
 
@@ -46,7 +43,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Get-PASSafeMember).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Get-PASSafeMember).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
@@ -148,31 +145,31 @@ Describe $FunctionName {
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 3
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 3
 
 			}
 
 			It "has expected number of nested array elements" {
 
-				($response.permissions).count | Should Be 3
+				($response.permissions).count | Should -Be 3
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Safe.Member
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Safe.Member
 
 			}
 
 			it "outputs object with expected safename property" {
 
-				$response.SafeName | Should Be "SomeSafe"
+				$response.SafeName | Should -Be "SomeSafe"
 
 			}
 
@@ -216,7 +213,7 @@ Describe $FunctionName {
 
 				$response = $InputObj | Get-PASSafeMember -MemberName SomeMember
 
-				$response.UserName | Should Be "SomeMember"
+				$response.UserName | Should -Be "SomeMember"
 
 			}
 

--- a/Tests/Get-PASSafeMember.Tests.ps1
+++ b/Tests/Get-PASSafeMember.Tests.ps1
@@ -128,6 +128,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 								"FalseKey"        = $false
 								"AnotherKey"      = $true
 								"AnotherFalseKey" = $false
+								"IntegerKey" 	  = 1
 							}
 						}
 					}
@@ -155,9 +156,30 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has expected number of nested array elements" {
+			It "has expected number of nested permission properties"{
 
-				($response.permissions).count | Should -Be 3
+				($response.permissions | Get-Member -MemberType NoteProperty).count | Should -Be 6
+
+			}
+
+			It "has expected boolean false property value"{
+
+				$response.permissions.FalseKey | Should -Be $False
+
+
+			}
+
+			It "has expected boolean true property value" {
+
+
+				$response.permissions.Key1 | Should -Be $True
+
+			}
+
+			It "has expected integer property value" {
+
+
+				$response.permissions.IntegerKey | Should -Be 1
 
 			}
 

--- a/Tests/Get-PASSafeShareLogo.Tests.ps1
+++ b/Tests/Get-PASSafeShareLogo.Tests.ps1
@@ -1,47 +1,45 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
-
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 			Write-output "Squint and This is an Image"
 		}
-
+			$response = Get-PASSafeShareLogo -ImageType Square
+}
 		Context "Mandatory Parameters" {
 
 			$Parameters = @{Parameter = 'ImageType' }
@@ -50,19 +48,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Get-PASSafeShareLogo).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Get-PASSafeShareLogo).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = Get-PASSafeShareLogo -ImageType Square
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -72,19 +70,19 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Logo?type=Square"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
@@ -94,7 +92,7 @@ Describe $FunctionName {
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 

--- a/Tests/Get-PASServer.Tests.ps1
+++ b/Tests/Get-PASServer.Tests.ps1
@@ -1,54 +1,52 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 			[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
 		}
 
 		$response = Get-PASServer
-
+}
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -58,19 +56,19 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Server"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
@@ -80,13 +78,13 @@ Describe $FunctionName {
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 2
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 

--- a/Tests/Get-PASServerWebService.Tests.ps1
+++ b/Tests/Get-PASServerWebService.Tests.ps1
@@ -1,43 +1,40 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
-
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 			[PSCustomObject]@{
 				"ServerName"            = "Val1";
@@ -48,12 +45,12 @@ Describe $FunctionName {
 		}
 
 		$response = Get-PASServerWebService -BaseURI "https://SomeURL" -PVWAAppName SomeApp
-
+}
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -63,19 +60,19 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Verify"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
@@ -85,13 +82,13 @@ Describe $FunctionName {
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 4
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 4
 
 			}
 

--- a/Tests/Get-PASSession.Tests.ps1
+++ b/Tests/Get-PASSession.Tests.ps1
@@ -1,66 +1,63 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
-
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+BeforeEach{
 		Mock Get-PASLoggedOnUser -MockWith {
 			[PSCustomObject]@{"Username" = "SomeUser"; "Prop2" = "Val2" }
 		}
 
 		$response = Get-PASSession
-
+}
 		Context "Standard Operation" {
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 4
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 4
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Session
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Session
 
 			}
 

--- a/Tests/Get-PASUser.Tests.ps1
+++ b/Tests/Get-PASUser.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Mandatory Parameters" {
 
@@ -46,7 +43,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Get-PASUser).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Get-PASUser).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
@@ -131,7 +128,7 @@ Describe $FunctionName {
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "1.0"
 
-				{ $InputObjV10 | Get-PASUser } | Should Throw
+				{ $InputObjV10 | Get-PASUser } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 
 			}
@@ -139,7 +136,7 @@ Describe $FunctionName {
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "10.9"
 
-				{ Get-PASUser -id 123 } | Should Throw
+				{ Get-PASUser -id 123 } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 
 			}
@@ -170,19 +167,19 @@ Describe $FunctionName {
 			}
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 2
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.User
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.User
 
 			}
 
@@ -194,7 +191,7 @@ Describe $FunctionName {
 				}
 
 				$response = $InputObjV10 | Get-PASUser
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.User.Extended
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.User.Extended
 
 			}
 

--- a/Tests/Get-PASUserLoginInfo.Tests.ps1
+++ b/Tests/Get-PASUserLoginInfo.Tests.ps1
@@ -1,54 +1,52 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 			[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
 		}
 
 		$response = Get-PASUserLoginInfo
-
+}
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -58,25 +56,25 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/api/LoginsInfo"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "throws error if version requirement not met" {
 $Script:ExternalVersion = "1.0"
-				{ Get-PASUserLoginInfo  } | Should Throw
+				{ Get-PASUserLoginInfo  } | Should -Throw
 $Script:ExternalVersion = "0.0"
 			}
 
@@ -86,13 +84,13 @@ $Script:ExternalVersion = "0.0"
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 2
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 

--- a/Tests/Get-ParentFunction.Tests.ps1
+++ b/Tests/Get-ParentFunction.Tests.ps1
@@ -1,34 +1,46 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repo Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-Describe $FunctionName {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	InModuleScope $ModuleName {
+	}
+
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		It 'returns parent function name' {
 			Function Test-Parent {Test-Child}
 			Function Test-Child {Get-ParentFunction}
 			$ThisTest = Test-Parent
 
-			$ThisTest.FunctionName | Should Be Test-Parent
+			$ThisTest.FunctionName | Should -Be Test-Parent
 		}
 
 		It 'returns expected parent function name from expected scope' {
@@ -41,7 +53,7 @@ Describe $FunctionName {
 			Function Test-Child {Get-ParentFunction -Scope 3}
 			$ThisTest = Test-Example -Name "test"
 
-			$ThisTest.FunctionName | Should Be "Test-Example"
+			$ThisTest.FunctionName | Should -Be "Test-Example"
 
 		}
 
@@ -55,7 +67,7 @@ Describe $FunctionName {
 			Function Test-Child {Get-ParentFunction -Scope 3}
 			$ThisTest = Test-Example -Name "test"
 
-			$ThisTest.ParameterSetName | Should Be "ExampleParamSet"
+			$ThisTest.ParameterSetName | Should -Be "ExampleParamSet"
 		}
 
 

--- a/Tests/Hide-SecretValue.Tests.ps1
+++ b/Tests/Hide-SecretValue.Tests.ps1
@@ -1,74 +1,92 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
-
-}
-
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
-
-		[array]$Secrets = @(
-			"Secret",
-			"Password",
-			"NewCredentials",
-			"NewPassword",
-			"BindPassword",
-			"InitialPassword"
-		)
-
-		$String = [pscustomobject]@{
-			"Property"         = "Value"
-			"Password"         = "SecretValue"
-			"Secret"           = "DontShareThis"
-			"NewCredentials"   = "S3cr3t"
-			"NewPassword"      = "Password123!"
-			"BindPassword"     = "ABCDE123!"
-			"InitialPassword"  = "123456"
-			"InnocentProperty" = "SomeValue"
-		} | ConvertTo-Json
-
-		It 'returns a string' {
-			$ReturnData = Hide-SecretValue -InputValue $String -SecretsToRemove Property
-			$ReturnData | Should BeOfType System.String
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
 		}
 
-		$Secrets | ForEach-Object {
-
-			It "does not include $_ value in return data" {
-				$ReturnData = Hide-SecretValue -InputValue $String -SecretsToRemove Property
-				$ReturnData | ConvertFrom-Json | Select-Object -ExpandProperty $_ | Should Be "******"
-
-			}
-
-		}
-
-		It 'does not return additional specified parameters' {
-			$ReturnData = Hide-SecretValue -InputValue $String -SecretsToRemove Property
-			$ReturnData | ConvertFrom-Json | Select-Object -ExpandProperty Property | Should Be "******"
-		}
-
-		It 'returns expected value' {
-			$ReturnData = Hide-SecretValue -InputValue $String -SecretsToRemove Property
-			$ReturnData | ConvertFrom-Json | Select-Object -ExpandProperty InnocentProperty | Should Be "SomeValue"
-		}
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
 
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+		Context	"General Tests"{
+			BeforeEach{
+
+				[array]$Secrets = @(
+					"Secret",
+					"Password",
+					"NewCredentials",
+					"NewPassword",
+					"BindPassword",
+					"InitialPassword"
+				)
+
+				$String = [pscustomobject]@{
+					"Property"         = "Value"
+					"Password"         = "SecretValue"
+					"Secret"           = "DontShareThis"
+					"NewCredentials"   = "S3cr3t"
+					"NewPassword"      = "Password123!"
+					"BindPassword"     = "ABCDE123!"
+					"InitialPassword"  = "123456"
+					"InnocentProperty" = "SomeValue"
+				} | ConvertTo-Json
+			}
+
+			It 'returns a string' {
+				$ReturnData = Hide-SecretValue -InputValue $String -SecretsToRemove Property
+				$ReturnData | Should -BeOfType System.String
+
+			}
+
+
+				It "does not include <Parameter> value in return data" -TestCases @{Parameter = 'Secret' },
+				@{Parameter = 'Password' },
+				@{Parameter = 'NewCredentials' },
+				@{Parameter = 'NewPassword' },
+				@{Parameter = 'BindPassword' },
+				@{Parameter = 'InitialPassword' } {
+					$ReturnData = Hide-SecretValue -InputValue $String -SecretsToRemove Property
+					$ReturnData | ConvertFrom-Json | Select-Object -ExpandProperty $Parameter | Should -Be "******"
+
+				}
+
+			It 'does not return additional specified parameters' {
+				$ReturnData = Hide-SecretValue -InputValue $String -SecretsToRemove Property
+				$ReturnData | ConvertFrom-Json | Select-Object -ExpandProperty Property | Should -Be "******"
+			}
+
+			It 'returns expected value' {
+				$ReturnData = Hide-SecretValue -InputValue $String -SecretsToRemove Property
+				$ReturnData | ConvertFrom-Json | Select-Object -ExpandProperty InnocentProperty | Should -Be "SomeValue"
+			}
+
+		}
+	}
 }

--- a/Tests/Import-PASConnectionComponent.Tests.ps1
+++ b/Tests/Import-PASConnectionComponent.Tests.ps1
@@ -1,51 +1,54 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 			[PSCustomObject]@{"ConnectionComponentID" = "SomeConnectionComponent" }
 		}
 
-		#Create a 512b file to test with
-		$file = [System.IO.File]::Create("$env:Temp\test.zip")
-		$file.SetLength(0.5kb)
-		$file.Close()
+			#Create a 512b file to test with
+			$file = [System.IO.File]::Create("$env:Temp\test.zip")
+			$file.SetLength(0.5kb)
+			$file.Close()
+
+		$response = Import-PASConnectionComponent -ImportFile $($file.name)
+
+}
+
 
 		Context "Mandatory Parameters" {
 
@@ -55,31 +58,29 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Import-PASConnectionComponent).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Import-PASConnectionComponent).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = Import-PASConnectionComponent -ImportFile $($file.name)
-
 		Context "Input" {
 
 			It "throws if InputFile does not exist" {
-				{ Import-PASConnectionComponent -ImportFile SomeFile.txt } | Should throw
+				{ Import-PASConnectionComponent -ImportFile SomeFile.txt } | Should -Throw
 			}
 
 			It "throws if InputFile resolves to a folder" {
-				{ Import-PASConnectionComponent -ImportFile $pwd } | Should throw
+				{ Import-PASConnectionComponent -ImportFile $pwd } | Should -Throw
 			}
 
 			It "throws if InputFile does not have a zip extention" {
-				{ Import-PASConnectionComponent -ImportFile README.MD } | Should throw
+				{ Import-PASConnectionComponent -ImportFile README.MD } | Should -Throw
 			}
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -89,13 +90,13 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/API/ConnectionComponents/Import"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
@@ -107,25 +108,25 @@ Describe $FunctionName {
 
 					($Script:RequestBody.ImportFile) -ne $null
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "has a request body with expected number of properties" {
 
-				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 1
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
 			}
 
 			It "has body content of expected length" {
 
-				($Script:RequestBody.ImportFile).length | Should Be 512
+				($Script:RequestBody.ImportFile).length | Should -Be 512
 
 			}
 
 			It "throws error if version requirement not met" {
 $Script:ExternalVersion = "1.0"
-				{ Import-PASConnectionComponent -ImportFile $($file.name)  } | Should Throw
+				{ Import-PASConnectionComponent -ImportFile $($file.name)  } | Should -Throw
 $Script:ExternalVersion = "0.0"
 			}
 
@@ -135,19 +136,19 @@ $Script:ExternalVersion = "0.0"
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 1
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be System.Management.Automation.PSCustomObject
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be System.Management.Automation.PSCustomObject
 
 			}
 

--- a/Tests/Import-PASPlatform.Tests.ps1
+++ b/Tests/Import-PASPlatform.Tests.ps1
@@ -1,44 +1,42 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
-		Mock Invoke-PASRestMethod -MockWith {
+		BeforeEach{
+			Mock Invoke-PASRestMethod -MockWith {
 			[PSCustomObject]@{"PlatformID" = "SomePlatform" }
 		}
 
@@ -46,6 +44,10 @@ Describe $FunctionName {
 		$file = [System.IO.File]::Create("$env:Temp\testPlatform.zip")
 		$file.SetLength(0.5kb)
 		$file.Close()
+
+			$response = Import-PASPlatform -ImportFile $($file.name)
+
+		}
 
 		Context "Mandatory Parameters" {
 
@@ -55,31 +57,31 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Import-PASPlatform).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Import-PASPlatform).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = Import-PASPlatform -ImportFile $($file.name)
+
 
 		Context "Input" {
 
 			It "throws if InputFile does not exist" {
-				{ Import-PASPlatform -ImportFile SomeFile.txt } | Should throw
+				{ Import-PASPlatform -ImportFile SomeFile.txt } | Should -Throw
 			}
 
 			It "throws if InputFile resolves to a folder" {
-				{ Import-PASPlatform -ImportFile $pwd } | Should throw
+				{ Import-PASPlatform -ImportFile $pwd } | Should -Throw
 			}
 
 			It "throws if InputFile does not have a zip extention" {
-				{ Import-PASPlatform -ImportFile README.MD } | Should throw
+				{ Import-PASPlatform -ImportFile README.MD } | Should -Throw
 			}
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -89,13 +91,13 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/API/Platforms/Import"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
@@ -107,25 +109,25 @@ Describe $FunctionName {
 
 					($Script:RequestBody.ImportFile) -ne $null
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "has a request body with expected number of properties" {
 
-				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 1
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
 			}
 
 			It "has body content of expected length" {
 
-				($Script:RequestBody.ImportFile).length | Should Be 512
+				($Script:RequestBody.ImportFile).length | Should -Be 512
 
 			}
 
 			It "throws error if version requirement not met" {
 $Script:ExternalVersion = "1.0"
-				{ Import-PASPlatform -ImportFile $($file.name)  } | Should Throw
+				{ Import-PASPlatform -ImportFile $($file.name)  } | Should -Throw
 $Script:ExternalVersion = "0.0"
 			}
 
@@ -136,19 +138,19 @@ $Script:ExternalVersion = "0.0"
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 1
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be System.Management.Automation.PSCustomObject
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be System.Management.Automation.PSCustomObject
 
 			}
 

--- a/Tests/Invoke-PASCPMOperation.Tests.ps1
+++ b/Tests/Invoke-PASCPMOperation.Tests.ps1
@@ -1,39 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+	}
 
 
+	AfterAll {
 
-}
+		$Script:RequestBody = $null
 
-AfterAll {
+	}
 
-	$Script:RequestBody = $null
-
-}
-
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 
 		Context "Standard Operation" {

--- a/Tests/New-PASAccountGroup.Tests.ps1
+++ b/Tests/New-PASAccountGroup.Tests.ps1
@@ -1,43 +1,41 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 
 		}
@@ -48,6 +46,9 @@ Describe $FunctionName {
 			"Safe"            = "SomeSafe"
 		}
 
+			$response = $InputObj | New-PASAccountGroup
+
+}
 		Context "Mandatory Parameters" {
 
 			$Parameters = @{Parameter = 'GroupName'},
@@ -58,19 +59,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command New-PASAccountGroup).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command New-PASAccountGroup).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | New-PASAccountGroup
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -80,13 +81,13 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/API/AccountGroups/"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
@@ -98,19 +99,19 @@ Describe $FunctionName {
 
 					($Script:RequestBody) -ne $null
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "has a request body with expected number of properties" {
 
-				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 3
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 3
 
 			}
 
 			It "throws error if version requirement not met" {
 $Script:ExternalVersion = "1.0"
-				{$InputObj | New-PASAccountGroup } | Should Throw
+				{$InputObj | New-PASAccountGroup } | Should -Throw
 $Script:ExternalVersion = "0.0"
 			}
 
@@ -120,7 +121,7 @@ $Script:ExternalVersion = "0.0"
 
 			it "provides no output" {
 
-				$response | Should BeNullOrEmpty
+				$response | Should -BeNullOrEmpty
 
 			}
 

--- a/Tests/New-PASDirectoryMapping.Tests.ps1
+++ b/Tests/New-PASDirectoryMapping.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Standard Operation" {
 

--- a/Tests/New-PASGroup.Tests.ps1
+++ b/Tests/New-PASGroup.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Input" {
 
@@ -76,10 +73,10 @@ Describe $FunctionName {
 
 			It "sends request with expected body" {
 				New-PASGroup -groupName SomeGroup -description "Some Description" -location "/Some/Location"
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { 
-					
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
 					$Body -ne $null
-				
+
 				} -Times 1 -Exactly -Scope It
 
 			}
@@ -87,7 +84,7 @@ Describe $FunctionName {
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "1.2"
 
-				{ $InputObject | New-PASGroup } | Should throw
+				{ $InputObject | New-PASGroup } | Should -Throw
 
 				$Script:ExternalVersion = "0.0"
 
@@ -119,14 +116,14 @@ Describe $FunctionName {
 			it "provides output" {
 
 				$response = $InputObject | New-PASGroup
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
 				$response = $InputObject | New-PASGroup
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 4
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 4
 
 			}
 

--- a/Tests/New-PASOnboardingRule.Tests.ps1
+++ b/Tests/New-PASOnboardingRule.Tests.ps1
@@ -1,43 +1,40 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
-
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 			[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
 		}
@@ -49,6 +46,9 @@ Describe $FunctionName {
 
 		}
 
+		$response = $InputObj | New-PASOnboardingRule
+
+}
 		Context "Mandatory Parameters" {
 
 			$Parameters = @{Parameter = 'DecisionPlatformId' },
@@ -61,19 +61,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command New-PASOnboardingRule).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command New-PASOnboardingRule).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | New-PASOnboardingRule
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -83,13 +83,13 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/api/AutomaticOnboardingRules"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
@@ -101,19 +101,19 @@ Describe $FunctionName {
 
 					($Script:RequestBody) -ne $null
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "has a request body with expected number of properties" {
 
-				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 3
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 3
 
 			}
 
 			It "throws error if minimum version requirement not met" {
 				$Script:ExternalVersion = "1.0"
-				{ $InputObj | New-PASOnboardingRule } | Should Throw
+				{ $InputObj | New-PASOnboardingRule } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 
@@ -126,7 +126,7 @@ Describe $FunctionName {
 
 				}
 
-				{ $InputObj | New-PASOnboardingRule } | Should Not Throw
+				{ $InputObj | New-PASOnboardingRule } | Should -Not -Throw
 
 			}
 
@@ -139,7 +139,7 @@ Describe $FunctionName {
 
 				}
 				$Script:ExternalVersion = "10.1.0"
-				{ $InputObj | New-PASOnboardingRule } | Should Throw
+				{ $InputObj | New-PASOnboardingRule } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 
@@ -151,19 +151,19 @@ Describe $FunctionName {
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 2
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.OnboardingRule
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.OnboardingRule
 
 			}
 

--- a/Tests/New-PASRequest.Tests.ps1
+++ b/Tests/New-PASRequest.Tests.ps1
@@ -1,43 +1,40 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
-
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 			[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "val2"; "PropA" = "ValA"; "PropB" = "ValB"; "PropC" = "ValC" }
 		}
@@ -52,6 +49,9 @@ Describe $FunctionName {
 			"ToDate"              = (Get-Date 12-12-2018)
 		}
 
+		$response = $InputObj | New-PASRequest
+
+}
 		Context "Mandatory Parameters" {
 
 			$Parameters = @{Parameter = 'AccountID' }
@@ -60,19 +60,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command New-PASRequest).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command New-PASRequest).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | New-PASRequest
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -82,13 +82,13 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/API/MyRequests"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
@@ -100,31 +100,31 @@ Describe $FunctionName {
 
 					($Script:RequestBody) -ne $null
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "has a request body with expected number of properties" {
 
-				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 7
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 7
 
 			}
 
 			It "converts datetime 'FromDate' to expected value" {
 
-				$Script:RequestBody.FromDate | Should Be 1514764800
+				$Script:RequestBody.FromDate | Should -Be 1514764800
 
 			}
 
 			It "converts datetime 'ToDate' to expected value" {
 
-				$Script:RequestBody.ToDate | Should Be 1544572800
+				$Script:RequestBody.ToDate | Should -Be 1544572800
 
 			}
 
 			It "throws error if version requirement not met" {
 $Script:ExternalVersion = "1.0"
-				{ $InputObj | New-PASRequest  } | Should Throw
+				{ $InputObj | New-PASRequest  } | Should -Throw
 $Script:ExternalVersion = "0.0"
 			}
 
@@ -134,19 +134,19 @@ $Script:ExternalVersion = "0.0"
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 5
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 5
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Request
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Request
 
 			}
 

--- a/Tests/New-PASSession.Tests.ps1
+++ b/Tests/New-PASSession.Tests.ps1
@@ -1,39 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Mandatory Parameters" {
 
@@ -44,7 +44,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command New-PASSession).Parameters["$Parameter"].Attributes.Mandatory | Select-Object -Unique | Should Be $true
+				(Get-Command New-PASSession).Parameters["$Parameter"].Attributes.Mandatory | Select-Object -Unique | Should -Be $true
 
 			}
 
@@ -113,25 +113,25 @@ Describe $FunctionName {
 
 			It "has a request body with expected number of properties" {
 
-				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 3
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 3
 
 			}
 
 			It "sends expected username in request" {
 
-				$Script:RequestBody.username | Should Be SomeUser
+				$Script:RequestBody.username | Should -Be SomeUser
 
 			}
 
 			It "sends expected password in request" {
 
-				$Script:RequestBody.password | Should Be SomePassword
+				$Script:RequestBody.password | Should -Be SomePassword
 
 			}
 
 			It "sends expected new password in request" {
 
-				$Script:RequestBody.newpassword | Should Be SomeNewPassword
+				$Script:RequestBody.newpassword | Should -Be SomeNewPassword
 
 			}
 
@@ -357,7 +357,7 @@ Describe $FunctionName {
 				}
 
 				$Credentials | New-PASSession -BaseURI "https://P_URI" -PVWAAppName "SomeApp" -WarningAction SilentlyContinue
-				$Script:ExternalVersion | Should be "0.0"
+				$Script:ExternalVersion | Should -Be "0.0"
 
 			}
 
@@ -553,7 +553,7 @@ Describe $FunctionName {
 
 			It "throws if no session token is returned after successful IIS authentication" {
 				if ($IsCoreCLR) {
-					{ $Credentials | New-PASSession -BaseURI "https://P_URI" -type Windows } | should throw
+					{ $Credentials | New-PASSession -BaseURI "https://P_URI" -type Windows } | Should -Throw
 				}Else{Set-ItResult -Inconclusive}
 			}
 
@@ -579,7 +579,7 @@ Describe $FunctionName {
 				if ($IsCoreCLR) {
 					Mock -CommandName Invoke-PASRestMethod {Throw $errorRecord} -ParameterFilter { $Uri -eq "https://P_URI/PasswordVault/api/Auth/RADIUS/Logon" }
 
-					{ $Credentials | New-PASSession -BaseURI "https://P_URI" -type Windows -OTP 123456 -OTPMode Challenge } | Should throw
+					{ $Credentials | New-PASSession -BaseURI "https://P_URI" -type Windows -OTP 123456 -OTPMode Challenge } | Should -Throw
 
 					Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 

--- a/Tests/New-PASUser.Tests.ps1
+++ b/Tests/New-PASUser.Tests.ps1
@@ -1,60 +1,57 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Mandatory Parameters" {
 
 			It "specifies parameter UserName as mandatory for ParameterSet legacy" {
 
-				(Get-Command New-PASUser).Parameters["UserName"].ParameterSets["legacy"].IsMandatory | Should be $true
+				(Get-Command New-PASUser).Parameters["UserName"].ParameterSets["legacy"].IsMandatory | Should -Be $true
 
 			}
 
 			It "specifies parameter UserName as mandatory for ParameterSet 10_9" {
 
-				(Get-Command New-PASUser).Parameters["UserName"].ParameterSets["10_9"].IsMandatory | Should be $true
+				(Get-Command New-PASUser).Parameters["UserName"].ParameterSets["10_9"].IsMandatory | Should -Be $true
 
 			}
 
 			It "specifies parameter InitialPassword as mandatory for ParameterSet legacy" {
 
-				(Get-Command New-PASUser).Parameters["InitialPassword"].ParameterSets["legacy"].IsMandatory | Should be $true
+				(Get-Command New-PASUser).Parameters["InitialPassword"].ParameterSets["legacy"].IsMandatory | Should -Be $true
 
 			}
 
@@ -117,7 +114,7 @@ Describe $FunctionName {
 
 			It "has a request body with expected number of properties" {
 
-				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 5
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 5
 
 			}
 
@@ -183,14 +180,14 @@ Describe $FunctionName {
 
 			It "has a request body with expected number of properties" {
 
-				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 7
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 7
 
 			}
 
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "1.0"
 
-				{ $InputObj | New-PASUser } | Should Throw
+				{ $InputObj | New-PASUser } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 
 			}
@@ -221,25 +218,25 @@ Describe $FunctionName {
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 2
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.User
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.User
 
 			}
 
 			it "outputs object with expected typename - V10" {
 				$response = $InputObj | New-PASUser
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.User.Extended
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.User.Extended
 
 			}
 

--- a/Tests/Out-PASFile.Tests.ps1
+++ b/Tests/Out-PASFile.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 
 
@@ -49,7 +46,7 @@ Describe $FunctionName {
 				}
 
 				Mock Get-Item -MockWith { }
-				
+
 				Mock Set-Content -MockWith { }
 
 			}

--- a/Tests/Remove-PASAccountACL.Tests.ps1
+++ b/Tests/Remove-PASAccountACL.Tests.ps1
@@ -1,43 +1,41 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 			#[pscustomobject]@{"AddAccountPrivilegedCommandResult" = [pscustomobject]@{"some" = "thing"}}
 
@@ -50,6 +48,10 @@ Describe $FunctionName {
 			"Id"              = 22
 		}
 
+			$response = $InputObj | Remove-PASAccountACL
+
+
+	}
 		Context "Mandatory Parameters" {
 
 			$Parameters = @{Parameter = 'AccountPolicyId'},
@@ -61,19 +63,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Remove-PASAccountACL).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Remove-PASAccountACL).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Remove-PASAccountACL
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -82,13 +84,13 @@ Describe $FunctionName {
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Account/ServerA.domain.com|root|UNIXSSH/PrivilegedCommands/22"
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
@@ -98,7 +100,7 @@ Describe $FunctionName {
 
 					$Body -eq @{}
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
@@ -108,7 +110,7 @@ Describe $FunctionName {
 
 			it "provides no output" {
 
-				$response | Should BeNullOrEmpty
+				$response | Should -BeNullOrEmpty
 
 			}
 

--- a/Tests/Remove-PASAccountGroupMember.Tests.ps1
+++ b/Tests/Remove-PASAccountGroupMember.Tests.ps1
@@ -1,43 +1,41 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 
 		}
@@ -47,7 +45,8 @@ Describe $FunctionName {
 			"GroupID"      = "88_8"
 
 		}
-
+			$response = $InputObj | Remove-PASAccountGroupMember
+}
 		Context "Mandatory Parameters" {
 
 			$Parameters = @{Parameter = 'AccountID'},
@@ -57,19 +56,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Remove-PASAccountGroupMember).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Remove-PASAccountGroupMember).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Remove-PASAccountGroupMember
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -79,25 +78,25 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/API/AccountGroups/88_8/Members/99_9"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "throws error if version requirement not met" {
 $Script:ExternalVersion = "1.0"
-				{$InputObj | Remove-PASAccountGroupMember } | Should Throw
+				{$InputObj | Remove-PASAccountGroupMember } | Should -Throw
 $Script:ExternalVersion = "0.0"
 			}
 
@@ -107,7 +106,7 @@ $Script:ExternalVersion = "0.0"
 
 			it "provides no output" {
 
-				$response | Should BeNullOrEmpty
+				$response | Should -BeNullOrEmpty
 
 			}
 

--- a/Tests/Remove-PASApplication.Tests.ps1
+++ b/Tests/Remove-PASApplication.Tests.ps1
@@ -1,43 +1,41 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 
 		}
@@ -46,7 +44,8 @@ Describe $FunctionName {
 "AppID"        = "SomeApplication"
 
 		}
-
+			$response = $InputObj | Remove-PASApplication
+}
 		Context "Mandatory Parameters" {
 
 			$Parameters = @{Parameter = 'AppID'}
@@ -55,19 +54,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Remove-PASApplication).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Remove-PASApplication).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Remove-PASApplication
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -77,19 +76,19 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Applications/SomeApplication/"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
 
 			}
 
@@ -99,7 +98,7 @@ Describe $FunctionName {
 
 			it "provides no output" {
 
-				$response | Should BeNullOrEmpty
+				$response | Should -BeNullOrEmpty
 
 			}
 

--- a/Tests/Remove-PASApplicationAuthenticationMethod.Tests.ps1
+++ b/Tests/Remove-PASApplicationAuthenticationMethod.Tests.ps1
@@ -1,53 +1,52 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 
 		}
 
 		$InputObj = [pscustomobject]@{
-"AppID"        = "SomeApplication"
+			"AppID"        = "SomeApplication"
 			"AuthID"       = "SomeAuth"
 
 		}
-
+			$response = $InputObj | Remove-PASApplicationAuthenticationMethod
+}
 		Context "Mandatory Parameters" {
 
 			$Parameters = @{Parameter = 'AppID'},
@@ -57,19 +56,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Remove-PASApplicationAuthenticationMethod).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Remove-PASApplicationAuthenticationMethod).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Remove-PASApplicationAuthenticationMethod
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -79,19 +78,19 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Applications/SomeApplication/Authentications/SomeAuth"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
 
 			}
 
@@ -101,7 +100,7 @@ Describe $FunctionName {
 
 			it "provides no output" {
 
-				$response | Should BeNullOrEmpty
+				$response | Should -BeNullOrEmpty
 
 			}
 

--- a/Tests/Remove-PASDirectory.Tests.ps1
+++ b/Tests/Remove-PASDirectory.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Mandatory Parameters" {
 
@@ -46,7 +43,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Remove-PASDirectory).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Remove-PASDirectory).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
@@ -92,7 +89,7 @@ Describe $FunctionName {
 
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "1.0"
-				{ Get-PASDirectory } | Should Throw
+				{ Get-PASDirectory } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 
@@ -110,7 +107,7 @@ Describe $FunctionName {
 
 			it "provides no output" {
 
-				$response | Should BeNullOrEmpty
+				$response | Should -BeNullOrEmpty
 
 			}
 

--- a/Tests/Remove-PASDirectoryMapping.Tests.ps1
+++ b/Tests/Remove-PASDirectoryMapping.Tests.ps1
@@ -1,53 +1,50 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Mandatory Parameters" {
 
-			$Parameters = @{Parameter = 'DirectoryName' }, 
+			$Parameters = @{Parameter = 'DirectoryName' },
 				@{Parameter = 'MappingID' }
 
 			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
 
 				param($Parameter)
 
-				(Get-Command Remove-PASDirectoryMapping).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Remove-PASDirectoryMapping).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
@@ -93,7 +90,7 @@ Describe $FunctionName {
 
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "1.0"
-				{ Get-PASDirectory } | Should Throw
+				{ Get-PASDirectory } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 
@@ -111,7 +108,7 @@ Describe $FunctionName {
 
 			it "provides no output" {
 
-				$response | Should BeNullOrEmpty
+				$response | Should -BeNullOrEmpty
 
 			}
 

--- a/Tests/Remove-PASGroupMember.Tests.ps1
+++ b/Tests/Remove-PASGroupMember.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Mandatory Parameters" {
 
@@ -47,7 +44,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Remove-PASGroupMember ).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Remove-PASGroupMember ).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
@@ -92,7 +89,7 @@ Describe $FunctionName {
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "1.2"
 
-				{ Remove-PASGroupMember -GroupID X1_Y2 -Member TargetUser } | Should throw
+				{ Remove-PASGroupMember -GroupID X1_Y2 -Member TargetUser } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 
@@ -107,7 +104,7 @@ Describe $FunctionName {
 
 			it "provides no output" {
 				$response = Remove-PASGroupMember -GroupID X1_Y2 -Member TargetUser
-				$response | Should BeNullOrEmpty
+				$response | Should -BeNullOrEmpty
 
 			}
 

--- a/Tests/Remove-PASOnboardingRule.Tests.ps1
+++ b/Tests/Remove-PASOnboardingRule.Tests.ps1
@@ -1,43 +1,41 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 
 		}
@@ -46,7 +44,9 @@ Describe $FunctionName {
 "RuleID"       = "SomeRule"
 
 		}
+			$response = $InputObj | Remove-PASOnboardingRule
 
+}
 		Context "Mandatory Parameters" {
 
 			$Parameters = @{Parameter = 'RuleID'}
@@ -55,19 +55,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Remove-PASOnboardingRule).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Remove-PASOnboardingRule).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Remove-PASOnboardingRule
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -77,19 +77,19 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/api/AutomaticOnboardingRules/SomeRule"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
 
 			}
 
@@ -99,7 +99,7 @@ Describe $FunctionName {
 
 			it "provides no output" {
 
-				$response | Should BeNullOrEmpty
+				$response | Should -BeNullOrEmpty
 
 			}
 

--- a/Tests/Remove-PASPolicyACL.Tests.ps1
+++ b/Tests/Remove-PASPolicyACL.Tests.ps1
@@ -1,43 +1,41 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 			#[pscustomobject]@{"AddAccountPrivilegedCommandResult" = [pscustomobject]@{"some" = "thing"}}
 
@@ -47,7 +45,8 @@ Describe $FunctionName {
 "PolicyID"     = "UNIXSSH"
 			"Id"           = 22
 		}
-
+			$response = $InputObj | Remove-PASPolicyACL
+}
 		Context "Mandatory Parameters" {
 
 			$Parameters = @{Parameter = 'PolicyId'},
@@ -57,19 +56,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Remove-PASPolicyACL).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Remove-PASPolicyACL).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Remove-PASPolicyACL
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -78,13 +77,13 @@ Describe $FunctionName {
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Policy/UNIXSSH/PrivilegedCommands/22"
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
@@ -94,7 +93,7 @@ Describe $FunctionName {
 
 					$Body -eq $null
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
@@ -104,7 +103,7 @@ Describe $FunctionName {
 
 			it "provides no output" {
 
-				$response | Should BeNullOrEmpty
+				$response | Should -BeNullOrEmpty
 
 			}
 

--- a/Tests/Remove-PASPublicSSHKey.Tests.ps1
+++ b/Tests/Remove-PASPublicSSHKey.Tests.ps1
@@ -1,43 +1,41 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 
 		}
@@ -47,7 +45,8 @@ Describe $FunctionName {
 			"KeyID"        = "SomeKeyID"
 
 		}
-
+			$response = $InputObj | Remove-PASPublicSSHKey
+}
 		Context "Mandatory Parameters" {
 
 			$Parameters = @{Parameter = 'UserName'},
@@ -57,19 +56,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Remove-PASPublicSSHKey).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Remove-PASPublicSSHKey).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Remove-PASPublicSSHKey
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -79,19 +78,19 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/SomeUser/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys/SomeKeyID"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
 
 			}
 
@@ -101,7 +100,7 @@ Describe $FunctionName {
 
 			it "provides no output" {
 
-				$response | Should BeNullOrEmpty
+				$response | Should -BeNullOrEmpty
 
 			}
 

--- a/Tests/Remove-PASRequest.Tests.ps1
+++ b/Tests/Remove-PASRequest.Tests.ps1
@@ -1,43 +1,41 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 
 		}
@@ -46,7 +44,8 @@ Describe $FunctionName {
 "RequestID"    = "99_9"
 
 		}
-
+			$response = $InputObj | Remove-PASRequest
+}
 		Context "Mandatory Parameters" {
 
 			$Parameters = @{Parameter = 'RequestID'}
@@ -55,19 +54,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Remove-PASRequest).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Remove-PASRequest).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Remove-PASRequest
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -77,25 +76,25 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/API/MyRequests/99_9"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "throws error if version requirement not met" {
 $Script:ExternalVersion = "1.0"
-				{$InputObj | Remove-PASRequest } | Should Throw
+				{$InputObj | Remove-PASRequest } | Should -Throw
 $Script:ExternalVersion = "0.0"
 			}
 
@@ -105,7 +104,7 @@ $Script:ExternalVersion = "0.0"
 
 			it "provides no output" {
 
-				$response | Should BeNullOrEmpty
+				$response | Should -BeNullOrEmpty
 
 			}
 

--- a/Tests/Remove-PASSafe.Tests.ps1
+++ b/Tests/Remove-PASSafe.Tests.ps1
@@ -1,52 +1,51 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 
 		}
 
 		$InputObj = [pscustomobject]@{
-"SafeName"     = "SomeSafe"
+			"SafeName"     = "SomeSafe"
 
 		}
-
+			$response = $InputObj | Remove-PASSafe
+}
 		Context "Mandatory Parameters" {
 
 			$Parameters = @{Parameter = 'SafeName'}
@@ -55,19 +54,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Remove-PASSafe).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Remove-PASSafe).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Remove-PASSafe
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -77,19 +76,19 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Safes/SomeSafe"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
 
 			}
 
@@ -99,7 +98,7 @@ Describe $FunctionName {
 
 			it "provides no output" {
 
-				$response | Should BeNullOrEmpty
+				$response | Should -BeNullOrEmpty
 
 			}
 

--- a/Tests/Remove-PASSafeMember.Tests.ps1
+++ b/Tests/Remove-PASSafeMember.Tests.ps1
@@ -1,53 +1,53 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 
 		}
 
 		$InputObj = [pscustomobject]@{
-"MemberName"   = "SomeUser"
+			"MemberName"   = "SomeUser"
 			"SafeName"     = "SomeSafe"
 
 		}
 
+			$response = $InputObj | Remove-PASSafeMember
+}
 		Context "Mandatory Parameters" {
 
 			$Parameters = @{Parameter = 'MemberName'},
@@ -57,19 +57,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Remove-PASSafeMember).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Remove-PASSafeMember).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Remove-PASSafeMember
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -79,19 +79,19 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Safes/SomeSafe/Members/SomeUser"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
 
 			}
 
@@ -101,7 +101,7 @@ Describe $FunctionName {
 
 			it "provides no output" {
 
-				$response | Should BeNullOrEmpty
+				$response | Should -BeNullOrEmpty
 
 			}
 

--- a/Tests/Remove-PASUser.Tests.ps1
+++ b/Tests/Remove-PASUser.Tests.ps1
@@ -1,44 +1,42 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
-		Mock Invoke-PASRestMethod -MockWith {
+BeforeEach{
+			Mock Invoke-PASRestMethod -MockWith {
 
 		}
 
@@ -46,6 +44,7 @@ Describe $FunctionName {
 			"UserName"     = "ThatUser"
 
 		}
+}
 
 		Context "Mandatory Parameters" {
 
@@ -55,13 +54,13 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Remove-PASUser).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Remove-PASUser).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		
+
 
 		Context "Input" {
 
@@ -109,7 +108,7 @@ Describe $FunctionName {
 
 			it "provides no output" {
 				$response = $InputObj | Remove-PASUser
-				$response | Should BeNullOrEmpty
+				$response | Should -BeNullOrEmpty
 
 			}
 

--- a/Tests/Request-PASAdHocAccess.Tests.ps1
+++ b/Tests/Request-PASAdHocAccess.Tests.ps1
@@ -1,43 +1,41 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 
 		}
@@ -47,6 +45,9 @@ Describe $FunctionName {
 
 		}
 
+			$response = $InputObj | Request-PASAdHocAccess
+
+}
 		Context "Mandatory Parameters" {
 
 			$Parameters = @{Parameter = 'AccountID'}
@@ -55,19 +56,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Request-PASAdHocAccess).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Request-PASAdHocAccess).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Request-PASAdHocAccess
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -77,19 +78,19 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/API/Accounts/22_2/grantAdministrativeAccess"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
 
 			}
 
@@ -99,7 +100,7 @@ Describe $FunctionName {
 
 			it "provides no output" {
 
-				$response | Should BeNullOrEmpty
+				$response | Should -BeNullOrEmpty
 
 			}
 

--- a/Tests/Set-PASAccount.Tests.ps1
+++ b/Tests/Set-PASAccount.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Mandatory Parameters" {
 
@@ -51,14 +48,14 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Set-PASAccount).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Set-PASAccount).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		Context "v10 API" { 
-			
+		Context "v10 API" {
+
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
@@ -128,28 +125,28 @@ Describe $FunctionName {
 
 			it "provides output - V10 ParameterSet" {
 				$response = $InputObjV10 | Set-PASAccount -op Replace -path "/somepath" -value SomeValue
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties - V10 ParameterSet" {
 				$response = $InputObjV10 | Set-PASAccount -op Replace -path "/somepath" -value SomeValue
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 2
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
 			it "outputs object with expected typename - V10 ParameterSet" {
 				$response = $InputObjV10 | Set-PASAccount -op Replace -path "/somepath" -value SomeValue
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Account.V10
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Account.V10
 
 			}
 
 		}
-		
+
 		Context "Classic API" {
 
 			BeforeEach {
-				
+
 				Mock Invoke-PASRestMethod -MockWith {
 					[pscustomobject]@{
 						"UpdateAccountResult" = [pscustomobject]@{
@@ -173,9 +170,9 @@ Describe $FunctionName {
 
 				}
 				[void]$InputObj.PSObject.TypeNames.Insert(0, "psPAS.CyberArk.Vault.Account")
-				
+
 			}
-				
+
 			It "sends request - V9 ParameterSet" {
 				$InputObj | Set-PASAccount -Properties @{"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = "Val3" }
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
@@ -207,22 +204,22 @@ Describe $FunctionName {
 				} -Times 1 -Exactly -Scope It
 
 			}
-			
+
 			it "provides output - V9 ParameterSet" {
 				$response = $InputObj | Set-PASAccount -Properties @{"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = "Val3" }
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties - V9 ParameterSet" {
 				$response = $InputObj | Set-PASAccount -Properties @{"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = "Val3" }
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 5
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 5
 
 			}
 
 			it "outputs object with expected typename - V9 ParameterSet" {
 				$response = $InputObj | Set-PASAccount -Properties @{"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = "Val3" }
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Account
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Account
 
 			}
 

--- a/Tests/Set-PASDirectoryMapping.Tests.ps1
+++ b/Tests/Set-PASDirectoryMapping.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Standard Operation" {
 
@@ -80,13 +77,13 @@ Describe $FunctionName {
 
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "1.0"
-				{ $InputObj | Set-PASDirectoryMapping } | Should Throw
+				{ $InputObj | Set-PASDirectoryMapping } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "10.9"
-				{ $InputObj | Set-PASDirectoryMapping -UserActivityLogPeriod 10 } | Should Throw
+				{ $InputObj | Set-PASDirectoryMapping -UserActivityLogPeriod 10 } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 

--- a/Tests/Set-PASDirectoryMappingOrder.Tests.ps1
+++ b/Tests/Set-PASDirectoryMappingOrder.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Standard Operation" {
 

--- a/Tests/Set-PASOnboardingRule.Tests.ps1
+++ b/Tests/Set-PASOnboardingRule.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Mandatory Parameters" {
 
@@ -49,7 +46,7 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Set-PASOnboardingRule ).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Set-PASOnboardingRule ).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
@@ -113,7 +110,7 @@ Describe $FunctionName {
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "1.2"
 
-				{ $InputObj | Set-PASOnboardingRule } | Should throw
+				{ $InputObj | Set-PASOnboardingRule } | Should -Throw
 
 				$Script:ExternalVersion = "0.0"
 			}
@@ -150,13 +147,13 @@ Describe $FunctionName {
 
 			it "provides output" {
 				$response = $InputObj | Set-PASOnboardingRule
-				$response | Should Not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			it "outputs object with expected typename" {
 				$response = $InputObj | Set-PASOnboardingRule
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.OnboardingRule
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.OnboardingRule
 
 			}
 

--- a/Tests/Set-PASPTAEvent.Tests.ps1
+++ b/Tests/Set-PASPTAEvent.Tests.ps1
@@ -50,42 +50,32 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 			}
 
 			It "sends request" {
-				Get-PASPTAEvent -lastUpdatedEventDate 1-1-1979
+				Set-PASPTAEvent -EventID 1234 -mStatus CLOSED
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request to expected endpoint" {
-				Get-PASPTAEvent -lastUpdatedEventDate 1-1-1979
+				Set-PASPTAEvent -EventID 1234 -mStatus CLOSED
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -match "$($Script:BaseURI)/API/pta/API/Events/"
+					$URI -match "$($Script:BaseURI)/API/pta/API/Events/1234"
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
-				Get-PASPTAEvent -lastUpdatedEventDate 1-1-1979
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
+				Set-PASPTAEvent -EventID 1234 -mStatus CLOSED
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PATCH' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected header" {
-				Get-PASPTAEvent -lastUpdatedEventDate 1-1-1979 -UseLegacyMethod
+			It "sends request with expected body" {
+				Set-PASPTAEvent  -EventID 1234 -mStatus CLOSED
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$($Websession.headers["lastUpdatedEventDate"]) -eq "283996800"
-
-				} -Times 1 -Exactly -Scope It
-
-			}
-
-			It "sends request with no body" {
-				Get-PASPTAEvent -lastUpdatedEventDate 1-1-1979
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-
-					$Body -eq $null
+					($Body | ConvertFrom-Json | Select-Object -ExpandProperty mStatus) -eq "ClOSED"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -93,7 +83,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "1.0"
-				{ Get-PASPTAEvent  } | Should -Throw
+				{ Set-PASPTAEvent  -EventID 1234 -mStatus CLOSED } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 
@@ -111,21 +101,22 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 			}
+
 			it "provides output" {
 
-				Get-PASPTAEvent -lastUpdatedEventDate 1-1-1979 | Should -Not -BeNullOrEmpty
+				Set-PASPTAEvent -EventID 1234 -mStatus CLOSED | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				(Get-PASPTAEvent -lastUpdatedEventDate 1-1-1979 | Get-Member -MemberType NoteProperty).length | Should -Be 1
+				(Set-PASPTAEvent -EventID 1234 -mStatus CLOSED | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
 			}
 
 			it "outputs object with expected typename" {
 
-				Get-PASPTAEvent -lastUpdatedEventDate 1-1-1979 | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PTA.Event
+				Set-PASPTAEvent -EventID 1234 -mStatus CLOSED | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PTA.Event
 
 			}
 

--- a/Tests/Set-PASPTARemediation.Tests.ps1
+++ b/Tests/Set-PASPTARemediation.Tests.ps1
@@ -1,43 +1,41 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 			[PSCustomObject]@{"automaticRemediation" = [PSCustomObject]@{
 					"prop1" = "Value1"
@@ -49,12 +47,12 @@ Describe $FunctionName {
 		}
 
 		$response = Set-PASPTARemediation -changePassword_OverPassTheHash $true -reconcilePassword_SuspectedPasswordChange $true
-
+}
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -64,13 +62,13 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/API/pta/API/Settings/AutomaticRemediations/"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PATCH' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PATCH' } -Times 1 -Exactly -Scope It
 
 			}
 
@@ -82,19 +80,19 @@ Describe $FunctionName {
 
 					($Script:RequestBody) -ne $null
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "has a request body with expected number of properties" {
 
-				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 2
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
 			It "throws error if version requirement not met" {
 $Script:ExternalVersion = "1.0"
-				{ Set-PASPTARemediation  } | Should Throw
+				{ Set-PASPTARemediation  } | Should -Throw
 $Script:ExternalVersion = "0.0"
 			}
 
@@ -104,19 +102,19 @@ $Script:ExternalVersion = "0.0"
 
 			it "provides output" {
 
-				$response | Should Not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 4
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 4
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.PTA.Remediation
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PTA.Remediation
 
 			}
 

--- a/Tests/Set-PASPTARule.Tests.ps1
+++ b/Tests/Set-PASPTARule.Tests.ps1
@@ -1,43 +1,41 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 
 		}
@@ -53,6 +51,9 @@ Describe $FunctionName {
 
 		}
 
+			$response = $InputObj | Set-PASPTARule
+
+}
 		Context "Mandatory Parameters" {
 
 			$Parameters = @{Parameter = 'id'},
@@ -67,19 +68,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Set-PASPTARule).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Set-PASPTARule).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Set-PASPTARule
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -89,13 +90,13 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/API/pta/API/Settings/RiskyActivity/"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'PUT' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'PUT' } -Times 1 -Exactly -Scope It
 
 			}
 
@@ -107,19 +108,19 @@ Describe $FunctionName {
 
 					($Script:RequestBody) -ne $null
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "has a request body with expected number of properties" {
 
-				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should Be 7
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 7
 
 			}
 
 			It "throws error if version requirement not met" {
 $Script:ExternalVersion = "1.0"
-				{$InputObj | Set-PASPTARule } | Should Throw
+				{$InputObj | Set-PASPTARule } | Should -Throw
 $Script:ExternalVersion = "0.0"
 			}
 
@@ -129,7 +130,7 @@ $Script:ExternalVersion = "0.0"
 
 			it "provides no output" {
 
-				$response | Should BeNullOrEmpty
+				$response | Should -BeNullOrEmpty
 
 			}
 

--- a/Tests/Set-PASSafe.Tests.ps1
+++ b/Tests/Set-PASSafe.Tests.ps1
@@ -1,52 +1,53 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 			[PSCustomObject]@{"UpdateSafeResult" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2"}}
 		}
 
 		$InputObj = [pscustomobject]@{
-"SafeName"     = "SomeName"
+			"SafeName"     = "SomeName"
 
 		}
 
+			$response = $InputObj | Set-PASSafe -NumberOfDaysRetention 1 -ManagingCPM SomeCPM -NewSafeName SomeNewName
+
+}
 		Context "Mandatory Parameters" {
 
 			$Parameters = @{Parameter = 'SafeName'}
@@ -55,19 +56,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Add-PASSafe).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Add-PASSafe).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Set-PASSafe -NumberOfDaysRetention 1 -ManagingCPM SomeCPM -NewSafeName SomeNewName
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -77,13 +78,13 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Safes/SomeName"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'PUT' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'PUT' } -Times 1 -Exactly -Scope It
 
 			}
 
@@ -95,13 +96,13 @@ Describe $FunctionName {
 
 					($Script:RequestBody.safe) -ne $null
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "has a request body with expected number of properties" {
 
-				($Script:RequestBody.safe | Get-Member -MemberType NoteProperty).length | Should Be 3
+				($Script:RequestBody.safe | Get-Member -MemberType NoteProperty).length | Should -Be 3
 
 			}
 
@@ -111,19 +112,19 @@ Describe $FunctionName {
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 2
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Safe
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Safe
 
 			}
 

--- a/Tests/Set-PASSafeMember.Tests.ps1
+++ b/Tests/Set-PASSafeMember.Tests.ps1
@@ -40,7 +40,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 			[PSCustomObject]@{
 				"member" = [PSCustomObject]@{
 					"MembershipExpirationDate" = "31/12/2018"
-					"Permissions"              = @(
+					"Permissions" = @(
 						[pscustomobject]@{
 							"Key"   = "Key1"
 							"Value" = $true
@@ -65,7 +65,10 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 							"Key"   = "AnotherFalseKey"
 							"Value" = $false
 						}
-
+						[pscustomobject]@{
+							"Key"   = "IntegerKey"
+							"Value" = 1
+						}
 
 					)
 				}
@@ -92,7 +95,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 			"BackupSafe"                             = $false
 			"ViewAuditLog"                           = $true
 			"ViewSafeMembers"                        = $true
-			"RequestsAuthorizationLevel"             = 0
+			"RequestsAuthorizationLevel"             = 1
 			"AccessWithoutConfirmation"              = $false
 			"CreateFolders"                          = $false
 			"DeleteFolders"                          = $false
@@ -190,9 +193,30 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has expected number of nested array elements" {
+			It "has expected number of nested permission properties" {
 
-				($response.permissions).count | Should -Be 4
+				($response.permissions | Get-Member -MemberType NoteProperty).count | Should -Be 7
+
+			}
+
+			It "has expected boolean false property value" {
+
+				$response.permissions.FalseKey | Should -Be $False
+
+
+			}
+
+			It "has expected boolean true property value" {
+
+
+				$response.permissions.TrueKey | Should -Be $True
+
+			}
+
+			It "has expected integer property value" {
+
+
+				$response.permissions.IntegerKey | Should -Be 1
 
 			}
 

--- a/Tests/Set-PASSafeMember.Tests.ps1
+++ b/Tests/Set-PASSafeMember.Tests.ps1
@@ -1,43 +1,41 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 			[PSCustomObject]@{
 				"member" = [PSCustomObject]@{
@@ -103,6 +101,8 @@ Describe $FunctionName {
 
 		}
 
+			$response = $InputObj | Set-PASSafeMember -MembershipExpirationDate 12/31/18
+}
 		Context "Mandatory Parameters" {
 
 			$Parameters = @{Parameter = 'SafeName' },
@@ -112,19 +112,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Set-PASSafeMember).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Set-PASSafeMember).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Set-PASSafeMember -MembershipExpirationDate 12/31/18
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -134,19 +134,19 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Safes/SomeSafe/Members/SomeUser"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PUT' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PUT' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "throws if invalid date pattern specified" {
 
-				{ $InputObj | Set-PASSafeMember -MembershipExpirationDate "31/12/18" } | Should throw
+				{ $InputObj | Set-PASSafeMember -MembershipExpirationDate "31/12/18" } | Should -Throw
 
 			}
 
@@ -158,19 +158,19 @@ Describe $FunctionName {
 
 					($Script:RequestBody.member) -ne $null
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "has a request body with expected number of properties" {
 
-				($Script:RequestBody.member | Get-Member -MemberType NoteProperty).length | Should Be 2
+				($Script:RequestBody.member | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
 			It "has expected number of nested properties" {
 
-				($Script:RequestBody.member.permissions).Count | Should Be 21
+				($Script:RequestBody.member.permissions).Count | Should -Be 21
 
 			}
 
@@ -180,37 +180,37 @@ Describe $FunctionName {
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 4
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 4
 
 			}
 
 			It "has expected number of nested array elements" {
 
-				($response.permissions).count | Should Be 4
+				($response.permissions).count | Should -Be 4
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.Safe.Member
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Safe.Member
 
 			}
 
 			it "outputs object with expected safename property" {
 
-				$response.SafeName | Should Be "SomeSafe"
+				$response.SafeName | Should -Be "SomeSafe"
 
 			}
 
 			it "outputs object with expected username property" {
 
-				$response.UserName | Should Be "SomeUser"
+				$response.UserName | Should -Be "SomeUser"
 
 			}
 

--- a/Tests/Set-PASUser.Tests.ps1
+++ b/Tests/Set-PASUser.Tests.ps1
@@ -1,54 +1,51 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Mandatory Parameters" {
 
 			It "specifies parameter UserName as mandatory for ParameterSet legacy" {
 
-				(Get-Command Set-PASUser).Parameters["UserName"].ParameterSets["legacy"].IsMandatory | Should be $true
+				(Get-Command Set-PASUser).Parameters["UserName"].ParameterSets["legacy"].IsMandatory | Should -Be $true
 
 			}
 
 			It "specifies parameter UserName as mandatory for ParameterSet 11_1" {
 
-				(Get-Command Set-PASUser).Parameters["UserName"].ParameterSets["11_1"].IsMandatory | Should be $true
+				(Get-Command Set-PASUser).Parameters["UserName"].ParameterSets["11_1"].IsMandatory | Should -Be $true
 
 			}
 
@@ -161,7 +158,7 @@ Describe $FunctionName {
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "1.0"
 
-				{ $InputObj | Set-PASUser } | Should Throw
+				{ $InputObj | Set-PASUser } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 
 			}
@@ -192,19 +189,19 @@ Describe $FunctionName {
 
 			it "provides output" {
 
-				$response | Should not BeNullOrEmpty
+				$response | Should -Not -BeNullOrEmpty
 
 			}
 
 			It "has output with expected number of properties" {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should Be 2
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
 			it "outputs object with expected typename" {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should Be psPAS.CyberArk.Vault.User
+				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.User
 
 			}
 

--- a/Tests/Set-PASUserPassword.Tests.ps1
+++ b/Tests/Set-PASUserPassword.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Standard Operation" {
 

--- a/Tests/Skip-CertificateCheck.Tests.ps1
+++ b/Tests/Skip-CertificateCheck.Tests.ps1
@@ -1,39 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$Global:ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$Global:ManifestPath" -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	#$Script:RequestBody = $null
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	#$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "General" {
 

--- a/Tests/Stop-PASPSMSession.Tests.ps1
+++ b/Tests/Stop-PASPSMSession.Tests.ps1
@@ -1,43 +1,41 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 
 		}
@@ -46,7 +44,8 @@ Describe $FunctionName {
 			"LiveSessionId" = "SomeSessionID"
 
 		}
-
+			$response = $InputObj | Stop-PASPSMSession
+}
 		Context "Mandatory Parameters" {
 
 			$Parameters = @{Parameter = 'LiveSessionId' }
@@ -55,19 +54,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Stop-PASPSMSession).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Stop-PASPSMSession).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Stop-PASPSMSession
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -77,25 +76,25 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/api/LiveSessions/SomeSessionID/Terminate"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "throws error if version requirement not met" {
 $Script:ExternalVersion = "1.0"
-				{ $InputObj | Stop-PASPSMSession  } | Should Throw
+				{ $InputObj | Stop-PASPSMSession  } | Should -Throw
 $Script:ExternalVersion = "0.0"
 			}
 
@@ -105,7 +104,7 @@ $Script:ExternalVersion = "0.0"
 
 			it "provides no output" {
 
-				$response | Should Be $null
+				$response | Should -Be $null
 
 			}
 

--- a/Tests/Suspend-PASPSMSession.Tests.ps1
+++ b/Tests/Suspend-PASPSMSession.Tests.ps1
@@ -1,43 +1,41 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 
 		}
@@ -47,6 +45,8 @@ Describe $FunctionName {
 
 		}
 
+			$response = $InputObj | Suspend-PASPSMSession
+}
 		Context "Mandatory Parameters" {
 
 			$Parameters = @{Parameter = 'LiveSessionId'}
@@ -55,19 +55,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Suspend-PASPSMSession).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Suspend-PASPSMSession).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Suspend-PASPSMSession
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -77,25 +77,25 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/api/LiveSessions/SomeSessionID/Suspend"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "throws error if version requirement not met" {
 $Script:ExternalVersion = "1.0"
-				{$InputObj | Suspend-PASPSMSession } | Should Throw
+				{$InputObj | Suspend-PASPSMSession } | Should -Throw
 $Script:ExternalVersion = "0.0"
 			}
 
@@ -105,7 +105,7 @@ $Script:ExternalVersion = "0.0"
 
 			it "provides no output" {
 
-				$response | Should Be $null
+				$response | Should -Be $null
 
 			}
 

--- a/Tests/Test-PASPSMRecording.Tests.ps1
+++ b/Tests/Test-PASPSMRecording.Tests.ps1
@@ -1,42 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Standard Operation" {
 

--- a/Tests/Unblock-PASUser.Tests.ps1
+++ b/Tests/Unblock-PASUser.Tests.ps1
@@ -1,37 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-}
+	}
 
-AfterAll {
 
-	$Script:RequestBody = $null
+	AfterAll {
 
-}
+		$Script:RequestBody = $null
 
-Describe $FunctionName {
+	}
 
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Standard Operation" {
 

--- a/Tests/Unlock-PASAccount.Tests.ps1
+++ b/Tests/Unlock-PASAccount.Tests.ps1
@@ -1,52 +1,53 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
-	$Script:BaseURI = "https://SomeURL/SomeApp"
-	$Script:ExternalVersion = "0.0"
-	$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-	InModuleScope $ModuleName {
-
+		BeforeEach{
 		Mock Invoke-PASRestMethod -MockWith {
 
 		}
 
 		$InputObj = [pscustomobject]@{
-"AccountID"    = "22_2"
+			"AccountID"    = "22_2"
 
 		}
 
+			$response = $InputObj | Unlock-PASAccount
+
+	}
 		Context "Mandatory Parameters" {
 
 			$Parameters = @{Parameter = 'AccountID'}
@@ -55,19 +56,19 @@ Describe $FunctionName {
 
 				param($Parameter)
 
-				(Get-Command Unlock-PASAccount).Parameters["$Parameter"].Attributes.Mandatory | Should Be $true
+				(Get-Command Unlock-PASAccount).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-		$response = $InputObj | Unlock-PASAccount
+
 
 		Context "Input" {
 
 			It "sends request" {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
@@ -77,19 +78,19 @@ Describe $FunctionName {
 
 					$URI -eq "$($Script:BaseURI)/API/Accounts/22_2/CheckIn"
 
-				} -Times 1 -Exactly -Scope Describe
+				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "sends request with no body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope Describe
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
 
 			}
 
@@ -99,7 +100,7 @@ Describe $FunctionName {
 
 			it "provides no output" {
 
-				$response | Should BeNullOrEmpty
+				$response | Should -BeNullOrEmpty
 
 			}
 

--- a/Tests/Use-PASSession.Tests.ps1
+++ b/Tests/Use-PASSession.Tests.ps1
@@ -1,39 +1,39 @@
-#Get Current Directory
-$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
-#Get Function Name
-$FunctionName = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -Replace ".Tests.ps1"
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
 
-#Assume ModuleName from Repository Root folder
-$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
 
-#Resolve Path to Module Directory
-$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
 
-#Define Path to Module Manifest
-$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
 
-if ( -not (Get-Module -Name $ModuleName -All)) {
+		if ( -not (Get-Module -Name $ModuleName -All)) {
 
-	Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
 
-}
+		}
 
-BeforeAll {
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$Script:RequestBody = $null
+	}
 
-}
 
-AfterAll {
+	AfterAll {
 
-	$Script:RequestBody = $null
+		$Script:RequestBody = $null
 
-}
+	}
 
-Describe $FunctionName {
-
-	InModuleScope $ModuleName {
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		Context "Standard Operation" {
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # version format
-version: 3.5.{build}
+version: 4.0.{build}
 
 environment:
   #GIT_TRACE: 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,21 +39,22 @@ only_commits:
     - psPAS\
     - tests\
 
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 install:
-  - ps: . .\build\install.ps1
+  #- ps: . .\build\install.ps1
   - pwsh.exe -File .\build\install.ps1
 
 build_script:
-  - ps: . .\build\build.ps1
-
+  #- ps: . .\build\build.ps1
+  - pwsh.exe -File .\build\build.ps1
 test_script:
-  - ps: . .\build\test.ps1
+  #- ps: . .\build\test.ps1
   - pwsh.exe -File .\build\test.ps1
 
 #deploy_script:
-  - ps: . .\build\deploy-github.ps1
+  #- ps: . .\build\deploy-github.ps1
+  - pwsh.exe -File .\build\deploy-github.ps1
   - pwsh.exe -File .\build\deploy-psgallery.ps1
 
 on_failure:

--- a/build/deploy-psgallery.ps1
+++ b/build/deploy-psgallery.ps1
@@ -60,7 +60,7 @@ if (-not ($ENV:APPVEYOR_PULL_REQUEST_NUMBER)) {
 
 		<# No Deployment      #>
 
-		Write-Host "Finished testing: $($env:APPVEYOR_PROJECT_NAME) $env:APPVEYOR_REPO_BRANCH ($($env:APPVEYOR_BUILD_VERSION)) - Exiting" -ForegroundColor Cyan
+		Write-Host "$ENV:APPVEYOR_REPO_BRANCH Branch; No Deployment - Finished testing: $($env:APPVEYOR_PROJECT_NAME) ($($env:APPVEYOR_BUILD_VERSION)) - Exiting" -ForegroundColor Cyan
 		exit;
 
 	}

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -104,6 +104,8 @@ commands:
     children:
       - title: "Get-PASPTAEvent"
         url: /commands/Get-PASPTAEvent
+      - title: "Set-PASPTAEvent"
+        url: /commands/Set-PASPTAEvent
       - title: "Add-PASPTARule"
         url: /commands/Add-PASPTARule
       - title: "Get-PASPTARule"

--- a/docs/collections/_commands/Get-PASPTAEvent.md
+++ b/docs/collections/_commands/Get-PASPTAEvent.md
@@ -8,28 +8,54 @@ Returns PTA security events
 
 ## SYNTAX
 
-    Get-PASPTAEvent [[-lastUpdatedEventDate] <DateTime>] [<CommonParameters>]
+    Get-PASPTAEvent [-lastUpdatedEventDate <DateTime>] [-status <String>] [-accountID <String>] [<CommonParameters>]
+
+    Get-PASPTAEvent [-lastUpdatedEventDate <DateTime>] [-UseLegacyMethod] [<CommonParameters>]
 
 ## DESCRIPTION
 
-Returns PTA security events
+    Returns PTA security events
 
 ## PARAMETERS
 
     -lastUpdatedEventDate <DateTime>
-        Parameter description
+        Starting date from which to get security events.
 
         Required?                    false
-        Position?                    1
+        Position?                    named
         Default value
         Accept pipeline input?       true (ByPropertyName)
         Accept wildcard characters?  false
 
-    <CommonParameters>
-        This cmdlet supports the common parameters: Verbose, Debug,
-        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
-        OutBuffer, PipelineVariable, and OutVariable. For more information, see
-        about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).
+    -status <String>
+        The status of the security event (open or closed).
+        Requires 11.4
+
+        Required?                    false
+        Position?                    named
+        Default value
+        Accept pipeline input?       true (ByPropertyName)
+        Accept wildcard characters?  false
+
+    -accountID <String>
+        The unique account identifier of the account relating to the Security Event.
+        Requires 11.4
+
+        Required?                    false
+        Position?                    named
+        Default value
+        Accept pipeline input?       true (ByPropertyName)
+        Accept wildcard characters?  false
+
+    -UseLegacyMethod [<SwitchParameter>]
+        Specify to send lastUpdatedEventDate using legacy method
+        Requires 11.4
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       false
+        Accept wildcard characters?  false
 
 ## EXAMPLES
 
@@ -38,3 +64,30 @@ Returns PTA security events
     PS C:\>Get-PASPTAEvent
 
     Returns all PTA security events
+
+
+
+
+    -------------------------- EXAMPLE 2 --------------------------
+
+    PS C:\>Get-PASPTAEvent -lastUpdatedEventDate $date
+
+    Returns all PTA security events since $date
+
+
+
+
+    -------------------------- EXAMPLE 3 --------------------------
+
+    PS C:\>Get-PASPTAEvent -status OPEN
+
+    Returns all PTA security events with an Open status.
+
+
+
+
+    -------------------------- EXAMPLE 4 --------------------------
+
+    PS C:\>Get-PASPTAEvent -lastUpdatedEventDate $date -UseLegacyMethod
+
+    Returns all PTA security events since $date

--- a/docs/collections/_commands/New-PASSession.md
+++ b/docs/collections/_commands/New-PASSession.md
@@ -18,6 +18,8 @@ Authenticates a user to CyberArk Vault/API.
     New-PASSession -Credential <PSCredential> [-type <String>] [-OTP <String>] [-OTPMode <String>] [-OTPDelimiter <String>] [-RadiusChallenge <String>] [-concurrentSession <Boolean>] -BaseURI <String> [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate <X509Certificate>] [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf]
     [-Confirm] [<CommonParameters>]
 
+    New-PASSession -SAMLAuth [-concurrentSession <Boolean>] -BaseURI <String> [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate <X509Certificate>] [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
+
     New-PASSession -SAMLToken <String> -BaseURI <String> [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate <X509Certificate>] [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
 
     New-PASSession -UseSharedAuthentication -BaseURI <String> [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate <X509Certificate>] [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
@@ -67,6 +69,16 @@ For CyberArk version older than 9.7:
         Required?                    false
         Position?                    named
         Default value
+        Accept pipeline input?       true (ByPropertyName)
+        Accept wildcard characters?  false
+
+    -SAMLAuth [<SwitchParameter>]
+        Supported from 11.4
+        Specify to authenticate after retrieval of saml token.
+
+        Required?                    true
+        Position?                    named
+        Default value                False
         Accept pipeline input?       true (ByPropertyName)
         Accept wildcard characters?  false
 
@@ -424,3 +436,9 @@ For CyberArk version older than 9.7:
     PS C:\>New-PASSession -Credential $cred -BaseURI https://PVWA -type Windows -OTP passcode -OTPMode Challenge
 
     Perform initial authentication and then get prompted to supply OTP value for  RADIUS challenge.
+
+    -------------------------- EXAMPLE 19 --------------------------
+
+    PS C:\>New-PASSession -BaseURI $url -SAMLAuth
+
+    Perform saml authentication from version 11.4

--- a/docs/collections/_commands/Set-PASPTAEvent.md
+++ b/docs/collections/_commands/Set-PASPTAEvent.md
@@ -1,0 +1,49 @@
+---
+title: Set-PASPTAEvent
+---
+
+## SYNOPSIS
+
+Updates the status of a security event
+
+## SYNTAX
+
+    Set-PASPTAEvent [-EventID] <String> [[-mStatus] <String>] [<CommonParameters>]
+
+## DESCRIPTION
+
+    Updates the status of a security event to open or closed
+
+## PARAMETERS
+
+    -EventID <String>
+        The event ID.
+
+        Required?                    true
+        Position?                    1
+        Default value
+        Accept pipeline input?       true (ByPropertyName)
+        Accept wildcard characters?  false
+
+    -mStatus <String>
+        The status to update (open or closed).
+
+        Required?                    false
+        Position?                    2
+        Default value
+        Accept pipeline input?       true (ByPropertyName)
+        Accept wildcard characters?  false
+
+    <CommonParameters>
+        This cmdlet supports the common parameters: Verbose, Debug,
+        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
+        OutBuffer, PipelineVariable, and OutVariable. For more information, see
+        about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).
+
+## EXAMPLES
+
+        Minimum Version CyberArk 11.3
+
+    -------------------------- EXAMPLE 1 --------------------------
+
+    PS C:\>Set-PASPTAEvent -EventID $id

--- a/docs/collections/_docs/10-compatibility.md
+++ b/docs/collections/_docs/10-compatibility.md
@@ -2,7 +2,7 @@
 title: "Compatibility"
 permalink: /docs/compatibility/
 excerpt: "Module Compatibility"
-last_modified_at: 2020-01-21T22:05:00-00:00
+last_modified_at: 2020-06-28T01:33:52-00:00
 toc: false
 ---
 
@@ -100,7 +100,8 @@ If you are using version 9.7+, and the function being invoked requires version 9
 [`Add-PASDirectory`][Add-PASDirectory]                                                   | **10.4** ([Notes](#add-pasdirectory))              |Add a new LDAP directory
 [`New-PASDirectoryMapping`][New-PASDirectoryMapping]                                     | **10.4** ([Notes](#new-pasdirectorymapping))       |Create a new LDAP directory mapping
 [`Add-PASPTARule`][Add-PASPTARule]                                                       | **10.4**                                           |Add a new Risky Commandrule to PTA
-[`Get-PASPTAEvent`][Get-PASPTAEvent]                                                     | **10.3**                                           |Get security eventsfrom PTA
+[`Get-PASPTAEvent`][Get-PASPTAEvent]                                                     | **10.3**                                           |Get security events from PTA
+[`Set-PASPTAEvent`][Set-PASPTAEvent]                                                     | **11.3**                                           |Set status of PTA security events
 [`Get-PASPTARemediation`][Get-PASPTARemediation]                                         | **10.4**                                           |Get automatic response config from PTA
 [`Get-PASPTARule`][Get-PASPTARule]                                                       | **10.4**                                           |List Risky Command rules from PTA
 [`Set-PASPTARemediation`][Set-PASPTARemediation]                                         | **10.4**                                           |Update automaticresponse config in PTA
@@ -125,8 +126,8 @@ If you are using version 9.7+, and the function being invoked requires version 9
 [`New-PASGroup`][New-PASGroup]                                                           | **11.1**                                           |Create a new CyberArk group
 [`Get-PASPlatformSafe`][Get-PASPlatformSafe]                                             | **11.1**                                           |List details for all platforms
 [`Remove-PASDirectoryMapping`][Remove-PASDirectoryMapping]                               | **11.1**                                           |Deletes a Directory Mapping
-[`Enable-PASCPMAutoManagement`][Enable-PASCPMAutoManagement]                             | **10.4**                                           |Enables Automatic CPM Managment for an account
-[`Disable-PASCPMAutoManagement`][Disable-PASCPMAutoManagement]                           | **10.4**                                           |Disables Automatic CPM Managment for an account
+[`Enable-PASCPMAutoManagement`][Enable-PASCPMAutoManagement]                             | **10.4**                                           |Enables Automatic CPM Management for an account
+[`Disable-PASCPMAutoManagement`][Disable-PASCPMAutoManagement]                           | **10.4**                                           |Disables Automatic CPM Management for an account
 [`Test-PASPSMRecording`][Test-PASPSMRecording]                                           | **11.2**                                           |Determine validity of PSM Session Recording
 
 [New-PASSession]:/commands/New-PASSession
@@ -206,6 +207,7 @@ If you are using version 9.7+, and the function being invoked requires version 9
 [New-PASDirectoryMapping]:/commands/New-PASDirectoryMapping
 [Add-PASPTARule]:/commands/Add-PASPTARule
 [Get-PASPTAEvent]:/commands/Get-PASPTAEvent
+[Set-PASPTAEvent]:/commands/Set-PASPTAEvent
 [Get-PASPTARemediation]:/commands/Get-PASPTARemediation
 [Get-PASPTARule]:/commands/Get-PASPTARule
 [Set-PASPTARemediation]:/commands/Set-PASPTARemediation
@@ -249,6 +251,7 @@ If you are using version 9.7+, and the function being invoked requires version 9
   - New Authentication Method:
     - Windows
 - Version 11.3 introduced support for concurrent API sessions.
+- Version 11.4 introduced updated support for SAML auth.
 - The Classic API endpoint can be used by specifying the `-UseClassicAPI` parameter.
 
 ### Close-PASSession
@@ -430,3 +433,10 @@ If you are using version 9.7+, and the function being invoked requires version 9
 - Version 11.1 introduced a new API endpoint.
   - Supports:
     - Additional parameters for updating users.
+
+### Get-PASPTAEvent
+
+- Version 11.4 introduced new parameters for filtering events
+  - Supports:
+    - status
+    - accountID

--- a/docs/collections/_docs/20-search.md
+++ b/docs/collections/_docs/20-search.md
@@ -2,7 +2,7 @@
 title: "Search"
 permalink: /docs/search/
 excerpt: "Basic Operations - Searching"
-last_modified_at: 2019-09-01T01:33:52-00:00
+last_modified_at: 2020-06-28T01:33:52-00:00
 ---
 
 ## Safes
@@ -32,7 +32,7 @@ Get-PASSafeMember -SafeName 3_TestSafe_028_XYJ -MemberName ACC-G-3_TestSafe_028_
 
 UserName                     SafeName           Permissions
 --------                     --------           ---------- -
-ACC-G-3_TestSafe_028_XYJ-Usr 3_TestSafe_028_XYJ { UseAccounts, RetrieveAccounts, ListAccounts, ViewAuditLog… }
+ACC-G-3_TestSafe_028_XYJ-Usr 3_TestSafe_028_XYJ @{Add=True; AddRenameFolder=True; BackupSafe=True...
 ````
 
 ## Users

--- a/docs/collections/_docs/22-administration.md
+++ b/docs/collections/_docs/22-administration.md
@@ -2,7 +2,7 @@
 title: "Administration"
 permalink: /docs/administration/
 excerpt: "psPAS Administration"
-last_modified_at: 2019-09-01T01:33:52-00:00
+last_modified_at: 2020-06-28T01:33:52-00:00
 ---
 
 ## Add An Account
@@ -47,7 +47,7 @@ Add-PASSafeMember -SafeName NewSafe -MemberName NewMember -UseAccounts $false -L
 
 MemberName SearchIn SafeName Permissions
 ---------- -------- -------- ---------- -
-NewMember  vault    NewSafe { ListAccounts, ViewAuditLog, ViewSafeMembers }
+NewMember  vault    NewSafe @{Add=True; AddRenameFolder=True; BackupSafe=True...
 ````
 
 ## Update Accounts

--- a/docs/collections/_docs/26-pipeline-operations.md
+++ b/docs/collections/_docs/26-pipeline-operations.md
@@ -2,7 +2,7 @@
 title: "Pipeline Operations"
 permalink: /docs/pipeline-operations/
 excerpt: "psPAS Pipeline Operations"
-last_modified_at: 2019-09-01T01:33:52-00:00
+last_modified_at: 2020-06-28T01:33:52-00:00
 ---
 
 - Work with the PowerShell pipeline:
@@ -14,12 +14,12 @@ Where-Object { Get-PASGroup -search $_.UserName -filter 'groupType eq Directory'
 
 UserName                     SafeName           Permissions
 --------                     --------           ---------- -
-ACC-G-1_TestSafe_049_JXW-Usr 1_TestSafe_049_JXW { ListContent, RestrictedRetrieve, Retrieve, ViewAudit… }
-ACC-G-1_TestSafe_049_JXW-Adm 1_TestSafe_049_JXW { ListContent, RestrictedRetrieve, Retrieve, Unlock… }
-ACC-G-2_TestSafe_049_JXW-Usr 2_TestSafe_049_JXW { ListContent, RestrictedRetrieve, Retrieve, ViewAudit… }
-ACC-G-2_TestSafe_049_JXW-Adm 2_TestSafe_049_JXW { ListContent, RestrictedRetrieve, Retrieve, Unlock… }
-ACC-G-3_TestSafe_049_JXW-Usr 3_TestSafe_049_JXW { ListContent, RestrictedRetrieve, Retrieve, ViewAudit… }
-ACC-G-3_TestSafe_049_JXW-Adm 3_TestSafe_049_JXW { ListContent, RestrictedRetrieve, Retrieve, Unlock… }
+ACC-G-1_TestSafe_049_JXW-Usr 1_TestSafe_049_JXW @{Add=True; AddRenameFolder=True; BackupSafe=True...}
+ACC-G-1_TestSafe_049_JXW-Adm 1_TestSafe_049_JXW @{Add=True; AddRenameFolder=True; BackupSafe=True...}
+ACC-G-2_TestSafe_049_JXW-Usr 2_TestSafe_049_JXW @{Add=True; AddRenameFolder=True; BackupSafe=True...}
+ACC-G-2_TestSafe_049_JXW-Adm 2_TestSafe_049_JXW @{Add=True; AddRenameFolder=True; BackupSafe=True...}
+ACC-G-3_TestSafe_049_JXW-Usr 3_TestSafe_049_JXW @{Add=True; AddRenameFolder=True; BackupSafe=True...}
+ACC-G-3_TestSafe_049_JXW-Adm 3_TestSafe_049_JXW @{Add=True; AddRenameFolder=True; BackupSafe=True...}
 ````
 
 - Multiple `psPAS` commands can be used together, along with standard PowerShell CmdLets:
@@ -34,17 +34,17 @@ Get-PASAccount -id 330_5 | Get-PASSafe | Get-PASSafeMember
 
 UserName             SafeName    Permissions
 --------             --------    ---------- -
-Master               ApproveTest { Add, AddRenameFolder, BackupSafe, Delete... }
-Batch                ApproveTest { Add, AddRenameFolder, BackupSafe, Delete... }
-Backup Users         ApproveTest BackupSafe
-Auditors             ApproveTest { ListContent, ViewAudit, ViewMembers }
-Operators            ApproveTest { AddRenameFolder, DeleteFolder, ManageSafe, MoveFilesAndFolders... }
-DR Users             ApproveTest BackupSafe
-Notification Engines ApproveTest { ListContent, ViewAudit, ViewMembers }
-PVWAGWAccounts       ApproveTest { ListContent, ViewAudit, ViewMembers }
-PasswordManager      ApproveTest { Add, AddRenameFolder, Delete, DeleteFolder... }
-SafeAdmin            ApproveTest { Add, AddRenameFolder, BackupSafe, Delete... }
-SafeAdmin1           ApproveTest { Add, AddRenameFolder, BackupSafe, Delete... }
-zApprover_1          ApproveTest { ListContent, ViewAudit, ViewMembers }
-xReq                 ApproveTest { ListContent, RestrictedRetrieve, Retrieve, ViewAudit... }
+Master               ApproveTest @{Add=True; AddRenameFolder=True; BackupSafe=True...}
+Batch                ApproveTest @{Add=True; AddRenameFolder=True; BackupSafe=True...}
+Backup Users         ApproveTest @{Add=False; AddRenameFolder=False; BackupSafe=True...}
+Auditors             ApproveTest @{Add=False; AddRenameFolder=False; BackupSafe=False...}
+Operators            ApproveTest @{Add=True; AddRenameFolder=True; BackupSafe=True...}
+DR Users             ApproveTest @{Add=False; AddRenameFolder=False; BackupSafe=True...}
+Notification Engines ApproveTest @{Add=False; AddRenameFolder=False; BackupSafe=False...}
+PVWAGWAccounts       ApproveTest @{Add=False; AddRenameFolder=False; BackupSafe=False...}
+PasswordManager      ApproveTest @{Add=False; AddRenameFolder=True; BackupSafe=False...}
+SafeAdmin            ApproveTest @{Add=True; AddRenameFolder=True; BackupSafe=True...}
+SafeAdmin1           ApproveTest @{Add=True; AddRenameFolder=True; BackupSafe=True...}
+zApprover_1          ApproveTest @{Add=False; AddRenameFolder=False; BackupSafe=False...}
+xReq                 ApproveTest @{Add=False; AddRenameFolder=False; BackupSafe=False...}
 ````

--- a/docs/collections/_docs/32-safe-permissions.md
+++ b/docs/collections/_docs/32-safe-permissions.md
@@ -2,7 +2,7 @@
 title: "Safe Permissions"
 permalink: /docs/safe-permissions/
 excerpt: "psPAS Safe Permissions"
-last_modified_at: 2019-09-01T01:33:52-00:00
+last_modified_at: 2020-06-28T01:33:52-00:00
 ---
 
 - Define Safe Roles and assign to safe members:
@@ -43,11 +43,11 @@ $Role1 | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn Vault
 
 MemberName SearchIn SafeName Permissions
 ---------- -------- -------- -----------
-User23     Vault    NewSafe  {UseAccounts, RetrieveAccounts, ListAccounts}
+User23     Vault    NewSafe  @{Add=False; AddRenameFolder=False; BackupSafe=False...}
 
 $Role2 | Add-PASSafeMember -SafeName NewSafe -MemberName SafeAdmin1 -SearchIn Vault
 
 MemberName SearchIn SafeName Permissions
 ---------- -------- -------- -----------
-SafeAdmin1 Vault    NewSafe  {ListAccounts, AddAccounts, UpdateAccountContent, UpdateAccountProperties…}
+SafeAdmin1 Vault    NewSafe  @{Add=True; AddRenameFolder=True; BackupSafe=True...}
 ````

--- a/psPAS/Functions/EventSecurity/Set-PASPTAEvent.ps1
+++ b/psPAS/Functions/EventSecurity/Set-PASPTAEvent.ps1
@@ -1,0 +1,72 @@
+Function Set-PASPTAEvent {
+	<#
+.SYNOPSIS
+Updates the status of a security event
+
+.DESCRIPTION
+Updates the status of a security event to open or closed
+
+.PARAMETER EventID
+The event ID.
+
+.PARAMETER mStatus
+The status to update (open or closed).
+
+.EXAMPLE
+Set-PASPTAEvent -EventID $id
+
+.NOTES
+Minimum Version CyberArk 11.3
+
+.LINK
+https://pspas.pspete.dev/commands/Set-PASPTAEvent
+#>
+	[CmdletBinding()]
+	param(
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$EventID,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateSet("OPEN","CLOSED")]
+		[string]$mStatus
+
+	)
+
+	BEGIN {
+		$MinimumVersion = [System.Version]"11.3"
+
+	}#begin
+
+	PROCESS {
+
+		Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $MinimumVersion
+
+		#Create request URL
+		$URI = "$Script:BaseURI/API/pta/API/Events/$EventID"
+
+		#Get Parameters to include in request
+		$body = $PSBoundParameters | Get-PASParameter -ParametersToRemove EventID | ConvertTo-Json
+
+		#Send request to web service
+		$result = Invoke-PASRestMethod -Uri $URI -Method PATCH -Body $body
+
+		If ($result) {
+
+			#Return Results
+			$result |
+
+			Add-ObjectDetail -typename psPAS.CyberArk.Vault.PTA.Event
+
+		}
+
+	}#process
+
+	END { }#end
+
+}

--- a/psPAS/Functions/SafeMembers/Add-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Add-PASSafeMember.ps1
@@ -394,12 +394,23 @@ https://pspas.pspete.dev/commands/Add-PASSafeMember
 
 		if ($result) {
 
+			$MemberPermissions = [PSCustomObject]@{ }
+
+			$result.member.Permissions | ForEach-Object {
+
+				$MemberPermissions |
+					Add-Member -MemberType NoteProperty -Name $($PSItem |
+						Select-Object -ExpandProperty key) -Value $($PSItem |
+							Select-Object -ExpandProperty value)
+
+			}
+
 			#format output
 			$result.member | Select-Object MemberName, MembershipExpirationDate, SearchIn,
 
 			@{Name = "Permissions"; "Expression" = {
 
-					$_.Permissions | Where-Object { $_.value } | Select-Object -ExpandProperty key }
+					$MemberPermissions }
 
 			} | Add-ObjectDetail -typename psPAS.CyberArk.Vault.Safe.Member.Extended -PropertyToAdd @{
 

--- a/psPAS/Functions/SafeMembers/Add-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Add-PASSafeMember.ps1
@@ -333,11 +333,32 @@ https://pspas.pspete.dev/commands/Add-PASSafeMember
 
 	BEGIN {
 
-		#Set base Parameters the exist at the top level of required JSON object
-		$baseParameters = @("MemberName", "SearchIn", "MembershipExpirationDate", "SafeName")
-
 		#Create empty hashtable to hold permission related parameters
-		$permissions = @{ }
+		$Permissions = [ordered]@{ }
+
+		$OrderedPermisions = [ordered]@{
+			UseAccounts                            = $false
+			RetrieveAccounts                       = $false
+			ListAccounts                           = $false
+			AddAccounts                            = $false
+			UpdateAccountContent                   = $false
+			UpdateAccountProperties                = $false
+			InitiateCPMAccountManagementOperations = $false
+			SpecifyNextAccountContent              = $false
+			RenameAccounts                         = $false
+			DeleteAccounts                         = $false
+			UnlockAccounts                         = $false
+			ManageSafe                             = $false
+			ManageSafeMembers                      = $false
+			BackupSafe                             = $false
+			ViewAuditLog                           = $false
+			ViewSafeMembers                        = $false
+			RequestsAuthorizationLevel             = 0
+			AccessWithoutConfirmation              = $false
+			CreateFolders                          = $false
+			DeleteFolders                          = $false
+			MoveAccountsAndFolders                 = $false
+		}
 
 		#array for parameter names which will do not appear in the top-tier of the JSON object
 		$keysToRemove = [Collections.Generic.List[String]]@('SafeName')
@@ -364,19 +385,24 @@ https://pspas.pspete.dev/commands/Add-PASSafeMember
 
 		}
 
-		#For every passed permission ("Non-Base") parameter
-		$boundParameters.keys | Where-Object { $baseParameters -notcontains $_ } | ForEach-Object {
+		#For each Member Permission parameter
+		$OrderedPermisions.keys | ForEach-Object {
 
-			#Add Key=Value pair to permissions hashtable
-			$permissions[$_] = $boundParameters[$_]
+			#include permission in request
+			If ($boundParameters.ContainsKey($PSItem)) {
 
-			#Add parameter name to array
-			$null = $keysToRemove.Add($_)
+				#Add to hash table in key/value pair
+				$Permissions.Add($PSItem, $boundParameters[$PSItem])
+
+				#permission parameter name
+				$null = $keysToRemove.Add($PSItem)
+
+			}
 
 		}
 
 		#add all required permissions  as value to "Permissions" key
-		$boundParameters["Permissions"] = @($permissions.getenumerator() | ForEach-Object { $_ })
+		$boundParameters["Permissions"] = @($Permissions.getenumerator() | ForEach-Object { $PSItem })
 
 		#Create required request object
 		$body = @{

--- a/psPAS/Functions/SafeMembers/Get-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Get-PASSafeMember.ps1
@@ -9,53 +9,53 @@ View Safe Members permission is required.
 
 When querying all members of a safe, the permissions are reported as per the following table:
 
-List accounts							ListContent
+List accounts							    ListContent
 Retrieve accounts							Retrieve
-Add accounts (includes update properties)				Add
+Add accounts (includes update properties)	Add
 Update account content						Update
-Update account properties						UpdateMetadata
-Rename accounts							Rename
-Delete accounts							Delete
-View Audit log							ViewAudit
+Update account properties					UpdateMetadata
+Rename accounts							    Rename
+Delete accounts							    Delete
+View Audit log							    ViewAudit
 View Safe Members							ViewMembers
-Use accounts							RestrictedRetrieve
-Initiate CPM account management operations				<NOT RETURNED>
-Specify next account content					<NOT RETURNED>
-Create folders							AddRenameFolder
-Delete folders							DeleteFolder
-Unlock accounts							Unlock
+Use accounts								RestrictedRetrieve
+Initiate CPM account management operations	<NOT RETURNED>
+Specify next account content			    <NOT RETURNED>
+Create folders							    AddRenameFolder
+Delete folders							    DeleteFolder
+Unlock accounts							    Unlock
 Move accounts/folders						MoveFilesAndFolders
-Manage Safe								ManageSafe
+Manage Safe								    ManageSafe
 Manage Safe Members							ManageSafeMembers
 Validate Safe Content						ValidateSafeContent
-Backup Safe								BackupSafe
-Access Safe without confirmation					<NOT RETURNED>
-Authorize account requests�(level1, level2)				<NOT RETURNED>
+Backup Safe								    BackupSafe
+Access Safe without confirmation			<NOT RETURNED>
+Authorize account requests�(level1, level2)	<NOT RETURNED>
 
 If a Safe Member Name is provided, the full permissions of the member on the Safe will be returned:
 
-List accounts							ListAccounts
+List accounts							    ListAccounts
 Retrieve accounts							RetrieveAccounts
-Add accounts (includes update properties)				AddAccounts
+Add accounts (includes update properties)	AddAccounts
 Update account content						UpdateAccountContent
-Update account properties						UpdateAccountProperties
-Rename accounts							RenameAccounts
-Delete accounts							DeleteAccounts
-View Audit log							ViewAuditLog
+Update account properties					UpdateAccountProperties
+Rename accounts							    RenameAccounts
+Delete accounts							    DeleteAccounts
+View Audit log							    ViewAuditLog
 View Safe Members							ViewSafeMembers
-Use accounts							UseAccounts
-Initiate CPM account management operations				InitiateCPMAccountManagementOperations
-Specify next account content					SpecifyNextAccountContent
-Create folders							CreateFolders
-Delete folders							DeleteFolder
-Unlock accounts							UnlockAccounts
+Use accounts							    UseAccounts
+Initiate CPM account management operations	InitiateCPMAccountManagementOperations
+Specify next account content				SpecifyNextAccountContent
+Create folders							    CreateFolders
+Delete folders							    DeleteFolder
+Unlock accounts							    UnlockAccounts
 Move accounts/folders						MoveAccountsAndFolders
-Manage Safe								ManageSafe
+Manage Safe								    ManageSafe
 Manage Safe Members							ManageSafeMembers
 Validate Safe Content						<NOT RETURNED>
-Backup Safe								BackupSafe
-Access Safe without confirmation					AccessWithoutConfirmation
-Authorize account requests (level1, level2)				RequestsAuthorizationLevel
+Backup Safe								    BackupSafe
+Access Safe without confirmation			AccessWithoutConfirmation
+Authorize account requests (level1, level2)	RequestsAuthorizationLevel
 
 .PARAMETER SafeName
 The name of the safe to get the members of
@@ -147,6 +147,17 @@ https://pspas.pspete.dev/commands/Get-PASSafeMember
 
 			if ($PSCmdlet.ParameterSetName -eq "MemberPermissions") {
 
+				$MemberPermissions = [PSCustomObject]@{}
+
+				$result.member.Permissions | ForEach-Object {
+
+					$MemberPermissions |
+						Add-Member -MemberType NoteProperty -Name $($PSItem |
+							Select-Object -ExpandProperty key) -Value $($PSItem |
+								Select-Object -ExpandProperty value)
+
+				}
+
 				#format output
 				$Output = $result.member | Select-Object MembershipExpirationDate,
 
@@ -158,7 +169,7 @@ https://pspas.pspete.dev/commands/Get-PASSafeMember
 
 				@{Name = "Permissions"; "Expression" = {
 
-						$_.Permissions | Where-Object { $_.value } | Select-Object -ExpandProperty key }
+						$MemberPermissions }
 
 				}
 
@@ -167,13 +178,7 @@ https://pspas.pspete.dev/commands/Get-PASSafeMember
 			Else {
 
 				#output
-				$Output = $result.members | Select-Object UserName, @{Name = "Permissions"; "Expression" = {
-
-						($_.Permissions).psobject.properties | Where-Object { $_.Value -eq $true } |
-
-						Select-Object -ExpandProperty Name }
-
-				}
+				$Output = $result.members | Select-Object UserName, Permissions
 
 			}
 

--- a/psPAS/Functions/SafeMembers/Set-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Set-PASSafeMember.ps1
@@ -329,12 +329,23 @@ https://pspas.pspete.dev/commands/Set-PASSafeMember
 
 			if ($result) {
 
+				$MemberPermissions = [PSCustomObject]@{ }
+
+				$result.member.Permissions | ForEach-Object {
+
+					$MemberPermissions |
+						Add-Member -MemberType NoteProperty -Name $($PSItem |
+							Select-Object -ExpandProperty key) -Value $($PSItem |
+								Select-Object -ExpandProperty value)
+
+				}
+
 				#format output
 				$result.member | Select-Object MembershipExpirationDate,
 
 				@{Name = "Permissions"; "Expression" = {
 
-						$_.Permissions | Where-Object { $_.value } | Select-Object -ExpandProperty key }
+						$MemberPermissions }
 
 				} | Add-ObjectDetail -typename psPAS.CyberArk.Vault.Safe.Member -PropertyToAdd @{
 

--- a/psPAS/Functions/User/Set-PASUser.ps1
+++ b/psPAS/Functions/User/Set-PASUser.ps1
@@ -701,10 +701,8 @@ https://pspas.pspete.dev/commands/Set-PASUser
 
 			}
 
-			#Construct Request Body
-			$body = $boundParameters |
-			Get-PASParameter -ParametersToRemove id, @($businessAddressParams + $internetParams + $phonesParams + $personalDetailsParams) |
-			ConvertTo-Json -depth 4
+			#Prepare Request Body
+			$boundParameters = $boundParameters | Get-PASParameter -ParametersToRemove @("id", $businessAddressParams + $internetParams + $phonesParams + $personalDetailsParams)
 
 			$TypeName = "psPAS.CyberArk.Vault.User.Extended"
 
@@ -729,12 +727,13 @@ https://pspas.pspete.dev/commands/Set-PASUser
 
 			$TypeName = "psPAS.CyberArk.Vault.User"
 
+			#Prepare Request Body
 			$boundParameters = $boundParameters | Get-PASParameter -ParametersToRemove UserName
 
 		}
 
-		#create request body
-		$body = $boundParameters | ConvertTo-Json
+		#Construct Request Body
+		$body = $boundParameters | ConvertTo-Json -depth 4
 
 		if ($PSCmdlet.ShouldProcess($UserName, "Update User Properties")) {
 			#send request to web service

--- a/psPAS/Private/Get-PASSAMLResponse.ps1
+++ b/psPAS/Private/Get-PASSAMLResponse.ps1
@@ -1,0 +1,43 @@
+Function Get-PASSAMLResponse {
+<#
+.SYNOPSIS
+Get SAML Token for PAS SAML Auth
+
+.DESCRIPTION
+Get SAML Token from pvwa webresponse
+
+.PARAMETER URL
+The PVWA URL
+
+.EXAMPLE
+Get-PASSAMLResponse -URL "https://pvwa.somecompany.com/PasswordVault"
+
+.NOTES
+https://gist.github.com/infamousjoeg/b44faa299ec3de65bdd1d3b8474b0649
+#>
+	[CmdletBinding()]
+	param(
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipeline = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		$URL
+	)
+
+	Try {
+
+		$WebResponse = Invoke-WebRequest -Uri "$URL/auth/saml/" -MaximumRedirection 0 -ErrorAction SilentlyContinue -UseBasicParsing
+
+		$SAMLResponse = Invoke-WebRequest -Uri ($WebResponse.links.href) -MaximumRedirection 1 -UseDefaultCredentials -UseBasicParsing
+
+		If ($SAMLResponse.InputFields[0].name -eq "SAMLResponse") {
+			$SAMLResponse.InputFields[0].value
+		}
+		Else { Throw }
+
+	}
+
+	Catch { Throw "Failed to get SAMLResponse" }
+
+}

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -181,7 +181,8 @@
 		'Get-PASPlatformSafe',
 		'Remove-PASDirectoryMapping',
 		'Disable-PASCPMAutoManagement',
-		'Test-PASPSMRecording'
+		'Test-PASPSMRecording',
+		'Set-PASPTAEvent'
 	)
 
 	# AliasesToExport   = @( )


### PR DESCRIPTION
<!-- _A similar PR may already be submitted.
Please search existing `Pull Requests` before creating one._

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.  -->

## Summary

### Module update to cover CyberArk 11.4 API features

- **Breaking Changes**
  - `Get-PASSafeMember`, `Add-PASSafeMember` & `Set-PASSafeMember`: Output Changed
    - "Permission" property of returned object now contains a nested property=value pair for each permission instead of an array containing only the name of the assigned permissions.
    - Existing scripts which rely on the legacy array value of the `Permissions` property when working with the `*-PASSafeMember` functions must either be updated to work with the new output or use an earlier compatible psPAS version.

- New Function
  - Added `Set-PASPTAEvent`
    - Appeared in 11.3
    - Set status of PTA events

- Updated Functions
  - `New-PASSession`
    - Adds support for updated saml auth updated in 11.4
  - `Get-PASPTAEvent`
    - Adds newly documented parameters for 11.4 and updates request format for filtering events

- Fixes
  - `Set-PASUser`
    - Corrects issue where an incorrectly formed json body was being sent with the request if using the parameters introduced in psPAS 3.3.88.
  - `Add-PASSafeMember` & `Set-PASSafeMember`
    - Update ensures json body of request is always sent with the permission properties statically ordered.

## Test Plan

_Demonstrate the code is solid. Example: The exact commands you ran and their output._

## Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes. -->
closes #272 

closes #275 

<!--
## Code formatting

 See the `CONTRIBUTING` guide.

_Ensure your code adheres to the project's PowerShell Styleguide_
-->