### PR TITLE
Feature 11.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@
 - Continued development to encompass any new documented features of the CyberArk API.
 - psPAS v5.0...
 
+## **4.1.X** (July X 2020)
+
+### Module update to cover CyberArk 11.5 API features
+
+- **Behavior Changes**
+  - `Get-PASPlatform`
+    - When invoked with no parameters to return details of all configured platforms, defaults to operation against the endpoint for the 11.4 API.
+    - When invoked with a value provided for the `Active` parameter, will perform operation against the endpoint for the 11.4 API.
+    - To utilise the 11.1 api endpoint, a value should be provided for the `PlatformType` and/or `Search` parameters,  or, `Active` and `PlatformType` and/or `Search` parameters.
+
+- New Functions
+  - `Copy-PASPlatform`
+    - Duplicates target, dependent, group or rotational group platform to a new platform.
+    - 11.4 functionality, missed in the `4.0.0` release.
+  - `Disable-PASPlatform`
+    - Disables, target, group or rotational group platform.
+    - 11.4 functionality, missed in the `4.0.0` release.
+  - `Enable-PASPlatform`
+    - Enables, target, group or rotational group platform.
+    - 11.4 functionality, missed in the `4.0.0` release.
+  - `Remove-PASPlatform`
+    - Deletes, target, dependent, group or rotational group platform.
+    - 11.4 functionality, missed in the `4.0.0` release.
+  - `Remove-PASGroup`
+    - Deletes a specified vault user group
+    - 11.5 functionality.
+
+- Updated Functions
+  - `Get-PASUser`
+    - 11.5 output includes group membership details.
+    - group membership property may be included in output when function is executed from earlier versions, but its content will be blank.
+
+- Other Fixes & Updates
+  - Documentation updated.
+
 ## **4.0.0** (July 1st 2020)
 
 ### Module update to cover CyberArk 11.4 API features

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Use PowerShell to manage CyberArk via the Web Services REST API.
 
