### PR TITLE
New-PASPSMSession

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,7 +776,7 @@ Check the output of `Get-Help` for the `psPAS` functions for further details of 
 [`Remove-PASApplication`][Remove-PASApplication]                                         |**9.1**             |Deletes an application
 [`Remove-PASApplicationAuthenticationMethod`][Remove-PASApplicationAuthenticationMethod] |**9.1**             |Delete auth method from an application
 [`Import-PASConnectionComponent`][Import-PASConnectionComponent]                         |**10.3**            |Imports a Connection Component
-[`Get-PASPSMConnectionParameter`][Get-PASPSMConnectionParameter]                         |**9.10**            |Get required parameters to connect through PSM
+[`New-PASPSMSession`][New-PASPSMSession]                                                 |**9.10**            |Get required parameters to connect through PSM
 [`Get-PASPSMRecording`][Get-PASPSMRecording]                                             |**9.10**            |Get details of PSM Recording
 [`Get-PASPSMSession`][Get-PASPSMSession]                                                 |**9.10**            |Get details of PSM Sessions
 [`Resume-PASPSMSession`][Resume-PASPSMSession]                                           |**10.2**            |Resumes a Suspended PSM Session.
@@ -887,7 +887,7 @@ Check the output of `Get-Help` for the `psPAS` functions for further details of 
 [Remove-PASApplication]:/psPAS/Functions/Applications/Remove-PASApplication.ps1
 [Remove-PASApplicationAuthenticationMethod]:/psPAS/Functions/Applications/Remove-PASApplicationAuthenticationMethod.ps1
 [Import-PASConnectionComponent]:/psPAS/Functions/Connections/Import-PASConnectionComponent.ps1
-[Get-PASPSMConnectionParameter]:/psPAS/Functions/Connections/Get-PASPSMConnectionParameter.ps1
+[New-PASPSMSession]:/psPAS/Functions/Connections/New-PASPSMSession.ps1
 [Get-PASPSMRecording]:/psPAS/Functions/Monitoring/Get-PASPSMRecording.ps1
 [Get-PASPSMSession]:/psPAS/Functions/Monitoring/Get-PASPSMSession.ps1
 [Resume-PASPSMSession]:/psPAS/Functions/Monitoring/Resume-PASPSMSession.ps1

--- a/Tests/New-PASPSMSession.Tests.ps1
+++ b/Tests/New-PASPSMSession.Tests.ps1
@@ -44,7 +44,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 				param($Parameter)
 
-				(Get-Command Get-PASPSMConnectionParameter).Parameters["$Parameter"].Attributes.Mandatory | Select-Object -Unique | Should -Be $true
+				(Get-Command New-PASPSMSession).Parameters["$Parameter"].Attributes.Mandatory | Select-Object -Unique | Should -Be $true
 
 			}
 
