### PR TITLE
RADIUS Auth

### DIFF
--- a/docs/collections/_commands/New-PASSession.md
+++ b/docs/collections/_commands/New-PASSession.md
@@ -121,8 +121,7 @@ For CyberArk version older than 9.7:
         Accept wildcard characters?  false
 
     -OTP <String>
-        One Time Passcode for RADIUS authentication.
-        To provide an OTP value after the initial RADIUS authentication, specify a value of 'passcode' to get prompted for the OTP to use.
+        One Time Passcode, if known, for RADIUS authentication.
 
         Required?                    false
         Position?                    named
@@ -278,7 +277,7 @@ For CyberArk version older than 9.7:
 
     -------------------------- EXAMPLE 1 --------------------------
 
-    PS C:\>New-PASSession -Credential $cred -BaseURI https://PVWA -type LDAP
+    PS > New-PASSession -Credential $cred -BaseURI https://PVWA -type LDAP
 
     Logon to Version 10 with LDAP credential
 
@@ -287,7 +286,7 @@ For CyberArk version older than 9.7:
 
     -------------------------- EXAMPLE 2 --------------------------
 
-    PS C:\>New-PASSession -Credential $cred -BaseURI https://PVWA -type LDAP -concurrentSession $true
+    PS > New-PASSession -Credential $cred -BaseURI https://PVWA -type LDAP -concurrentSession $true
 
     Establish a concurrent session
 
@@ -296,7 +295,7 @@ For CyberArk version older than 9.7:
 
     -------------------------- EXAMPLE 3 --------------------------
 
-    PS C:\>New-PASSession -Credential $cred -BaseURI https://PVWA -type CyberArk
+    PS > New-PASSession -Credential $cred -BaseURI https://PVWA -type CyberArk
 
     Logon to Version 10 with CyberArk credential
 
@@ -305,7 +304,7 @@ For CyberArk version older than 9.7:
 
     -------------------------- EXAMPLE 4 --------------------------
 
-    PS C:\>New-PASSession -BaseURI https://PVWA -UseDefaultCredentials
+    PS > New-PASSession -BaseURI https://PVWA -UseDefaultCredentials
 
     Logon to Version 10 with Windows Integrated Authentication
 
@@ -314,7 +313,7 @@ For CyberArk version older than 9.7:
 
     -------------------------- EXAMPLE 5 --------------------------
 
-    PS C:\>New-PASSession -Credential $cred -BaseURI https://PVWA -UseClassicAPI
+    PS > New-PASSession -Credential $cred -BaseURI https://PVWA -UseClassicAPI
 
     Logon to Version 9 with credential
     Request would be sent to PVWA URL https://PVWA/PasswordVault/
@@ -324,7 +323,7 @@ For CyberArk version older than 9.7:
 
     -------------------------- EXAMPLE 6 --------------------------
 
-    PS C:\>New-PASSession -Credential $cred -BaseURI https://PVWA -PVWAAppName CustomVault -UseClassicAPI
+    PS > New-PASSession -Credential $cred -BaseURI https://PVWA -PVWAAppName CustomVault -UseClassicAPI
 
     Logon to Version 9 where PVWA Virtual Directory has non-default name
     Request would be sent to PVWA URL https://PVWA/CustomVault/
@@ -334,7 +333,7 @@ For CyberArk version older than 9.7:
 
     -------------------------- EXAMPLE 7 --------------------------
 
-    PS C:\>New-PASSession -UseSharedAuthentication -BaseURI https://PVWA.domain.com
+    PS > New-PASSession -UseSharedAuthentication -BaseURI https://PVWA.domain.com
 
     Gets authorisation token by authenticating to a CyberArk Vault using shared authentication.
 
@@ -343,7 +342,7 @@ For CyberArk version older than 9.7:
 
     -------------------------- EXAMPLE 8 --------------------------
 
-    PS C:\>New-PASSession -SAMLToken $SAMLToken -BaseURI https://PVWA.domain.com
+    PS > New-PASSession -SAMLToken $SAMLToken -BaseURI https://PVWA.domain.com
 
     Authenticates to a CyberArk Vault using SAML authentication.
 
@@ -352,7 +351,7 @@ For CyberArk version older than 9.7:
 
     -------------------------- EXAMPLE 9 --------------------------
 
-    PS C:\>New-PASSession -Credential $cred -BaseURI https://PVWA -type RADIUS
+    PS > New-PASSession -Credential $cred -BaseURI https://PVWA -type RADIUS
 
     Logon to Version 10 using RADIUS
 
@@ -361,7 +360,7 @@ For CyberArk version older than 9.7:
 
     -------------------------- EXAMPLE 10 --------------------------
 
