### PR TITLE
FIX Set-PASAccount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 - Continued development to encompass any new documented features of the CyberArk API.
 - psPAS v5.0...
 
+## **4.5.90** (November 25th 2020)
+
+- Fixes
+  - `Set-PASAccount`
+    - Fix issue where JSON was not formatted as required when attempting to execute multiple operations in a single request.
+
 ## **4.5.87** (November 25th 2020)
 
 ### Module update to cover all CyberArk 11.7 API features

--- a/psPAS/Functions/Accounts/Set-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Set-PASAccount.ps1
@@ -148,7 +148,7 @@ function Set-PASAccount {
 				#Define type of output object
 				$Type = "psPAS.CyberArk.Vault.Account.V10"
 
-				if ($PSCmdlet.ParameterSetName -match "V10MultiOp") {
+				if ($PSCmdlet.ParameterSetName -match "Gen2MultiOp") {
 
 					$boundParameters = $boundParameters["operations"]
 
@@ -156,7 +156,7 @@ function Set-PASAccount {
 
 				#Do Not Pipe into ConvertTo-JSON.
 				#Correct JSON Format is only achieved when the array is not sent along the pipe
-				$body = ConvertTo-Json @($boundParameters) -Depth 3
+				$body = ConvertTo-Json @($boundParameters)
 
 			}
 


### PR DESCRIPTION
<!-- _A similar PR may already be submitted.
Please search existing `Pull Requests` before creating one._

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.  -->

## Summary

Fixes condition where attempting updates to multiple properties of an account results in an error.
ParameterSetName was recently changed from `V10MultiOp` to `Gen2MultiOp`, but the logic in the function still referenced the old name.
- Updating code to reflect correct ParameterSetName `Gen2MultiOp`
  - Resuts in JSON payload being formatted as required.
- Removes  `-Depth 3` parameter from `ConvertTo-Json`
  - The correctly formatted JSON does not have a depth of 3, so this is not required.

## Test Plan

Operation to update multiple properties in a single request completes without error

## Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes. -->
Fixes #

Closes #326

<!--
## Code formatting

 See the `CONTRIBUTING` guide.

_Ensure your code adheres to the project's PowerShell Styleguide_
-->