@@ -81,12 +81,12 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 			}
 
 			It "throws if path is invalid" {
-				{ $InputObj | Get-PASPSMConnectionParameter -ConnectionMethod RDP -path A:\test.txt } | Should -Throw
+				{ $InputObj | New-PASPSMSession -ConnectionMethod RDP -path A:\test.txt } | Should -Throw
 			}
 
 			It "sends request" {
 
-				$InputObj | Get-PASPSMConnectionParameter -ConnectionMethod RDP
+				$InputObj | New-PASPSMSession -ConnectionMethod RDP
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
@@ -94,7 +94,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			It "sends request to expected endpoint for PSMConnect" {
 
-				$InputObj | Get-PASPSMConnectionParameter -ConnectionMethod RDP
+				$InputObj | New-PASPSMSession -ConnectionMethod RDP
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -106,7 +106,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			It "uses expected method" {
 
-				$InputObj | Get-PASPSMConnectionParameter -ConnectionMethod RDP
+				$InputObj | New-PASPSMSession -ConnectionMethod RDP
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
@@ -114,7 +114,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			It "sends request with expected body" {
 
-				$InputObj | Get-PASPSMConnectionParameter -ConnectionMethod RDP
+				$InputObj | New-PASPSMSession -ConnectionMethod RDP
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -128,7 +128,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			It "has a request body with expected number of properties" {
 
-				$InputObj | Get-PASPSMConnectionParameter -ConnectionMethod RDP
+				$InputObj | New-PASPSMSession -ConnectionMethod RDP
 
 				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
@@ -136,7 +136,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			It "has expected Accept key in header" {
 
-				$InputObj | Get-PASPSMConnectionParameter -ConnectionMethod RDP
+				$InputObj | New-PASPSMSession -ConnectionMethod RDP
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -146,7 +146,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			It "specifies expected Accept key in header for PSMGW requests" {
 
-				$InputObj | Get-PASPSMConnectionParameter -ConnectionMethod PSMGW
+				$InputObj | New-PASPSMSession -ConnectionMethod PSMGW
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -156,20 +156,20 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			It "throws error if version requirement not met for RDP connection method" {
 				$Script:ExternalVersion = "9.8"
-				{ $InputObj | Get-PASPSMConnectionParameter -ConnectionMethod RDP } | Should -Throw
+				{ $InputObj | New-PASPSMSession -ConnectionMethod RDP } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 
 			It "throws error if version requirement not met for PSMGW connection method" {
 
 				$Script:ExternalVersion = "9.10"
-				{ $InputObj | Get-PASPSMConnectionParameter -ConnectionMethod PSMGW } | Should -Throw
+				{ $InputObj | New-PASPSMSession -ConnectionMethod PSMGW } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 
 			It "sends request to expected endpoint for AdHocConnect" {
 
-				$AdHocObj | Get-PASPSMConnectionParameter -ConnectionMethod RDP
+				$AdHocObj | New-PASPSMSession -ConnectionMethod RDP
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$URI -eq "$($Script:BaseURI)/API/Accounts/AdHocConnect"
@@ -180,7 +180,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			It "throws error if version requirement not met for AdHocConnect" {
 				$Script:ExternalVersion = "10.4"
-				{ $AdHocObj | Get-PASPSMConnectionParameter -ConnectionMethod PSMGW } | Should -Throw
+				{ $AdHocObj | New-PASPSMSession -ConnectionMethod PSMGW } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 
@@ -209,7 +209,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 			}
 
 			It "outputs PSMGW connection information" {
-				$InputObj | Get-PASPSMConnectionParameter -ConnectionMethod PSMGW | Should -Not -Be Null
+				$InputObj | New-PASPSMSession -ConnectionMethod PSMGW | Should -Not -Be Null
 			}
 
 		}

--- a/Tests/New-PASPSMSession.Tests.ps1
+++ b/Tests/New-PASPSMSession.Tests.ps1
@@ -114,7 +114,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			It "sends request with expected body" {
 
-				$InputObj | New-PASPSMSession -ConnectionMethod RDP
+				$InputObj | New-PASPSMSession -ConnectionMethod RDP -PSMRemoteMachine "SomeMachine"
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -128,9 +128,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			It "has a request body with expected number of properties" {
 
-				$InputObj | New-PASPSMSession -ConnectionMethod RDP
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
-				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 1
+			}
+
+			It "has a request body with expected ConnectionParams" {
+
+				$Script:RequestBody.ConnectionParams.PSMRemoteMachine.Value | Should -Be "SomeMachine"
 
 			}
 
@@ -169,11 +173,31 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			It "sends request to expected endpoint for AdHocConnect" {
 
-				$AdHocObj | New-PASPSMSession -ConnectionMethod RDP
+				$AdHocObj | New-PASPSMSession -ConnectionMethod RDP -PSMRemoteMachine "SomeServer"
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$URI -eq "$($Script:BaseURI)/API/Accounts/AdHocConnect"
 
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request with expected PSMConnectPrerequisites ConnectionComponent for AdHocConnect" {
+
+				$AdHocObj | New-PASPSMSession -ConnectionMethod RDP -PSMRemoteMachine "SomeServer"
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+					$RequestBody = $Body | ConvertFrom-Json
+					$RequestBody.PSMConnectPrerequisites.ConnectionComponent -eq "SomeConnectionComponent"
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It "sends request with expected PSMConnectPrerequisites ConnectionParams for AdHocConnect" {
+
+				$AdHocObj | New-PASPSMSession -ConnectionMethod RDP -PSMRemoteMachine "SomeServer"
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+					$RequestBody = $Body | ConvertFrom-Json
+					$RequestBody.PSMConnectPrerequisites.ConnectionParams.PSMRemoteMachine.value -eq "SomeServer"
 				} -Times 1 -Exactly -Scope It
 
 			}

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -95,8 +95,8 @@ commands:
 
   - title: "Connections"
     children:
-      - title: "Get-PASPSMConnectionParameter"
-        url: /commands/Get-PASPSMConnectionParameter
+      - title: "New-PASPSMSession"
+        url: /commands/New-PASPSMSession
       - title: "Import-PASConnectionComponent"
         url: /commands/Import-PASConnectionComponent
 

--- a/docs/collections/_commands/New-PASPSMSession.md
+++ b/docs/collections/_commands/New-PASPSMSession.md
@@ -1,5 +1,5 @@
 ---
-title: Get-PASPSMConnectionParameter
+title: New-PASPSMSession
 ---
 
 ## SYNOPSIS
@@ -8,11 +8,11 @@ Get required parameters to connect through PSM
 
 ## SYNTAX
 
-    Get-PASPSMConnectionParameter -AccountID <String> [-reason <String>] [-TicketingSystemName <String>]
+    New-PASPSMSession -AccountID <String> [-reason <String>] [-TicketingSystemName <String>]
     [-TicketId <String>] -ConnectionComponent <String> [-ConnectionParams <Hashtable>]
     [-ConnectionMethod <String>] [-Path <String>] [<CommonParameters>]
 
-    Get-PASPSMConnectionParameter -userName <String> -secret <SecureString> -address <String>
+    New-PASPSMSession -userName <String> -secret <SecureString> -address <String>
     -platformID <String> [-extraFields <String>] [-reason <String>] [-TicketingSystemName <String>]
     [-TicketId <String>] -ConnectionComponent <String> [-ConnectionParams <Hashtable>]
     [-ConnectionMethod <String>] [-Path <String>] [<CommonParameters>]
@@ -157,7 +157,7 @@ RDP files or the HTML5 Gateway.
 
     -------------------------- EXAMPLE 1 --------------------------
 
-    PS C:\>Get-PASPSMConnectionParameter -AccountID $ID -ConnectionComponent PSM-SSH
+    PS C:\>New-PASPSMSession -AccountID $ID -ConnectionComponent PSM-SSH
     -reason "Fix XYZ"
 
     Outputs RDP file for Direct Connection via PSM using account with ID in $ID

--- a/docs/collections/_commands/New-PASPSMSession.md
+++ b/docs/collections/_commands/New-PASPSMSession.md
@@ -4,148 +4,82 @@ title: New-PASPSMSession
 
 ## SYNOPSIS
 
-Get required parameters to connect through PSM
+    Get required parameters to connect through PSM
 
 ## SYNTAX
 
-    New-PASPSMSession -AccountID <String> [-reason <String>] [-TicketingSystemName <String>]
-    [-TicketId <String>] -ConnectionComponent <String> [-ConnectionParams <Hashtable>]
+    New-PASPSMSession -AccountID <String> [-reason <String>] [-TicketingSystemName <String>] [-TicketId <String>] -ConnectionComponent <String> [-AllowMappingLocalDrives
+    <String>] [-AllowConnectToConsole <String>] [-RedirectSmartCards <String>] [-PSMRemoteMachine <String>] [-LogonDomain <String>] [-AllowSelectHTML5 <String>]
     [-ConnectionMethod <String>] [-Path <String>] [<CommonParameters>]
 
-    New-PASPSMSession -userName <String> -secret <SecureString> -address <String>
-    -platformID <String> [-extraFields <String>] [-reason <String>] [-TicketingSystemName <String>]
-    [-TicketId <String>] -ConnectionComponent <String> [-ConnectionParams <Hashtable>]
-    [-ConnectionMethod <String>] [-Path <String>] [<CommonParameters>]
+    New-PASPSMSession -userName <String> -secret <SecureString> -address <String> -platformID <String> [-extraFields <String>] [-reason <String>] [-TicketingSystemName
+    <String>] [-TicketId <String>] -ConnectionComponent <String> [-AllowMappingLocalDrives <String>] [-AllowConnectToConsole <String>] [-RedirectSmartCards <String>]
+    [-PSMRemoteMachine <String>] [-LogonDomain <String>] [-AllowSelectHTML5 <String>] [-ConnectionMethod <String>] [-Path <String>] [<CommonParameters>]
 
 ## DESCRIPTION
 
-This method enables you to connect to an account through PSM (PSMConnect).
-
-The function returns either an RDP file or URL for PSM connections.
-
-It requires the PVWA and PSM to be configured for either transparent connections through PSM with
-RDP files or the HTML5 Gateway.
+    This method enables you to connect to an account through PSM (PSMConnect).
+    The function returns either an RDP file or URL for PSM connections.
+    It requires the PVWA and PSM to be configured for either transparent connections through PSM with RDP files
+    or the HTML5 Gateway.
 
 ## PARAMETERS
 
     -AccountID <String>
         The unique ID of the account to retrieve and use to connect to the target via PSM
 
-        Required?                    true
-        Position?                    named
-        Default value
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
-
     -userName <String>
         For Ad-Hoc connections: the username of the account to connect with.
-
-        Required?                    true
-        Position?                    named
-        Default value
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
 
     -secret <SecureString>
         For Ad-Hoc connections: The target account password.
 
-        Required?                    true
-        Position?                    named
-        Default value
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
-
     -address <String>
         For Ad-Hoc connections: The target account address.
-
-        Required?                    true
-        Position?                    named
-        Default value
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
 
     -platformID <String>
         For Ad-Hoc connections: A configured secure connect platform.
 
-        Required?                    true
-        Position?                    named
-        Default value
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
-
     -extraFields <String>
         For Ad-Hoc connections: Additional needed parameters for the various connection components.
-
-        Required?                    false
-        Position?                    named
-        Default value
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
 
     -reason <String>
         The reason that is required to request access to this account.
 
-        Required?                    false
-        Position?                    named
-        Default value
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
-
     -TicketingSystemName <String>
         The name of the Ticketing System used in the request.
-
-        Required?                    false
-        Position?                    named
-        Default value
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
 
     -TicketId <String>
         The TicketId to use with the Ticketing System
 
-        Required?                    false
-        Position?                    named
-        Default value
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
-
     -ConnectionComponent <String>
         The name of the connection component to connect with as defined in the configuration
 
-        Required?                    true
-        Position?                    named
-        Default value
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
+    -AllowMappingLocalDrives <String>
+        Whether or not to redirect their local hard drives to the remote server.
 
-    -ConnectionParams <Hashtable>
-        List of params
+    -AllowConnectToConsole <String>
+        Whether or not to connect to the administrative console of the remote machine.
 
-        Required?                    false
-        Position?                    named
-        Default value
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
+    -RedirectSmartCards <String>
+        Whether or not to redirect Smart Card so that the certificate stored on the card can be accessed on the target
+
+    -PSMRemoteMachine <String>
+        Address of the remote machine to connect to.
+
+    -LogonDomain <String>
+        The netbios domain name of the account being used.
+
+    -AllowSelectHTML5 <String>
+        Specify which connection method, HTML5-based or RDP-file, to use when connecting to the remote server
 
     -ConnectionMethod <String>
         The expected parameters to be returned, either RDP or PSMGW.
 
         PSMGW is only available from version 10.2 onwards
 
-        Required?                    false
-        Position?                    named
-        Default value
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
-
     -Path <String>
         The folder to save the output file in.
-
-        Required?                    false
-        Position?                    named
-        Default value
-        Accept pipeline input?       true (ByPropertyName)
-        Accept wildcard characters?  false
 
     <CommonParameters>
         This cmdlet supports the common parameters: Verbose, Debug,
@@ -157,18 +91,12 @@ RDP files or the HTML5 Gateway.
 
     -------------------------- EXAMPLE 1 --------------------------
 
-    PS C:\>New-PASPSMSession -AccountID $ID -ConnectionComponent PSM-SSH
-    -reason "Fix XYZ"
+    PS C:\>New-PASPSMSession -AccountID $ID -ConnectionComponent PSM-SSH -reason "Fix XYZ"
 
     Outputs RDP file for Direct Connection via PSM using account with ID in $ID
 
     -------------------------- EXAMPLE 2 --------------------------
 
-    PS C:\>[Hashtable]$connectionParams = @{
-    "AllowMappingLocalDrives" = @{"value"="No";"ShouldSave"=$false}
-    "PSMRemoteMachine" = @{"value"="ServerName";"ShouldSave"=$false}
-    }
-
-    New-PASPSMSession -AccountID $id -ConnectionParams $connectionParams -ConnectionComponent PSM-RDP
+    PS C:\>New-PASPSMSession -AccountID $id -ConnectionComponent PSM-RDP -AllowMappingLocalDrives No -PSMRemoteMachine ServerName
 
     Provide connection parameters for the new PSM connection

--- a/docs/collections/_commands/New-PASPSMSession.md
+++ b/docs/collections/_commands/New-PASPSMSession.md
@@ -161,3 +161,14 @@ RDP files or the HTML5 Gateway.
     -reason "Fix XYZ"
 
     Outputs RDP file for Direct Connection via PSM using account with ID in $ID
+
+    -------------------------- EXAMPLE 2 --------------------------
+
+    PS C:\>[Hashtable]$connectionParams = @{
+    "AllowMappingLocalDrives" = @{"value"="No";"ShouldSave"=$false}
+    "PSMRemoteMachine" = @{"value"="ServerName";"ShouldSave"=$false}
+    }
+
+    New-PASPSMSession -AccountID $id -ConnectionParams $connectionParams -ConnectionComponent PSM-RDP
+
+    Provide connection parameters for the new PSM connection

--- a/docs/collections/_docs/10-compatibility.md
+++ b/docs/collections/_docs/10-compatibility.md
@@ -54,7 +54,7 @@ If you are using version 9.7+, and the function being invoked requires version 9
 [`Remove-PASApplication`][Remove-PASApplication]                                         |**9.1**                                             |Deletes an application
 [`Remove-PASApplicationAuthenticationMethod`][Remove-PASApplicationAuthenticationMethod] |**9.1**                                             |Delete auth method from an application
 [`Import-PASConnectionComponent`][Import-PASConnectionComponent]                         |**10.3**                                            |Imports a Connection Component
-[`Get-PASPSMConnectionParameter`][Get-PASPSMConnectionParameter]                         |**9.10** ([Notes](#get-paspsmConnectionparameter))  |Get required parameters to connect through PSM
+[`New-PASPSMSession`][New-PASPSMSession]                         |**9.10** ([Notes](#New-PASPSMSession))  |Get required parameters to connect through PSM
 [`Get-PASPSMRecording`][Get-PASPSMRecording]                                             |**9.10** ([Notes](#get-paspsmrecording))            |Get details of PSM Recording
 [`Get-PASPSMSession`][Get-PASPSMSession]                                                 |**9.10** ([Notes](#get-paspsmsession))              |Get details of PSM Sessions
 [`Resume-PASPSMSession`][Resume-PASPSMSession]                                           |**10.2**                                            |Resumes a Suspended PSM Session.
@@ -165,7 +165,7 @@ If you are using version 9.7+, and the function being invoked requires version 9
 [Remove-PASApplication]:/commands/Remove-PASApplication
 [Remove-PASApplicationAuthenticationMethod]:/commands/Remove-PASApplicationAuthenticationMethod
 [Import-PASConnectionComponent]:/commands/Import-PASConnectionComponent
-[Get-PASPSMConnectionParameter]:/commands/Get-PASPSMConnectionParameter
+[New-PASPSMSession]:/commands/New-PASPSMSession
 [Get-PASPSMRecording]:/commands/Get-PASPSMRecording
 [Get-PASPSMSession]:/commands/Get-PASPSMSession
 [Resume-PASPSMSession]:/commands/Resume-PASPSMSession
@@ -325,7 +325,7 @@ If you are using version 9.7+, and the function being invoked requires version 9
   - Using the `-ImmediateChangeByCPM` parameter.
   - Specifying the `-UseClassicAPI` parameter.
 
-### Get-PASPSMConnectionParameter
+### New-PASPSMSession
 
 - Version 10.2 introduced a new API endpoint.
   - Supports:

--- a/psPAS/Functions/Connections/New-PASPSMSession.ps1
+++ b/psPAS/Functions/Connections/New-PASPSMSession.ps1
@@ -4,7 +4,7 @@ function New-PASPSMSession {
 Get required parameters to connect through PSM
 
 .DESCRIPTION
-This method enables you to connect to an account through PSM (PSMConnect) using.
+This method enables you to connect to an account through PSM (PSMConnect).
 The function returns either an RDP file or URL for PSM connections.
 It requires the PVWA and PSM to be configured for either transparent connections through PSM with RDP files
 or the HTML5 Gateway.
@@ -54,6 +54,16 @@ The folder to save the output file in.
 New-PASPSMSession -AccountID $ID -ConnectionComponent PSM-SSH -reason "Fix XYZ"
 
 Outputs RDP file for Direct Connection via PSM using account with ID in $ID
+
+.EXAMPLE
+[Hashtable]$connectionParams = @{
+"AllowMappingLocalDrives" = @{"value"="No";"ShouldSave"=$false}
+"PSMRemoteMachine" = @{"value"="ServerName";"ShouldSave"=$false}
+}
+
+New-PASPSMSession -AccountID $id -ConnectionParams $connectionParams -ConnectionComponent PSM-RDP
+
+Provide connection parameters for the new PSM connection
 
 .NOTES
 Minimum CyberArk Version 9.10

--- a/psPAS/Functions/Connections/New-PASPSMSession.ps1
+++ b/psPAS/Functions/Connections/New-PASPSMSession.ps1
@@ -1,4 +1,4 @@
-function Get-PASPSMConnectionParameter {
+function New-PASPSMSession {
 	<#
 .SYNOPSIS
 Get required parameters to connect through PSM
@@ -51,7 +51,7 @@ PSMGW is only available from version 10.2 onwards
 The folder to save the output file in.
 
 .EXAMPLE
-Get-PASPSMConnectionParameter -AccountID $ID -ConnectionComponent PSM-SSH -reason "Fix XYZ"
+New-PASPSMSession -AccountID $ID -ConnectionComponent PSM-SSH -reason "Fix XYZ"
 
 Outputs RDP file for Direct Connection via PSM using account with ID in $ID
 
@@ -61,9 +61,10 @@ PSMGW connections require 10.2
 Ad-Hoc connections require 10.5
 
 .LINK
-https://pspas.pspete.dev/commands/Get-PASPSMConnectionParameter
+https://pspas.pspete.dev/commands/New-PASPSMSession
 #>
 	[CmdletBinding()]
+	[Alias("Get-PASPSMConnectionParameter")]
 	param(
 		[parameter(
 			Mandatory = $true,

--- a/psPAS/Functions/Platforms/Copy-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Copy-PASPlatform.ps1
@@ -1,5 +1,5 @@
-Function Copy-PASPlatform{
-<#
+Function Copy-PASPlatform {
+	<#
 .SYNOPSIS
 Duplicates a platform
 
@@ -48,7 +48,10 @@ Copy-PASPlatform -RotationalGroup -ID 59 -name SomeNewPlatform -description "Som
 Duplicates Rotational Group Platform with ID of 59 to SomeNewPlatform
 
 .NOTES
-General notes
+Minimum version 11.4
+
+.LINK
+https://pspas.pspete.dev/commands/Copy-PASPlatform
 #>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
@@ -105,7 +108,7 @@ General notes
 
 	}#begin
 
-	Process{
+	Process {
 
 		Assert-VersionRequirement -ExternalVersion $Script:ExternalVersion -RequiredVersion $MinimumVersion
 
@@ -133,6 +136,6 @@ General notes
 
 	}
 
-	End{}
+	End { }
 
 }

--- a/psPAS/Functions/Platforms/Disable-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Disable-PASPlatform.ps1
@@ -35,6 +35,10 @@ Disables Rotational Group Platform with ID of 65
 
 .NOTES
 PAS 11.4 minimum
+
+.LINK
+https://pspas.pspete.dev/commands/Disable-PASPlatform
+
 #>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(

--- a/psPAS/Functions/Platforms/Enable-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Enable-PASPlatform.ps1
@@ -1,5 +1,5 @@
 Function Enable-PASPlatform {
-<#
+	<#
 .SYNOPSIS
 Activates a platform.
 
@@ -35,6 +35,9 @@ Enables Rotational Group Platform with ID of 65
 
 .NOTES
 PAS 11.4 minimum
+
+.LINK
+https://pspas.pspete.dev/commands/Enable-PASPlatform
 #>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(

--- a/psPAS/Functions/Platforms/Remove-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Remove-PASPlatform.ps1
@@ -1,5 +1,5 @@
 Function Remove-PASPlatform {
-<#
+	<#
 .SYNOPSIS
 Deletes a platform.
 
@@ -43,6 +43,9 @@ Deletes Rotational Group Platform with ID of 59
 
 .NOTES
 PAS 11.4 minimum
+
+.LINK
+https://pspas.pspete.dev/commands/Remove-PASPlatform
 #>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(

--- a/psPAS/Functions/User/Remove-PASGroup.ps1
+++ b/psPAS/Functions/User/Remove-PASGroup.ps1
@@ -1,5 +1,5 @@
 Function Remove-PASGroup {
-<#
+	<#
 .SYNOPSIS
 Deletes a user group
 
@@ -17,6 +17,9 @@ The unique ID of the group to delete.
 Delete-PASGroup -GroupID 3
 
 Deletes Group with ID of 3
+
+.LINK
+https://pspas.pspete.dev/commands/Remove-PASGroup
 #>
 	[CmdletBinding(SupportsShouldProcess)]
 	param(

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -13,7 +13,7 @@
 	Author            = 'Pete Maan'
 
 	# Company or vendor of this module
-	CompanyName = 'PSPETE LTD'
+	CompanyName       = 'PSPETE LTD'
 
 	# Copyright statement for this module
 	Copyright         = '(c) 2020 PSPETE LTD. All rights reserved.'
@@ -135,7 +135,7 @@
 		'Deny-PASRequest',
 		'Get-PASRequest',
 		'Get-PASRequestDetail',
-		'Get-PASPSMConnectionParameter',
+		'New-PASPSMSession',
 		'Get-PASPSMRecording',
 		'Get-PASPSMSession',
 		'Stop-PASPSMSession',
@@ -190,7 +190,9 @@
 		'Remove-PASGroup'
 	)
 
-	# AliasesToExport   = @( )
+	AliasesToExport   = @(
+		'Get-PASPSMConnectionParameter'
+	)
 
 	# Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
 	PrivateData       = @{
@@ -198,16 +200,16 @@
 		PSData = @{
 
 			# Tags applied to this module. These help with module discovery in online galleries.
-			Tags       = @('CyberArk', 'REST', 'API', 'Security')
+			Tags         = @('CyberArk', 'REST', 'API', 'Security')
 
 			# A URL to the license for this module.
-			LicenseUri = 'https://github.com/pspete/psPAS/blob/master/LICENSE.md'
+			LicenseUri   = 'https://github.com/pspete/psPAS/blob/master/LICENSE.md'
 
 			# A URL to the main website for this project.
-			ProjectUri = 'https://pspas.pspete.dev/'
+			ProjectUri   = 'https://pspas.pspete.dev/'
 
 			# A URL to an icon representing this module.
-			IconUri    = 'https://pspas.pspete.dev/assets/images/symbol.png'
+			IconUri      = 'https://pspas.pspete.dev/assets/images/symbol.png'
 
 			# ReleaseNotes of this module
 			ReleaseNotes = 'https://github.com/pspete/psPAS/blob/master/CHANGELOG.md'


### PR DESCRIPTION
## Summary
- Renames `Get-PASPSMConnectionParameter` to `New-PASPSMSession`
- Removes Parameter: `connectionParams`
- Adds Parameters: `AllowMappingLocalDrives`, `AllowConnectToConsole`, `RedirectSmartCards`, `PSMRemoteMachine`, `LogonDomain` & `AllowSelectHTML5`
  - These are the documented properties expected to be sent as connectionParams.
  - This update removes the need from a module user to specify these manually as a hashtable.

Update formats the request as required for both PSMConnect & AdHoc/Secure Connect.

Refactors code for clarity & performance.

Fixes issue where `Path`, if specified, would be inclued in the request body.

## Test Plan

Pester Tests updated, request body confirmed as being in expected format.
Test Invocations & Connections successful

## Closes issues

Related #263 
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes. -->
Fixes #

Closes #

<!--
## Code formatting

 See the `CONTRIBUTING` guide.

_Ensure your code adheres to the project's PowerShell Styleguide_
-->