### PR TITLE
Issue 339

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 - Continued development to encompass any new documented features of the CyberArk API.
 - psPAS v6.0...
 
+## **vNext 5.x.x**
+
+- Updates
+  - `New-PASSession`
+    - Introduce support for providing response to RADIUS challenges featuring sub-options.
+
 ## **5.0.0** (April 11th 2021)
 
 ### Module update to cover all CyberArk 12.0 & 12.1 API features

--- a/Tests/New-PASSession.Tests.ps1
+++ b/Tests/New-PASSession.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,12 +35,12 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'BaseURI' },
 			@{Parameter = 'Credential' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -50,57 +50,57 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input" {
+		Context 'Input' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
 					[PSCustomObject]@{
-						"CyberArkLogonResult" = "AAAAAAA\\\REEEAAAAALLLLYYYYY\\\\LOOOOONNNNGGGGG\\\ACCCCCEEEEEEEESSSSSSS\\\\\\TTTTTOOOOOKKKKKEEEEEN"
+						'CyberArkLogonResult' = 'AAAAAAA\\\REEEAAAAALLLLYYYYY\\\\LOOOOONNNNGGGGG\\\ACCCCCEEEEEEEESSSSSSS\\\\\\TTTTTOOOOOKKKKKEEEEEN'
 					}
 				}
 
 				Mock Get-PASServer -MockWith {
 					[PSCustomObject]@{
-						ExternalVersion = "6.6.6"
+						ExternalVersion = '6.6.6'
 					}
 				}
 
 				Mock Set-Variable -MockWith { }
 
-				$Credentials = New-Object System.Management.Automation.PSCredential ("SomeUser", $(ConvertTo-SecureString "SomePassword" -AsPlainText -Force))
+				$Credentials = New-Object System.Management.Automation.PSCredential ('SomeUser', $(ConvertTo-SecureString 'SomePassword' -AsPlainText -Force))
 
-				$NewPass = ConvertTo-SecureString "SomeNewPassword" -AsPlainText -Force
+				$NewPass = ConvertTo-SecureString 'SomeNewPassword' -AsPlainText -Force
 
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 			}
 
