### PR TITLE
UPDATE Get-PASAccountPassword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
     - (Thanks [liamwh](https://github.com/liamwh)!).
   - `Set-PASUser`
     - Sets `ValueFromPipelinebyPropertyName = $false` for `ExpiryDate` parameter, avoids parameter validation exception when piping object representing user, such as the output from `Get-PASUSer`, into `Set-PASUser`.
+  - `Get-PASAccountPassword`
+    - MachineName parameter changed to `string` type (previously was incorrectly specified as `switch`)
+    - Added `UserName` parameter & `ToPsCredential()` Method to enable return of Credential Object.
+      - (Thanks [zamothh](https://github.com/zamothh))
 
 ## **5.1.21 (June 7th 2021)**
 

--- a/docs/collections/_commands/Get-PASAccountPassword.md
+++ b/docs/collections/_commands/Get-PASAccountPassword.md
@@ -17,12 +17,13 @@ Returns password for an account.
 ### Gen2 (Default)
 ```
 Get-PASAccountPassword -AccountID <String> [-Reason <String>] [-TicketingSystem <String>] [-TicketId <String>]
- [-Version <Int32>] [-ActionType <String>] [-isUse <Boolean>] [-Machine] [<CommonParameters>]
+ [-Version <Int32>] [-ActionType <String>] [-isUse <Boolean>] [-Machine <String>] [-UserName <String>]
+ [<CommonParameters>]
 ```
 
 ### Gen1
 ```
-Get-PASAccountPassword -AccountID <String> [-UseGen1API] [<CommonParameters>]
+Get-PASAccountPassword -AccountID <String> [-UseGen1API] [-UserName <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -186,7 +187,7 @@ The address of the remote machine to connect to.
 Use of parameter requires version 10.1 at a minimum.
 
 ```yaml
-Type: SwitchParameter
+Type: String
 Parameter Sets: Gen2
 Aliases:
 
@@ -209,6 +210,21 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UserName
+UserName value, specified either manually or via input object.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 

--- a/psPAS/Functions/Accounts/Get-PASAccountPassword.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccountPassword.ps1
@@ -1,77 +1,78 @@
 # .ExternalHelp psPAS-help.xml
 function Get-PASAccountPassword {
-	[CmdletBinding(DefaultParameterSetName = "Gen2")]
+	[CmdletBinding(DefaultParameterSetName = 'Gen2')]
 	param(
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
-		[Alias("id")]
+		[Alias('id')]
 		[string]$AccountID,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $false,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
-		[Alias("UseClassicAPI")]
+		[Alias('UseClassicAPI')]
 		[switch]$UseGen1API,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $false,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[string]$Reason,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $false,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[string]$TicketingSystem,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $false,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[string]$TicketId,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $false,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[int]$Version,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $false,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
-		[ValidateSet("show", "copy", "connect")]
+		[ValidateSet('show', 'copy', 'connect')]
 		[string]$ActionType,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $false,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[boolean]$isUse,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $false,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
-		[switch]$Machine,
+		[string]$Machine,
+
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
@@ -88,19 +89,19 @@ function Get-PASAccountPassword {
 		#Build Request
 		switch ($PSCmdlet.ParameterSetName) {
 
-			"Gen2" {
+			'Gen2' {
 
 				Assert-VersionRequirement -RequiredVersion 10.1
 
 				#For Version 10.1+
 				$Request = @{
 
-					"URI"    = "$Script:BaseURI/api/Accounts/$($AccountID | Get-EscapedString)/Password/Retrieve"
+					'URI'    = "$Script:BaseURI/api/Accounts/$($AccountID | Get-EscapedString)/Password/Retrieve"
 
-					"Method" = "POST"
+					'Method' = 'POST'
 
 					#Get all parameters that will be sent in the request
-					"Body"   = $PSBoundParameters | Get-PASParameter -ParametersToRemove AccountID,UserName | ConvertTo-Json
+					'Body'   = $PSBoundParameters | Get-PASParameter -ParametersToRemove AccountID, UserName | ConvertTo-Json
 
 				}
 
@@ -108,14 +109,14 @@ function Get-PASAccountPassword {
 
 			}
 
-			"Gen1" {
+			'Gen1' {
 
 				#For Version 9.7+
 				$Request = @{
 
-					"URI"    = "$Script:BaseURI/WebServices/PIMServices.svc/Accounts/$($AccountID | Get-EscapedString)/Credentials"
+					'URI'    = "$Script:BaseURI/WebServices/PIMServices.svc/Accounts/$($AccountID | Get-EscapedString)/Credentials"
 
-					"Method" = "GET"
+					'Method' = 'GET'
 
 				}
 
@@ -126,7 +127,7 @@ function Get-PASAccountPassword {
 		}
 
 		#Add default Request parameters
-		$Request.Add("WebSession", $Script:WebSession)
+		$Request.Add('WebSession', $Script:WebSession)
 
 		#splat request to web service
 		$result = Invoke-PASRestMethod @Request
@@ -135,7 +136,7 @@ function Get-PASAccountPassword {
 
 			switch ($PSCmdlet.ParameterSetName) {
 
-				"Gen1" {
+				'Gen1' {
 
 					$result = [System.Text.Encoding]::ASCII.GetString([PSCustomObject]$result.Content)
 
@@ -143,10 +144,18 @@ function Get-PASAccountPassword {
 
 				}
 
-				"Gen2" {
+				'Gen2' {
 
 					#Unescape returned string and remove enclosing quotes.
 					$result = $([System.Text.RegularExpressions.Regex]::Unescape($result) -replace '^"|"$', '')
+
+					#Get UserName if parameter value not provided.
+					if ($PSBoundParameters.Keys -notcontains 'UserName') {
+
+						$UserName = Get-PASAccount -id $AccountID -ErrorAction SilentlyContinue |
+							Select-Object -ExpandProperty UserName
+
+					}
 
 					break
 
@@ -155,9 +164,10 @@ function Get-PASAccountPassword {
 			}
 
 			[PSCustomObject]@{
-					"Password" = $result
-					"UserName" = $UserName
+				'Password' = $result
+				'UserName' = $UserName
 			} | Add-ObjectDetail -typename psPAS.CyberArk.Vault.Credential
+
 		}
 
 	}#process

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -11021,17 +11021,19 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
             <maml:para>The address of the remote machine to connect to.</maml:para>
             <maml:para>Use of parameter requires version 10.1 at a minimum.</maml:para>
           </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
-            <maml:name>SwitchParameter</maml:name>
+            <maml:name>String</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-		<command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>UserName</maml:name>
           <maml:description>
-            <maml:para>Per default, will pick the UserName of the InputObject, but a user may specify a UserName if wanted.</maml:para>
+            <maml:para>UserName value, specified either manually or via input object.</maml:para>
           </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -11063,6 +11065,18 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
             <maml:uri />
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>UserName</maml:name>
+          <maml:description>
+            <maml:para>UserName value, specified either manually or via input object.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
       </command:syntaxItem>
     </command:syntax>
@@ -11164,9 +11178,9 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           <maml:para>The address of the remote machine to connect to.</maml:para>
           <maml:para>Use of parameter requires version 10.1 at a minimum.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
-          <maml:name>SwitchParameter</maml:name>
+          <maml:name>String</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
@@ -11182,6 +11196,18 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           <maml:uri />
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>UserName</maml:name>
+        <maml:description>
+          <maml:para>UserName value, specified either manually or via input object.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes />


### PR DESCRIPTION
## Summary

- Fixes assigned type of parameter `MachineName` (was `switch`, now `string`)
- Updates command markdown and external help file with details of updated Syntax & `UserName` Parameter.
- Adds capability to get username via query when no value is assigned against `UserName` parameter.