-Contains all published methods of the API up to CyberArk v11.4.
+Contains all published methods of the API up to CyberArk v11.5.
 
 Docs: [https://pspas.pspete.dev](https://pspas.pspete.dev)
 
@@ -850,7 +850,12 @@ Check the output of `Get-Help` for the `psPAS` functions for further details of 
 [`Remove-PASDirectoryMapping`][Remove-PASDirectoryMapping]                               |**11.1**            |Deletes a Directory Mapping
 [`Enable-PASCPMAutoManagement`][Enable-PASCPMAutoManagement]                             |**10.4**            |Enables Automatic CPM Management for an account
 [`Disable-PASCPMAutoManagement`][Disable-PASCPMAutoManagement]                           |**10.4**            |Disables Automatic CPM Management for an account
-[`Test-PASPSMRecording`][Test-PASPSMRecording]                                           | **11.2**           |Determine validity of PSM Session Recording
+[`Test-PASPSMRecording`][Test-PASPSMRecording]                                           |**11.2**            |Determine validity of PSM Session Recording
+[`Copy-PASPlatform`][Copy-PASPlatform]                                                   |**11.4**            |Duplicate a platform
+[`Enable-PASPlatform`][Enable-PASPlatform]                                               |**11.4**            |Enable a platform
+[`Disable-PASPlatform`][Disable-PASPlatform]                                             |**11.4**            |Disable a platform
+[`Remove-PASPlatform`][Remove-PASPlatform]                                               |**11.4**            |Delete a platform
+[`Remove-PASGroup`][Remove-PASGroup]                                                     |**11.5**            |Delete a user group
 
 [New-PASSession]:/psPAS/Functions/Authentication/New-PASSession.ps1
 [Close-PASSession]:/psPAS/Functions/Authentication/Close-PASSession.ps1
@@ -958,6 +963,11 @@ Check the output of `Get-Help` for the `psPAS` functions for further details of 
 [Get-PASPlatformSafe]:/psPAS/Functions/Platforms/Get-PASPlatformSafe.ps1
 [New-PASGroup]:/psPAS/Functions/User/New-PASGroup.ps1
 [Test-PASPSMRecording]:/psPAS/Functions/Monitoring/Test-PASPSMRecording.ps1
+[Copy-PASPlatform]:psPAS/Functions/Platforms/Copy-PASPlatform.ps1
+[Disable-PASPlatform]:psPAS/Functions/Platforms/Disable-PASPlatform.ps1
+[Enable-PASPlatform]:psPAS/Functions/Platforms/Enable-PASPlatform.ps1
+[Remove-PASPlatform]:psPAS/Functions/Platforms/Remove-PASPlatform.ps1
+[Remove-PASGroup]:psPAS/Functions/User/Remove-PASGroup.ps1
 
 ## Installation
 

--- a/Tests/Copy-PASPlatform.Tests.ps1
+++ b/Tests/Copy-PASPlatform.Tests.ps1
@@ -1,0 +1,181 @@
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
+
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
+
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+		if ( -not (Get-Module -Name $ModuleName -All)) {
+
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+		}
+
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "11.4"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+	}
+
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'TargetPlatform' },
+			@{Parameter = 'DependentPlatform' },
+			@{Parameter = 'GroupPlatform' },
+			@{Parameter = 'RotationalGroup' },
+			@{Parameter = 'ID' },
+			@{Parameter = 'name' }
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Copy-PASPlatform).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
+
+			}
+
+		}
+
+		Context "Input" {
+
+			BeforeEach {
+				Mock Invoke-PASRestMethod -MockWith {
+					[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+				}
+
+				$InputObj = [pscustomobject]@{
+					"name" = "SomeName"
+					"ID"   = 1234
+				}
+
+				$response = $InputObj | Copy-PASPlatform -TargetPlatform
+
+			}
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request to expected endpoint - TargetPlatform" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/API/Platforms/targets/1234/duplicate"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request to expected endpoint - DependentPlatform" {
+				$response = $InputObj | Copy-PASPlatform -DependentPlatform
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/API/Platforms/dependents/1234/duplicate"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request to expected endpoint - RotationalGroup" {
+
+				$response = $InputObj | Copy-PASPlatform -RotationalGroup
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/API/Platforms/rotationalGroups/1234/duplicate"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request to expected endpoint - GroupPlatform" {
+
+				$response = $InputObj | Copy-PASPlatform -GroupPlatform
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/API/Platforms/groups/1234/duplicate"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request with expected body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody) -ne $null
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "has a request body with expected number of properties" {
+
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 1
+
+			}
+
+			It "throws error if version requirement not met" {
+				$Script:ExternalVersion = "11.0"
+				{ $InputObj | Copy-PASPlatform -GroupPlatform } | Should -Throw
+				$Script:ExternalVersion = "0.0"
+			}
+
+		}
+
+		Context "Output" {
+
+			BeforeEach {
+
+				$Script:ExternalVersion = "11.4"
+				Mock Invoke-PASRestMethod -MockWith {
+					[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+				}
+
+				$InputObj = [pscustomobject]@{
+					"name" = "SomeName"
+					"ID"   = 1234
+				}
+
+				$response = $InputObj | Copy-PASPlatform -TargetPlatform
+
+			}
+
+			it "provides output" {
+
+				$response | Should -Not -BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Disable-PASPlatform.Tests.ps1
+++ b/Tests/Disable-PASPlatform.Tests.ps1
@@ -1,0 +1,132 @@
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
+
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
+
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+		if ( -not (Get-Module -Name $ModuleName -All)) {
+
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+		}
+
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+	}
+
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
+
+			}
+
+			$InputObj = [pscustomobject]@{
+				"ID" = 1234
+
+			}
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'ID' },
+			@{Parameter = 'TargetPlatform' },
+			@{Parameter = 'GroupPlatform' },
+			@{Parameter = 'RotationalGroup' }
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Disable-PASPlatform).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
+
+			}
+
+		}
+
+
+
+		Context "Input" {
+
+			It "sends request" {
+				$InputObj | Disable-PASPlatform -TargetPlatform
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request to expected endpoint - TargetPlatform" {
+				$InputObj | Disable-PASPlatform -TargetPlatform
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/API/Platforms/targets/1234/deactivate"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request to expected endpoint - GroupPlatform" {
+				$InputObj | Disable-PASPlatform -GroupPlatform
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/API/Platforms/groups/1234/deactivate"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request to expected endpoint - RotationalGroup" {
+				$InputObj | Disable-PASPlatform -RotationalGroup
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/API/Platforms/rotationalGroups/1234/deactivate"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "uses expected method" {
+				$InputObj | Disable-PASPlatform -GroupPlatform
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request with no body" {
+				$InputObj | Disable-PASPlatform -RotationalGroup
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+				$response = $InputObj | Disable-PASPlatform -TargetPlatform
+				$response | Should -BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Enable-PASPlatform.Tests.ps1
+++ b/Tests/Enable-PASPlatform.Tests.ps1
@@ -1,0 +1,132 @@
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
+
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
+
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+		if ( -not (Get-Module -Name $ModuleName -All)) {
+
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+		}
+
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+	}
+
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
+
+			}
+
+			$InputObj = [pscustomobject]@{
+				"ID" = 1234
+
+			}
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'ID' },
+			@{Parameter = 'TargetPlatform' },
+			@{Parameter = 'GroupPlatform' },
+			@{Parameter = 'RotationalGroup' }
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Enable-PASPlatform).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
+
+			}
+
+		}
+
+
+
+		Context "Input" {
+
+			It "sends request" {
+				$InputObj | Enable-PASPlatform -TargetPlatform
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request to expected endpoint - TargetPlatform" {
+				$InputObj | Enable-PASPlatform -TargetPlatform
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/API/Platforms/targets/1234/activate"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request to expected endpoint - GroupPlatform" {
+				$InputObj | Enable-PASPlatform -GroupPlatform
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/API/Platforms/groups/1234/activate"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request to expected endpoint - RotationalGroup" {
+				$InputObj | Enable-PASPlatform -RotationalGroup
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/API/Platforms/rotationalGroups/1234/activate"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "uses expected method" {
+				$InputObj | Enable-PASPlatform -GroupPlatform
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request with no body" {
+				$InputObj | Enable-PASPlatform -RotationalGroup
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+				$response = $InputObj | Enable-PASPlatform -TargetPlatform
+				$response | Should -BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASPlatform.Tests.ps1
+++ b/Tests/Get-PASPlatform.Tests.ps1
@@ -139,6 +139,95 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
+		Context "Input - 11.4" {
+			BeforeEach {
+
+				Mock Invoke-PASRestMethod -MockWith {
+
+					[PSCustomObject]@{
+						"Platforms" = [PSCustomObject]@{
+							"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = 123
+						}
+					}
+
+				}
+
+				Get-PASPlatform
+
+			}
+
+			It "sends request" {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+
+			}
+
+			It "uses expected method" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request to expected endpoint - target" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/API/Platforms/targets"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request to expected endpoint - dependent" {
+
+				Get-PASPlatform -DependentPlatform
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/API/Platforms/dependents"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request to expected endpoint - group" {
+
+				Get-PASPlatform -GroupPlatform
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/API/Platforms/groups"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request to expected endpoint - rotational group" {
+
+				Get-PASPlatform -RotationalGroup
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/API/Platforms/rotationalGroups"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request with no body" {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
+
+			}
+
+			It "throws error if version requirement not met" {
+				$Script:ExternalVersion = "11.3"
+				{ Get-PASPlatform } | Should -Throw
+				$Script:ExternalVersion = "0.0"
+			}
+
+		}
+
 		Context "Output" {
 
 			BeforeEach {
@@ -171,6 +260,24 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 			}
 
 			It "has output with expected number of properties - 11.1" {
+
+				Mock Invoke-PASRestMethod -MockWith {
+
+					[PSCustomObject]@{
+						"Platforms" = [PSCustomObject]@{
+							"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = 123
+						}
+					}
+
+				}
+
+				$response = Get-PASPlatform -Active $true -PlatformType Regular
+
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 3
+
+			}
+
+			It "has output with expected number of properties - 11.4" {
 
 				Mock Invoke-PASRestMethod -MockWith {
 

--- a/Tests/Remove-PASGroup.Tests.ps1
+++ b/Tests/Remove-PASGroup.Tests.ps1
@@ -1,0 +1,106 @@
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
+
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
+
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+		if ( -not (Get-Module -Name $ModuleName -All)) {
+
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+		}
+
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "11.5"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+	}
+
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
+
+			}
+
+			$InputObj = [pscustomobject]@{
+				"GroupID" = 1234
+
+			}
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'GroupID' }
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Remove-PASGroup).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
+
+			}
+
+		}
+
+
+
+		Context "Input" {
+
+			It "sends request" {
+				$InputObj | Remove-PASGroup
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request to expected endpoint"{
+				Remove-PASGroup -GroupID 1234
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+					$URI -eq "$($Script:BaseURI)/API/UserGroups/1234"
+				}-Times 1 -Exactly -Scope It
+			}
+
+			It "uses expected method" {
+				$InputObj | Remove-PASGroup
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'DELETE' } -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request with no body" {
+				$InputObj | Remove-PASGroup
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+				$response = $InputObj | Remove-PASGroup
+				$response | Should -BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Remove-PASPlatform.Tests.ps1
+++ b/Tests/Remove-PASPlatform.Tests.ps1
@@ -1,0 +1,143 @@
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
+
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
+
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+		if ( -not (Get-Module -Name $ModuleName -All)) {
+
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+		}
+
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+	}
+
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
+
+			}
+
+			$InputObj = [pscustomobject]@{
+				"ID" = 1234
+
+			}
+		}
+
+		Context "Mandatory Parameters" {
+
+			$Parameters = @{Parameter = 'ID' },
+			@{Parameter = 'TargetPlatform' },
+			@{Parameter = 'DependentPlatform' },
+			@{Parameter = 'GroupPlatform' },
+			@{Parameter = 'RotationalGroup' }
+
+			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Remove-PASPlatform).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
+
+			}
+
+		}
+
+
+
+		Context "Input" {
+
+			It "sends request" {
+				$InputObj | Remove-PASPlatform -TargetPlatform
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request to expected endpoint - TargetPlatform" {
+				$InputObj | Remove-PASPlatform -TargetPlatform
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/API/Platforms/targets/1234"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request to expected endpoint - DependentPlatform" {
+				$InputObj | Remove-PASPlatform -DependentPlatform
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/API/Platforms/dependents/1234"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request to expected endpoint - GroupPlatform" {
+				$InputObj | Remove-PASPlatform -GroupPlatform
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/API/Platforms/groups/1234"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request to expected endpoint - RotationalGroup" {
+				$InputObj | Remove-PASPlatform -RotationalGroup
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/API/Platforms/rotationalGroups/1234"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "uses expected method" {
+				$InputObj | Remove-PASPlatform -GroupPlatform
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'DELETE' } -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request with no body" {
+				$InputObj | Remove-PASPlatform -RotationalGroup
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
+
+			}
+
+		}
+
+		Context "Output" {
+
+			it "provides no output" {
+				$response = $InputObj | Remove-PASPlatform -TargetPlatform
+				$response | Should -BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -184,6 +184,14 @@ commands:
         url: /commands/Export-PASPlatform
       - title: "Import-PASPlatform"
         url: /commands/Import-PASPlatform
+      - title: "Copy-PASPlatform"
+        url: /commands/Copy-PASPlatform
+      - title: "Enable-PASPlatform"
+        url: /commands/Enable-PASPlatform
+      - title: "Disable-PASPlatform"
+        url: /commands/Disable-PASPlatform
+      - title: "Remove-PASPlatform"
+        url: /commands/Remove-PASPlatform
 
   - title: "Policy ACL"
     children:
@@ -275,6 +283,8 @@ commands:
         url: /commands/Remove-PASGroupMember
       - title: "New-PASGroup"
         url: /commands/New-PASGroup
+      - title: "Remove-PASGroup"
+        url: /commands/Remove-PASGroup
 
 # documentation links
 docs:

--- a/docs/collections/_commands/Add-PASAccount.md
+++ b/docs/collections/_commands/Add-PASAccount.md
@@ -303,7 +303,7 @@ Parameters are processed to create request object in the required format.
     PS C:\>Add-PASAccount -address ThisServer -userName ThisUser -platformID UNIXSSH
     -SafeName UNIXSafe -automaticManagementEnabled $false
 
-    Using the version 10 API, adds an account which is disbaled for automatic password management
+    Using the version 10 API, adds an account which is disabled for automatic password management
 
 
 

--- a/docs/collections/_commands/Add-PASPTARule.md
+++ b/docs/collections/_commands/Add-PASPTARule.md
@@ -68,7 +68,7 @@ Adds a new Risky Activity rule in the PTA server configuration.
         Accept wildcard characters?  false
 
     -active <Boolean>
-        Indicate if the rule should be active or disbaled
+        Indicate if the rule should be active or disabled
 
         Required?                    true
         Position?                    6

--- a/docs/collections/_commands/Copy-PASPlatform.md
+++ b/docs/collections/_commands/Copy-PASPlatform.md
@@ -1,0 +1,89 @@
+---
+title: Copy-PASPlatform
+---
+
+## SYNOPSIS
+
+    Duplicates a platform
+
+## SYNTAX
+
+    Copy-PASPlatform -TargetPlatform -ID <Int32> -name <String> [-description <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+
+    Copy-PASPlatform -DependentPlatform -ID <Int32> -name <String> [-description <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+
+    Copy-PASPlatform -GroupPlatform -ID <Int32> -name <String> [-description <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+
+    Copy-PASPlatform -RotationalGroup -ID <Int32> -name <String> [-description <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+
+## DESCRIPTION
+
+    Duplicates target, dependent, group or rotational group platform to a new platform.
+
+## PARAMETERS
+
+    -TargetPlatform [<SwitchParameter>]
+        Specify if ID relates to Target platform
+
+    -DependentPlatform [<SwitchParameter>]
+        Specify if ID relates to Dependent platform
+
+    -GroupPlatform [<SwitchParameter>]
+        Specify if ID relates to Group platform
+
+    -RotationalGroup [<SwitchParameter>]
+        Specify if ID relates to Rotational Group platform
+
+    -ID <Int32>
+        The unique ID number of the platofrm to duplicate
+
+    -name <String>
+        The name for the duplicate platform
+
+    -description <String>
+        A description for the duplicate platform
+
+    -WhatIf [<SwitchParameter>]
+
+    -Confirm [<SwitchParameter>]
+
+    <CommonParameters>
+        This cmdlet supports the common parameters: Verbose, Debug,
+        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
+        OutBuffer, PipelineVariable, and OutVariable. For more information, see
+        about_CommonParameters (https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## EXAMPLES
+
+    -------------------------- EXAMPLE 1 --------------------------
+
+    PS > Copy-PASPlatform -TargetPlatform -ID 9 -name SomeNewPlatform -description "Some Description"
+
+    Duplicates Target Platform with ID of 9 to SomeNewPlatform
+
+
+
+
+    -------------------------- EXAMPLE 2 --------------------------
+
+    PS > Copy-PASPlatform -DependentPlatform -ID 9 -name SomeNewPlatform -description "Some Description"
+
+    Duplicates Dependent Platform with ID of 9 to SomeNewPlatform
+
+
+
+
+    -------------------------- EXAMPLE 3 --------------------------
+
+    PS > Copy-PASPlatform -GroupPlatform -ID 39 -name SomeNewPlatform -description "Some Description"
+
+    Duplicates Group Platform with ID of 39 to SomeNewPlatform
+
+
+
+
+    -------------------------- EXAMPLE 4 --------------------------
+
+    PS > Copy-PASPlatform -RotationalGroup -ID 59 -name SomeNewPlatform -description "Some Description"
+
+    Duplicates Rotational Group Platform with ID of 59 to SomeNewPlatform

--- a/docs/collections/_commands/Disable-PASPlatform.md
+++ b/docs/collections/_commands/Disable-PASPlatform.md
@@ -1,0 +1,69 @@
+---
+title: Disable-PASPlatform
+---
+
+## SYNOPSIS
+
+    Deactivates a platform.
+
+## SYNTAX
+
+    Disable-PASPlatform -TargetPlatform -ID <Int32> [-WhatIf] [-Confirm] [<CommonParameters>]
+
+    Disable-PASPlatform -GroupPlatform -ID <Int32> [-WhatIf] [-Confirm] [<CommonParameters>]
+
+    Disable-PASPlatform -RotationalGroup -ID <Int32> [-WhatIf] [-Confirm] [<CommonParameters>]
+
+## DESCRIPTION
+
+    Disables, target, group or rotational group platform.
+
+## PARAMETERS
+
+    -TargetPlatform [<SwitchParameter>]
+        Specify if ID relates to Target platform
+
+    -GroupPlatform [<SwitchParameter>]
+        Specify if ID relates to Group platform
+
+    -RotationalGroup [<SwitchParameter>]
+        Specify if ID relates to Rotational Group platform
+
+    -ID <Int32>
+        The unique ID number of the platofrm to disable.
+
+    -WhatIf [<SwitchParameter>]
+
+    -Confirm [<SwitchParameter>]
+
+    <CommonParameters>
+        This cmdlet supports the common parameters: Verbose, Debug,
+        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
+        OutBuffer, PipelineVariable, and OutVariable. For more information, see
+        about_CommonParameters (https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## EXAMPLES
+
+    -------------------------- EXAMPLE 1 --------------------------
+
+    PS > Disable-PASPlatform -TargetPlatform -ID 53
+
+    Disables Target Platform with ID of 53
+
+
+
+
+    -------------------------- EXAMPLE 2 --------------------------
+
+    PS > Disable-PASPlatform -GroupPlatform -id 64
+
+    Disables Group Platform with ID of 64
+
+
+
+
+    -------------------------- EXAMPLE 3 --------------------------
+
+    PS > Disable-PASPlatform -RotationalGroup -id 65
+
+    Disables Rotational Group Platform with ID of 65

--- a/docs/collections/_commands/Enable-PASPlatform.md
+++ b/docs/collections/_commands/Enable-PASPlatform.md
@@ -1,0 +1,69 @@
+---
+title: Enable-PASPlatform
+---
+
+## SYNOPSIS
+
+    Activates a platform.
+
+## SYNTAX
+
+    Enable-PASPlatform -TargetPlatform -ID <Int32> [-WhatIf] [-Confirm] [<CommonParameters>]
+
+    Enable-PASPlatform -GroupPlatform -ID <Int32> [-WhatIf] [-Confirm] [<CommonParameters>]
+
+    Enable-PASPlatform -RotationalGroup -ID <Int32> [-WhatIf] [-Confirm] [<CommonParameters>]
+
+## DESCRIPTION
+
+    Enables, target, group or rotational group platform.
+
+## PARAMETERS
+
+    -TargetPlatform [<SwitchParameter>]
+        Specify if ID relates to Target platform
+
+    -GroupPlatform [<SwitchParameter>]
+        Specify if ID relates to Group platform
+
+    -RotationalGroup [<SwitchParameter>]
+        Specify if ID relates to Rotational Group platform
+
+    -ID <Int32>
+        The unique ID number of the platofrm to enable.
+
+    -WhatIf [<SwitchParameter>]
+
+    -Confirm [<SwitchParameter>]
+
+    <CommonParameters>
+        This cmdlet supports the common parameters: Verbose, Debug,
+        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
+        OutBuffer, PipelineVariable, and OutVariable. For more information, see
+        about_CommonParameters (https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## EXAMPLES
+
+    -------------------------- EXAMPLE 1 --------------------------
+
+    PS > Enable-PASPlatform -TargetPlatform -ID 53
+
+    Enables Target Platform with ID of 53
+
+
+
+
+    -------------------------- EXAMPLE 2 --------------------------
+
+    PS > Enable-PASPlatform -GroupPlatform -id 64
+
+    Enables Group Platform with ID of 64
+
+
+
+
+    -------------------------- EXAMPLE 3 --------------------------
+
+    PS > Enable-PASPlatform -RotationalGroup -id 65
+
+    Enables Rotational Group Platform with ID of 65

--- a/docs/collections/_commands/Get-PASPlatform.md
+++ b/docs/collections/_commands/Get-PASPlatform.md
@@ -8,22 +8,32 @@ Retrieves details of Vault platforms.
 
 ## SYNTAX
 
+    Get-PASPlatform [-Active <Boolean>] [-SystemType <String>] [-PeriodicVerify <Boolean>] [-ManualVerify <Boolean>] [-PeriodicChange <Boolean>] [-ManualChange <Boolean>] [-AutomaticReconcile <Boolean>] [-ManualReconcile <Boolean>] [<CommonParameters>]
+
     Get-PASPlatform [-Active <Boolean>] [-PlatformType <String>] [-Search <String>] [<CommonParameters>]
 
     Get-PASPlatform -PlatformID <String> [<CommonParameters>]
+
+    Get-PASPlatform [-DependentPlatform] [<CommonParameters>]
+
+    Get-PASPlatform [-GroupPlatform] [<CommonParameters>]
+
+    Get-PASPlatform [-RotationalGroup] [<CommonParameters>]
 
 ## DESCRIPTION
 
 Request platform configuration information from the Vault.
 
-11.1+ can return details of all platforms.
-Filters can be used to retrieve a subset of the platforms
+    11.4+ can return detials of target, dependent, group & rotational group platforms,
+    with additional filters available for target group queries.
+    11.1+ can return details of all target platforms.
+    Limited filters can be used to retrieve a subset of the platforms
 
-For 9.10+, the "PlatformID" parameter must be used to retrieve details of a single
-specified platform from the Vault.
+    For 9.10+, the "PlatformID" parameter must be used to retrieve details of a single
+    specified platform from the Vault.
 
-The output contained under the "Details" property differs depending
-on which method (9.10+ or 11.1+) is used.
+    The output contained under the "Details" property differs depending
+    on which method (9.10+,11.1+ or 11.4) is used, and which platform type is queried.
 
 ## PARAMETERS
 
@@ -63,22 +73,114 @@ on which method (9.10+ or 11.1+) is used.
         Accept pipeline input?       true (ByPropertyName)
         Accept wildcard characters?  false
 
+    -DependentPlatform [<SwitchParameter>]
+        Specify to return details of dependent platforms
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       true (ByPropertyName)
+        Accept wildcard characters?  false
+
+    -GroupPlatform [<SwitchParameter>]
+        Specify to return details of group platforms
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       true (ByPropertyName)
+        Accept wildcard characters?  false
+
+    -RotationalGroup [<SwitchParameter>]
+        Specify to return details of rotational group platforms
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       true (ByPropertyName)
+        Accept wildcard characters?  false
+
+    -SystemType <String>
+        Filter target platforms for specific system type
+
+        Required?                    false
+        Position?                    named
+        Default value
+        Accept pipeline input?       true (ByPropertyName)
+        Accept wildcard characters?  false
+
+    -PeriodicVerify <Boolean>
+        Filter target platforms by periodic verification configuration
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       true (ByPropertyName)
+        Accept wildcard characters?  false
+
+    -ManualVerify <Boolean>
+        Filter target platforms by manual verification configuration
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       true (ByPropertyName)
+        Accept wildcard characters?  false
+
+    -PeriodicChange <Boolean>
+        Filter target platforms by periodic change configuration
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       true (ByPropertyName)
+        Accept wildcard characters?  false
+
+    -ManualChange <Boolean>
+        Filter target platforms by manual change configuration
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       true (ByPropertyName)
+        Accept wildcard characters?  false
+
+    -AutomaticReconcile <Boolean>
+        Filter target platforms by automatic reconciliation configuration
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       true (ByPropertyName)
+        Accept wildcard characters?  false
+
+    -ManualReconcile <Boolean>
+        Filter target platforms by manual reconciliation configuration
+
+        Required?                    false
+        Position?                    named
+        Default value                False
+        Accept pipeline input?       true (ByPropertyName)
+        Accept wildcard characters?  false
+
     <CommonParameters>
         This cmdlet supports the common parameters: Verbose, Debug,
         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
         OutBuffer, PipelineVariable, and OutVariable. For more information, see
-        about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).
+        about_CommonParameters (https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## NOTES
 
         Minimum CyberArk version 9.10
         CyberArk version 11.1 required for Active, PlatformType & Search paramters.
+        CyberArk version 11.4 required for extended filters for target platforms,
+        and requests for  dependent, group & rotational group platforms
 
 ## EXAMPLES
 
     -------------------------- EXAMPLE 1 --------------------------
 
-    PS C:\>Get-PASPlatform
+    PS > Get-PASPlatform
 
     Return details of all platforms
 
@@ -87,7 +189,7 @@ on which method (9.10+ or 11.1+) is used.
 
     -------------------------- EXAMPLE 2 --------------------------
 
-    PS C:\>Get-PASPlatform -Active $true
+    PS > Get-PASPlatform -Active $true
 
     Get all active platforms
 
@@ -96,7 +198,7 @@ on which method (9.10+ or 11.1+) is used.
 
     -------------------------- EXAMPLE 3 --------------------------
 
-    PS C:\>Get-PASPlatform -Active $true -Search "WIN_"
+    PS > Get-PASPlatform -Active $true -Search "WIN_"
 
     Get active platforms matching search string "WIN_"
 
@@ -105,6 +207,51 @@ on which method (9.10+ or 11.1+) is used.
 
     -------------------------- EXAMPLE 4 --------------------------
 
-    PS C:\>Get-PASPlatform -PlatformID "CyberArk"
+    PS > Get-PASPlatform -PlatformID "CyberArk"
 
     Get details of specific platform CyberArk
+
+
+
+
+    -------------------------- EXAMPLE 5 --------------------------
+
+    PS > Get-PASPlatform -GroupPlatform
+
+    Get details of all group platfoms
+
+
+
+
+    -------------------------- EXAMPLE 6 --------------------------
+
+    PS > Get-PASPlatform -RotationalGroup
+
+    Get details of all rotational group platforms
+
+
+
+
+    -------------------------- EXAMPLE 7 --------------------------
+
+    PS > Get-PASPlatform -DependentPlatform
+
+    Get details of all dependent platforms
+
+
+
+
+    -------------------------- EXAMPLE 8 --------------------------
+
+    PS > Get-PASPlatform -Active $false -SystemType Windows
+
+    Get details of all deactivated Windows platforms
+
+
+
+
+    -------------------------- EXAMPLE 9 --------------------------
+
+    PS > Get-PASPlatform -Active $true -SystemType '*NIX' -AutomaticReconcile $true
+
+    Get details of all active Unix platforms configured for automatic reconciliation.

--- a/docs/collections/_commands/New-PASUser.md
+++ b/docs/collections/_commands/New-PASUser.md
@@ -188,7 +188,7 @@ Adds a new user to the vault
         Accept wildcard characters?  false
 
     -Disabled <Boolean>
-        Whether or not the user will be created as a disbaled user
+        Whether or not the user will be created as a disabled user
         Default is Enabled
 
         Required?                    false

--- a/docs/collections/_commands/Remove-PASGroup.md
+++ b/docs/collections/_commands/Remove-PASGroup.md
@@ -1,0 +1,42 @@
+---
+title: Remove-PASGroup
+---
+
+## SYNOPSIS
+
+    Deletes a user group
+
+## SYNTAX
+
+    Remove-PASGroup [-GroupID] <Int32> [-WhatIf] [-Confirm] [<CommonParameters>]
+
+## DESCRIPTION
+
+    Deletes a user group.
+
+    To delete a user group, the following authorizations are required:
+
+    - Add/Update Users
+
+## PARAMETERS
+
+    -GroupID <Int32>
+        The unique ID of the group to delete.
+
+    -WhatIf [<SwitchParameter>]
+
+    -Confirm [<SwitchParameter>]
+
+    <CommonParameters>
+        This cmdlet supports the common parameters: Verbose, Debug,
+        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
+        OutBuffer, PipelineVariable, and OutVariable. For more information, see
+        about_CommonParameters (https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## EXAMPLES
+
+    -------------------------- EXAMPLE 1 --------------------------
+
+    PS > Delete-PASGroup -GroupID 3
+
+    Deletes Group with ID of 3

--- a/docs/collections/_commands/Remove-PASPlatform.md
+++ b/docs/collections/_commands/Remove-PASPlatform.md
@@ -1,0 +1,83 @@
+---
+title: Remove-PASPlatform
+---
+
+## SYNOPSIS
+
+    Deletes a platform.
+
+## SYNTAX
+
+    Remove-PASPlatform -TargetPlatform -ID <Int32> [-WhatIf] [-Confirm] [<CommonParameters>]
+
+    Remove-PASPlatform -DependentPlatform -ID <Int32> [-WhatIf] [-Confirm] [<CommonParameters>]
+
+    Remove-PASPlatform -GroupPlatform -ID <Int32> [-WhatIf] [-Confirm] [<CommonParameters>]
+
+    Remove-PASPlatform -RotationalGroup -ID <Int32> [-WhatIf] [-Confirm] [<CommonParameters>]
+
+## DESCRIPTION
+
+    Deletes, target, dependent, group or rotational group platform.
+
+## PARAMETERS
+
+    -TargetPlatform [<SwitchParameter>]
+        Specify if ID relates to Target platform
+
+    -DependentPlatform [<SwitchParameter>]
+        Specify if ID relates to Dependent platform
+
+    -GroupPlatform [<SwitchParameter>]
+        Specify if ID relates to Group platform
+
+    -RotationalGroup [<SwitchParameter>]
+        Specify if ID relates to Rotational Group platform
+
+    -ID <Int32>
+        The unique ID number of the platofrm to delete.
+
+    -WhatIf [<SwitchParameter>]
+
+    -Confirm [<SwitchParameter>]
+
+    <CommonParameters>
+        This cmdlet supports the common parameters: Verbose, Debug,
+        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
+        OutBuffer, PipelineVariable, and OutVariable. For more information, see
+        about_CommonParameters (https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## EXAMPLES
+
+    -------------------------- EXAMPLE 1 --------------------------
+
+    PS > Remove-PASPlatform -TargetPlatform -ID 9
+
+    Deletes Target Platform with ID of 9
+
+
+
+
+    -------------------------- EXAMPLE 2 --------------------------
+
+    PS > Remove-PASPlatform -DependentPlatform -ID 9
+
+    Deletes Dependent Platform with ID of 9
+
+
+
+
+    -------------------------- EXAMPLE 3 --------------------------
+
+    PS > Remove-PASPlatform -GroupPlatform -ID 39
+
+    Deletes Group Platform with ID of 39
+
+
+
+
+    -------------------------- EXAMPLE 4 --------------------------
+
+    PS > Remove-PASPlatform -RotationalGroup -ID 59
+
+    Deletes Rotational Group Platform with ID of 59

--- a/docs/collections/_commands/Set-PASPTARule.md
+++ b/docs/collections/_commands/Set-PASPTARule.md
@@ -77,7 +77,7 @@ Updates an existing Risky Activity rule in the PTA server configuration.
         Accept wildcard characters?  false
 
     -active <Boolean>
-        Indicate if the rule should be active or disbaled
+        Indicate if the rule should be active or disabled
 
         Required?                    true
         Position?                    7

--- a/docs/collections/_commands/Set-PASUser.md
+++ b/docs/collections/_commands/Set-PASUser.md
@@ -202,7 +202,7 @@ Not passing a value to an already set property will result in it being cleared.
         Accept wildcard characters?  false
 
     -Disabled <Boolean>
-        Whether or not the user will be created as a disbaled user
+        Whether or not the user will be created as a disabled user
         Default is Enabled
 
         Required?                    false

--- a/docs/collections/_docs/10-compatibility.md
+++ b/docs/collections/_docs/10-compatibility.md
@@ -2,7 +2,7 @@
 title: "Compatibility"
 permalink: /docs/compatibility/
 excerpt: "Module Compatibility"
-last_modified_at: 2020-06-28T01:33:52-00:00
+last_modified_at: 2020-07-12zT01:33:52-00:00
 toc: false
 ---
 
@@ -129,6 +129,11 @@ If you are using version 9.7+, and the function being invoked requires version 9
 [`Enable-PASCPMAutoManagement`][Enable-PASCPMAutoManagement]                             | **10.4**                                           |Enables Automatic CPM Management for an account
 [`Disable-PASCPMAutoManagement`][Disable-PASCPMAutoManagement]                           | **10.4**                                           |Disables Automatic CPM Management for an account
 [`Test-PASPSMRecording`][Test-PASPSMRecording]                                           | **11.2**                                           |Determine validity of PSM Session Recording
+[`Copy-PASPlatform`][Copy-PASPlatform]                                                   |**11.4**                                            |Duplicate a platform
+[`Enable-PASPlatform`][Enable-PASPlatform]                                               |**11.4**                                            |Enable a platform
+[`Disable-PASPlatform`][Disable-PASPlatform]                                             |**11.4**                                            |Disable a platform
+[`Remove-PASPlatform`][Remove-PASPlatform]                                               |**11.4**                                            |Delete a platform
+[`Remove-PASGroup`][Remove-PASGroup]                                                     |**11.5**                                            |Delete a user group
 
 [New-PASSession]:/commands/New-PASSession
 [Close-PASSession]:/commands/Close-PASSession
@@ -236,6 +241,11 @@ If you are using version 9.7+, and the function being invoked requires version 9
 [Get-PASPlatformSafe]:/commands/Get-PASPlatformSafe.ps1
 [New-PASGroup]:/commands/New-PASGroup.ps1
 [Test-PASPSMRecording]:/commands/Test-PASPSMRecording.ps1
+[Copy-PASPlatform]:/commands/Copy-PASPlatform.ps1
+[Disable-PASPlatform]:/commands/Disable-PASPlatform.ps1
+[Enable-PASPlatform]:/commands/Enable-PASPlatform.ps1
+[Remove-PASPlatform]:/commands/Remove-PASPlatform.ps1
+[Remove-PASGroup]:/commands/Remove-PASGroup.ps1
 
 ## Notes
 
@@ -366,6 +376,7 @@ If you are using version 9.7+, and the function being invoked requires version 9
 - Version 10.10 introduced a new API endpoint.
   - Supports:
     - Get user by ID.
+- Version 11.5 returns additional group membership  detail for user accounts.
 
 ### New-PASUser
 
@@ -421,6 +432,9 @@ If you are using version 9.7+, and the function being invoked requires version 9
 - Version 11.1 introduced a new API endpoint.
   - Supports:
     - New options for finding platforms
+- Version 11.4 introduced new API endpoints
+  - Parameters added to enable more filtering options for querying target platforms
+  - Parameters addded to request details of dependent, group & rotational group platforms.
 
 ### Remove-PASUser
 

--- a/psPAS/Functions/Accounts/Add-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Add-PASAccount.ps1
@@ -125,7 +125,7 @@ All parameters can be piped by property name
 
 .OUTPUTS
 None for v9
-v10.4 outputs th details of the created account.
+v10.4 outputs the details of the created account.
 
 .LINK
 https://pspas.pspete.dev/commands/Add-PASAccount

--- a/psPAS/Functions/Accounts/Add-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Add-PASAccount.ps1
@@ -112,7 +112,7 @@ Relevant for CyberArk versions earlier than 10.4
 .EXAMPLE
 Add-PASAccount -address ThisServer -userName ThisUser -platformID UNIXSSH -SafeName UNIXSafe -automaticManagementEnabled $false
 
-Using the version 10 API, adds an account which is disbaled for automatic password management
+Using the version 10 API, adds an account which is disabled for automatic password management
 
 .EXAMPLE
 Add-PASAccount -safe Prod_Access -PlatformID WINDOMAIN -Address domain.com -Password $secureString -username domainUser

--- a/psPAS/Functions/EventSecurity/Add-PASPTARule.ps1
+++ b/psPAS/Functions/EventSecurity/Add-PASPTARule.ps1
@@ -27,7 +27,7 @@ Automatic response to be executed
 Valid Values: NONE, TERMINATE or SUSPEND
 
 .PARAMETER active
-Indicate if the rule should be active or disbaled
+Indicate if the rule should be active or disabled
 
 .EXAMPLE
 Add-PASPTARule -category KEYSTROKES -regex '(*.)risky command(.*)' -score 60 -description "Example Rule" -response NONE -active $true

--- a/psPAS/Functions/EventSecurity/Set-PASPTARule.ps1
+++ b/psPAS/Functions/EventSecurity/Set-PASPTARule.ps1
@@ -30,7 +30,7 @@ Automatic response to be executed
 Valid Values: NONE, TERMINATE or SUSPEND
 
 .PARAMETER active
-Indicate if the rule should be active or disbaled
+Indicate if the rule should be active or disabled
 
 .EXAMPLE
 Set-PASPTARule -id 66 -category KEYSTROKES -regex '(*.)risky cmd(.*)' -score 65 -description "Updated Rule" -response SUSPEND -active $true

--- a/psPAS/Functions/Platforms/Copy-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Copy-PASPlatform.ps1
@@ -1,0 +1,138 @@
+Function Copy-PASPlatform{
+<#
+.SYNOPSIS
+Duplicates a platform
+
+.DESCRIPTION
+Duplicates target, dependent, group or rotational group platform to a new platform.
+
+.PARAMETER TargetPlatform
+Specify if ID relates to Target platform
+
+.PARAMETER DependentPlatform
+Specify if ID relates to Dependent platform
+
+.PARAMETER GroupPlatform
+Specify if ID relates to Group platform
+
+.PARAMETER RotationalGroup
+Specify if ID relates to Rotational Group platform
+
+.PARAMETER ID
+The unique ID number of the platofrm to duplicate
+
+.PARAMETER name
+The name for the duplicate platform
+
+.PARAMETER description
+A description for the duplicate platform
+
+.EXAMPLE
+Copy-PASPlatform -TargetPlatform -ID 9 -name SomeNewPlatform -description "Some Description"
+
+Duplicates Target Platform with ID of 9 to SomeNewPlatform
+
+.EXAMPLE
+Copy-PASPlatform -DependentPlatform -ID 9 -name SomeNewPlatform -description "Some Description"
+
+Duplicates Dependent Platform with ID of 9 to SomeNewPlatform
+
+.EXAMPLE
+Copy-PASPlatform -GroupPlatform -ID 39 -name SomeNewPlatform -description "Some Description"
+
+Duplicates Group Platform with ID of 39 to SomeNewPlatform
+
+.EXAMPLE
+Copy-PASPlatform -RotationalGroup -ID 59 -name SomeNewPlatform -description "Some Description"
+
+Duplicates Rotational Group Platform with ID of 59 to SomeNewPlatform
+
+.NOTES
+General notes
+#>
+	[CmdletBinding(SupportsShouldProcess)]
+	param(
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "targets"
+		)]
+		[switch]$TargetPlatform,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "dependents"
+		)]
+		[switch]$DependentPlatform,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "groups"
+		)]
+		[switch]$GroupPlatform,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "rotationalGroups"
+		)]
+		[switch]$RotationalGroup,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[int]$ID,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$name,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[string]$description
+	)
+
+	BEGIN {
+
+		$MinimumVersion = [System.Version]"11.4"
+
+	}#begin
+
+	Process{
+
+		Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $MinimumVersion
+
+		#Create URL for request
+		$URI = "$Script:BaseURI/API/Platforms/$($PSCmdLet.ParameterSetName)/$ID/duplicate"
+
+		#Get request parameters
+		$boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove ID, TargetPlatform,
+		DependentPlatform, GroupPlatform, RotationalGroup
+
+		$body = $boundParameters | ConvertTo-Json
+
+		if ($PSCmdlet.ShouldProcess($ID, "Duplicate $($PSCmdLet.ParameterSetName) Platform")) {
+
+			#send request
+			$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $body -WebSession $Script:WebSession
+
+			if ($result) {
+
+				$result
+
+			}
+
+		}
+
+	}
+
+	End{}
+
+}

--- a/psPAS/Functions/Platforms/Disable-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Disable-PASPlatform.ps1
@@ -1,0 +1,91 @@
+Function Disable-PASPlatform {
+	<#
+.SYNOPSIS
+Deactivates a platform.
+
+.DESCRIPTION
+Disables, target, group or rotational group platform.
+
+.PARAMETER TargetPlatform
+Specify if ID relates to Target platform
+
+.PARAMETER GroupPlatform
+Specify if ID relates to Group platform
+
+.PARAMETER RotationalGroup
+Specify if ID relates to Rotational Group platform
+
+.PARAMETER ID
+The unique ID number of the platofrm to disable.
+
+.EXAMPLE
+Disable-PASPlatform -TargetPlatform -ID 53
+
+Disables Target Platform with ID of 53
+
+.EXAMPLE
+Disable-PASPlatform -GroupPlatform -id 64
+
+Disables Group Platform with ID of 64
+
+.EXAMPLE
+Disable-PASPlatform -RotationalGroup -id 65
+
+Disables Rotational Group Platform with ID of 65
+
+.NOTES
+PAS 11.4 minimum
+#>
+	[CmdletBinding(SupportsShouldProcess)]
+	param(
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "targets"
+		)]
+		[switch]$TargetPlatform,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "groups"
+		)]
+		[switch]$GroupPlatform,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "rotationalGroups"
+		)]
+		[switch]$RotationalGroup,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[int]$ID
+	)
+
+	BEGIN {
+
+		$MinimumVersion = [System.Version]"11.4"
+
+	}#begin
+
+	Process {
+
+		Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $MinimumVersion
+
+		#Create URL for request
+		$URI = "$Script:BaseURI/api/platforms/$($PSCmdLet.ParameterSetName)/$ID/deactivate"
+
+		if ($PSCmdlet.ShouldProcess($ID, "Deactivate $($PSCmdLet.ParameterSetName) Platform")) {
+
+			#send request to web service
+			Invoke-PASRestMethod -Uri $URI -Method POST -WebSession $Script:WebSession
+
+		}
+
+	}
+
+}