-    PS C:\>New-PASSession -Credential $cred -BaseURI https://PVWA -useRadiusAuthentication $True
+    PS > New-PASSession -Credential $cred -BaseURI https://PVWA -useRadiusAuthentication $True
 
     Logon using RADIUS via the Classic API
 
@@ -370,7 +369,7 @@ For CyberArk version older than 9.7:
 
     -------------------------- EXAMPLE 11 --------------------------
 
-    PS C:\>New-PASSession -Credential $cred -BaseURI https://PVWA -type RADIUS -OTP 123456 -OTPMode Challenge
+    PS > New-PASSession -Credential $cred -BaseURI https://PVWA -type RADIUS -OTP 123456
 
     Logon to Version 10 using RADIUS (Challenge) & OTP (Response)
 
@@ -379,7 +378,7 @@ For CyberArk version older than 9.7:
 
     -------------------------- EXAMPLE 12 --------------------------
 
-    PS C:\>New-PASSession -Credential $cred -BaseURI https://PVWA -UseClassicAPI -useRadiusAuthentication $True -OTP 123456 -OTPMode Append
+    PS > New-PASSession -Credential $cred -BaseURI https://PVWA -UseClassicAPI -useRadiusAuthentication $True -OTP 123456 -OTPMode Append
 
     Logon using RADIUS & OTP (Append Mode) via the Classic API
 
@@ -388,7 +387,7 @@ For CyberArk version older than 9.7:
 
     -------------------------- EXAMPLE 13 --------------------------
 
-    PS C:\>New-PASSession -Credential $cred -BaseURI https://PVWA -type RADIUS -OTP push -OTPMode Append
+    PS > New-PASSession -Credential $cred -BaseURI https://PVWA -type RADIUS -OTP push -OTPMode Append
 
     Logon to Version 10 using RADIUS & Push Authentication (works with DUO 2FA)
 
@@ -397,7 +396,7 @@ For CyberArk version older than 9.7:
 
     -------------------------- EXAMPLE 14 --------------------------
 
-    PS C:\>New-PASSession -UseSharedAuthentication -BaseURI https://pvwa.some.co -CertificateThumbprint 0e194289c57e666115109d6e2800c24fb7db6edb
+    PS > New-PASSession -UseSharedAuthentication -BaseURI https://pvwa.some.co -CertificateThumbprint 0e194289c57e666115109d6e2800c24fb7db6edb
 
     If authentication via certificates is configured, provide CertificateThumbprint details.
 
@@ -406,7 +405,7 @@ For CyberArk version older than 9.7:
 
     -------------------------- EXAMPLE 15 --------------------------
 
-    PS C:\>New-PASSession -Credential $cred -BaseURI $url -SkipCertificateCheck
+    PS > New-PASSession -Credential $cred -BaseURI $url -SkipCertificateCheck
 
     Skip SSL Certificate validation for the session.
 
@@ -415,7 +414,7 @@ For CyberArk version older than 9.7:
 
     -------------------------- EXAMPLE 16 --------------------------
 
-    PS C:\>New-PASSession -Credential $cred -BaseURI https://PVWA -type LDAP -Certificate $Certificate
+    PS > New-PASSession -Credential $cred -BaseURI https://PVWA -type LDAP -Certificate $Certificate
 
     Logon to Version 10 with LDAP credential & Client Certificate
 
@@ -424,7 +423,7 @@ For CyberArk version older than 9.7:
 
     -------------------------- EXAMPLE 17 --------------------------
 
-    PS C:\>New-PASSession -Credential $cred -BaseURI https://PVWA -type Windows -OTP 123456 -OTPMode Challenge
+    PS > New-PASSession -Credential $cred -BaseURI https://PVWA -type Windows -OTP 123456
 
     Perform initial Windows authentication and satisfy secondary RADIUS challenge
 
@@ -433,12 +432,24 @@ For CyberArk version older than 9.7:
 
     -------------------------- EXAMPLE 18 --------------------------
 
-    PS C:\>New-PASSession -Credential $cred -BaseURI https://PVWA -type Windows -OTP passcode -OTPMode Challenge
+    PS > New-PASSession -Credential $cred -BaseURI https://PVWA -type RADIUS -OTP 123456 -RadiusChallenge Password -OTPMode Challenge
 
-    Perform initial authentication and then get prompted to supply OTP value for  RADIUS challenge.
+    For RADIUS, send OTP first and password value as response to challenge.
+
+
+
 
     -------------------------- EXAMPLE 19 --------------------------
 
