### PR TITLE
URL Helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 
 - Other Fixes & Updates
   - Documentation updated.
+  - Duplicated code for creating the query portion of a URL replaced with new helper function internal to the module.
 
 ## **4.0.0** (July 1st 2020)
 

--- a/Tests/ConvertTo-QueryString.Tests.ps1
+++ b/Tests/ConvertTo-QueryString.Tests.ps1
@@ -1,0 +1,77 @@
+Describe $($PSCommandPath -Replace ".Tests.ps1") {
+
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
+
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+		if ( -not (Get-Module -Name $ModuleName -All)) {
+
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+		}
+
+		$Script:RequestBody = $null
+		$Script:BaseURI = "https://SomeURL/SomeApp"
+		$Script:ExternalVersion = "0.0"
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+	}
+
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+		Context "General" {
+
+			BeforeEach {
+
+				$InputObj = @{
+					Property1 = "Value"
+					Property2 = "Another Value"
+				}
+
+			}
+
+			It "does not throw" {
+
+				{ ConvertTo-QueryString } | Should -Not -Throw
+
+			}
+
+			It "produces no output if given no input" {
+
+				ConvertTo-QueryString | Should -BeNullOrEmpty
+
+			}
+
+			It "converts hashtable to expected query string" {
+
+				$InputObj | ConvertTo-QueryString | Should -Be "Property1=Value&Property2=Another%20Value"
+
+			}
+
+			It "converts hashtable to expected filter string" {
+
+				$InputObj | ConvertTo-QueryString -Format Filter | Should -Be "Property1%20eq%20Value%20AND%20Property2%20eq%20Another%20Value"
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Get-PASGroup.Tests.ps1
+++ b/Tests/Get-PASGroup.Tests.ps1
@@ -53,7 +53,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 				Get-PASGroup
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/UserGroups?"
+					$URI -eq "$($Script:BaseURI)/API/UserGroups"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/psPAS/Functions/Accounts/Get-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccount.ps1
@@ -232,11 +232,7 @@ https://pspas.pspete.dev/commands/Get-PASAccount
 		$boundParameters = $PSBoundParameters | Get-PASParameter
 
 		#Create Query String, escaped for inclusion in request URL
-		$query = ($boundParameters.keys | ForEach-Object {
-
-				"$_=$($boundParameters[$_] | Get-EscapedString)"
-
-			}) -join '&'
+		$queryString = $boundParameters | ConvertTo-QueryString
 
 		#Version 10.4 process
 		If ($PSCmdlet.ParameterSetName -match "v10") {
@@ -262,8 +258,12 @@ https://pspas.pspete.dev/commands/Get-PASAccount
 			$URI = "$Script:BaseURI/api/Accounts"
 
 			If ($PSCmdlet.ParameterSetName -eq "v10ByQuery") {
-				#define query URL
-				$URI = "$URI`?$query"
+				if ($queryString) {
+
+					#Build URL from base URL
+					$URI = "$URI`?$queryString"
+
+				}
 			}
 
 			If ($PSCmdlet.ParameterSetName -eq "v10ByID") {
@@ -282,7 +282,14 @@ https://pspas.pspete.dev/commands/Get-PASAccount
 			$typeName = "psPAS.CyberArk.Vault.Account"
 
 			#Create request URL
-			$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Accounts?$query"
+			$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Accounts"
+
+			if ($queryString) {
+
+				#Build URL from base URL
+				$URI = "$URI`?$queryString"
+
+			}
 
 		}
 

--- a/psPAS/Functions/Applications/Get-PASApplication.ps1
+++ b/psPAS/Functions/Applications/Get-PASApplication.ps1
@@ -123,14 +123,14 @@ https://pspas.pspete.dev/commands/Get-PASApplication
 			$boundParameters = $PSBoundParameters | Get-PASParameter
 
 			#Create query string
-			$query = ($boundParameters.keys | ForEach-Object {
+			$queryString = $boundParameters | ConvertTo-QueryString
 
-					"$_=$($boundParameters[$_] | Get-EscapedString)"
+			if ($queryString) {
 
-				}) -join '&'
+				#Build URL from base URL
+				$URI = "$URI`?$queryString"
 
-			#Build URL from base URL
-			$URI = "$URI`?$query"
+			}
 
 		}
 

--- a/psPAS/Functions/Authentication/New-PASSession.ps1
+++ b/psPAS/Functions/Authentication/New-PASSession.ps1
@@ -625,11 +625,7 @@ https://pspas.pspete.dev/commands/New-PASSession
 					$boundParameters.Add("apiUse", $true)
 
 					#Create Logon URL
-					$LogonString = ($boundParameters.keys | ForEach-Object {
-
-							"$_=$($boundParameters[$_] | Get-EscapedString)"
-
-						}) -join '&'
+					$LogonString = $boundParameters | ConvertTo-QueryString
 
 					if ($LogonString) {
 

--- a/psPAS/Functions/EventSecurity/Get-PASPTAEvent.ps1
+++ b/psPAS/Functions/EventSecurity/Get-PASPTAEvent.ps1
@@ -67,7 +67,7 @@ https://pspas.pspete.dev/commands/Get-PASPTAEvent
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = "11_4"
 		)]
-		[ValidateSet("OPEN","CLOSED")]
+		[ValidateSet("OPEN", "CLOSED")]
 		[string]$status,
 
 		[parameter(
@@ -111,18 +111,14 @@ https://pspas.pspete.dev/commands/Get-PASPTAEvent
 
 		}
 
-		if($PSCmdlet.ParameterSetName -eq "11_4"){
+		if ($PSCmdlet.ParameterSetName -eq "11_4") {
 
 			Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $RequiredVersion
 
 			#Create Query String, escaped for inclusion in request URL
-			$queryString = ($boundParameters.keys | ForEach-Object {
+			$queryString = $boundParameters | ConvertTo-QueryString
 
-					"$_=$($boundParameters[$_] | Get-EscapedString)"
-
-				}) -join '&'
-
-			if ($queryString){
+			if ($queryString) {
 
 				#Build URL from base URL
 				$URI = "$URI`?$queryString"
@@ -130,7 +126,7 @@ https://pspas.pspete.dev/commands/Get-PASPTAEvent
 			}
 
 		}
-		Else{
+		Else {
 
 			if ($PSBoundParameters.ContainsKey("lastUpdatedEventDate")) {
 

--- a/psPAS/Functions/Monitoring/Get-PASPSMRecording.ps1
+++ b/psPAS/Functions/Monitoring/Get-PASPSMRecording.ps1
@@ -168,11 +168,7 @@ https://pspas.pspete.dev/commands/Get-PASPSMRecording
 			$boundParameters = $PSBoundParameters | Get-PASParameter
 
 			#Create Query String, escaped for inclusion in request URL
-			$queryString = ($boundParameters.keys | ForEach-Object {
-
-					"$_=$($boundParameters[$_] | Get-EscapedString)"
-
-				}) -join '&'
+			$queryString = $boundParameters | ConvertTo-QueryString
 
 			if ($queryString) {
 

--- a/psPAS/Functions/Monitoring/Get-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Get-PASPSMSession.ps1
@@ -174,11 +174,7 @@ https://pspas.pspete.dev/commands/Get-PASPSMSession
 			$boundParameters = $PSBoundParameters | Get-PASParameter
 
 			#Create Query String, escaped for inclusion in request URL
-			$queryString = ($boundParameters.keys | ForEach-Object {
-
-					"$_=$($boundParameters[$_] | Get-EscapedString)"
-
-				}) -join '&'
+			$queryString = $boundParameters | ConvertTo-QueryString
 
 			if ($queryString) {
 

--- a/psPAS/Functions/Platforms/Get-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Get-PASPlatform.ps1
@@ -243,11 +243,7 @@ https://pspas.pspete.dev/commands/Get-PASPlatform
 				$boundParameters = $PSBoundParameters | Get-PASParameter
 
 				#Create Query String, escaped for inclusion in request URL
-				$queryString = ($boundParameters.keys | ForEach-Object {
-
-						"$_=$($boundParameters[$_] | Get-EscapedString)"
-
-					}) -join '&'
+				$queryString = $boundParameters | ConvertTo-QueryString
 
 				If ($queryString) {
 					#Build URL from base URL
@@ -274,9 +270,7 @@ https://pspas.pspete.dev/commands/Get-PASPlatform
 				#Get Parameters to include in request
 				$boundParameters = $PSBoundParameters | Get-PASParameter
 
-				$queryString = ($boundParameters.keys | ForEach-Object {
-						"$_ eq $($boundParameters[$_])"
-					}) -join ' AND ' | Get-EscapedString
+				$queryString = $boundParameters | ConvertTo-QueryString -Format Filter
 
 				If ($queryString) {
 					$URI = "$URI`?filter=$queryString"

--- a/psPAS/Functions/Safes/Get-PASSafe.ps1
+++ b/psPAS/Functions/Safes/Get-PASSafe.ps1
@@ -85,14 +85,14 @@ https://pspas.pspete.dev/commands/Get-PASSafe
 			$boundParameters = $PSBoundParameters | Get-PASParameter
 
 			#Create Query String, escaped for inclusion in request URL
-			$queryString = ($boundParameters.keys | ForEach-Object {
+			$queryString = $boundParameters | ConvertTo-QueryString
 
-					"$_=$($boundParameters[$_] | Get-EscapedString)"
+			if ($queryString) {
 
-				}) -join '&'
+				#Build URL from base URL
+				$URI = "$URI`?$queryString"
 
-			#Build URL from base URL
-			$URI = "$URI`?$queryString"
+			}
 
 		}
 

--- a/psPAS/Functions/User/Get-PASGroup.ps1
+++ b/psPAS/Functions/User/Get-PASGroup.ps1
@@ -84,14 +84,14 @@ https://pspas.pspete.dev/commands/Get-PASGroup
 		$boundParameters = $PSBoundParameters | Get-PASParameter
 
 		#Create Query String, escaped for inclusion in request URL
-		$queryString = ($boundParameters.keys | ForEach-Object {
+		$queryString = $boundParameters | ConvertTo-QueryString
 
-				"$_=$($boundParameters[$_] | Get-EscapedString)"
+		if ($queryString) {
 
-			}) -join '&'
+			#Build URL from base URL
+			$URI = "$URI`?$queryString"
 
-		#Build URL from base URL
-		$URI = "$URI`?$queryString"
+		}
 
 		#send request to web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession

--- a/psPAS/Functions/User/Get-PASUser.ps1
+++ b/psPAS/Functions/User/Get-PASUser.ps1
@@ -116,14 +116,14 @@ https://pspas.pspete.dev/commands/Get-PASUser
 			$boundParameters = $PSBoundParameters | Get-PASParameter
 
 			#Create Query String, escaped for inclusion in request URL
-			$queryString = ($boundParameters.keys | ForEach-Object {
+			$queryString = $boundParameters | ConvertTo-QueryString
 
-					"$_=$($boundParameters[$_] | Get-EscapedString)"
+			if ($queryString) {
 
-				}) -join '&'
+				#Build URL from base URL
+				$URI = "$URI`?$queryString"
 
-			#Build URL from base URL
-			$URI = "$URI`?$queryString"
+			}
 
 			$TypeName = "psPAS.CyberArk.Vault.User.Extended"
 

--- a/psPAS/Private/ConvertTo-QueryString.ps1
+++ b/psPAS/Private/ConvertTo-QueryString.ps1
@@ -1,0 +1,83 @@
+Function ConvertTo-QueryString {
+	<#
+.SYNOPSIS
+Converts Hastable to a string for use as a url query string
+
+.DESCRIPTION
+When given a hashtable as input, converts key value pairs to query string
+
+.PARAMETER Parameters
+Hashtable containing parameter names and values to include in output string
+
+.PARAMETER Format
+Provide value of "Filter" to output string as REST filter
+
+.EXAMPLE
+$input | ConvertTo-QueryString
+
+Joins Key & Value with "="
+Joins Multiple Key Value pairs with '&'
+Formats input as: "Key=Value&Key=Value"
+
+.EXAMPLE
+$input | ConvertTo-QueryString -Format Filter
+
+Joins Key & Value with "eq"
+Joins Multiple Key Value pairs with ' AND '
+Formats input as: "Key%20eq%20Value%20AND%20Key%20eq%20Value"
+#>
+
+	[CmdletBinding()]
+	[OutputType('System.String')]
+	param(
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipeline = $true
+		)]
+		[hashtable]$Parameters,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipeline = $false
+		)]
+		[ValidateSet("Filter")]
+		[string]$Format
+	)
+
+	Begin { }
+
+	Process {
+
+		If ($Parameters) {
+
+			Switch ($Format) {
+
+				"Filter" {
+
+					($Parameters.Keys | ForEach-Object {
+
+							"$PSItem eq $($Parameters[$PSItem])"
+
+						}) -join ' AND ' | Get-EscapedString
+
+				}
+
+				default {
+
+					($Parameters.Keys | ForEach-Object {
+
+							"$PSItem=$($Parameters[$PSItem] | Get-EscapedString)"
+
+						}) -join '&'
+
+				}
+
+			}
+
+		}
+
+	}
+
+	End { }
+
+}


### PR DESCRIPTION
<!-- _A similar PR may already be submitted.
Please search existing `Pull Requests` before creating one._

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.  -->

## Summary

Adds `ConvertTo-QueryString`, a new helper function which formats a provided hashtable as query string for use in urls.
Replaces repeated code in various module functions.
Adds logic to only include query in URLs if there is a value assigned to the variable holding the query. Prevents a trailing `?` when no value is present.

## Test Plan

All existing pester tests pass.
Invocation of updated functions shows no change in existing module operation