--- a/psPAS/Functions/Platforms/Enable-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Enable-PASPlatform.ps1
@@ -1,0 +1,91 @@
+Function Enable-PASPlatform {
+<#
+.SYNOPSIS
+Activates a platform.
+
+.DESCRIPTION
+Enables, target, group or rotational group platform.
+
+.PARAMETER TargetPlatform
+Specify if ID relates to Target platform
+
+.PARAMETER GroupPlatform
+Specify if ID relates to Group platform
+
+.PARAMETER RotationalGroup
+Specify if ID relates to Rotational Group platform
+
+.PARAMETER ID
+The unique ID number of the platofrm to enable.
+
+.EXAMPLE
+Enable-PASPlatform -TargetPlatform -ID 53
+
+Enables Target Platform with ID of 53
+
+.EXAMPLE
+Enable-PASPlatform -GroupPlatform -id 64
+
+Enables Group Platform with ID of 64
+
+.EXAMPLE
+Enable-PASPlatform -RotationalGroup -id 65
+
+Enables Rotational Group Platform with ID of 65
+
+.NOTES
+PAS 11.4 minimum
+#>
+	[CmdletBinding(SupportsShouldProcess)]
+	param(
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "targets"
+		)]
+		[switch]$TargetPlatform,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "groups"
+		)]
+		[switch]$GroupPlatform,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "rotationalGroups"
+		)]
+		[switch]$RotationalGroup,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[int]$ID
+	)
+
+	BEGIN {
+
+		$MinimumVersion = [System.Version]"11.4"
+
+	}#begin
+
+	Process {
+
+		Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $MinimumVersion
+
+		#Create URL for request
+		$URI = "$Script:BaseURI/api/platforms/$($PSCmdLet.ParameterSetName)/$ID/activate"
+
+		if ($PSCmdlet.ShouldProcess($ID, "Activate $($PSCmdLet.ParameterSetName) Platform")) {
+
+			#send request to web service
+			Invoke-PASRestMethod -Uri $URI -Method POST -WebSession $Script:WebSession
+
+		}
+
+	}
+
+}