-    PS C:\>New-PASSession -BaseURI $url -SAMLAuth
+    PS > New-PASSession -Credential $cred -BaseURI https://PVWA -type RADIUS
+
+    Perform initial authentication and supply OTP value for  RADIUS challenge when prompted.
+
+
+
+
+    -------------------------- EXAMPLE 20 --------------------------
+
+    PS > New-PASSession -BaseURI $url -SAMLAuth
 
     Perform saml authentication from version 11.4

--- a/docs/collections/_docs/01-authentication.md
+++ b/docs/collections/_docs/01-authentication.md
@@ -62,7 +62,7 @@ User: DuoUser
 Password for user DuoUser: **********
 
 
-New-PASSession -Credential $cred -BaseURI https://pvwa.somedomain.com -type RADIUS -OTP 123456 -OTPMode Challenge
+New-PASSession -Credential $cred -BaseURI https://pvwa.somedomain.com -type RADIUS -OTP 123456
 
 Get-PASLoggedOnUser
 

--- a/psPAS/Functions/Authentication/New-PASSession.ps1
+++ b/psPAS/Functions/Authentication/New-PASSession.ps1
@@ -47,8 +47,7 @@ Valid values are CyberArk, LDAP, Windows or RADIUS
 Windows is only a valid option for version 10.4 onward.
 
 .PARAMETER OTP
-One Time Passcode for RADIUS authentication.
-To provide an OTP value after the initial RADIUS authentication, specify a value of 'passcode' to get prompted for the OTP to use.
+One Time Passcode, if known, for RADIUS authentication.
 
 .PARAMETER OTPMode
 Specify if OTP is to be sent in 'Append' (appended to the password) or 'Challenge' mode (sent in response to RADIUS Challenge).
@@ -155,7 +154,7 @@ New-PASSession -Credential $cred -BaseURI https://PVWA -useRadiusAuthentication 
 Logon using RADIUS via the Classic API
 
 .EXAMPLE
-New-PASSession -Credential $cred -BaseURI https://PVWA -type RADIUS -OTP 123456 -OTPMode Challenge
+New-PASSession -Credential $cred -BaseURI https://PVWA -type RADIUS -OTP 123456
 
 Logon to Version 10 using RADIUS (Challenge) & OTP (Response)
 
@@ -185,14 +184,19 @@ New-PASSession -Credential $cred -BaseURI https://PVWA -type LDAP -Certificate $
 Logon to Version 10 with LDAP credential & Client Certificate
 
 .EXAMPLE
-New-PASSession -Credential $cred -BaseURI https://PVWA -type Windows -OTP 123456 -OTPMode Challenge
+New-PASSession -Credential $cred -BaseURI https://PVWA -type Windows -OTP 123456
 
 Perform initial Windows authentication and satisfy secondary RADIUS challenge
 
 .EXAMPLE
-New-PASSession -Credential $cred -BaseURI https://PVWA -type Windows -OTP passcode -OTPMode Challenge
+New-PASSession -Credential $cred -BaseURI https://PVWA -type RADIUS -OTP 123456 -RadiusChallenge Password -OTPMode Challenge
 
-Perform initial authentication and then get prompted to supply OTP value for  RADIUS challenge.
+For RADIUS, send OTP first and password value as response to challenge.
+
+.EXAMPLE
+New-PASSession -Credential $cred -BaseURI https://PVWA -type RADIUS
+
+Perform initial authentication and supply OTP value for  RADIUS challenge when prompted.
 
 .EXAMPLE
 New-PASSession -BaseURI $url -SAMLAuth
@@ -641,7 +645,7 @@ https://pspas.pspete.dev/commands/New-PASSession
 				#Send Logon Request
 				$PASSession = Invoke-PASRestMethod @LogonRequest
 