-			It "sends request" {
-				$Credentials | New-PASSession -BaseURI "https://P_URI" -PVWAAppName "SomeApp" -newPassword $NewPass -UseClassicAPI
+			It 'sends request' {
+				$Credentials | New-PASSession -BaseURI 'https://P_URI' -PVWAAppName 'SomeApp' -newPassword $NewPass -UseClassicAPI
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
-				$Credentials | New-PASSession -BaseURI "https://P_URI" -PVWAAppName "SomeApp" -newPassword $NewPass -UseClassicAPI
+			It 'sends request to expected endpoint' {
+				$Credentials | New-PASSession -BaseURI 'https://P_URI' -PVWAAppName 'SomeApp' -newPassword $NewPass -UseClassicAPI
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "https://P_URI/SomeApp/WebServices/auth/Cyberark/CyberArkAuthenticationService.svc/Logon"
+					$URI -eq 'https://P_URI/SomeApp/WebServices/auth/Cyberark/CyberArkAuthenticationService.svc/Logon'
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "uses expected method" {
-				$Credentials | New-PASSession -BaseURI "https://P_URI" -PVWAAppName "SomeApp" -newPassword $NewPass -UseClassicAPI
+			It 'uses expected method' {
+				$Credentials | New-PASSession -BaseURI 'https://P_URI' -PVWAAppName 'SomeApp' -newPassword $NewPass -UseClassicAPI
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
-				$Credentials | New-PASSession -BaseURI "https://P_URI" -PVWAAppName "SomeApp" -newPassword $NewPass -UseClassicAPI
+			It 'sends request with expected body' {
+				$Credentials | New-PASSession -BaseURI 'https://P_URI' -PVWAAppName 'SomeApp' -newPassword $NewPass -UseClassicAPI
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$Script:RequestBody = $Body | ConvertFrom-Json
@@ -111,82 +111,82 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected number of properties" {
+			It 'has a request body with expected number of properties' {
 
 				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 3
 
 			}
 
-			It "sends expected username in request" {
+			It 'sends expected username in request' {
 
 				$Script:RequestBody.username | Should -Be SomeUser
 
 			}
 
-			It "sends expected password in request" {
+			It 'sends expected password in request' {
 
 				$Script:RequestBody.password | Should -Be SomePassword
 
 			}
 
-			It "sends expected new password in request" {
+			It 'sends expected new password in request' {
 
 				$Script:RequestBody.newpassword | Should -Be SomeNewPassword
 
 			}
 
-			It "sends request with password value when OTP is used via classic API" {
-				$Credentials | New-PASSession -BaseURI "https://P_URI" -UseClassicAPI -useRadiusAuthentication $true -OTP 987654 -OTPMode Append
+			It 'sends request with password value when OTP is used via classic API' {
+				$Credentials | New-PASSession -BaseURI 'https://P_URI' -UseClassicAPI -useRadiusAuthentication $true -OTP 987654 -OTPMode Append
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$Script:RequestBody = $Body | ConvertFrom-Json
 
-					$Script:RequestBody.password -eq "SomePassword,987654"
+					$Script:RequestBody.password -eq 'SomePassword,987654'
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with password value when OTP is used via V10 API" {
-				$Credentials | New-PASSession -BaseURI "https://P_URI" -type RADIUS -OTP 987654 -OTPMode Append
+			It 'sends request with password value when OTP is used via V10 API' {
+				$Credentials | New-PASSession -BaseURI 'https://P_URI' -type RADIUS -OTP 987654 -OTPMode Append
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$Script:RequestBody = $Body | ConvertFrom-Json
 
-					$Script:RequestBody.password -eq "SomePassword,987654"
+					$Script:RequestBody.password -eq 'SomePassword,987654'
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with password value when RadiusChallenge is Password" {
-				$Credentials | New-PASSession -BaseURI "https://P_URI" -type RADIUS -OTP 987654 -OTPMode Challenge -RadiusChallenge Password
+			It 'sends request with password value when RadiusChallenge is Password' {
+				$Credentials | New-PASSession -BaseURI 'https://P_URI' -type RADIUS -OTP 987654 -OTPMode Challenge -RadiusChallenge Password
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$Script:RequestBody = $Body | ConvertFrom-Json
 
-					$Script:RequestBody.password -eq "987654"
+					$Script:RequestBody.password -eq '987654'
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with password value when OTPDelimiter is specified" {
-				$Credentials | New-PASSession -BaseURI "https://P_URI" -type RADIUS -OTP 987654 -OTPMode Append -OTPDelimiter "#"
+			It 'sends request with password value when OTPDelimiter is specified' {
+				$Credentials | New-PASSession -BaseURI 'https://P_URI' -type RADIUS -OTP 987654 -OTPMode Append -OTPDelimiter '#'
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$Script:RequestBody = $Body | ConvertFrom-Json
 
-					$Script:RequestBody.password -eq "SomePassword#987654"
+					$Script:RequestBody.password -eq 'SomePassword#987654'
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with concurrentSession value when specified" {
+			It 'sends request with concurrentSession value when specified' {
 
 
-				New-PASSession -BaseURI "https://P_URI" -type LDAP -Credential $Credentials -concurrentSession $true
+				New-PASSession -BaseURI 'https://P_URI' -type LDAP -Credential $Credentials -concurrentSession $true
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$Script:RequestBody = $Body | ConvertFrom-Json
@@ -197,9 +197,9 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected v10 URL for CyberArk Authentication" {
+			It 'sends request to expected v10 URL for CyberArk Authentication' {
 
-				$RandomString = "ZDE0YTY3MzYtNTk5Ni00YjFiLWFhMWUtYjVjMGFhNjM5MmJiOzY0MjY0NkYyRkE1NjY3N0M7MDAwMDAwMDI4ODY3MDkxRDUzMjE3NjcxM0ZBODM2REZGQTA2MTQ5NkFCRTdEQTAzNzQ1Q0JDNkRBQ0Q0NkRBMzRCODcwNjA0MDAwMDAwMDA7"
+				$RandomString = 'ZDE0YTY3MzYtNTk5Ni00YjFiLWFhMWUtYjVjMGFhNjM5MmJiOzY0MjY0NkYyRkE1NjY3N0M7MDAwMDAwMDI4ODY3MDkxRDUzMjE3NjcxM0ZBODM2REZGQTA2MTQ5NkFCRTdEQTAzNzQ1Q0JDNkRBQ0Q0NkRBMzRCODcwNjA0MDAwMDAwMDA7'
 
 
 				Mock Invoke-PASRestMethod -MockWith {
@@ -208,128 +208,128 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 				}
 
-				$Credentials | New-PASSession -BaseURI "https://P_URI" -type CyberArk
+				$Credentials | New-PASSession -BaseURI 'https://P_URI' -type CyberArk
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "https://P_URI/PasswordVault/api/AUTH/CyberArk/Logon"
+					$URI -eq 'https://P_URI/PasswordVault/api/AUTH/CyberArk/Logon'
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to v10 URL for CyberArk Authentication by default" {
+			It 'sends request to v10 URL for CyberArk Authentication by default' {
 
-				$Credentials | New-PASSession -BaseURI "https://P_URI"
+				$Credentials | New-PASSession -BaseURI 'https://P_URI'
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "https://P_URI/PasswordVault/api/AUTH/CyberArk/Logon"
+					$URI -eq 'https://P_URI/PasswordVault/api/AUTH/CyberArk/Logon'
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected v10 URL for LDAP Authentication" {
+			It 'sends request to expected v10 URL for LDAP Authentication' {
 
-				$Credentials | New-PASSession -BaseURI "https://P_URI" -type LDAP
+				$Credentials | New-PASSession -BaseURI 'https://P_URI' -type LDAP
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "https://P_URI/PasswordVault/api/AUTH/LDAP/Logon"
+					$URI -eq 'https://P_URI/PasswordVault/api/AUTH/LDAP/Logon'
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected v10 URL for RADIUS Authentication" {
+			It 'sends request to expected v10 URL for RADIUS Authentication' {
 
-				$Credentials | New-PASSession -BaseURI "https://P_URI" -type RADIUS
+				$Credentials | New-PASSession -BaseURI 'https://P_URI' -type RADIUS
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "https://P_URI/PasswordVault/api/AUTH/RADIUS/Logon"
+					$URI -eq 'https://P_URI/PasswordVault/api/AUTH/RADIUS/Logon'
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected v10 URL for WINDOWS Authentication" {
+			It 'sends request to expected v10 URL for WINDOWS Authentication' {
 
-				$Credentials | New-PASSession -BaseURI "https://P_URI" -type Windows
+				$Credentials | New-PASSession -BaseURI 'https://P_URI' -type Windows
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "https://P_URI/PasswordVault/api/Auth/Windows/Logon"
+					$URI -eq 'https://P_URI/PasswordVault/api/Auth/Windows/Logon'
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected v10 URL for WINDOWS Integrated Authentication" {
+			It 'sends request to expected v10 URL for WINDOWS Integrated Authentication' {
 
-				New-PASSession -BaseURI "https://P_URI" -UseDefaultCredentials
+				New-PASSession -BaseURI 'https://P_URI' -UseDefaultCredentials
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "https://P_URI/PasswordVault/api/Auth/Windows/Logon"
+					$URI -eq 'https://P_URI/PasswordVault/api/Auth/Windows/Logon'
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected URL for SAML Authentication" {
+			It 'sends request to expected URL for SAML Authentication' {
 
-				New-PASSession -BaseURI "https://P_URI" -SAMLToken "SomeSAMLToken"
+				New-PASSession -BaseURI 'https://P_URI' -SAMLToken 'SomeSAMLToken'
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "https://P_URI/PasswordVault/WebServices/auth/SAML/SAMLAuthenticationService.svc/Logon"
+					$URI -eq 'https://P_URI/PasswordVault/WebServices/auth/SAML/SAMLAuthenticationService.svc/Logon'
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends expected header for SAML Authentication" {
+			It 'sends expected header for SAML Authentication' {
 
-				New-PASSession -BaseURI "https://P_URI" -SAMLToken "SomeSAMLToken"
+				New-PASSession -BaseURI 'https://P_URI' -SAMLToken 'SomeSAMLToken'
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$Headers["Authorization"] -eq "SomeSAMLToken"
+					$Headers['Authorization'] -eq 'SomeSAMLToken'
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected URL for Shared Authentication" {
+			It 'sends request to expected URL for Shared Authentication' {
 
 				Mock Invoke-PASRestMethod -MockWith {
 					[PSCustomObject]@{
-						"LogonResult" = "AAAAAAA\\\REEEAAAAALLLLYYYYY\\\\LOOOOONNNNGGGGG\\\ACCCCCEEEEEEEESSSSSSS\\\\\\TTTTTOOOOOKKKKKEEEEEN"
+						'LogonResult' = 'AAAAAAA\\\REEEAAAAALLLLYYYYY\\\\LOOOOONNNNGGGGG\\\ACCCCCEEEEEEEESSSSSSS\\\\\\TTTTTOOOOOKKKKKEEEEEN'
 					}
 				}
 
-				New-PASSession -BaseURI "https://P_URI" -UseSharedAuthentication
+				New-PASSession -BaseURI 'https://P_URI' -UseSharedAuthentication
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "https://P_URI/PasswordVault/WebServices/auth/Shared/RestfulAuthenticationService.svc/Logon"
+					$URI -eq 'https://P_URI/PasswordVault/WebServices/auth/Shared/RestfulAuthenticationService.svc/Logon'
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "includes expected certificate thumbprint in request" {
+			It 'includes expected certificate thumbprint in request' {
 
-				New-PASSession -BaseURI "https://P_URI" -UseSharedAuthentication -CertificateThumbprint "SomeCertificateThumbprint"
+				New-PASSession -BaseURI 'https://P_URI' -UseSharedAuthentication -CertificateThumbprint 'SomeCertificateThumbprint'
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$CertificateThumbprint -eq "SomeCertificateThumbprint"
+					$CertificateThumbprint -eq 'SomeCertificateThumbprint'
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "includes expected certificate in request" {
+			It 'includes expected certificate in request' {
 
 				$certificate = Get-ChildItem -Path Cert:\CurrentUser\My\ | Select-Object -First 1
-				New-PASSession -BaseURI "https://P_URI" -UseSharedAuthentication -Certificate $certificate
+				New-PASSession -BaseURI 'https://P_URI' -UseSharedAuthentication -Certificate $certificate
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -339,10 +339,10 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "includes expected credential for Windows Auth" {
+			It 'includes expected credential for Windows Auth' {
 
 
-				New-PASSession -BaseURI "https://P_URI" -type Windows -Credential $Credentials
+				New-PASSession -BaseURI 'https://P_URI' -type Windows -Credential $Credentials
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$Credential -ne $null
@@ -353,36 +353,36 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			It "`$Script:ExternalVersion has expected value on Get-PASServer error" {
 				Mock Get-PASServer -MockWith {
-					throw "Some Error"
+					throw 'Some Error'
 				}
 
-				$Credentials | New-PASSession -BaseURI "https://P_URI" -PVWAAppName "SomeApp" -WarningAction SilentlyContinue
-				$Script:ExternalVersion | Should -Be "0.0"
+				$Credentials | New-PASSession -BaseURI 'https://P_URI' -PVWAAppName 'SomeApp' -WarningAction SilentlyContinue
+				$Script:ExternalVersion | Should -Be '0.0'
 
 			}
 
-			It "calls Get-PASServer" {
+			It 'calls Get-PASServer' {
 
-				$Credentials | New-PASSession -BaseURI "https://P_URI" -type LDAP
+				$Credentials | New-PASSession -BaseURI 'https://P_URI' -type LDAP
 				Assert-MockCalled Get-PASServer -Times 1 -Exactly -Scope It
 
 			}
 
-			It "skips version check" {
+			It 'skips version check' {
 
-				$Credentials | New-PASSession -BaseURI "https://P_URI" -type LDAP -SkipVersionCheck
+				$Credentials | New-PASSession -BaseURI 'https://P_URI' -type LDAP -SkipVersionCheck
 				Assert-MockCalled Get-PASServer -Times 0 -Exactly -Scope It
 
 			}
 
 		}
 
-		Context "Radius Challenge" {
+		Context 'Radius Challenge' {
 
 			BeforeEach {
 
 				if ($IsCoreCLR) {
-					$errorDetails = $([pscustomobject]@{"ErrorCode" = "ITATS542I"; "ErrorMessage" = "Some Radius Message" } | ConvertTo-Json)
+					$errorDetails = $([pscustomobject]@{'ErrorCode' = 'ITATS542I'; 'ErrorMessage' = 'Some Radius Message' } | ConvertTo-Json)
 					$statusCode = 500
 					$response = New-Object System.Net.Http.HttpResponseMessage $statusCode
 					$exception = New-Object Microsoft.PowerShell.Commands.HttpResponseException "$statusCode ($($response.ReasonPhrase))", $response
@@ -392,42 +392,42 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 					$errorRecord = New-Object Management.Automation.ErrorRecord $exception, $errorID, $errorCategory, $targetObject
 					$errorRecord.ErrorDetails = $errorDetails
 				}
-				Mock -CommandName Invoke-WebRequest -ParameterFilter { $SessionVariable -eq "PASSession" } -MockWith { Throw $errorRecord }
-				Mock -CommandName Invoke-WebRequest -ParameterFilter { $WebSession -eq $Script:WebSession } -MockWith { [PSCustomObject]@{"CyberArkLogonResult" = "AAAAAAA\\\REEEAAAAALLLLYYYYY\\\\LOOOOONNNNGGGGG\\\ACCCCCEEEEEEEESSSSSSS\\\\\\TTTTTOOOOOKKKKKEEEEEN" } }
+				Mock -CommandName Invoke-WebRequest -ParameterFilter { $SessionVariable -eq 'PASSession' } -MockWith { Throw $errorRecord }
+				Mock -CommandName Invoke-WebRequest -ParameterFilter { $WebSession -eq $Script:WebSession } -MockWith { [PSCustomObject]@{'CyberArkLogonResult' = 'AAAAAAA\\\REEEAAAAALLLLYYYYY\\\\LOOOOONNNNGGGGG\\\ACCCCCEEEEEEEESSSSSSS\\\\\\TTTTTOOOOOKKKKKEEEEEN' } }
 
 				Mock Read-Host -MockWith {
-					return "123456"
+					return '123456'
 				}
 				Mock Get-Variable -MockWith { }
 				Mock Get-PASServer -MockWith {
 					[PSCustomObject]@{
-						ExternalVersion = "6.6.6"
+						ExternalVersion = '6.6.6'
 					}
 				}
 
-				$Credentials = New-Object System.Management.Automation.PSCredential ("SomeUser", $(ConvertTo-SecureString "SomePassword" -AsPlainText -Force))
+				$Credentials = New-Object System.Management.Automation.PSCredential ('SomeUser', $(ConvertTo-SecureString 'SomePassword' -AsPlainText -Force))
 
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 			}
 
-			It "sends expected number of requests when exception ITATS542I is raised" {
+			It 'sends expected number of requests when exception ITATS542I is raised' {
 				if ($IsCoreCLR) {
-					$Credentials | New-PASSession -BaseURI "https://P_URI" -type RADIUS -OTP 123456 -OTPMode Challenge
+					$Credentials | New-PASSession -BaseURI 'https://P_URI' -type RADIUS -OTP 123456 -OTPMode Challenge
 					Assert-MockCalled Invoke-WebRequest -Times 2 -Exactly -Scope It
 				} Else { Set-ItResult -Inconclusive }
 			}
 
-			It "sends expected OTP value for Radius Challenge" {
+			It 'sends expected OTP value for Radius Challenge' {
 				if ($IsCoreCLR) {
-					$Credentials | New-PASSession -BaseURI "https://P_URI" -type RADIUS -OTP 987654 -OTPMode Challenge
+					$Credentials | New-PASSession -BaseURI 'https://P_URI' -type RADIUS -OTP 987654 -OTPMode Challenge
 
 					Assert-MockCalled Invoke-WebRequest -ParameterFilter {
 
 						$Script:RequestBody = $Body | ConvertFrom-Json
 
-						$Script:RequestBody.password -eq "SomePassword"
+						$Script:RequestBody.password -eq 'SomePassword'
 
 					} -Times 1 -Exactly -Scope It
 
@@ -435,21 +435,21 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 						$Script:RequestBody = $Body | ConvertFrom-Json
 
-						$Script:RequestBody.password -eq "987654"
+						$Script:RequestBody.password -eq '987654'
 
 					} -Times 1 -Exactly -Scope It
 				} Else { Set-ItResult -Inconclusive }
 			}
 
-			It "sends expected password value as radius challenge" {
+			It 'sends expected password value as radius challenge' {
 				if ($IsCoreCLR) {
-					$Credentials | New-PASSession -BaseURI "https://P_URI" -type RADIUS -OTP 987654 -OTPMode Challenge -RadiusChallenge Password
+					$Credentials | New-PASSession -BaseURI 'https://P_URI' -type RADIUS -OTP 987654 -OTPMode Challenge -RadiusChallenge Password
 
 					Assert-MockCalled Invoke-WebRequest -ParameterFilter {
 
 						$Script:RequestBody = $Body | ConvertFrom-Json
 
-						$Script:RequestBody.password -eq "987654"
+						$Script:RequestBody.password -eq '987654'
 
 					} -Times 1 -Exactly -Scope It
 
@@ -457,34 +457,34 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 						$Script:RequestBody = $Body | ConvertFrom-Json
 
-						$Script:RequestBody.password -eq "SomePassword"
+						$Script:RequestBody.password -eq 'SomePassword'
 
 					} -Times 1 -Exactly -Scope It
 				} Else { Set-ItResult -Inconclusive }
 			}
 
-			It "prompts for OTP value" {
+			It 'prompts for OTP value' {
 				if ($IsCoreCLR) {
-					$Credentials | New-PASSession -BaseURI "https://P_URI" -type RADIUS -OTPMode Challenge
+					$Credentials | New-PASSession -BaseURI 'https://P_URI' -type RADIUS -OTPMode Challenge
 					Assert-MockCalled Read-Host -Times 1 -Exactly -Scope It
 				} Else { Set-ItResult -Inconclusive }
 			}
 
-			It "relay RADIUS response as prompt" {
+			It 'relay RADIUS response as prompt' {
 				if ($IsCoreCLR) {
 
-					$Credentials | New-PASSession -BaseURI "https://P_URI" -type RADIUS -OTPMode Challenge
+					$Credentials | New-PASSession -BaseURI 'https://P_URI' -type RADIUS -OTPMode Challenge
 					Assert-MockCalled Read-Host -ParameterFilter {
 
-						$Prompt -eq "[500] Some Radius Message"
+						$Prompt -eq '[500] Some Radius Message'
 
 					} -Times 1 -Exactly -Scope It
 				} Else { Set-ItResult -Inconclusive }
 			}
 
-			It "throws if error code does not indicate Radius Challenge" {
+			It 'throws if error code does not indicate Radius Challenge' {
 				if ($IsCoreCLR) {
-					$errorDetails = $([pscustomobject]@{"ErrorCode" = "ITATS123I"; "ErrorMessage" = "Some Message" } | ConvertTo-Json)
+					$errorDetails = $([pscustomobject]@{'ErrorCode' = 'ITATS123I'; 'ErrorMessage' = 'Some Message' } | ConvertTo-Json)
 					$statusCode = 500
 					$response = New-Object System.Net.Http.HttpResponseMessage $statusCode
 					$exception = New-Object Microsoft.PowerShell.Commands.HttpResponseException "$statusCode ($($response.ReasonPhrase))", $response
@@ -494,107 +494,149 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 					$errorRecord = New-Object Management.Automation.ErrorRecord $exception, $errorID, $errorCategory, $targetObject
 					$errorRecord.ErrorDetails = $errorDetails
 
-					Mock -CommandName Invoke-WebRequest -ParameterFilter { $SessionVariable -eq "PASSession" } -MockWith { Throw $errorRecord }
+					Mock -CommandName Invoke-WebRequest -ParameterFilter { $SessionVariable -eq 'PASSession' } -MockWith { Throw $errorRecord }
 
-					{ $Credentials | New-PASSession -BaseURI "https://P_URI" -type RADIUS -OTPMode Append -OTP 123456 } | Should -Throw
+					{ $Credentials | New-PASSession -BaseURI 'https://P_URI' -type RADIUS -OTPMode Append -OTP 123456 } | Should -Throw
 				} Else { Set-ItResult -Inconclusive }
 			}
 
 			It "prompts for OTP if parameter value for $OTP is 'passcode'" {
 				if ($IsCoreCLR) {
-					$Credentials | New-PASSession -BaseURI "https://P_URI" -type RADIUS -OTP passcode -OTPMode Challenge
+					$Credentials | New-PASSession -BaseURI 'https://P_URI' -type RADIUS -OTP passcode -OTPMode Challenge
 					Assert-MockCalled Read-Host -Times 1 -Exactly -Scope It
 				} Else { Set-ItResult -Inconclusive }
 			}
 
+			It 'prompts for response to multiple challenge levels' {
+
+				$Script:counter = 0
+				if ($IsCoreCLR) {
+					Mock -CommandName Invoke-PASRestMethod {
+						If ($Script:counter -lt 4) {
+							$Script:counter++
+							Throw $errorRecord
+						} ElseIf ($Script:counter -ge 5) {
+
+							Return [PSCustomObject]@{'CyberArkLogonResult' = 'AAAAAAA\\\REEEAAAAALLLLYYYYY\\\\LOOOOONNNNGGGGG\\\ACCCCCEEEEEEEESSSSSSS\\\\\\TTTTTOOOOOKKKKKEEEEEN' }
+
+						}
+
+					} -ParameterFilter { $Uri -eq 'https://P_URI/PasswordVault/api/Auth/RADIUS/Logon' }
+
+					$Credentials | New-PASSession -BaseURI 'https://P_URI' -type RADIUS
+
+					Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+						$URI -eq 'https://P_URI/PasswordVault/api/Auth/RADIUS/Logon'
+
+					} -Times 5 -Exactly -Scope It
+
+				} Else { Set-ItResult -Inconclusive }
+
+			}
+
 		}
 
-		Context "Windows + Radius" {
+		Context 'Windows + Radius' {
 
 			BeforeEach {
 				if ($IsCoreCLR) {
-					$errorDetails = $([pscustomobject]@{"ErrorCode" = "ITATS542I"; "ErrorMessage" = "Some Radius Message" } | ConvertTo-Json)
+					$errorDetails1 = $([pscustomobject]@{'ErrorCode' = 'ITATS542I'; 'ErrorMessage' = 'Some Radius Message' } | ConvertTo-Json)
+					$errorDetails2 = $([pscustomobject]@{'ErrorCode' = 'ITATS555E'; 'ErrorMessage' = 'Some Error Message' } | ConvertTo-Json)
 					$statusCode = 500
 					$response = New-Object System.Net.Http.HttpResponseMessage $statusCode
 					$exception = New-Object Microsoft.PowerShell.Commands.HttpResponseException "$statusCode ($($response.ReasonPhrase))", $response
 					$errorCategory = [System.Management.Automation.ErrorCategory]::InvalidOperation
-					$errorID = 'ITATS542I'
+					$errorID1 = 'ITATS542I'
+					$errorID2 = 'ITATS555E'
 					$targetObject = $null
-					$errorRecord = New-Object Management.Automation.ErrorRecord $exception, $errorID, $errorCategory, $targetObject
-					$errorRecord.ErrorDetails = $errorDetails
+					$errorRecord1 = New-Object Management.Automation.ErrorRecord $exception, $errorID1, $errorCategory, $targetObject
+					$errorRecord2 = New-Object Management.Automation.ErrorRecord $exception, $errorID2, $errorCategory, $targetObject
+					$errorRecord1.ErrorDetails = $errorDetails1
+					$errorRecord2.ErrorDetails = $errorDetails2
 				}
 				$Script:counter = 0
 
-				$RandomString = "ZDE0YTY3MzYtNTk5Ni00YjFiLWFhMWUtYjVjMGFhNjM5MmJiOzY0MjY0NkYyRkE1NjY3N0M7MDAwMDAwMDI4ODY3MDkxRDUzMjE3NjcxM0ZBODM2REZGQTA2MTQ5NkFCRTdEQTAzNzQ1Q0JDNkRBQ0Q0NkRBMzRCODcwNjA0MDAwMDAwMDA7"
+				$RandomString = 'ZDE0YTY3MzYtNTk5Ni00YjFiLWFhMWUtYjVjMGFhNjM5MmJiOzY0MjY0NkYyRkE1NjY3N0M7MDAwMDAwMDI4ODY3MDkxRDUzMjE3NjcxM0ZBODM2REZGQTA2MTQ5NkFCRTdEQTAzNzQ1Q0JDNkRBQ0Q0NkRBMzRCODcwNjA0MDAwMDAwMDA7'
 
 				Mock -CommandName Invoke-PASRestMethod {
 					If ($Script:counter -eq 0) {
 						$Script:counter++
-						Throw $errorRecord
+						Throw $errorRecord1
 					} ElseIf ($Script:counter -ge 1) {
 
 						return $RandomString
 
 					}
 
-				} -ParameterFilter { $Uri -eq "https://P_URI/PasswordVault/api/Auth/RADIUS/Logon" }
+				} -ParameterFilter { $Uri -eq 'https://P_URI/PasswordVault/api/Auth/RADIUS/Logon' }
 
-				Mock -CommandName Invoke-PASRestMethod { return @{UserName = "AUserName" } } -ParameterFilter { $Uri -eq "https://P_URI/PasswordVault/api/Auth/Windows/Logon" }
+				Mock -CommandName Invoke-PASRestMethod { return @{UserName = 'AUserName' } } -ParameterFilter { $Uri -eq 'https://P_URI/PasswordVault/api/Auth/Windows/Logon' }
 
 				Mock Set-Variable -MockWith { }
 				Mock Get-Variable -MockWith { }
 				Mock Get-PASServer -MockWith {
 					[PSCustomObject]@{
-						ExternalVersion = "6.6.6"
+						ExternalVersion = '6.6.6'
 					}
 				}
 
-				$Credentials = New-Object System.Management.Automation.PSCredential ("SomeUser", $(ConvertTo-SecureString "SomePassword" -AsPlainText -Force))
+				$Credentials = New-Object System.Management.Automation.PSCredential ('SomeUser', $(ConvertTo-SecureString 'SomePassword' -AsPlainText -Force))
 
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 			}
 
-			It "throws if no session token is returned after successful IIS authentication" {
+			It 'throws if no session token is returned after successful IIS authentication' {
 				if ($IsCoreCLR) {
-					{ $Credentials | New-PASSession -BaseURI "https://P_URI" -type Windows } | Should -Throw
+					{ $Credentials | New-PASSession -BaseURI 'https://P_URI' -type Windows } | Should -Throw
 				} Else { Set-ItResult -Inconclusive }
 			}
 
-			It "sends expected number of requests for Windows Auth + RADIUS" {
+			It 'sends expected number of requests for Windows Auth + RADIUS' {
 				if ($IsCoreCLR) {
-					$Credentials | New-PASSession -BaseURI "https://P_URI" -type Windows -OTP 123456 -OTPMode Challenge
+					$Credentials | New-PASSession -BaseURI 'https://P_URI' -type Windows -OTP 123456 -OTPMode Challenge
 
 					Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-						$URI -eq "https://P_URI/PasswordVault/api/Auth/Windows/Logon"
+						$URI -eq 'https://P_URI/PasswordVault/api/Auth/Windows/Logon'
 
 					} -Times 1 -Exactly -Scope It
 
 					Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-						$URI -eq "https://P_URI/PasswordVault/api/Auth/RADIUS/Logon"
+						$URI -eq 'https://P_URI/PasswordVault/api/Auth/RADIUS/Logon'
 
 					} -Times 2 -Exactly -Scope It
 				} Else { Set-ItResult -Inconclusive }
 			}
 
-			It "throws if RADIUS challenge fails" {
+			It 'throws if RADIUS challenge fails' {
 				if ($IsCoreCLR) {
-					Mock -CommandName Invoke-PASRestMethod { Throw $errorRecord } -ParameterFilter { $Uri -eq "https://P_URI/PasswordVault/api/Auth/RADIUS/Logon" }
+					Mock -CommandName Invoke-PASRestMethod {
+						If ($Script:counter -eq 0) {
+							$Script:counter++
+							Throw $errorRecord1
+						} ElseIf ($Script:counter -ge 1) {
 
-					{ $Credentials | New-PASSession -BaseURI "https://P_URI" -type Windows -OTP 123456 -OTPMode Challenge } | Should -Throw
+							Throw $errorRecord2
+
+						}
+
+					} -ParameterFilter { $Uri -eq 'https://P_URI/PasswordVault/api/Auth/RADIUS/Logon' }
+
+					{ $Credentials | New-PASSession -BaseURI 'https://P_URI' -type Windows -OTP 123456 -OTPMode Challenge } | Should -Throw
 
 					Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-						$URI -eq "https://P_URI/PasswordVault/api/Auth/Windows/Logon"
+						$URI -eq 'https://P_URI/PasswordVault/api/Auth/Windows/Logon'
 
 					} -Times 1 -Exactly -Scope It
 
 					Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-						$URI -eq "https://P_URI/PasswordVault/api/Auth/RADIUS/Logon"
+						$URI -eq 'https://P_URI/PasswordVault/api/Auth/RADIUS/Logon'
 
 					} -Times 2 -Exactly -Scope It
 
@@ -604,62 +646,62 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "SAML" {
+		Context 'SAML' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
 					[PSCustomObject]@{
-						"CyberArkLogonResult" = "AAAAAAA\\\REEEAAAAALLLLYYYYY\\\\LOOOOONNNNGGGGG\\\ACCCCCEEEEEEEESSSSSSS\\\\\\TTTTTOOOOOKKKKKEEEEEN"
+						'CyberArkLogonResult' = 'AAAAAAA\\\REEEAAAAALLLLYYYYY\\\\LOOOOONNNNGGGGG\\\ACCCCCEEEEEEEESSSSSSS\\\\\\TTTTTOOOOOKKKKKEEEEEN'
 					}
 				}
 
 				Mock Get-PASServer -MockWith {
 					[PSCustomObject]@{
-						ExternalVersion = "6.6.6"
+						ExternalVersion = '6.6.6'
 					}
 				}
 
 				Mock Set-Variable -MockWith { }
 
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 				Mock Get-PASSAMLResponse -MockWith {
 
-					"ThisIsTheSAMLResponse"
+					'ThisIsTheSAMLResponse'
 
 				}
 
 			}
 
-			It "sends request" {
-				New-PASSession -BaseURI "https://P_URI" -SAMLAuth
+			It 'sends request' {
+				New-PASSession -BaseURI 'https://P_URI' -SAMLAuth
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
-				New-PASSession -BaseURI "https://P_URI" -SAMLAuth
+				New-PASSession -BaseURI 'https://P_URI' -SAMLAuth
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					($URI -eq "https://P_URI/PasswordVault/api/Auth/SAML/Logon?apiUse=true&SAMLResponse=ThisIsTheSAMLResponse") -or
-					($URI -eq "https://P_URI/PasswordVault/api/Auth/SAML/Logon?SAMLResponse=ThisIsTheSAMLResponse&apiUse=true")
+					($URI -eq 'https://P_URI/PasswordVault/api/Auth/SAML/Logon?apiUse=true&SAMLResponse=ThisIsTheSAMLResponse') -or
+					($URI -eq 'https://P_URI/PasswordVault/api/Auth/SAML/Logon?SAMLResponse=ThisIsTheSAMLResponse&apiUse=true')
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws if saml response is not available" {
+			It 'throws if saml response is not available' {
 
 				Mock Get-PASSAMLResponse -MockWith {
 
-					Throw "ThisIsTheSAMLResponse"
+					Throw 'ThisIsTheSAMLResponse'
 
 				}
 
-				{ New-PASSession -BaseURI "https://P_URI" -SAMLAuth } | Should -Throw
+				{ New-PASSession -BaseURI 'https://P_URI' -SAMLAuth } | Should -Throw
 
 			}
 

--- a/Tests/Send-RADIUSResponse.Tests.ps1
+++ b/Tests/Send-RADIUSResponse.Tests.ps1
@@ -1,0 +1,115 @@
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
+
+    BeforeAll {
+        #Get Current Directory
+        $Here = Split-Path -Parent $PSCommandPath
+
+        #Assume ModuleName from Repository Root folder
+        $ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+        #Resolve Path to Module Directory
+        $ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+        #Define Path to Module Manifest
+        $ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+        if ( -not (Get-Module -Name $ModuleName -All)) {
+
+            Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+        }
+
+        $Script:RequestBody = $null
+        $Script:BaseURI = 'https://SomeURL/SomeApp'
+        $Script:ExternalVersion = '0.0'
+        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+    }
+
+
+    AfterAll {
+
+        $Script:RequestBody = $null
+
+    }
+
+    InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+        Context 'Radius Challenge' {
+
+            BeforeEach {
+
+                if ($IsCoreCLR) {
+                    $errorDetails = $([pscustomobject]@{'ErrorCode' = 'ITATS542I'; 'ErrorMessage' = 'Some Radius Message' } | ConvertTo-Json)
+                    $statusCode = 500
+                    $response = New-Object System.Net.Http.HttpResponseMessage $statusCode
+                    $exception = New-Object Microsoft.PowerShell.Commands.HttpResponseException "$statusCode ($($response.ReasonPhrase))", $response
+                    $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidOperation
+                    $errorID = 'ITATS542I'
+                    $targetObject = $null
+                    $errorRecord = New-Object Management.Automation.ErrorRecord $exception, $errorID, $errorCategory, $targetObject
+                    $errorRecord.ErrorDetails = $errorDetails
+                }
+                $Script:counter = 0
+                Mock -CommandName Invoke-PASRestMethod {
+
+                    If ($Script:counter -lt 4) {
+
+                        $Script:counter++
+
+                        Throw $errorRecord
+
+                    } ElseIf ($Script:counter -ge 5) {
+
+                        Return [PSCustomObject]@{'CyberArkLogonResult' = 'SomeValue' }
+
+                    }
+
+                }
+
+                Mock Read-Host -MockWith {
+                    return '123456'
+                }
+
+                $Response = @{
+                    'LogonRequest' = @{
+                        'Body'   = [PSCustomObject]@{
+                            'Password' = 'SomePasswordValue'
+                        } | ConvertTo-Json
+                        'Method' = 'POST'
+                        'URI'    = 'Value'
+                    }
+                    'Message'      = 'SomeMessage'
+                }
+
+                $Script:ExternalVersion = '0.0'
+
+
+            }
+
+            It 'sends expected number of requests when exception ITATS542I is raised' {
+                if ($IsCoreCLR) {
+                    Send-RADIUSResponse @Response
+                    Assert-MockCalled Invoke-PASRestMethod -Times 5 -Exactly -Scope It
+                } Else { Set-ItResult -Inconclusive }
+            }
+
+            It 'sends expected OTP' {
+                if ($IsCoreCLR) {
+                    Send-RADIUSResponse @Response
+                    Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+                        $Script:RequestBody = $Body | ConvertFrom-Json
+
+                        $Script:RequestBody.password -eq '123456'
+
+                    } -Times 5 -Exactly -Scope It
+
+                } Else { Set-ItResult -Inconclusive }
+            }
+
+        }
+
+    }
+
+}

--- a/psPAS/Functions/Authentication/New-PASSession.ps1
+++ b/psPAS/Functions/Authentication/New-PASSession.ps1
@@ -1,28 +1,28 @@
 # .ExternalHelp psPAS-help.xml
 function New-PASSession {
-	[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = "Gen2")]
+	[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'Gen2')]
 	param(
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipeline = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipeline = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2Radius"
+			ParameterSetName = 'Gen2Radius'
 		)]
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipeline = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipeline = $true,
-			ParameterSetName = "Gen1Radius"
+			ParameterSetName = 'Gen1Radius'
 		)]
 		[ValidateNotNullOrEmpty()]
 		[PSCredential]$Credential,
@@ -30,27 +30,27 @@ function New-PASSession {
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipeline = $true,
-			ParameterSetName = "Gen1Radius"
+			ParameterSetName = 'Gen1Radius'
 		)]
-		[Alias("UseClassicAPI")]
+		[Alias('UseClassicAPI')]
 		[switch]$UseGen1API,
 
 		[Parameter(
 			Mandatory = $false,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[Parameter(
 			Mandatory = $false,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[SecureString]$newPassword,
 
@@ -58,7 +58,7 @@ function New-PASSession {
 			Mandatory = $true,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2SAML"
+			ParameterSetName = 'Gen2SAML'
 		)]
 		[switch]$SAMLAuth,
 
@@ -66,7 +66,7 @@ function New-PASSession {
 			Mandatory = $true,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1SAML"
+			ParameterSetName = 'Gen1SAML'
 		)]
 		[String]$SAMLToken,
 
@@ -74,7 +74,7 @@ function New-PASSession {
 			Mandatory = $True,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "shared"
+			ParameterSetName = 'shared'
 		)]
 		[switch]$UseSharedAuthentication,
 
@@ -82,7 +82,7 @@ function New-PASSession {
 			Mandatory = $true,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1Radius"
+			ParameterSetName = 'Gen1Radius'
 		)]
 		[bool]$useRadiusAuthentication,
 
@@ -90,28 +90,28 @@ function New-PASSession {
 			Mandatory = $false,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[Parameter(
 			Mandatory = $false,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2Radius"
+			ParameterSetName = 'Gen2Radius'
 		)]
-		[ValidateSet("CyberArk", "LDAP", "Windows", "RADIUS")]
-		[string]$type = "CyberArk",
+		[ValidateSet('CyberArk', 'LDAP', 'Windows', 'RADIUS')]
+		[string]$type = 'CyberArk',
 
 		[Parameter(
 			Mandatory = $false,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2Radius"
+			ParameterSetName = 'Gen2Radius'
 		)]
 		[Parameter(
 			Mandatory = $false,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1Radius"
+			ParameterSetName = 'Gen1Radius'
 		)]
 		[string]$OTP,
 
@@ -119,28 +119,28 @@ function New-PASSession {
 			Mandatory = $false,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2Radius"
+			ParameterSetName = 'Gen2Radius'
 		)]
 		[Parameter(
 			Mandatory = $false,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1Radius"
+			ParameterSetName = 'Gen1Radius'
 		)]
-		[ValidateSet("Append", "Challenge")]
+		[ValidateSet('Append', 'Challenge')]
 		[string]$OTPMode,
 
 		[Parameter(
 			Mandatory = $false,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2Radius"
+			ParameterSetName = 'Gen2Radius'
 		)]
 		[Parameter(
 			Mandatory = $false,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1Radius"
+			ParameterSetName = 'Gen1Radius'
 		)]
 		[ValidateLength(1, 1)]
 		[string]$OTPDelimiter,
@@ -149,22 +149,22 @@ function New-PASSession {
 			Mandatory = $false,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2Radius"
+			ParameterSetName = 'Gen2Radius'
 		)]
 		[Parameter(
 			Mandatory = $false,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1Radius"
+			ParameterSetName = 'Gen1Radius'
 		)]
-		[ValidateSet("Password", "OTP")]
+		[ValidateSet('Password', 'OTP')]
 		[string]$RadiusChallenge,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "integrated"
+			ParameterSetName = 'integrated'
 		)]
 		[switch]$UseDefaultCredentials,
 
@@ -172,25 +172,25 @@ function New-PASSession {
 			Mandatory = $false,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2Radius"
+			ParameterSetName = 'Gen2Radius'
 		)]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "integrated"
+			ParameterSetName = 'integrated'
 		)]
 		[Parameter(
 			Mandatory = $false,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2SAML"
+			ParameterSetName = 'Gen2SAML'
 		)]
 		[Boolean]$concurrentSession,
 
@@ -198,13 +198,13 @@ function New-PASSession {
 			Mandatory = $false,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[Parameter(
 			Mandatory = $false,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1Radius"
+			ParameterSetName = 'Gen1Radius'
 		)]
 		[ValidateRange(1, 100)]
 		[int]$connectionNumber,
@@ -221,7 +221,7 @@ function New-PASSession {
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault",
+		[string]$PVWAAppName = 'PasswordVault',
 
 		[Parameter(
 			Mandatory = $false,
@@ -259,26 +259,26 @@ function New-PASSession {
 		$LogonRequest = @{ }
 
 		#Define Logon Request Parameters
-		$LogonRequest["Method"] = "POST"
-		$LogonRequest["SessionVariable"] = "PASSession"
-		$LogonRequest["UseDefaultCredentials"] = $UseDefaultCredentials.IsPresent
-		$LogonRequest["SkipCertificateCheck"] = $SkipCertificateCheck.IsPresent
+		$LogonRequest['Method'] = 'POST'
+		$LogonRequest['SessionVariable'] = 'PASSession'
+		$LogonRequest['UseDefaultCredentials'] = $UseDefaultCredentials.IsPresent
+		$LogonRequest['SkipCertificateCheck'] = $SkipCertificateCheck.IsPresent
 
-		If ($PSBoundParameters["type"] -eq "Windows") {
+		If ($PSBoundParameters['type'] -eq 'Windows') {
 
-			$LogonRequest["Credential"] = $Credential
+			$LogonRequest['Credential'] = $Credential
 
 		}
 
 		If ($CertificateThumbprint) {
 
-			$LogonRequest["CertificateThumbprint"] = $CertificateThumbprint
+			$LogonRequest['CertificateThumbprint'] = $CertificateThumbprint
 
 		}
 
 		If ($Certificate) {
 
-			$LogonRequest["Certificate"] = $Certificate
+			$LogonRequest['Certificate'] = $Certificate
 
 		}
 
@@ -288,55 +288,55 @@ function New-PASSession {
 
 		Switch ($PSCmdlet.ParameterSetName) {
 
-			"integrated" {
+			'integrated' {
 
-				$LogonRequest["Uri"] = "$baseURI/$PVWAAppName/api/Auth/Windows/Logon"  #hardcode Windows for integrated auth
+				$LogonRequest['Uri'] = "$baseURI/$PVWAAppName/api/Auth/Windows/Logon"  #hardcode Windows for integrated auth
 
 				#Construct Request Body
 				#The only expected parameter should be concurrentSessions
-				$LogonRequest["Body"] = $PSBoundParameters | Get-PASParameter -ParametersToKeep concurrentSession | ConvertTo-Json
+				$LogonRequest['Body'] = $PSBoundParameters | Get-PASParameter -ParametersToKeep concurrentSession | ConvertTo-Json
 
 				break
 
 			}
 
-			"shared" {
+			'shared' {
 
-				$LogonRequest["Uri"] = "$baseURI/$PVWAAppName/WebServices/auth/Shared/RestfulAuthenticationService.svc/Logon"
+				$LogonRequest['Uri'] = "$baseURI/$PVWAAppName/WebServices/auth/Shared/RestfulAuthenticationService.svc/Logon"
 				break
 
 			}
 
-			"Gen1SAML" {
+			'Gen1SAML' {
 
-				$LogonRequest["Uri"] = "$baseURI/$PVWAAppName/WebServices/auth/SAML/SAMLAuthenticationService.svc/Logon"
+				$LogonRequest['Uri'] = "$baseURI/$PVWAAppName/WebServices/auth/SAML/SAMLAuthenticationService.svc/Logon"
 
 				#add token to header
-				$LogonRequest["Headers"] = @{"Authorization" = $SAMLToken }
+				$LogonRequest['Headers'] = @{'Authorization' = $SAMLToken }
 				break
 
 			}
 
-			"Gen2SAML" {
+			'Gen2SAML' {
 
 				$URI = "$baseURI/$PVWAAppName/api/Auth/SAML/Logon"
 				break
 
 			}
 
-			( { $PSItem -match "^Gen2" } ) {
+			( { $PSItem -match '^Gen2' } ) {
 
-				$LogonRequest["Uri"] = "$baseURI/$PVWAAppName/api/Auth/$type/Logon"
-
-			}
-
-			( { $PSItem -match "^Gen1" } ) {
-
-				$LogonRequest["Uri"] = "$baseURI/$PVWAAppName/WebServices/auth/Cyberark/CyberArkAuthenticationService.svc/Logon"
+				$LogonRequest['Uri'] = "$baseURI/$PVWAAppName/api/Auth/$type/Logon"
 
 			}
 
-			( { $PSItem -match "^Gen" } ) {
+			( { $PSItem -match '^Gen1' } ) {
+
+				$LogonRequest['Uri'] = "$baseURI/$PVWAAppName/WebServices/auth/Cyberark/CyberArkAuthenticationService.svc/Logon"
+
+			}
+
+			( { $PSItem -match '^Gen' } ) {
 
 
 				#Get request parameters
@@ -344,17 +344,17 @@ function New-PASSession {
 				UseDefaultCredentials, CertificateThumbprint, BaseURI, PVWAAppName, OTP, type, OTPMode, OTPDelimiter, RadiusChallenge, Certificate
 
 				#Add user name from credential object
-				$boundParameters["username"] = $($Credential.UserName)
+				$boundParameters['username'] = $($Credential.UserName)
 				#Add decoded password value from credential object
-				$boundParameters["password"] = $($Credential.GetNetworkCredential().Password)
+				$boundParameters['password'] = $($Credential.GetNetworkCredential().Password)
 
 				#RADIUS Auth
-				If ($PSCmdlet.ParameterSetName -match "Radius$") {
+				If ($PSCmdlet.ParameterSetName -match 'Radius$') {
 
 					#OTP in Append Mode
-					If (($PSBoundParameters.ContainsKey("OTP")) -and ($PSBoundParameters["OTPMode"] -eq "Append")) {
+					If (($PSBoundParameters.ContainsKey('OTP')) -and ($PSBoundParameters['OTPMode'] -eq 'Append')) {
 
-						If ($PSBoundParameters.ContainsKey("OTPDelimiter")) {
+						If ($PSBoundParameters.ContainsKey('OTPDelimiter')) {
 
 							#Use specified delimiter to append OTP
 							$Delimiter = $OTPDelimiter
@@ -362,22 +362,22 @@ function New-PASSession {
 						} Else {
 
 							#delimit with comma by default
-							$Delimiter = ","
+							$Delimiter = ','
 
 						}
 
 						#Append OTP to password
-						$boundParameters["password"] = "$($boundParameters["password"])$Delimiter$OTP"
+						$boundParameters['password'] = "$($boundParameters['password'])$Delimiter$OTP"
 
 					}
 
 					#RADIUS Challenge Mode
-					ElseIf (($PSBoundParameters.ContainsKey("OTP")) -and ($PSBoundParameters["OTPMode"] -eq "Challenge")) {
+					ElseIf (($PSBoundParameters.ContainsKey('OTP')) -and ($PSBoundParameters['OTPMode'] -eq 'Challenge')) {
 
-						If ($RadiusChallenge -eq "Password") {
+						If ($RadiusChallenge -eq 'Password') {
 
 							#Send OTP first + then Password
-							$boundParameters["password"] = $OTP
+							$boundParameters['password'] = $OTP
 							$OTP = $($Credential.GetNetworkCredential().Password)
 
 						}
@@ -387,15 +387,15 @@ function New-PASSession {
 				}
 
 				#deal with newPassword SecureString
-				If ($PSBoundParameters.ContainsKey("newPassword")) {
+				If ($PSBoundParameters.ContainsKey('newPassword')) {
 
 					#Include decoded password in request
-					$boundParameters["newPassword"] = $(ConvertTo-InsecureString -SecureString $newPassword)
+					$boundParameters['newPassword'] = $(ConvertTo-InsecureString -SecureString $newPassword)
 
 				}
 
 				#Construct Request Body
-				$LogonRequest["Body"] = $boundParameters | ConvertTo-Json
+				$LogonRequest['Body'] = $boundParameters | ConvertTo-Json
 
 				break
 
@@ -403,11 +403,11 @@ function New-PASSession {
 
 		}
 
-		if ($PSCmdlet.ShouldProcess("$BaseURI/$PVWAAppName", "Logon")) {
+		if ($PSCmdlet.ShouldProcess("$BaseURI/$PVWAAppName", 'Logon')) {
 
 			try {
 
-				If ($PSCmdlet.ParameterSetName -eq "Gen2SAML") {
+				If ($PSCmdlet.ParameterSetName -eq 'Gen2SAML') {
 
 					#The only expected parameter should be concurrentSessions
 					$boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove SAMLAuth,
@@ -418,8 +418,8 @@ function New-PASSession {
 					$SAMLResponse = Get-PASSAMLResponse -URL "$baseURI/$PVWAAppName"
 
 					#add required parameters
-					$boundParameters.Add("SAMLResponse", $SAMLResponse)
-					$boundParameters.Add("apiUse", $true)
+					$boundParameters.Add('SAMLResponse', $SAMLResponse)
+					$boundParameters.Add('apiUse', $true)
 
 					#Create Logon URL
 					$LogonString = $boundParameters | ConvertTo-QueryString
@@ -431,7 +431,7 @@ function New-PASSession {
 
 					}
 
-					$LogonRequest["Uri"] = $URI
+					$LogonRequest['Uri'] = $URI
 
 				}
 
@@ -444,15 +444,15 @@ function New-PASSession {
 					#*For IIS Windows auth:
 					#*An object with a username property can be returned if a secondary authentication is required
 
-					If ($PSCmdlet.ParameterSetName -match "Radius$") {
+					If ($PSCmdlet.ParameterSetName -match 'Radius$') {
 
 						#If RADIUS parameters are specified
 						#Prepare RADIUS auth request
-						$LogonRequest["Uri"] = "$baseURI/$PVWAAppName/api/Auth/RADIUS/Logon"
+						$LogonRequest['Uri'] = "$baseURI/$PVWAAppName/api/Auth/RADIUS/Logon"
 
 						#Use WebSession from initial request
-						$LogonRequest.Remove("SessionVariable")
-						$LogonRequest["WebSession"] = $Script:WebSession
+						$LogonRequest.Remove('SessionVariable')
+						$LogonRequest['WebSession'] = $Script:WebSession
 
 						#Submit initial RADIUS auth request
 						$PASSession = Invoke-PASRestMethod @LogonRequest
@@ -463,7 +463,7 @@ function New-PASSession {
 
 			} catch {
 
-				if ($PSItem.FullyQualifiedErrorId -notmatch "ITATS542I") {
+				if ($PSItem.FullyQualifiedErrorId -notmatch 'ITATS542I') {
 
 					#Throw all errors not related to ITATS542I
 					throw $PSItem
@@ -472,42 +472,25 @@ function New-PASSession {
 
 					#ITATS542I is expected for RADIUS Challenge
 
-					#OTP value has not yet been provided.
-					#Initial RADIUS auth attempt will trigger notification of OTP for user to provide.
-					#?"passcode" remains an option for backward compatibility.
-					If ((-not ($PSBoundParameters.ContainsKey("OTP"))) -or ($OTP -match "passcode")) {
+					#Use WebSession from initial request
+					$LogonRequest.Remove('SessionVariable')
+					$LogonRequest['WebSession'] = $Script:WebSession
 
-						#*The message of the exception should contain instructions from the RADIUS server
-						#*containing information the expected OTP value to provide or other available options.
-						If ($($PSItem.Exception.Message)) {
+					#Collect values required to respond to the challenge
+					$RADIUSResponse = @{}
+					$RADIUSResponse['LogonRequest'] = $LogonRequest
+					$RADIUSResponse['Message'] = $($PSItem.Exception.Message)
 
-							$Prompt = $($PSItem.Exception.Message)
+					#Include any OTP value provided in the RADIUS Response
+					If ($PSBoundParameters.ContainsKey('OTP')) {
 
-						} Else {
-
-							#Default value for the Read-Host prompt.
-							$Prompt = "Enter OTP"
-
-						}
-
-						#Prompt user for OTP
-						$OTP = $(Read-Host -Prompt $Prompt)
+						#!If $RadiusChallenge = Password, $OTP will be password value
+						$RADIUSResponse['OTP'] = $OTP
 
 					}
 
-					#$OTP as RADIUS response
-					#!If $RadiusChallenge = Password, $OTP will be password value
-					$boundParameters["password"] = $OTP
-
-					#Construct Request Body
-					$LogonRequest["Body"] = $boundParameters | ConvertTo-Json
-
-					#Use WebSession from initial request
-					$LogonRequest.Remove("SessionVariable")
-					$LogonRequest["WebSession"] = $Script:WebSession
-
 					#Respond to RADIUS challenge
-					$PASSession = Invoke-PASRestMethod @LogonRequest
+					$PASSession = Send-RADIUSResponse @RADIUSResponse
 
 				}
 
@@ -553,10 +536,10 @@ function New-PASSession {
 					Set-Variable -Name BaseURI -Value "$BaseURI/$PVWAAppName" -Scope Script
 
 					#Auth token added to WebSession
-					$Script:WebSession.Headers["Authorization"] = [string]$CyberArkLogonResult
+					$Script:WebSession.Headers['Authorization'] = [string]$CyberArkLogonResult
 
 					#Initial Value for Version variable
-					[System.Version]$Version = "0.0"
+					[System.Version]$Version = '0.0'
 
 					if ( -not ($SkipVersionCheck)) {
 
@@ -566,7 +549,7 @@ function New-PASSession {
 							[System.Version]$Version = Get-PASServer -ErrorAction Stop |
 								Select-Object -ExpandProperty ExternalVersion
 
-						} Catch { [System.Version]$Version = "0.0" }
+						} Catch { [System.Version]$Version = '0.0' }
 
 					}
 

--- a/psPAS/Private/Send-RADIUSResponse.ps1
+++ b/psPAS/Private/Send-RADIUSResponse.ps1
@@ -1,0 +1,98 @@
+Function Send-RADIUSResponse {
+    <#
+    .SYNOPSIS
+    Sends RADIUS challenge response as part of PAS logon process
+
+    .DESCRIPTION
+    psPAS helper function.
+    Sends (RADIUS) logon request to Invoke-PASRestMethod,
+    if response indicates RADIUS challenge, prompts for input.
+
+    .PARAMETER LogonRequest
+    The required parameters for PAS logon as defined in New-PASSession
+
+    .PARAMETER Message
+    An optional message to display as a prompt detailing the RADIUS challenge criteria
+
+    .PARAMETER OTP
+    An optional OTP value to provide as challenge response.
+
+    .EXAMPLE
+    Send-RADIUSResponse -LogonRequest $LogonRequest -Message "Some Message"
+    #>
+    [CmdletBinding()]
+    param(
+        [parameter(
+            Mandatory = $true,
+            ValueFromPipelineByPropertyName = $true)]
+        [hashtable]$LogonRequest,
+
+        [parameter(
+            Mandatory = $false,
+            ValueFromPipelineByPropertyName = $true)]
+        [string]$Message,
+
+        [parameter(
+            Mandatory = $false,
+            ValueFromPipelineByPropertyName = $true)]
+        [string]$OTP
+    )
+
+    Begin {
+
+        #Default value for the Read-Host prompt.
+        $Prompt = 'Enter OTP'
+
+    }
+
+    Process {
+
+        #OTP value has not yet been provided.
+        #Initial RADIUS auth attempt will trigger notification of OTP for user to provide.
+        #?"passcode" remains an option for backward compatibility.
+        If ((-not ($PSBoundParameters.ContainsKey('OTP'))) -or ($PSBoundParameters['OTP'] -match 'passcode')) {
+
+            If ($null -ne $Message) {
+
+                #*The message from the exception containing challenge instructions from the RADIUS server.
+                $Prompt = $Message
+
+            }
+
+            #Prompt user for OTP or Challenge Response
+            $OTP = $(Read-Host -Prompt $Prompt)
+
+        }
+
+        #Construct Request Body with $OTP value as RADIUS response
+        $Body = $LogonRequest['Body'] | ConvertFrom-Json
+        $Body.Password = $OTP
+        $LogonRequest['Body'] = $Body | ConvertTo-Json
+
+        try {
+
+            #Respond to RADIUS challenge
+            Invoke-PASRestMethod @LogonRequest
+
+        } catch {
+
+            if ($PSItem.FullyQualifiedErrorId -notmatch 'ITATS542I') {
+
+                #Throw all errors not related to ITATS542I
+                throw $PSItem
+
+            } Else {
+
+                #ITATS542I indicates further challenge required
+                #pass $LogonRequest and challenge message back into this function
+                Send-RADIUSResponse -LogonRequest $LogonRequest -Message "$($PSItem.Exception.Message)"
+
+            }
+
+        }
+
+    }
+
+    End {}
+
+}


### PR DESCRIPTION
<!-- _A similar PR may already be submitted.
Please search existing `Pull Requests` before creating one._

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.  -->

## Summary

Adds support multiple RADIUS challenge responses.

This PR fixes/implements the following **features**:

When a RADIUS implementation presents a user with multiple sub options at multiple levels, this update presents each challenge back to the user allowing them to respond.

Abstracts code from 'New-PASSession' into new helper function, `Send-RADIUSResponse` , simplifying `try\catch` usage and allowing recursion when a challenge is received.

## Test Plan

Tests updated to mock RADIUS responses featuring multiple challenge responses

## Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes. -->
Fixes #

Closes #339 

<!--
## Code formatting

 See the `CONTRIBUTING` guide.

_Ensure your code adheres to the project's PowerShell Styleguide_
-->