--- a/psPAS/Functions/Platforms/Get-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Get-PASPlatform.ps1
@@ -6,14 +6,16 @@ Retrieves details of Vault platforms.
 .DESCRIPTION
 Request platform configuration information from the Vault.
 
-11.1+ can return details of all platforms.
-Filters can be used to retrieve a subset of the platforms
+11.4+ can return detials of target, dependent, group & rotational group platforms,
+with additional filters available for target group queries.
+11.1+ can return details of all target platforms.
+Limited filters can be used to retrieve a subset of the platforms
 
 For 9.10+, the "PlatformID" parameter must be used to retrieve details of a single
 specified platform from the Vault.
 
 The output contained under the "Details" property differs depending
-on which method (9.10+ or 11.1+) is used.
+on which method (9.10+,11.1+ or 11.4) is used, and which platform type is queried.
 
 .PARAMETER Active
 Filter active/inactive platforms
@@ -26,6 +28,36 @@ Filter platform by search pattern
 
 .PARAMETER PlatformID
 The unique ID/Name of the platform.
+
+.PARAMETER DependentPlatform
+Specify to return details of dependent platforms
+
+.PARAMETER GroupPlatform
+Specify to return details of group platforms
+
+.PARAMETER RotationalGroup
+Specify to return details of rotational group platforms
+
+.PARAMETER SystemType
+Filter target platforms for specific system type
+
+.PARAMETER PeriodicVerify
+Filter target platforms by periodic verification configuration
+
+.PARAMETER ManualVerify
+Filter target platforms by manual verification configuration
+
+.PARAMETER PeriodicChange
+Filter target platforms by periodic change configuration
+
+.PARAMETER ManualChange
+Filter target platforms by manual change configuration
+
+.PARAMETER AutomaticReconcile
+Filter target platforms by automatic reconciliation configuration
+
+.PARAMETER ManualReconcile
+Filter target platforms by manual reconciliation configuration
 
 .EXAMPLE
 Get-PASPlatform