-				If($null -ne $PASSession.UserName){
+				If ($null -ne $PASSession.UserName) {
 
 					#*$PASSession is expected to be a string value
 					#*For IIS Windows auth:
@@ -676,56 +680,53 @@ https://pspas.pspete.dev/commands/New-PASSession
 				Else {
 
 					#ITATS542I is expected for RADIUS Challenge
-					If (($PSCmdlet.ParameterSetName -match "Radius$") -and ($PSBoundParameters["OTPMode"] -eq "Challenge")) {
+					#If (($PSCmdlet.ParameterSetName -match "Radius$") -and ($PSBoundParameters["OTPMode"] -eq "Challenge")) {
 
-						If ($PSBoundParameters.ContainsKey("OTP")) {
+					#OTP value has not yet been provided.
+					#Initial RADIUS auth attempt will trigger notification of OTP for user to provide.
+					#?"passcode" remains an option for backward compatibility.
+					If ((-not ($PSBoundParameters.ContainsKey("OTP"))) -or ($OTP -match "passcode")) {
 
-							If ($OTP -match "passcode") {
+						#*The message of the exception should contain instructions from the RADIUS server
+						#*containing information the expected OTP value to provide or other available options.
+						If ($($PSItem.Exception.Message)) {
 
-								#The message of the exception should contain instructions on the expected OTP or other options.
-								If ($($PSItem.Exception.Message)){
-
-									$Prompt = $($PSItem.Exception.Message)
-
-								}
-								Else {
-
-									$Prompt = "Enter OTP"
-
-								}
-								$OTP = $(Read-Host -Prompt $Prompt)
-
-							}
-
-							#$OTP as RADIUS response
-							#If $RadiusChallenge = Password, $OTP will be password value
-							$boundParameters["password"] = $OTP
-
-							#Construct Request Body
-							$LogonRequest["Body"] = $boundParameters | ConvertTo-Json
-
-							#Use WebSession from initial request
-							$LogonRequest.Remove("SessionVariable")
-							$LogonRequest["WebSession"] = $Script:WebSession
-
-							#Respond to RADIUS challenge
-							$PASSession = Invoke-PASRestMethod @LogonRequest
+							$Prompt = $($PSItem.Exception.Message)
 
 						}
 						Else {
 
-							#No OTP
-							throw $PSItem
+							#Default value for the Read-Host prompt.
+							$Prompt = "Enter OTP"
 
 						}
 
-					}
-					Else {
-
-						#Not RADIUS/Challenge Mode
-						throw $PSItem
+						#Prompt user for OTP
+						$OTP = $(Read-Host -Prompt $Prompt)
 
 					}
+
+					#$OTP as RADIUS response
+					#!If $RadiusChallenge = Password, $OTP will be password value
+					$boundParameters["password"] = $OTP
+
+					#Construct Request Body
+					$LogonRequest["Body"] = $boundParameters | ConvertTo-Json
+
+					#Use WebSession from initial request
+					$LogonRequest.Remove("SessionVariable")
+					$LogonRequest["WebSession"] = $Script:WebSession
+
+					#Respond to RADIUS challenge
+					$PASSession = Invoke-PASRestMethod @LogonRequest
+
+					#}
+					#Else {
+
+					#Not RADIUS/Challenge Mode
+					#throw $PSItem
+
+					#}
 
 				}
 

--- a/psPAS/Functions/Authentication/New-PASSession.ps1
+++ b/psPAS/Functions/Authentication/New-PASSession.ps1
@@ -680,7 +680,6 @@ https://pspas.pspete.dev/commands/New-PASSession
 				Else {
 
 					#ITATS542I is expected for RADIUS Challenge
-					#If (($PSCmdlet.ParameterSetName -match "Radius$") -and ($PSBoundParameters["OTPMode"] -eq "Challenge")) {
 
 					#OTP value has not yet been provided.
 					#Initial RADIUS auth attempt will trigger notification of OTP for user to provide.
@@ -719,14 +718,6 @@ https://pspas.pspete.dev/commands/New-PASSession
 
 					#Respond to RADIUS challenge
 					$PASSession = Invoke-PASRestMethod @LogonRequest
-
-					#}
-					#Else {
-
-					#Not RADIUS/Challenge Mode
-					#throw $PSItem
-
-					#}
 
 				}
 

--- a/psPAS/Functions/Authentication/New-PASSession.ps1
+++ b/psPAS/Functions/Authentication/New-PASSession.ps1
@@ -682,7 +682,18 @@ https://pspas.pspete.dev/commands/New-PASSession
 
 							If ($OTP -match "passcode") {
 
-								$OTP = $(Read-Host -Prompt "Enter OTP")
+								#The message of the exception should contain instructions on the expected OTP or other options.
+								If ($($PSItem.Exception.Message)){
+
+									$Prompt = $($PSItem.Exception.Message)
+
+								}
+								Else {
+
+									$Prompt = "Enter OTP"
+
+								}
+								$OTP = $(Read-Host -Prompt $Prompt)
 
 							}
 


### PR DESCRIPTION
<!-- _A similar PR may already be submitted.
Please search existing `Pull Requests` before creating one._

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.  -->

## Summary

Provides any exception text returned from the RADIUS server as the prompt requesting the OTP value.
OTP parameter can now be omitted if OTP is unknown at time of initial authentication, the literal value "passcode" no longer needs to be provided.
Removed need for OTPMode parameter to have a value of "Challenge" in order to reach the OTP prompt. OTPMode can now be omitted.

## Test Plan

Pester tests updated

## Related issues

#283 