### PR TITLE
Update Get-PASAccount + Get-PASApplicationAuthenticationMethod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 - Continued development to encompass any new documented features of the CyberArk API.
 - psPAS v5.0...
 
+## **4.3.65** (August 20th 2020)
+
+- Fixes
+  - `Get-PASAccount`
+    - Fixes issue where no output would be shown if `filter` parameter was used.
+  - `Get-PASApplicationAuthenticationMethod`
+    - Adds properties `Subject`, `Issuer` & `SubjectAlternativeName` to output view.
+
 ## **4.3.62** (August 14th 2020)
 
 - Updated Functions

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Docs: [https://pspas.pspete.dev](https://pspas.pspete.dev)
 [github]:https://img.shields.io/github/downloads/pspete/psPAS/total?color=brightgreen
 [github-site]:https://github.com/pspete/psPAS/releases/latest
 [release]:https://img.shields.io/github/v/release/pspete/psPAS?color=brightgreen
-[installlink]:https://github.com/pspete/psPAS/tree/required_version#install-options
+[installlink]:https://github.com/pspete/psPAS#install-options
 
 ----------
 

--- a/psPAS/Functions/Accounts/Get-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccount.ps1
@@ -373,30 +373,6 @@ https://pspas.pspete.dev/commands/Get-PASAccount
 
 				}
 
-				"v10ByQuery" {
-
-					#to store list of query results
-					$AccountList = [Collections.Generic.List[Object]]@()
-
-					#add resultst to list
-					$null = $AccountList.Add($result.value)
-
-					#iterate any nextLinks
-					$NextLink = $result.nextLink
-					While ( $null -ne $NextLink ) {
-						$URI = "$Script:BaseURI/$NextLink"
-						$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession -TimeoutSec $TimeoutSec
-						$NextLink = $result.nextLink
-						$null = $AccountList.AddRange(($result.value))
-					}
-
-					#return list
-					$return = $AccountList
-
-					break
-
-				}
-
 				"v9" {
 
 					$count = $($result.count)
@@ -461,6 +437,30 @@ https://pspas.pspete.dev/commands/Get-PASAccount
 						default { break }
 
 					}
+
+					break
+
+				}
+
+				default {
+
+					#to store list of query results
+					$AccountList = [Collections.Generic.List[Object]]@()
+
+					#add resultst to list
+					$null = $AccountList.Add($result.value)
+
+					#iterate any nextLinks
+					$NextLink = $result.nextLink
+					While ( $null -ne $NextLink ) {
+						$URI = "$Script:BaseURI/$NextLink"
+						$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession -TimeoutSec $TimeoutSec
+						$NextLink = $result.nextLink
+						$null = $AccountList.AddRange(($result.value))
+					}
+
+					#return list
+					$return = $AccountList
 
 					break
 

--- a/psPAS/xml/psPAS.CyberArk.Vault.Application.Formats.ps1xml
+++ b/psPAS/xml/psPAS.CyberArk.Vault.Application.Formats.ps1xml
@@ -113,6 +113,15 @@
 							<ListItem>
 								<PropertyName>Comment</PropertyName>
 							</ListItem>
+							<ListItem>
+								<PropertyName>Subject</PropertyName>
+							</ListItem>
+							<ListItem>
+								<PropertyName>Issuer</PropertyName>
+							</ListItem>
+							<ListItem>
+								<PropertyName>SubjectAlternativeName</PropertyName>
+							</ListItem>
 						</ListItems>
 					</ListEntry>
 				</ListEntries>


### PR DESCRIPTION
<!-- _A similar PR may already be submitted.
Please search existing `Pull Requests` before creating one._

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.  -->

## Summary

- Fixes
  - `Get-PASAccount`
    - Fixes issue where no output would be shown if `filter` parameter was used.
  - `Get-PASApplicationAuthenticationMethod`
    - Adds properties `Subject`, `Issuer` & `SubjectAlternativeName` to output view.

## Test Plan

Expected output returned for the below commands:
- `Get-PASAccount`
- `Get-PASAccount -Safe somesafe`
- `Get-PASAccount -SafeName somesafe`
- `Get-PASAccount -filter 'safeName eq somesafe'`

Expected certificate authentication values shown for the following command:
`Get-PASApplicationAuthenticationMethod -AppID SomeApp`

## Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes. -->
Fixes #303 
Fixes #304 

<!--
## Code formatting

 See the `CONTRIBUTING` guide.

_Ensure your code adheres to the project's PowerShell Styleguide_
-->