@@ -47,20 +79,52 @@ Get-PASPlatform -PlatformID "CyberArk"
 
 Get details of specific platform CyberArk
 
+.EXAMPLE
+Get-PASPlatform -GroupPlatform
+
+Get details of all group platfoms
+
+.EXAMPLE
+Get-PASPlatform -RotationalGroup
+
+Get details of all rotational group platforms
+
+.EXAMPLE
+Get-PASPlatform -DependentPlatform
+
+Get details of all dependent platforms
+
+.EXAMPLE
+Get-PASPlatform -Active $false -SystemType Windows
+
+Get details of all deactivated Windows platforms
+
+.EXAMPLE
+Get-PASPlatform -Active $true -SystemType '*NIX' -AutomaticReconcile $true
+
+Get details of all active Unix platforms configured for automatic reconciliation.
+
 .NOTES
 Minimum CyberArk version 9.10
 CyberArk version 11.1 required for Active, PlatformType & Search paramters.
+CyberArk version 11.4 required for extended filters for target platforms,
+and requests for  dependent, group & rotational group platforms
 
 .LINK
 https://pspas.pspete.dev/commands/Get-PASPlatform
 #>
 
-	[CmdletBinding(DefaultParameterSetName = "11_1")]
+	[CmdletBinding(DefaultParameterSetName = "targets")]
 	param(
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = "11_1"
+		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "targets"
 		)]
 		[boolean]$Active,
 
