### PR TITLE
Feature 11.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,23 @@
 - Continued development to encompass any new documented features of the CyberArk API.
 - psPAS v5.0...
 - **vNext**
-  - Updates
+  - New Functions
+    - `Add-PASOpenIDConnectProvider`
+      - Adds a new OIDC authentication provider configuration
+    - `Get-PASOpenIDConnectProvider`
+      - Lists configured OIDC authentication providers
+    - `Set-PASOpenIDConnectProvider`
+      - Updates a configured OIDC authentication provider
+    - `Remove-PASOpenIDConnectProvider`
+      - Deletes a configured OIDC authentication provider
+    - `Remove-PASAuthenticationMethod`
+      - Deletes a configured auth method
+  - Updated Functions
+    - `Add-PASDiscoveredAccount`
+      - Adds support for Azure platform
+    - `Get-PASDiscoveredAccount`
+      - Adds support for Azure platform
+  - Other Updates & Fixes
     - `New-PASSession`
       - Fix issue where `concurrentSession` body was not sent with request when using integrated authentication.
     - Replaced comment based help with external help.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Use PowerShell to manage CyberArk via the Web Services REST API.
 
-Contains all published methods of the API up to CyberArk v11.6.
+Contains all published methods of the API up to CyberArk v11.7.
 
 Docs: [https://pspas.pspete.dev](https://pspas.pspete.dev)
 
@@ -889,7 +889,17 @@ Click the below dropdown to view the current lis of psPAS functions and their mi
 [`Get-PASAccountImportJob`][Get-PASAccountImportJob]                                     |**11.6**            |Get status of account import
 [`New-PASAccountObject`][New-PASAccountObject]                                           |**---**             |Format an object to include in an import list
 [`Get-PASDiscoveredAccount`][Get-PASDiscoveredAccount]                                   |**11.6**            |List discovered accounts
+[`Add-PASOpenIDConnectProvider`][Add-PASOpenIDConnectProvider]                           |**11.7**            |Adds an OIDC Authentication Provider
+[`Get-PASOpenIDConnectProvider`][Get-PASOpenIDConnectProvider]                           |**11.7**            |Gets details of configured OIDC Authentication Providers
+[`Remove-PASOpenIDConnectProvider`][Remove-PASOpenIDConnectProvider]                     |**11.7**            |Deletes an OIDC Authentication Provider
+[`Set-PASOpenIDConnectProvider`][Set-PASOpenIDConnectProvider]                           |**11.7**            |Updates an OIDC Authentication Provider
+[`Remove-PASAuthenticationMethod`][Remove-PASAuthenticationMethod]                       |**11.7**            |Delete an authentication method
 
+[Add-PASOpenIDConnectProvider]:/psPAS/Functions/Authentication/Add-PASOpenIDConnectProvider
+[Get-PASOpenIDConnectProvider]:/psPAS/Functions/Authentication/Get-PASOpenIDConnectProvider
+[Remove-PASOpenIDConnectProvider]:/psPAS/Functions/Authentication/Remove-PASOpenIDConnectProvider
+[Set-PASOpenIDConnectProvider]:/psPAS/Functions/Authentication/Set-PASOpenIDConnectProvider
+[Remove-PASAuthenticationMethod]:/psPAS/Functions/Authentication/Remove-PASAuthenticationMethod
 [Get-PASDiscoveredAccount]:/psPAS/Functions/Accounts/Get-PASDiscoveredAccount.ps1
 [Start-PASAccountImportJob]:/psPAS/Functions/Accounts/Start-PASAccountImportJob.ps1
 [Get-PASAccountImportJob]:/psPAS/Functions/Accounts/Get-PASAccountImportJob.ps1

--- a/Tests/Add-PASOpenIDConnectProvider.Tests.ps1
+++ b/Tests/Add-PASOpenIDConnectProvider.Tests.ps1
@@ -44,13 +44,12 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			$InputObject = [PSCustomObject]@{
 
-				id                        = "idValue"
-				authenticationEndpointUrl = "authenticationEndpointUrlValue"
-				issuer                    = "issuerValue"
-				jwkSet                    = "jwkSetValue"
-				clientId                  = "clientIdValue"
-				clientSecret              = "clientSecretValue"
-				clientSecretMethod        = "Post"
+				id                   = "idValue"
+				authenticationFlow   = "Code"
+				discoveryEndpointUrl = "https://SomeValue"
+				clientId             = "00000159875dgjut02f5"
+				clientSecretMethod   = "Post"
+				clientSecret         = "SSSSSSSSSHHHHHHHHHHH"
 			}
 
 			$response = $InputObject | Add-PASOpenIDConnectProvider

--- a/Tests/Get-PASOpenIDConnectProvider.Tests.ps1
+++ b/Tests/Get-PASOpenIDConnectProvider.Tests.ps1
@@ -36,12 +36,18 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		BeforeEach {
+			$Script:ExternalVersion = "0.0"
+
 			Mock Invoke-PASRestMethod -MockWith {
-				[PSCustomObject]@{"Methods" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" } }
+
+				[PSCustomObject]@{"Providers" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" } }
+
 			}
 
-			$response = Get-PASAuthenticationMethod
+			$response = Get-PASOpenIDConnectProvider
+
 		}
+
 		Context "Input" {
 
 			It "sends request" {
@@ -54,7 +60,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/AuthenticationMethods/"
+					$URI -eq "$($Script:BaseURI)/api/Configuration/OIDC/Providers/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -62,11 +68,11 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			It "sends request to expected endpoint - get specific method" {
 
-				Get-PASAuthenticationMethod -ID SomeMethod
+				Get-PASOpenIDConnectProvider -id idValue
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/AuthenticationMethods/SomeMethod"
+					$URI -eq "$($Script:BaseURI)/api/Configuration/OIDC/Providers/idValue"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -86,7 +92,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "1.0"
-				{ Get-PASAuthenticationMethod } | Should -Throw
+				{ $InputObject | Get-PASOpenIDConnectProvider } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 

--- a/Tests/Remove-PASAuthenticationMethod.Tests.ps1
+++ b/Tests/Remove-PASAuthenticationMethod.Tests.ps1
@@ -36,12 +36,22 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		BeforeEach {
+			$Script:ExternalVersion = "0.0"
+
 			Mock Invoke-PASRestMethod -MockWith {
-				[PSCustomObject]@{"Methods" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" } }
+				[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
 			}
 
-			$response = Get-PASAuthenticationMethod
+			$InputObject = [PSCustomObject]@{
+
+				id = "idValue"
+
+			}
+
+			$response = $InputObject | Remove-PASAuthenticationMethod
+
 		}
+
 		Context "Input" {
 
 			It "sends request" {
@@ -50,23 +60,11 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected endpoint - get all method" {
+			It "sends request to expected endpoint" {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/AuthenticationMethods/"
-
-				} -Times 1 -Exactly -Scope It
-
-			}
-
-			It "sends request to expected endpoint - get specific method" {
-
-				Get-PASAuthenticationMethod -ID SomeMethod
-
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-
-					$URI -eq "$($Script:BaseURI)/api/Configuration/AuthenticationMethods/SomeMethod"
+					$URI -eq "$($Script:BaseURI)/api/Configuration/AuthenticationMethods/idValue"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -74,19 +72,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
-
-			}
-
-			It "sends request with no body" {
-
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "1.0"
-				{ Get-PASAuthenticationMethod } | Should -Throw
+				{ $InputObject | Remove-PASAuthenticationMethod } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 

--- a/Tests/Remove-PASOpenIDConnectProvider.Tests.ps1
+++ b/Tests/Remove-PASOpenIDConnectProvider.Tests.ps1
@@ -36,12 +36,22 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		BeforeEach {
+			$Script:ExternalVersion = "0.0"
+
 			Mock Invoke-PASRestMethod -MockWith {
-				[PSCustomObject]@{"Methods" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" } }
+				[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
 			}
 
-			$response = Get-PASAuthenticationMethod
+			$InputObject = [PSCustomObject]@{
+
+				id = "idValue"
+
+			}
+
+			$response = $InputObject | Remove-PASOpenIDConnectProvider
+
 		}
+
 		Context "Input" {
 
 			It "sends request" {
@@ -50,23 +60,11 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected endpoint - get all method" {
+			It "sends request to expected endpoint" {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/AuthenticationMethods/"
-
-				} -Times 1 -Exactly -Scope It
-
-			}
-
-			It "sends request to expected endpoint - get specific method" {
-
-				Get-PASAuthenticationMethod -ID SomeMethod
-
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-
-					$URI -eq "$($Script:BaseURI)/api/Configuration/AuthenticationMethods/SomeMethod"
+					$URI -eq "$($Script:BaseURI)/api/Configuration/OIDC/Providers/idValue"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -74,19 +72,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
-
-			}
-
-			It "sends request with no body" {
-
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "1.0"
-				{ Get-PASAuthenticationMethod } | Should -Throw
+				{ $InputObject | Remove-PASOpenIDConnectProvider } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 

--- a/Tests/Set-PASOpenIDConnectProvider.Tests.ps1
+++ b/Tests/Set-PASOpenIDConnectProvider.Tests.ps1
@@ -44,13 +44,12 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			$InputObject = [PSCustomObject]@{
 
-				id                        = "idValue"
-				authenticationEndpointUrl = "authenticationEndpointUrlValue"
-				issuer                    = "issuerValue"
-				jwkSet                    = "jwkSetValue"
-				clientId                  = "clientIdValue"
-				clientSecret              = "clientSecretValue"
-				clientSecretMethod        = "Post"
+				id                   = "idValue"
+				authenticationFlow   = "Code"
+				discoveryEndpointUrl = "https://SomeValue"
+				clientId             = "00000159875dgjut02f5"
+				clientSecretMethod   = "Post"
+				clientSecret         = "SSSSSSSSSHHHHHHHHHHH"
 			}
 
 			$response = $InputObject | Set-PASOpenIDConnectProvider

--- a/Tests/Set-PASOpenIDConnectProvider.Tests.ps1
+++ b/Tests/Set-PASOpenIDConnectProvider.Tests.ps1
@@ -36,12 +36,27 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		BeforeEach {
+			$Script:ExternalVersion = "0.0"
+
 			Mock Invoke-PASRestMethod -MockWith {
-				[PSCustomObject]@{"Methods" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" } }
+				[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
 			}
 
-			$response = Get-PASAuthenticationMethod
+			$InputObject = [PSCustomObject]@{
+
+				id                        = "idValue"
+				authenticationEndpointUrl = "authenticationEndpointUrlValue"
+				issuer                    = "issuerValue"
+				jwkSet                    = "jwkSetValue"
+				clientId                  = "clientIdValue"
+				clientSecret              = "clientSecretValue"
+				clientSecretMethod        = "Post"
+			}
+
+			$response = $InputObject | Set-PASOpenIDConnectProvider
+
 		}
+
 		Context "Input" {
 
 			It "sends request" {
@@ -50,23 +65,11 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected endpoint - get all method" {
+			It "sends request to expected endpoint" {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/AuthenticationMethods/"
-
-				} -Times 1 -Exactly -Scope It
-
-			}
-
-			It "sends request to expected endpoint - get specific method" {
-
-				Get-PASAuthenticationMethod -ID SomeMethod
-
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-
-					$URI -eq "$($Script:BaseURI)/api/Configuration/AuthenticationMethods/SomeMethod"
+					$URI -eq "$($Script:BaseURI)/api/Configuration/OIDC/Providers/idValue"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -74,19 +77,25 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			It "uses expected method" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PUT' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It "sends request with expected body" {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+					$($Body | ConvertFrom-Json) -ne $null
+				} -Times 1 -Exactly -Scope It
 
+			}
+
+			It "throws error if userNameClaim contains invalid characters" {
+				{ $InputObject | Add-PASOpenIDConnectProvider -userNameClaim "abc_123-456" } | Should -Throw
 			}
 
 			It "throws error if version requirement not met" {
 				$Script:ExternalVersion = "1.0"
-				{ Get-PASAuthenticationMethod } | Should -Throw
+				{ $InputObject | Set-PASOpenIDConnectProvider } | Should -Throw
 				$Script:ExternalVersion = "0.0"
 			}
 

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -32,6 +32,16 @@ commands:
         url: /commands/Add-PASAuthenticationMethod
       - title: "Set-PASAuthenticationMethod"
         url: /commands/Set-PASAuthenticationMethod
+      - title: "Remove-PASAuthenticationMethod"
+        url: /commands/Remove-PASAuthenticationMethod
+      - title: "Add-PASOpenIDConnectProvider"
+        url: /commands/Add-PASOpenIDConnectProvider
+      - title: "Get-PASOpenIDConnectProvider"
+        url: /commands/Get-PASOpenIDConnectProvider
+      - title: "Remove-PASOpenIDConnectProvider"
+        url: /commands/Remove-PASOpenIDConnectProvider
+      - title: "Set-PASOpenIDConnectProvider"
+        url: /commands/Set-PASOpenIDConnectProvider
 
   - title: "Account ACL"
     children:

--- a/docs/collections/_commands/Add-PASDiscoveredAccount.md
+++ b/docs/collections/_commands/Add-PASDiscoveredAccount.md
@@ -69,6 +69,17 @@ Add-PASDiscoveredAccount -UserName <String> -Address <String> -discoveryDate <Da
  [<CommonParameters>]
 ```
 
+### Azure
+```
+Add-PASDiscoveredAccount -UserName <String> -Address <String> -discoveryDate <DateTime>
+ -AccountEnabled <Boolean> [-osGroups <String>] [-platformType <String>] [-Domain <String>]
+ [-lastLogonDateTime <DateTime>] [-lastPasswordSetDateTime <DateTime>] [-passwordNeverExpires <Boolean>]
+ [-OSVersion <String>] [-privileged <Boolean>] [-privilegedCriteria <String>] [-UserDisplayName <String>]
+ [-description <String>] [-passwordExpirationDateTime <DateTime>] [-osFamily <String>]
+ [-additionalProperties <Hashtable>] [-organizationalUnit <String>] [-activeDirectoryID <String>]
+ [<CommonParameters>]
+```
+
 ## DESCRIPTION
 Enables an account or SSH key that is discovered by an external scanner to be added
 as a pending account to the Accounts Feed.
@@ -617,6 +628,21 @@ Requires 10.8+
 ```yaml
 Type: Hashtable[]
 Parameter Sets: Dependency
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -activeDirectoryID
+Azure Active Directory tenant ID
+
+```yaml
+Type: String
+Parameter Sets: Azure
 Aliases:
 
 Required: False

--- a/docs/collections/_commands/Add-PASOpenIDConnectProvider.md
+++ b/docs/collections/_commands/Add-PASOpenIDConnectProvider.md
@@ -1,0 +1,222 @@
+---
+category: PSPAS
+external help file: psPAS-help.xml
+Module Name: psPAS
+online version: https://pspas.pspete.dev/commands/Add-PASOpenIDConnectProvider
+schema: 2.0.0
+title: Add-PASOpenIDConnectProvider
+---
+
+# Add-PASOpenIDConnectProvider
+
+## SYNOPSIS
+Adds a new OIDC Identity Provider.
+
+## SYNTAX
+
+```
+Add-PASOpenIDConnectProvider -id <String> [-authenticationFlow <String>] [-authenticationEndpointUrl <String>]
+ [-issuer <String>] [-description <String>] -discoveryEndpointUrl <String> [-jwkSet <String>]
+ -clientId <String> [-clientSecret <String>] -clientSecretMethod <String> [-userNameClaim <String>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+Adds a new OIDC Identity Provider.
+Requires membership of Vault Admins group.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Add-PASOpenIDConnectProvider -id SomeOIDCProvider -discoveryEndpointUrl https://SomeURLValue
+ -clientId SomeID -clientSecretMethod POST
+```
+
+Adds an OIDC Identity Provider with ID SomeOIDCProvider.
+
+## PARAMETERS
+
+### -id
+The unique identifier of the provider.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -authenticationFlow
+The OIDC connection flow.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -authenticationEndpointUrl
+The URL of the provider's authorization endpoint.
+Authentication requests will be sent to this URL.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -issuer
+The Issuer Identifier for the OpenID Provider.
+Used to verify that the response was issued from a specific provider.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -description
+A description of the provider.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -discoveryEndpointUrl
+OIDC defines a discovery mechanism, called OpenID Connect Discovery, where an OIDC Identity provider publishes its metadata at a well-known URL.
+
+This URL is metadata that describes the provider's configuration.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -jwkSet
+The JSON web key set provided by the OIDC Identity Provider for validating JSON web tokens during the authentication flow.
+
+The JSON must include a "keys" parameter, which is an array of JWT signing keys.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -clientId
+The unique identifier for the client application.
+This ID is created by the provider, and assigned to each client application upon registration.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -clientSecret
+The client secret is only known to the application and the provider for secure communication during the authentication flow.
+This secret is created by the provider, and assigned to each client application upon registration.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -clientSecretMethod
+The client authentication method for the client secret.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -userNameClaim
+The property in the ID token provided by the OIDC Identity Provider that contains the user name.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS

--- a/docs/collections/_commands/Get-PASOpenIDConnectProvider.md
+++ b/docs/collections/_commands/Get-PASOpenIDConnectProvider.md
@@ -1,0 +1,67 @@
+---
+category: PSPAS
+external help file: psPAS-help.xml
+Module Name: psPAS
+online version: https://pspas.pspete.dev/commands/Get-PASOpenIDConnectProvider
+schema: 2.0.0
+title: Get-PASOpenIDConnectProvider
+---
+
+# Get-PASOpenIDConnectProvider
+
+## SYNOPSIS
+Returns details of configured OIDC Identity Providers.
+
+## SYNTAX
+
+```
+Get-PASOpenIDConnectProvider [[-id] <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+returns either a list of all OIDC Identity Providers, or details of a specific Provider.
+Requires membership of Vault Admins group.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Get-PASOpenIDConnectProvider
+```
+
+Returns details of all configured OIDC Providers.
+
+### Example 2
+```powershell
+PS C:\> Get-PASOpenIDConnectProvider -id SomeOIDCProvider
+```
+
+Returns details of OIDC Provider with ID SomeOIDCProvider
+
+## PARAMETERS
+
+### -id
+An identifier of a specific provider to retrieve details of.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS

--- a/docs/collections/_commands/Remove-PASAuthenticationMethod.md
+++ b/docs/collections/_commands/Remove-PASAuthenticationMethod.md
@@ -1,0 +1,60 @@
+---
+category: PSPAS
+external help file: psPAS-help.xml
+Module Name: psPAS
+online version: https://pspas.pspete.dev/commands/Remove-PASAuthenticationMethod
+schema: 2.0.0
+title: Remove-PASAuthenticationMethod
+---
+
+# Remove-PASAuthenticationMethod
+
+## SYNOPSIS
+Deletes a specific authentication method.
+
+## SYNTAX
+
+```
+Remove-PASAuthenticationMethod [-id] <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+Deletes a specific authentication method.
+Membership of the Vault admins group required.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Remove-PASAuthenticationMethod -id SomeID
+```
+
+Deletes authentication method with id "SomeID"
+
+## PARAMETERS
+
+### -id
+The authentication method identifier.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS

--- a/docs/collections/_commands/Remove-PASOpenIDConnectProvider.md
+++ b/docs/collections/_commands/Remove-PASOpenIDConnectProvider.md
@@ -1,0 +1,91 @@
+---
+category: PSPAS
+external help file: psPAS-help.xml
+Module Name: psPAS
+online version: https://pspas.pspete.dev/commands/Remove-PASOpenIDConnectProvider
+schema: 2.0.0
+title: Remove-PASOpenIDConnectProvider
+---
+
+# Remove-PASOpenIDConnectProvider
+
+## SYNOPSIS
+Deletes a configured OIDC Identity Provider.
+
+## SYNTAX
+
+```
+Remove-PASOpenIDConnectProvider [[-id] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Deletes an OIDC Identity Provider.
+Requires membership of Vault Admins group.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Remove-PASOpenIDConnectProvider -id SomeOIDCProvider
+```
+
+Deletes OIDC Identity Provider with ID SomeOIDCProvider
+
+## PARAMETERS
+
+### -id
+The unique identifier of the provider to delete.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS

--- a/docs/collections/_commands/Set-PASOpenIDConnectProvider.md
+++ b/docs/collections/_commands/Set-PASOpenIDConnectProvider.md
@@ -1,0 +1,252 @@
+---
+category: PSPAS
+external help file: psPAS-help.xml
+Module Name: psPAS
+online version: https://pspas.pspete.dev/commands/Set-PASOpenIDConnectProvider
+schema: 2.0.0
+title: Set-PASOpenIDConnectProvider
+---
+
+# Set-PASOpenIDConnectProvider
+
+## SYNOPSIS
+Updates an existing OIDC Identity Provider.
+
+## SYNTAX
+
+```
+Set-PASOpenIDConnectProvider -id <String> [-authenticationFlow <String>] [-authenticationEndpointUrl <String>]
+ [-issuer <String>] [-description <String>] -discoveryEndpointUrl <String> [-jwkSet <String>]
+ -clientId <String> [-clientSecret <String>] -clientSecretMethod <String> [-userNameClaim <String>] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Updates an existing OIDC Identity Provider.
+Requires membership of Vault Admins group.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Set-PASOpenIDConnectProvider -id SomeOIDCProvider -discoveryEndpointUrl https://SomeURL -clientId SomeIDValue -clientSecretMethod POST
+```
+
+Updates an existing OIDC Identity Provider with ID SomeOIDCProvider.
+
+## PARAMETERS
+
+### -id
+The unique identifier of the provider.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -authenticationFlow
+The OIDC connection flow.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -authenticationEndpointUrl
+The URL of the provider's authorization endpoint.
+Authentication requests will be sent to this URL.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -issuer
+The Issuer Identifier for the OpenID Provider.
+Used to verify that the response was issued from a specific provider.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -description
+A description of the provider.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -discoveryEndpointUrl
+OIDC defines a discovery mechanism, called OpenID Connect Discovery, where an OIDC Identity provider publishes its metadata at a well-known URL.
+
+This URL is metadata that describes the provider's configuration.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -jwkSet
+The JSON web key set provided by the OIDC Identity Provider for validating JSON web tokens during the authentication flow.
+
+The JSON must include a "keys" parameter, which is an array of JWT signing keys.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -clientId
+The unique identifier for the client application.
+This ID is created by the provider, and assigned to each client application upon registration.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -clientSecret
+The client secret is only known to the application and the provider for secure communication during the authentication flow.
+This secret is created by the provider, and assigned to each client application upon registration.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -clientSecretMethod
+The client authentication method for the client secret.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -userNameClaim
+The property in the ID token provided by the OIDC Identity Provider that contains the user name.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS

--- a/docs/collections/_docs/10-compatibility.md
+++ b/docs/collections/_docs/10-compatibility.md
@@ -148,7 +148,17 @@ If you are using version 9.7+, and the function being invoked requires version 9
 [`Get-PASAccountImportJob`][Get-PASAccountImportJob]                                     |**11.6**                                            |Get status of account import
 [`New-PASAccountObject`][New-PASAccountObject]                                           |**---**                                             |Format an object to include in an import list
 [`Get-PASDiscoveredAccount`][Get-PASDiscoveredAccount]                                   |**11.6**                                            |List discovered accounts
+[`Add-PASOpenIDConnectProvider`][Add-PASOpenIDConnectProvider]                           |**11.7**                                            |Adds an OIDC Authentication Provider
+[`Get-PASOpenIDConnectProvider`][Get-PASOpenIDConnectProvider]                           |**11.7**                                            |Gets details of configured OIDC Authentication Providers
+[`Remove-PASOpenIDConnectProvider`][Remove-PASOpenIDConnectProvider]                     |**11.7**                                            |Deletes an OIDC Authentication Provider
+[`Set-PASOpenIDConnectProvider`][Set-PASOpenIDConnectProvider]                           |**11.7**                                            |Updates an OIDC Authentication Provider
+[`Remove-PASAuthenticationMethod`][Remove-PASAuthenticationMethod]                       |**11.7**                                            |Delete an authentication method
 
+[Add-PASOpenIDConnectProvider]:/commands/Add-PASOpenIDConnectProvider
+[Get-PASOpenIDConnectProvider]:/commands/Get-PASOpenIDConnectProvider
+[Remove-PASOpenIDConnectProvider]:/commands/Remove-PASOpenIDConnectProvider
+[Set-PASOpenIDConnectProvider]:/commands/Set-PASOpenIDConnectProvider
+[Remove-PASAuthenticationMethod]:/commands/Remove-PASAuthenticationMethod
 [Get-PASDiscoveredAccount]:/commands/Get-PASDiscoveredAccount
 [Start-PASAccountImportJob]:/commands/Start-PASAccountImportJob
 [Get-PASAccountImportJob]:/commands/Get-PASAccountImportJob
@@ -455,6 +465,9 @@ If you are using version 9.7+, and the function being invoked requires version 9
 - Version 10.8 introduced a new API endpoint.
   - Supports:
     - Account Dependency & AWS specific parameters
+- Version 11.7
+  - Supports
+    - Azure specific parameter
 
 ### Get-PASPlatform
 

--- a/docs/collections/_pages/commands.md
+++ b/docs/collections/_pages/commands.md
@@ -180,6 +180,12 @@ A psPAS command may not appear in the below list due to it not being explicitly 
 [Delete User][Delete User]                                                                  | [Remove-PASUser][Remove-PASUser]
 [Activate User][Activate User]                                                              | [Unblock-PASUser][Unblock-PASUser]
 [Reset User Password][Reset User Password]                                                  | [Set-PASUserPassword][Set-PASUserPassword]
+[Add OpenID Connect Identity Provider][Add OpenID Connect Identity Provider]                | [Add-PASOpenIDConnectProvider][Add-PASOpenIDConnectProvider]
+[Get specific OpenID Connect Identity Provider][Get specific OpenID Connect Identity Provider] | [Get-PASOpenIDConnectProvider][Get-PASOpenIDConnectProvider]
+[Get all OpenID Connect Identity Providers][Get all OpenID Connect Identity Providers]         | [Get-PASOpenIDConnectProvider][Get-PASOpenIDConnectProvider]
+[Delete OpenID Connect Identity Provider][Delete OpenID Connect Identity Provider]             | [Remove-PASOpenIDConnectProvider][Remove-PASOpenIDConnectProvider]
+[Update OpenID Connect Identity Provider][Update OpenID Connect Identity Provider]             | [Set-PASOpenIDConnectProvider][Set-PASOpenIDConnectProvider]
+[Delete authentication method][Delete authentication method]                                   | [Remove-PASAuthenticationMethod][Remove-PASAuthenticationMethod]
 
 [Get-PASDiscoveredAccount]:/commands/Get-PASDiscoveredAccount
 [Start-PASAccountImportJob]:/commands/Start-PASAccountImportJob
@@ -306,7 +312,18 @@ A psPAS command may not appear in the below list due to it not being explicitly 
 [Enable-PASPlatform]:/commands/Enable-PASPlatform
 [Remove-PASPlatform]:/commands/Remove-PASPlatform
 [Remove-PASGroup]:/commands/Remove-PASGroup
+[Add-PASOpenIDConnectProvider]:/commands/Add-PASOpenIDConnectProvider
+[Get-PASOpenIDConnectProvider]:/commands/Get-PASOpenIDConnectProvider
+[Remove-PASOpenIDConnectProvider]:/commands/Remove-PASOpenIDConnectProvider
+[Set-PASOpenIDConnectProvider]:/commands/Set-PASOpenIDConnectProvider
+[Remove-PASAuthenticationMethod]:/commands/Remove-PASAuthenticationMethod
 
+[Delete OpenID Connect Identity Provider]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/OIDC-Delete-Provider.htm
+[Add OpenID Connect Identity Provider]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/OIDC-Add-Provider.htm
+[Update OpenID Connect Identity Provider]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/OIDC-Update-Provider.htm
+[Get all OpenID Connect Identity Providers]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/OIDC-Get-All-Providers.htm
+[Get specific OpenID Connect Identity Provider]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/OIDC-Get-Specific-Provider.htm
+[Delete authentication method]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/Authentication-Method-Delete.htm
 [CyberArk, LDAP, Radius, Windows Logon]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/CyberArk%20Authentication%20-%20Logon_v10.htm#CyberArkLDAPRadiusWindows
 [SAML Logon]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/SAML_%20Authentication_%20Logon_newgen.htm#SAMLlogon
 [Shared Logon authentication]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/Shared%20Logon%20Authentication%20-%20Logon.htm#Sharedlogonauthentication

--- a/psPAS/Functions/Accounts/Add-PASDiscoveredAccount.ps1
+++ b/psPAS/Functions/Accounts/Add-PASDiscoveredAccount.ps1
@@ -39,7 +39,7 @@ function Add-PASDiscoveredAccount {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("Windows Server Local", "Windows Desktop Local", "Windows Domain", "Unix", "Unix SSH Key", "AWS", "AWS Access Keys")]
+		[ValidateSet("Windows Server Local", "Windows Desktop Local", "Windows Domain", "Unix", "Unix SSH Key", "AWS", "AWS Access Keys", "Azure Password Management")]
 		[string]$platformType,
 
 		[parameter(
@@ -218,12 +218,26 @@ function Add-PASDiscoveredAccount {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = "Dependency"
 		)]
-		[hashtable[]]$Dependencies
+		[hashtable[]]$Dependencies,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = "Azure"
+		)]
+		[string]$activeDirectoryID
 	)
 
 	BEGIN {
 
 		switch ($PSCmdlet.ParameterSetName) {
+
+			{ $PSItem -match "Azure" } {
+
+				#v11.7 required for Azure
+				Assert-VersionRequirement -RequiredVersion 11.7
+
+			}
 
 			{ $PSItem -match "AWS|Dependency" } {
 
@@ -241,7 +255,7 @@ function Add-PASDiscoveredAccount {
 
 		}
 
-		$AccountProperties = [Collections.Generic.List[String]]@("SID", "uid", "gid", "fingerprint", "size", "path", "format", "comment", "encryption", "awsAccountID", "awsAccessKeyID")
+		$AccountProperties = [Collections.Generic.List[String]]@("SID", "uid", "gid", "fingerprint", "size", "path", "format", "comment", "encryption", "awsAccountID", "awsAccessKeyID", "activeDirectoryID")
 
 		$DateTimes = [Collections.Generic.List[String]]@("discoveryDate", "lastLogonDateTime", "lastPasswordSetDateTime", "passwordExpirationDateTime")
 

--- a/psPAS/Functions/Accounts/Get-PASDiscoveredAccount.ps1
+++ b/psPAS/Functions/Accounts/Get-PASDiscoveredAccount.ps1
@@ -14,7 +14,7 @@ Function Get-PASDiscoveredAccount {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = "byQuery"
 		)]
-		[ValidateSet("Windows Server Local", "Windows Desktop Local", "Windows Domain", "Unix", "Unix SSH Key", "AWS", "AWS Access Keys")]
+		[ValidateSet("Windows Server Local", "Windows Desktop Local", "Windows Domain", "Unix", "Unix SSH Key", "AWS", "AWS Access Keys", "Azure Password Management")]
 		[string]$platformType,
 
 		[parameter(
@@ -88,6 +88,12 @@ Function Get-PASDiscoveredAccount {
 			}
 
 			"byQuery" {
+
+				If ($platformType -eq "Azure Password Management") {
+
+					Assert-VersionRequirement -RequiredVersion 11.7
+
+				}
 
 				#Get Parameters to include in request
 				$boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove $Parameters

--- a/psPAS/Functions/Authentication/Add-PASOpenIDConnectProvider.ps1
+++ b/psPAS/Functions/Authentication/Add-PASOpenIDConnectProvider.ps1
@@ -1,0 +1,121 @@
+# .ExternalHelp psPAS-help.xml
+Function Add-PASOpenIDConnectProvider {
+
+	[CmdletBinding()]
+	param(
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateLength(1, 50)]
+		[ValidateNotNullOrEmpty()]
+		[string]$id,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateSet("Code", "Implicit")]
+		[ValidateNotNullOrEmpty()]
+		[string]$authenticationFlow,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[string]$authenticationEndpointUrl,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[string]$issuer,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateLength(1, 255)]
+		[ValidateNotNullOrEmpty()]
+		[string]$description,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[string]$discoveryEndpointUrl,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[string]$jwkSet,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateLength(1, 100)]
+		[ValidateNotNullOrEmpty()]
+		[string]$clientId,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateLength(1, 200)]
+		[ValidateNotNullOrEmpty()]
+		[string]$clientSecret,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateSet("Basic", "Post")]
+		[ValidateLength(1, 50)]
+		[ValidateNotNullOrEmpty()]
+		[string]$clientSecretMethod,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidatePattern('^[A-Za-z_]+$')]
+		[ValidateLength(1, 50)]
+		[ValidateNotNullOrEmpty()]
+		[string]$userNameClaim
+
+	)
+
+	BEGIN {
+
+		Assert-VersionRequirement -RequiredVersion 11.7
+
+	}#begin
+
+	PROCESS {
+
+		#Create URL for request
+		$URI = "$Script:BaseURI/api/Configuration/OIDC/Providers"
+
+		#Create body of request
+		$body = $PSBoundParameters | Get-PASParameter | ConvertTo-Json
+
+		#send request to web service
+		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $body -WebSession $Script:WebSession
+
+		If ($null -ne $result) {
+
+			$result
+
+		}
+
+	}#process
+
+	END { }#end
+
+}

--- a/psPAS/Functions/Authentication/Get-PASOpenIDConnectProvider.ps1
+++ b/psPAS/Functions/Authentication/Get-PASOpenIDConnectProvider.ps1
@@ -1,0 +1,45 @@
+# .ExternalHelp psPAS-help.xml
+Function Get-PASOpenIDConnectProvider {
+
+	[CmdletBinding()]
+	param(
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[string]$id
+
+	)
+
+	BEGIN {
+
+		Assert-VersionRequirement -RequiredVersion 11.7
+
+	}#begin
+
+	PROCESS {
+
+		#Create URL for request
+		$URI = "$Script:BaseURI/api/Configuration/OIDC/Providers/$($id | Get-EscapedString)"
+
+		#send request to web service
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+
+		If ($null -ne $result) {
+
+			if ($null -ne $result.Providers) {
+
+				$result = $result | Select-Object -ExpandProperty Providers
+
+			}
+
+			$result
+
+		}
+
+	}#process
+
+	END { }#end
+
+}

--- a/psPAS/Functions/Authentication/Remove-PASAuthenticationMethod.ps1
+++ b/psPAS/Functions/Authentication/Remove-PASAuthenticationMethod.ps1
@@ -1,0 +1,42 @@
+# .ExternalHelp psPAS-help.xml
+Function Remove-PASAuthenticationMethod {
+
+	[CmdletBinding(SupportsShouldProcess)]
+	param(
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateLength(1, 50)]
+		[string]$id
+	)
+
+	BEGIN {
+
+		Assert-VersionRequirement -RequiredVersion 11.7
+
+	}#begin
+
+	PROCESS {
+
+		#Create URL for request
+		$URI = "$Script:BaseURI/api/Configuration/AuthenticationMethods/$($id | Get-EscapedString)"
+
+		if ($PSCmdlet.ShouldProcess($id, "Delete Authentication Method")) {
+
+			#send request to web service
+			$result = Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+
+			If ($null -ne $result) {
+
+				$result
+
+			}
+
+		}
+
+	}#process
+
+	END { }#end
+
+}

--- a/psPAS/Functions/Authentication/Remove-PASOpenIDConnectProvider.ps1
+++ b/psPAS/Functions/Authentication/Remove-PASOpenIDConnectProvider.ps1
@@ -1,0 +1,37 @@
+# .ExternalHelp psPAS-help.xml
+Function Remove-PASOpenIDConnectProvider {
+
+	[CmdletBinding(SupportsShouldProcess)]
+	param(
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[string]$id
+
+	)
+
+	BEGIN {
+
+		Assert-VersionRequirement -RequiredVersion 11.7
+
+	}#begin
+
+	PROCESS {
+
+		#Create URL for request
+		$URI = "$Script:BaseURI/api/Configuration/OIDC/Providers/$($id | Get-EscapedString)"
+
+		if ($PSCmdlet.ShouldProcess($id, "Delete OIDC Provider")) {
+
+			#Send request to web service
+			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+
+		}
+
+	}#process
+
+	END { }#end
+
+}

--- a/psPAS/Functions/Authentication/Set-PASOpenIDConnectProvider.ps1
+++ b/psPAS/Functions/Authentication/Set-PASOpenIDConnectProvider.ps1
@@ -1,0 +1,125 @@
+# .ExternalHelp psPAS-help.xml
+Function Set-PASOpenIDConnectProvider {
+
+	[CmdletBinding(SupportsShouldProcess)]
+	param(
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateLength(1, 50)]
+		[ValidateNotNullOrEmpty()]
+		[string]$id,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateSet("Code", "Implicit")]
+		[ValidateNotNullOrEmpty()]
+		[string]$authenticationFlow,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[string]$authenticationEndpointUrl,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[string]$issuer,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateLength(1, 255)]
+		[ValidateNotNullOrEmpty()]
+		[string]$description,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[string]$discoveryEndpointUrl,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateNotNullOrEmpty()]
+		[string]$jwkSet,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateLength(1, 100)]
+		[ValidateNotNullOrEmpty()]
+		[string]$clientId,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateLength(1, 200)]
+		[ValidateNotNullOrEmpty()]
+		[string]$clientSecret,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidateSet("Basic", "Post")]
+		[ValidateLength(1, 50)]
+		[ValidateNotNullOrEmpty()]
+		[string]$clientSecretMethod,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[ValidatePattern('^[A-Za-z_]+$')]
+		[ValidateLength(1, 50)]
+		[ValidateNotNullOrEmpty()]
+		[string]$userNameClaim
+
+	)
+
+	BEGIN {
+
+		Assert-VersionRequirement -RequiredVersion 11.7
+
+	}#begin
+
+	PROCESS {
+
+		#Create URL for request
+		$URI = "$Script:BaseURI/api/Configuration/OIDC/Providers/$($id | Get-EscapedString)"
+
+		#Create body of request
+		$body = $PSBoundParameters | Get-PASParameter -ParametersToRemove id | ConvertTo-Json
+
+		if ($PSCmdlet.ShouldProcess($id, "Update OIDC Provider")) {
+
+			#send request to web service
+			$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $body -WebSession $Script:WebSession
+
+			If ($null -ne $result) {
+
+				$result
+
+			}
+
+		}
+
+	}#process
+
+	END { }#end
+
+}

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -3974,6 +3974,250 @@
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
       </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Add-PASDiscoveredAccount</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>UserName</maml:name>
+          <maml:Description>
+            <maml:para>The name of the account user.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>Address</maml:name>
+          <maml:Description>
+            <maml:para>The name or address of the machine where the account is located.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>discoveryDate</maml:name>
+          <maml:Description>
+            <maml:para>The date the account was discovered.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">DateTime</command:parameterValue>
+          <dev:type>
+            <maml:name>DateTime</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>AccountEnabled</maml:name>
+          <maml:Description>
+            <maml:para>The state of the account, defined in the discovery source.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>osGroups</maml:name>
+          <maml:Description>
+            <maml:para>The name of the group the account belongs to, such as Administrators or Operators.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>platformType</maml:name>
+          <maml:Description>
+            <maml:para>The platform where the discovered account is located.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>Domain</maml:name>
+          <maml:Description>
+            <maml:para>The domain of the account.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>lastLogonDateTime</maml:name>
+          <maml:Description>
+            <maml:para>The date this account was last logged into, defined in the discovery source.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">DateTime</command:parameterValue>
+          <dev:type>
+            <maml:name>DateTime</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>lastPasswordSetDateTime</maml:name>
+          <maml:Description>
+            <maml:para>The date this password was last set, defined in the discovery source.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">DateTime</command:parameterValue>
+          <dev:type>
+            <maml:name>DateTime</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>passwordNeverExpires</maml:name>
+          <maml:Description>
+            <maml:para>Whether or not this password expires, defined in the discovery source.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>OSVersion</maml:name>
+          <maml:Description>
+            <maml:para>The version of the OS where the account was discovered.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>privileged</maml:name>
+          <maml:Description>
+            <maml:para>Whether the discovered account is privileged or non-privileged.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>privilegedCriteria</maml:name>
+          <maml:Description>
+            <maml:para>The criteria that determines whether or not the discovered account is privileged.</maml:para>
+            <maml:para>For example, the user or group name.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>UserDisplayName</maml:name>
+          <maml:Description>
+            <maml:para>The user's display name.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>description</maml:name>
+          <maml:Description>
+            <maml:para>A description of the account, defined in the discovery source.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>passwordExpirationDateTime</maml:name>
+          <maml:Description>
+            <maml:para>The expiration date of the account, defined in the discovery source.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">DateTime</command:parameterValue>
+          <dev:type>
+            <maml:name>DateTime</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>osFamily</maml:name>
+          <maml:Description>
+            <maml:para>The type of machine where the account was discovered.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>additionalProperties</maml:name>
+          <maml:Description>
+            <maml:para>A hashtable of additional properties added to the account.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>organizationalUnit</maml:name>
+          <maml:Description>
+            <maml:para>The organizational unit where the account is defined.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>activeDirectoryID</maml:name>
+          <maml:Description>
+            <maml:para>Azure Active Directory tenant ID</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
     </command:syntax>
     <command:parameters>
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
@@ -4371,6 +4615,18 @@
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>activeDirectoryID</maml:name>
+        <maml:Description>
+          <maml:para>Azure Active Directory tenant ID</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
     </command:parameters>
     <command:inputTypes />
     <command:returnValues />
@@ -4625,6 +4881,317 @@ Add-PASDiscoveredAccount -UserName ServiceUser -Address 1.2.3.4 -discoveryDate (
       <maml:navigationLink>
         <maml:linkText>https://pspas.pspete.dev/commands/Add-PASGroupMember</maml:linkText>
         <maml:uri>https://pspas.pspete.dev/commands/Add-PASGroupMember</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Add-PASOpenIDConnectProvider</command:name>
+      <command:verb>Add</command:verb>
+      <command:noun>PASOpenIDConnectProvider</command:noun>
+      <maml:description>
+        <maml:para>Adds a new OIDC Identity Provider.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Adds a new OIDC Identity Provider. Requires membership of Vault Admins group.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Add-PASOpenIDConnectProvider</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>id</maml:name>
+          <maml:Description>
+            <maml:para>The unique identifier of the provider.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>authenticationFlow</maml:name>
+          <maml:Description>
+            <maml:para>The OIDC connection flow.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>authenticationEndpointUrl</maml:name>
+          <maml:Description>
+            <maml:para>The URL of the provider's authorization endpoint. Authentication requests will be sent to this URL.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>issuer</maml:name>
+          <maml:Description>
+            <maml:para>The Issuer Identifier for the OpenID Provider. Used to verify that the response was issued from a specific provider.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>description</maml:name>
+          <maml:Description>
+            <maml:para>A description of the provider.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>discoveryEndpointUrl</maml:name>
+          <maml:Description>
+            <maml:para>OIDC defines a discovery mechanism, called OpenID Connect Discovery, where an OIDC Identity provider publishes its metadata at a well-known URL.</maml:para>
+            <maml:para>This URL is metadata that describes the provider's configuration.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>jwkSet</maml:name>
+          <maml:Description>
+            <maml:para>The JSON web key set provided by the OIDC Identity Provider for validating JSON web tokens during the authentication flow.</maml:para>
+            <maml:para>The JSON must include a "keys" parameter, which is an array of JWT signing keys.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>clientId</maml:name>
+          <maml:Description>
+            <maml:para>The unique identifier for the client application. This ID is created by the provider, and assigned to each client application upon registration.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>clientSecret</maml:name>
+          <maml:Description>
+            <maml:para>The client secret is only known to the application and the provider for secure communication during the authentication flow. This secret is created by the provider, and assigned to each client application upon registration.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>clientSecretMethod</maml:name>
+          <maml:Description>
+            <maml:para>The client authentication method for the client secret.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>userNameClaim</maml:name>
+          <maml:Description>
+            <maml:para>The property in the ID token provided by the OIDC Identity Provider that contains the user name.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>id</maml:name>
+        <maml:Description>
+          <maml:para>The unique identifier of the provider.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>authenticationFlow</maml:name>
+        <maml:Description>
+          <maml:para>The OIDC connection flow.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>authenticationEndpointUrl</maml:name>
+        <maml:Description>
+          <maml:para>The URL of the provider's authorization endpoint. Authentication requests will be sent to this URL.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>issuer</maml:name>
+        <maml:Description>
+          <maml:para>The Issuer Identifier for the OpenID Provider. Used to verify that the response was issued from a specific provider.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>description</maml:name>
+        <maml:Description>
+          <maml:para>A description of the provider.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>discoveryEndpointUrl</maml:name>
+        <maml:Description>
+          <maml:para>OIDC defines a discovery mechanism, called OpenID Connect Discovery, where an OIDC Identity provider publishes its metadata at a well-known URL.</maml:para>
+          <maml:para>This URL is metadata that describes the provider's configuration.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>jwkSet</maml:name>
+        <maml:Description>
+          <maml:para>The JSON web key set provided by the OIDC Identity Provider for validating JSON web tokens during the authentication flow.</maml:para>
+          <maml:para>The JSON must include a "keys" parameter, which is an array of JWT signing keys.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>clientId</maml:name>
+        <maml:Description>
+          <maml:para>The unique identifier for the client application. This ID is created by the provider, and assigned to each client application upon registration.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>clientSecret</maml:name>
+        <maml:Description>
+          <maml:para>The client secret is only known to the application and the provider for secure communication during the authentication flow. This secret is created by the provider, and assigned to each client application upon registration.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>clientSecretMethod</maml:name>
+        <maml:Description>
+          <maml:para>The client authentication method for the client secret.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>userNameClaim</maml:name>
+        <maml:Description>
+          <maml:para>The property in the ID token provided by the OIDC Identity Provider that contains the user name.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; Add-PASOpenIDConnectProvider -id SomeOIDCProvider -discoveryEndpointUrl https://SomeURLValue
+ -clientId SomeID -clientSecretMethod POST</dev:code>
+        <dev:remarks>
+          <maml:para>Adds an OIDC Identity Provider with ID SomeOIDCProvider.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>Online Version:</maml:linkText>
+        <maml:uri>https://pspas.pspete.dev/commands/Add-PASOpenIDConnectProvider</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -6927,7 +7494,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 4 --------------------------</maml:title>
-        <dev:code>Close-PASSession -UseClassicAPI</dev:code>
+        <dev:code>Close-PASSession -UseGen1API</dev:code>
         <dev:remarks>
           <maml:para>Logs off from the session related to the authorisation token using the 1st gen API endpoint.</maml:para>
         </dev:remarks>
@@ -9867,7 +10434,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
-        <dev:code>Get-PASAccount -Keywords root -Safe Prod_Safe | Get-PASAccountPassword -UseClassicAPI</dev:code>
+        <dev:code>Get-PASAccount -Keywords root -Safe Prod_Safe | Get-PASAccountPassword -UseGen1API</dev:code>
         <dev:remarks>
           <maml:para>Will retrieve the password value of the account found by Get-PASAccount using the classic (v9) API</maml:para>
         </dev:remarks>
@@ -11348,6 +11915,79 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
       <maml:navigationLink>
         <maml:linkText>https://pspas.pspete.dev/commands/Get-PASOnboardingRule</maml:linkText>
         <maml:uri>https://pspas.pspete.dev/commands/Get-PASOnboardingRule</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Get-PASOpenIDConnectProvider</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>PASOpenIDConnectProvider</command:noun>
+      <maml:description>
+        <maml:para>Returns details of configured OIDC Identity Providers.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>returns either a list of all OIDC Identity Providers, or details of a specific Provider. Requires membership of Vault Admins group.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Get-PASOpenIDConnectProvider</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
+          <maml:name>id</maml:name>
+          <maml:Description>
+            <maml:para>An identifier of a specific provider to retrieve details of.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
+        <maml:name>id</maml:name>
+        <maml:Description>
+          <maml:para>An identifier of a specific provider to retrieve details of.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; Get-PASOpenIDConnectProvider</dev:code>
+        <dev:remarks>
+          <maml:para>Returns details of all configured OIDC Providers.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- Example 2 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; Get-PASOpenIDConnectProvider -id SomeOIDCProvider</dev:code>
+        <dev:remarks>
+          <maml:para>Returns details of OIDC Provider with ID SomeOIDCProvider</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>Online Version:</maml:linkText>
+        <maml:uri>https://pspas.pspete.dev/commands/Get-PASOpenIDConnectProvider</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -15140,7 +15780,7 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
-        <dev:code>Invoke-PASCPMOperation -AccountID $ID -VerifyTask -UseClassicAPI</dev:code>
+        <dev:code>Invoke-PASCPMOperation -AccountID $ID -VerifyTask -UseGen1API</dev:code>
         <dev:remarks>
           <maml:para>Marks an account for verification using the 1st gen API</maml:para>
         </dev:remarks>
@@ -18236,7 +18876,7 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
       <maml:para>Authenticates a user to a CyberArk Vault and stores an authentication token and a webrequest session object which are used in subsequent calls to the API.</maml:para>
       <maml:para>In addition, this method allows you to set a new password.</maml:para>
       <maml:para>Will attempt authentication against the V10 API by default.</maml:para>
-      <maml:para>For older CyberArk versions, specify the -UseClassicAPI switch parameter to force use of the V9 API endpoint.</maml:para>
+      <maml:para>For older CyberArk versions, specify the -UseGen1API switch parameter to force use of the V9 API endpoint.</maml:para>
       <maml:para>Windows authentication is only supported (from CyberArk 10.4+).</maml:para>
       <maml:para>Authenticate using CyberArk, LDAP, RADIUS, SAML or Shared authentication (From CyberArk version 9.7+).</maml:para>
       <maml:para>For CyberArk version older than 9.7: - Only CyberArk Authentication method is supported.</maml:para>
@@ -19794,14 +20434,14 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 5 --------------------------</maml:title>
-        <dev:code>New-PASSession -Credential $cred -BaseURI https://PVWA -UseClassicAPI</dev:code>
+        <dev:code>New-PASSession -Credential $cred -BaseURI https://PVWA -UseGen1API</dev:code>
         <dev:remarks>
           <maml:para>Logon to Version 9 with credential Request would be sent to PVWA URL https://PVWA/PasswordVault/</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 6 --------------------------</maml:title>
-        <dev:code>New-PASSession -Credential $cred -BaseURI https://PVWA -PVWAAppName CustomVault -UseClassicAPI</dev:code>
+        <dev:code>New-PASSession -Credential $cred -BaseURI https://PVWA -PVWAAppName CustomVault -UseGen1API</dev:code>
         <dev:remarks>
           <maml:para>Logon to Version 9 where PVWA Virtual Directory has non-default name Request would be sent to PVWA URL https://PVWA/CustomVault/</maml:para>
         </dev:remarks>
@@ -19843,7 +20483,7 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 12 --------------------------</maml:title>
-        <dev:code>New-PASSession -Credential $cred -BaseURI https://PVWA -UseClassicAPI -useRadiusAuthentication $True -OTP 123456 -OTPMode Append</dev:code>
+        <dev:code>New-PASSession -Credential $cred -BaseURI https://PVWA -UseGen1API -useRadiusAuthentication $True -OTP 123456 -OTPMode Append</dev:code>
         <dev:remarks>
           <maml:para>Logon using RADIUS &amp; OTP (Append Mode) via the 1st gen API</maml:para>
         </dev:remarks>
@@ -21246,7 +21886,7 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
     <command:examples>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
-        <dev:code>New-PASUser -UserName NewUser -InitialPassword $securePWD -UseClassicAPI</dev:code>
+        <dev:code>New-PASUser -UserName NewUser -InitialPassword $securePWD -UseGen1API</dev:code>
         <dev:remarks>
           <maml:para>Creates a Vault user named NewUser, with password set to securestring value from $securePWD, using the v9 (classic) API</maml:para>
         </dev:remarks>
@@ -22001,6 +22641,72 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
+      <command:name>Remove-PASAuthenticationMethod</command:name>
+      <command:verb>Remove</command:verb>
+      <command:noun>PASAuthenticationMethod</command:noun>
+      <maml:description>
+        <maml:para>Deletes a specific authentication method.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Deletes a specific authentication method. Membership of the Vault admins group required.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Remove-PASAuthenticationMethod</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
+          <maml:name>id</maml:name>
+          <maml:Description>
+            <maml:para>The authentication method identifier.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
+        <maml:name>id</maml:name>
+        <maml:Description>
+          <maml:para>The authentication method identifier.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; Remove-PASAuthenticationMethod -id SomeID</dev:code>
+        <dev:remarks>
+          <maml:para>Deletes authentication method with id "SomeID"</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>Online Version:</maml:linkText>
+        <maml:uri>https://pspas.pspete.dev/commands/Remove-PASAuthenticationMethod</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
       <command:name>Remove-PASDirectory</command:name>
       <command:verb>Remove</command:verb>
       <command:noun>PASDirectory</command:noun>
@@ -22608,6 +23314,118 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
       <maml:navigationLink>
         <maml:linkText>https://pspas.pspete.dev/commands/Remove-PASOnboardingRule</maml:linkText>
         <maml:uri>https://pspas.pspete.dev/commands/Remove-PASOnboardingRule</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Remove-PASOpenIDConnectProvider</command:name>
+      <command:verb>Remove</command:verb>
+      <command:noun>PASOpenIDConnectProvider</command:noun>
+      <maml:description>
+        <maml:para>Deletes a configured OIDC Identity Provider.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Deletes an OIDC Identity Provider. Requires membership of Vault Admins group.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Remove-PASOpenIDConnectProvider</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
+          <maml:name>id</maml:name>
+          <maml:Description>
+            <maml:para>The unique identifier of the provider to delete.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:Description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:Description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
+        <maml:name>id</maml:name>
+        <maml:Description>
+          <maml:para>The unique identifier of the provider to delete.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+        <maml:name>WhatIf</maml:name>
+        <maml:Description>
+          <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:Description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; Remove-PASOpenIDConnectProvider -id SomeOIDCProvider</dev:code>
+        <dev:remarks>
+          <maml:para>Deletes OIDC Identity Provider with ID SomeOIDCProvider</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>Online Version:</maml:linkText>
+        <maml:uri>https://pspas.pspete.dev/commands/Remove-PASOpenIDConnectProvider</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -25780,6 +26598,362 @@ Set-PASDirectoryMapping -DirectoryName $Directory -MappingAuthorizations AddUpda
       <maml:navigationLink>
         <maml:linkText>https://pspas.pspete.dev/commands/Set-PASOnboardingRule</maml:linkText>
         <maml:uri>https://pspas.pspete.dev/commands/Set-PASOnboardingRule</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Set-PASOpenIDConnectProvider</command:name>
+      <command:verb>Set</command:verb>
+      <command:noun>PASOpenIDConnectProvider</command:noun>
+      <maml:description>
+        <maml:para>Updates an existing OIDC Identity Provider.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Updates an existing OIDC Identity Provider. Requires membership of Vault Admins group.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Set-PASOpenIDConnectProvider</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>id</maml:name>
+          <maml:Description>
+            <maml:para>The unique identifier of the provider.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>authenticationFlow</maml:name>
+          <maml:Description>
+            <maml:para>The OIDC connection flow.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>authenticationEndpointUrl</maml:name>
+          <maml:Description>
+            <maml:para>The URL of the provider's authorization endpoint. Authentication requests will be sent to this URL.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>issuer</maml:name>
+          <maml:Description>
+            <maml:para>The Issuer Identifier for the OpenID Provider. Used to verify that the response was issued from a specific provider.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>description</maml:name>
+          <maml:Description>
+            <maml:para>A description of the provider.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>discoveryEndpointUrl</maml:name>
+          <maml:Description>
+            <maml:para>OIDC defines a discovery mechanism, called OpenID Connect Discovery, where an OIDC Identity provider publishes its metadata at a well-known URL.</maml:para>
+            <maml:para>This URL is metadata that describes the provider's configuration.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>jwkSet</maml:name>
+          <maml:Description>
+            <maml:para>The JSON web key set provided by the OIDC Identity Provider for validating JSON web tokens during the authentication flow.</maml:para>
+            <maml:para>The JSON must include a "keys" parameter, which is an array of JWT signing keys.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>clientId</maml:name>
+          <maml:Description>
+            <maml:para>The unique identifier for the client application. This ID is created by the provider, and assigned to each client application upon registration.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>clientSecret</maml:name>
+          <maml:Description>
+            <maml:para>The client secret is only known to the application and the provider for secure communication during the authentication flow. This secret is created by the provider, and assigned to each client application upon registration.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>clientSecretMethod</maml:name>
+          <maml:Description>
+            <maml:para>The client authentication method for the client secret.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>userNameClaim</maml:name>
+          <maml:Description>
+            <maml:para>The property in the ID token provided by the OIDC Identity Provider that contains the user name.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:Description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:Description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>id</maml:name>
+        <maml:Description>
+          <maml:para>The unique identifier of the provider.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>authenticationFlow</maml:name>
+        <maml:Description>
+          <maml:para>The OIDC connection flow.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>authenticationEndpointUrl</maml:name>
+        <maml:Description>
+          <maml:para>The URL of the provider's authorization endpoint. Authentication requests will be sent to this URL.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>issuer</maml:name>
+        <maml:Description>
+          <maml:para>The Issuer Identifier for the OpenID Provider. Used to verify that the response was issued from a specific provider.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>description</maml:name>
+        <maml:Description>
+          <maml:para>A description of the provider.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>discoveryEndpointUrl</maml:name>
+        <maml:Description>
+          <maml:para>OIDC defines a discovery mechanism, called OpenID Connect Discovery, where an OIDC Identity provider publishes its metadata at a well-known URL.</maml:para>
+          <maml:para>This URL is metadata that describes the provider's configuration.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>jwkSet</maml:name>
+        <maml:Description>
+          <maml:para>The JSON web key set provided by the OIDC Identity Provider for validating JSON web tokens during the authentication flow.</maml:para>
+          <maml:para>The JSON must include a "keys" parameter, which is an array of JWT signing keys.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>clientId</maml:name>
+        <maml:Description>
+          <maml:para>The unique identifier for the client application. This ID is created by the provider, and assigned to each client application upon registration.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>clientSecret</maml:name>
+        <maml:Description>
+          <maml:para>The client secret is only known to the application and the provider for secure communication during the authentication flow. This secret is created by the provider, and assigned to each client application upon registration.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>clientSecretMethod</maml:name>
+        <maml:Description>
+          <maml:para>The client authentication method for the client secret.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>userNameClaim</maml:name>
+        <maml:Description>
+          <maml:para>The property in the ID token provided by the OIDC Identity Provider that contains the user name.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+        <maml:name>WhatIf</maml:name>
+        <maml:Description>
+          <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:Description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; Set-PASOpenIDConnectProvider -id SomeOIDCProvider -discoveryEndpointUrl https://SomeURL -clientId SomeIDValue -clientSecretMethod POST</dev:code>
+        <dev:remarks>
+          <maml:para>Updates an existing OIDC Identity Provider with ID SomeOIDCProvider.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>Online Version:</maml:linkText>
+        <maml:uri>https://pspas.pspete.dev/commands/Set-PASOpenIDConnectProvider</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -201,7 +201,12 @@
 		'New-PASAccountObject',
 		'Start-PASAccountImportJob',
 		'Get-PASAccountImportJob',
-		'Get-PASDiscoveredAccount'
+		'Get-PASDiscoveredAccount',
+		'Add-PASOpenIDConnectProvider',
+		'Get-PASOpenIDConnectProvider',
+		'Set-PASOpenIDConnectProvider',
+		'Remove-PASOpenIDConnectProvider',
+		'Remove-PASAuthenticationMethod'
 	)
 
 	AliasesToExport   = @(


### PR DESCRIPTION
## Summary
initial commits of 11.7 features:

- New Functions
  - `Add-PASOpenIDConnectProvider`
    - Adds a new OIDC authentication provider configuration
  - `Get-PASOpenIDConnectProvider`
    - Lists configured OIDC authentication providers
  - `Set-PASOpenIDConnectProvider`
    - Updates a configured OIDC authentication provider
  - `Remove-PASOpenIDConnectProvider`
    - Deletes a configured OIDC authentication provider
  - `Remove-PASAuthenticationMethod`
    - Deletes a configured auth method
- Updated Functions
  - `Add-PASDiscoveredAccount`
    - Adds support for Azure platform
  - `Get-PASDiscoveredAccount`
    - Adds support for Azure platform

## Test Plan

Pester tests for new functions created, documentation updated.

