### PR TITLE
Resolving issue #361: Added culture awareness to ConvertTo-UnixTime function

### DIFF
--- a/Tests/ConvertTo-UnixTime.Tests.ps1
+++ b/Tests/ConvertTo-UnixTime.Tests.ps1
@@ -72,6 +72,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
+			It "converts date to expected unixtime in milliseconds, even when locale is not en-US" {
+				$currentCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
+				[System.Threading.Thread]::CurrentThread.CurrentCulture = "nl-NL"
+				ConvertTo-UnixTime -Date $(Get-Date 1/1/2020) -Milliseconds | Should -Be 1577836800000
+				[System.Threading.Thread]::CurrentThread.CurrentCulture = $currentCulture
+			}
+
 		}
 
 	}

--- a/psPAS/Private/ConvertTo-UnixTime.ps1
+++ b/psPAS/Private/ConvertTo-UnixTime.ps1
@@ -28,8 +28,12 @@ Get-Date | ConvertTo-UnixTime
 		)]
 		[switch]$Milliseconds
 	)
+	begin {
+		$currentCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
+	}
+	process {
+		[System.Threading.Thread]::CurrentThread.CurrentCulture = "en-US"
 
-	Process {
 		$UnixTime = [math]::Round($(Get-Date $Date.ToUniversalTime() -UFormat %s))
 
 		If ($Milliseconds) {
@@ -37,5 +41,8 @@ Get-Date | ConvertTo-UnixTime
 		}
 
 		$UnixTime
+	}
+	end {
+		[System.Threading.Thread]::CurrentThread.CurrentCulture = $currentCulture
 	}
 }


### PR DESCRIPTION
## Summary

<!-- Summary of the PR -->

This PR fixes issue #361, where the ConvertTo-UnixTime function provided invalid values to other functions when the culture is not en-US (or that of the PWV API), which are eventually used by Invoke-PASRestMethod.

## Closes issues

Closes #361 