@@ -85,44 +149,148 @@ https://pspas.pspete.dev/commands/Get-PASPlatform
 			ParameterSetName = "legacy"
 		)]
 		[Alias("Name")]
-		[string]$PlatformID
+		[string]$PlatformID,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "dependents"
+		)]
+		[switch]$DependentPlatform,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "groups"
+		)]
+		[switch]$GroupPlatform,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "rotationalGroups"
+		)]
+		[switch]$RotationalGroup,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "targets"
+		)]
+		[string]$SystemType,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "targets"
+		)]
+		[boolean]$PeriodicVerify,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "targets"
+		)]
+		[boolean]$ManualVerify,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "targets"
+		)]
+		[boolean]$PeriodicChange,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "targets"
+		)]
+		[boolean]$ManualChange,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "targets"
+		)]
+		[boolean]$AutomaticReconcile,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "targets"
+		)]
+		[boolean]$ManualReconcile
+
 	)
 
 	BEGIN {
 		$MinimumVersion = [System.Version]"9.10"
 		$RequiredVersion = [System.Version]"11.1"
+		$Version114 = [System.Version]"11.4"
 	}#begin
 
 	PROCESS {
 
-		If ($PSCmdlet.ParameterSetName -eq "11_1") {
+		switch ($PSCmdlet.ParameterSetName) {
 
-			Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $RequiredVersion
+			"11_1" {
+				Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $RequiredVersion
 
-			#Create request URL
-			$URI = "$Script:BaseURI/API/Platforms"
+				#Create request URL
+				$URI = "$Script:BaseURI/API/Platforms"
 
-			#Get Parameters to include in request
-			$boundParameters = $PSBoundParameters | Get-PASParameter
+				#Get Parameters to include in request
+				$boundParameters = $PSBoundParameters | Get-PASParameter
 
-			#Create Query String, escaped for inclusion in request URL
-			$queryString = ($boundParameters.keys | ForEach-Object {
+				#Create Query String, escaped for inclusion in request URL
+				$queryString = ($boundParameters.keys | ForEach-Object {
 
-					"$_=$($boundParameters[$_] | Get-EscapedString)"
+						"$_=$($boundParameters[$_] | Get-EscapedString)"
 
-				}) -join '&'
+					}) -join '&'
 
-			#Build URL from base URL
-			$URI = "$URI`?$queryString"
+				If ($queryString) {
+					#Build URL from base URL
+					$URI = "$URI`?$queryString"
+				}
 
-		}
+				break
 
-		ElseIf ($PSCmdlet.ParameterSetName -eq "legacy") {
+			}
 
-			Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $MinimumVersion
+			"legacy" {
+				Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $MinimumVersion
 
-			#Create request URL
-			$URI = "$Script:BaseURI/API/Platforms/$($PlatformID | Get-EscapedString)"
+				#Create request URL
+				$URI = "$Script:BaseURI/API/Platforms/$($PlatformID | Get-EscapedString)"
+				break
+			}
+
+			"targets" {
+				Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $Version114
+
+				$URI = "$Script:BaseURI/API/Platforms/$($PSCmdlet.ParameterSetName)"
+
+				#Get Parameters to include in request
+				$boundParameters = $PSBoundParameters | Get-PASParameter
+
+				$queryString = ($boundParameters.keys | ForEach-Object {
+						"$_ eq $($boundParameters[$_])"
+					}) -join ' AND ' | Get-EscapedString
+
+				If ($queryString) {
+					$URI = "$URI`?filter=$queryString"
+				}
+
+				break
+			}
+
+			default {
+				Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $Version114
+
+				$URI = "$Script:BaseURI/API/Platforms/$($PSCmdlet.ParameterSetName)"
+				break
+			}
 
 		}
 
@@ -131,19 +299,80 @@ https://pspas.pspete.dev/commands/Get-PASPlatform
 
 		If ($result) {
 
-			#11.1 returns result under "platforms" property
+			#11.1+ returns result under "platforms" property
 			If ($result.Platforms) {
+				$Global:Object = $result
+				$result = $result | Select-Object -ExpandProperty Platforms
+				switch ($PSCmdlet.ParameterSetName) {
 
-				$result = $result | Select-Object -ExpandProperty Platforms |
-				Select-Object @{ Name = 'PlatformID'; Expression = { $_.general.id } }, @{ Name = 'Active'; Expression = { $_.general.active } }, @{ Name = 'Details'; Expression = { [pscustomobject]@{
-							"General"                   = $_.general
-							"properties"                = $_.properties
-							"linkedAccounts"            = $_.linkedAccounts
-							"credentialsManagement"     = $_.credentialsManagement
-							"sessionManagement"         = $_.sessionManagement
-							"privilegedAccessWorkflows" = $_.privilegedAccessWorkflows
+					"11_1" {
+						$result = $result |
+						Select-Object @{ Name = 'PlatformID'; Expression = { $_.general.id } }, @{ Name = 'Active'; Expression = { $_.general.active } }, @{ Name = 'Details'; Expression = { [pscustomobject]@{
+									"General"                   = $_.general
+									"properties"                = $_.properties
+									"linkedAccounts"            = $_.linkedAccounts
+									"credentialsManagement"     = $_.credentialsManagement
+									"sessionManagement"         = $_.sessionManagement
+									"privilegedAccessWorkflows" = $_.privilegedAccessWorkflows
+								}
+							}
 						}
+
+						break
 					}
+
+					"targets" {
+						$result = $result |
+						Select-Object PlatformID, Active, @{ Name = 'Details'; Expression = { [pscustomobject]@{
+									"ID"                          = $_.ID
+									"Name"                        = $_.Name
+									"SystemType"                  = $_.SystemType
+									"AllowedSafes"                = $_.AllowedSafes
+									"CredentialsManagementPolicy" = $_.CredentialsManagementPolicy
+									"PrivilegedAccessWorkflows"   = $_.PrivilegedAccessWorkflows
+									"PrivilegedSessionManagement" = $_.PrivilegedSessionManagement
+								}
+							}
+						}
+						break
+					}
+
+					"groups" {
+						$result = $result |
+						Select-Object PlatformID, Active, @{ Name = 'Details'; Expression = { [pscustomobject]@{
+									"ID"   = $_.ID
+									"Name" = $_.Name
+								}
+							}
+						}
+						break
+					}
+
+					"dependents" {
+						$result = $result |
+						Select-Object PlatformID, @{ Name = 'Details'; Expression = { [pscustomobject]@{
+									"ID"                            = $_.ID
+									"Name"                          = $_.Name
+									"NumberOfLinkedTargetPlatforms" = $_.NumberOfLinkedTargetPlatforms
+									"CredentialsManagementPolicy"   = $_.CredentialsManagementPolicy
+								}
+							}
+						}
+						break
+					}
+
+					"rotationalGroups" {
+						$result = $result |
+						Select-Object PlatformID, Active, @{ Name = 'Details'; Expression = { [pscustomobject]@{
+									"ID"          = $_.ID
+									"Name"        = $_.Name
+									"GracePeriod" = $_.GracePeriod
+								}
+							}
+						}
+						break
+					}
+
 				}
 
 			}

--- a/psPAS/Functions/Platforms/Remove-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Remove-PASPlatform.ps1
@@ -1,0 +1,106 @@
+Function Remove-PASPlatform {
+<#
+.SYNOPSIS
+Deletes a platform.
+
+.DESCRIPTION
+Deletes, target, dependent, group or rotational group platform.
+
+.PARAMETER TargetPlatform
+Specify if ID relates to Target platform
+
+.PARAMETER DependentPlatform
+Specify if ID relates to Dependent platform
+
+.PARAMETER GroupPlatform
+Specify if ID relates to Group platform
+
+.PARAMETER RotationalGroup
+Specify if ID relates to Rotational Group platform
+
+.PARAMETER ID
+The unique ID number of the platofrm to delete.
+
+.EXAMPLE
+Remove-PASPlatform -TargetPlatform -ID 9
+
+Deletes Target Platform with ID of 9
+
+.EXAMPLE
+Remove-PASPlatform -DependentPlatform -ID 9
+
+Deletes Dependent Platform with ID of 9
+
+.EXAMPLE
+Remove-PASPlatform -GroupPlatform -ID 39
+
+Deletes Group Platform with ID of 39
+
+.EXAMPLE
+Remove-PASPlatform -RotationalGroup -ID 59
+
+Deletes Rotational Group Platform with ID of 59
+
+.NOTES
+PAS 11.4 minimum
+#>
+	[CmdletBinding(SupportsShouldProcess)]
+	param(
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "targets"
+		)]
+		[switch]$TargetPlatform,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "dependents"
+		)]
+		[switch]$DependentPlatform,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "groups"
+		)]
+		[switch]$GroupPlatform,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "rotationalGroups"
+		)]
+		[switch]$RotationalGroup,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[int]$ID
+	)
+
+	BEGIN {
+
+		$MinimumVersion = [System.Version]"11.4"
+
+	}#begin
+
+	Process {
+
+		Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $MinimumVersion
+
+		#Create URL for request
+		$URI = "$Script:BaseURI/API/Platforms/$($PSCmdLet.ParameterSetName)/$ID"
+
+		if ($PSCmdlet.ShouldProcess($ID, "Delete $($PSCmdLet.ParameterSetName) Platform")) {
+
+			#send request to web service
+			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+
+		}
+
+	}
+
+}

--- a/psPAS/Functions/User/New-PASUser.ps1
+++ b/psPAS/Functions/User/New-PASUser.ps1
@@ -182,7 +182,7 @@ The Type of User to create.
 EPVUser type will be created by default.
 
 .PARAMETER Disabled
-Whether or not the user will be created as a disbaled user
+Whether or not the user will be created as a disabled user
 Default is Enabled
 
 .PARAMETER Location

--- a/psPAS/Functions/User/Remove-PASGroup.ps1
+++ b/psPAS/Functions/User/Remove-PASGroup.ps1
@@ -1,0 +1,54 @@
+Function Remove-PASGroup {
+<#
+.SYNOPSIS
+Deletes a user group
+
+.DESCRIPTION
+Deletes a user group.
+
+To delete a user group, the following authorizations are required:
+
+- Add/Update Users
+
+.PARAMETER GroupID
+The unique ID of the group to delete.
+
+.EXAMPLE
+Delete-PASGroup -GroupID 3
+
+Deletes Group with ID of 3
+#>
+	[CmdletBinding(SupportsShouldProcess)]
+	param(
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[int]$GroupID
+	)
+
+	BEGIN {
+
+		$MinimumVersion = [System.Version]"11.5"
+
+	}#begin
+
+	Process {
+
+		Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $MinimumVersion
+
+		#Create URL for request
+		$URI = "$Script:BaseURI/API/UserGroups/$GroupID"
+
+		if ($PSCmdlet.ShouldProcess($GroupID, "Delete Group")) {
+
+			#send request to web service
+			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+
+		}
+
+	}
+
+	End { }
+
+}

--- a/psPAS/Functions/User/Set-PASUser.ps1
+++ b/psPAS/Functions/User/Set-PASUser.ps1
@@ -192,7 +192,7 @@ The Type of User to create.
 EPVUser type will be created by default.
 
 .PARAMETER Disabled
-Whether or not the user will be created as a disbaled user
+Whether or not the user will be created as a disabled user
 Default is Enabled
 
 .PARAMETER Location

--- a/psPAS/Private/Get-EscapedString.ps1
+++ b/psPAS/Private/Get-EscapedString.ps1
@@ -24,7 +24,7 @@ Escaped String Value
 	[OutputType('System.String')]
 	param(
 		[parameter(
-			Mandatory = $true,
+			Mandatory = $false,
 			ValueFromPipeline = $true
 		)]
 		[string]$inputString

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -182,7 +182,12 @@
 		'Remove-PASDirectoryMapping',
 		'Disable-PASCPMAutoManagement',
 		'Test-PASPSMRecording',
-		'Set-PASPTAEvent'
+		'Set-PASPTAEvent',
+		'Copy-PASPlatform',
+		'Disable-PASPlatform',
+		'Enable-PASPlatform',
+		'Remove-PASPlatform',
+		'Remove-PASGroup'
 	)
 
 	# AliasesToExport   = @( )

--- a/psPAS/xml/psPAS.CyberArk.Vault.User.Formats.ps1xml
+++ b/psPAS/xml/psPAS.CyberArk.Vault.User.Formats.ps1xml
@@ -116,6 +116,9 @@
 								<PropertyName>PersonalDetails</PropertyName>
 							</ListItem>
 							<ListItem>
+								<PropertyName>groupsMembership</PropertyName>
+							</ListItem>
+							<ListItem>
 								<PropertyName>BusinessAddress</PropertyName>
 							</ListItem>
 							<ListItem>


### PR DESCRIPTION
### Module update to cover CyberArk 11.5 API features
#### ... Includes 11.4 features missed from `psPAS 4.0.0` release

- **Behaviour Changes**
  - `Get-PASPlatform`
    - When invoked with no parameters to return details of all configured platforms, defaults to operation against the endpoint for the 11.4 API.
    - When invoked with a value provided for the `Active` parameter, will perform operation against the endpoint for the 11.4 API.
    - To utilise the 11.1 api endpoint, a value should be provided for the `PlatformType` and/or `Search` parameters,  or, `Active` and `PlatformType` and/or `Search` parameters.

- New Functions
  - `Copy-PASPlatform`
    - Duplicates target, dependent, group or rotational group platform to a new platform.
    - 11.4 functionality, missed in the `4.0.0` release.
  - `Disable-PASPlatform`
    - Disables, target, group or rotational group platform.
    - 11.4 functionality, missed in the `4.0.0` release.
  - `Enable-PASPlatform`
    - Enables, target, group or rotational group platform.
    - 11.4 functionality, missed in the `4.0.0` release.
  - `Remove-PASPlatform`
    - Deletes, target, dependent, group or rotational group platform.
    - 11.4 functionality, missed in the `4.0.0` release.
  - `Remove-PASGroup`
    - Deletes a specified vault user group
    - 11.5 functionality.

- Updated Functions
  - `Get-PASUser`
    - 11.5 output includes group membership details.
    - group membership property may be included in output when function is executed from earlier versions, but its content will be blank.

- Other Fixes & Updates
  - Documentation updated.