### PR TITLE
Release 5.1.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Fixes
   - Resolves issue where the `ConvertTo-UnixTime` helper function provided invalid values when the culture was not 'en-US'.
     - (Thanks [liamwh](https://github.com/liamwh)!).
+  - `Set-PASUser`
+    - Sets `ValueFromPipelinebyPropertyName = $false` for `ExpiryDate` parameter, avoids parameter validation exception when piping object representing user, such as the output from `Get-PASUSer`, into `Set-PASUser`.
 
 ## **5.1.21 (June 7th 2021)**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
     - (Thanks [liamwh](https://github.com/liamwh)!).
   - `Set-PASUser`
     - Sets `ValueFromPipelinebyPropertyName = $false` for `ExpiryDate` parameter, avoids parameter validation exception when piping object representing user, such as the output from `Get-PASUSer`, into `Set-PASUser`.
+  - `Get-PASAccountPassword`
+    - MachineName parameter changed to `string` type (previously was incorrectly specified as `switch`)
+    - Added `UserName` parameter & `ToPsCredential()` Method to enable return of Credential Object.
+      - (Thanks [zamothh](https://github.com/zamothh))
 
 ## **5.1.21 (June 7th 2021)**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@
 - Continued development to encompass any new documented features of the CyberArk API.
 - psPAS v6.0...
 
-## *Unreleased*
+## **5.1.37 (June 28th 2021)**
 
-- Fixes
+- Updates
   - Resolves issue where the `ConvertTo-UnixTime` helper function provided invalid values when the culture was not 'en-US'.
     - (Thanks [liamwh](https://github.com/liamwh)!).
   - `Set-PASUser`
@@ -15,7 +15,7 @@
   - `Get-PASAccountPassword`
     - MachineName parameter changed to `string` type (previously was incorrectly specified as `switch`)
     - Added `UserName` parameter & `ToPsCredential()` Method to enable return of Credential Object.
-      - (Thanks [zamothh](https://github.com/zamothh))
+      - (Thanks [zamothh](https://github.com/zamothh)!)
 
 ## **5.1.21 (June 7th 2021)**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 - Continued development to encompass any new documented features of the CyberArk API.
 - psPAS v6.0...
 
+## *Unreleased*
+
+- Fixes
+  - Resolves issue where the `ConvertTo-UnixTime` helper function provided invalid values when the culture was not 'en-US'.
+    - (Thanks [liamwh](https://github.com/liamwh)!).
+
 ## **5.1.21 (June 7th 2021)**
 
 - Updates

--- a/README.md
+++ b/README.md
@@ -662,11 +662,19 @@ Methods present on objects returned from psPAS functions can be leveraged to get
 Get-PASSafe | Where-Object{ ($_.safemembers() | Select-Object -ExpandProperty UserName) -notcontains "AppUser"}
 ```
 
-- Retrieved credentials can be immediately converted into Secure Strings:
+- Retrieved credentials can be immediately converted into Secure Strings or into a PsCredential object:
 
 ```powershell
+#Returns a Secure String 
 (Get-PASAccount -id 330_5 | Get-PASAccountPassword).ToSecureString()
+
+#Returns a PsCredential Object 
+(Get-PASAccount -id 330_5 | Get-PASAccountPassword).ToPsCredential()
+
+#Returns a PsCredential Object with a custom username (to include a domain for example)
+(Get-PASAccount -id 330_5 | Get-PASAccountPassword).ToPsCredential("MyDomain\MyAccount")
 ```
+
 
 ![Logo][Logo]
 

--- a/Tests/ConvertTo-UnixTime.Tests.ps1
+++ b/Tests/ConvertTo-UnixTime.Tests.ps1
@@ -72,6 +72,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
+			It "converts date to expected unixtime in milliseconds, even when locale is not en-US" {
+				$currentCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
+				[System.Threading.Thread]::CurrentThread.CurrentCulture = "nl-NL"
+				ConvertTo-UnixTime -Date $(Get-Date 1/1/2020) -Milliseconds | Should -Be 1577836800000
+				[System.Threading.Thread]::CurrentThread.CurrentCulture = $currentCulture
+			}
+
 		}
 
 	}

--- a/Tests/ConvertTo-UnixTime.Tests.ps1
+++ b/Tests/ConvertTo-UnixTime.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,11 +35,11 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'Date' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -49,32 +49,41 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "General" {
+		Context 'General' {
 
-			It "Converts date from pipeline" {
+			It 'Converts date from pipeline' {
 				$(Get-Date -Year 2020 -Month 01 -Day 01 -Hour 0 -Minute 0 -Second 0 -Millisecond 0) | ConvertTo-UnixTime | Should -Be 1577836800
 			}
 
-			It "Converts date" {
+			It 'Converts date' {
 				$date = $(Get-Date -Year 2020 -Month 01 -Day 01 -Hour 0 -Minute 0 -Second 0 -Millisecond 0)
 				ConvertTo-UnixTime -Date $date | Should -Be 1577836800
 			}
 
-			It "converts date to expected unixtime" {
+			It 'converts date to expected unixtime' {
 
 				ConvertTo-UnixTime -Date $(Get-Date 1/1/2020) | Should -Be 1577836800
 
 			}
 
-			It "converts date to expected unixtime in milliseconds" {
+			It 'converts date to expected unixtime in milliseconds' {
 
 				ConvertTo-UnixTime -Date $(Get-Date 1/1/2020) -Milliseconds | Should -Be 1577836800000
 
 			}
 
-			It "converts date to expected unixtime in milliseconds, even when locale is not en-US" {
+			It 'converts date to expected unixtime in milliseconds, even when locale is not en-US' {
 				$currentCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
-				[System.Threading.Thread]::CurrentThread.CurrentCulture = "nl-NL"
+				[System.Threading.Thread]::CurrentThread.CurrentCulture = 'nl-NL'
+				ConvertTo-UnixTime -Date $(Get-Date 1/1/2020) -Milliseconds | Should -Be 1577836800000
+				[System.Threading.Thread]::CurrentThread.CurrentCulture = $currentCulture
+			}
+
+			It 'converts date to expected unixtime in milliseconds, even when locale is "SomeLocale"' {
+				$currentCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
+				[System.Threading.Thread]::CurrentThread.CurrentCulture = $(Get-Culture -ListAvailable |
+						Select-Object -Index (Get-Random -Maximum $((Get-Culture -ListAvailable).Count)) |
+						Select-Object -ExpandProperty Name)
 				ConvertTo-UnixTime -Date $(Get-Date 1/1/2020) -Milliseconds | Should -Be 1577836800000
 				[System.Threading.Thread]::CurrentThread.CurrentCulture = $currentCulture
 			}

--- a/docs/collections/_commands/Get-PASAccountPassword.md
+++ b/docs/collections/_commands/Get-PASAccountPassword.md
@@ -17,12 +17,13 @@ Returns password for an account.
 ### Gen2 (Default)
 ```
 Get-PASAccountPassword -AccountID <String> [-Reason <String>] [-TicketingSystem <String>] [-TicketId <String>]
- [-Version <Int32>] [-ActionType <String>] [-isUse <Boolean>] [-Machine] [<CommonParameters>]
+ [-Version <Int32>] [-ActionType <String>] [-isUse <Boolean>] [-Machine <String>] [-UserName <String>]
+ [<CommonParameters>]
 ```
 
 ### Gen1
 ```
-Get-PASAccountPassword -AccountID <String> [-UseGen1API] [<CommonParameters>]
+Get-PASAccountPassword -AccountID <String> [-UseGen1API] [-UserName <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -186,7 +187,7 @@ The address of the remote machine to connect to.
 Use of parameter requires version 10.1 at a minimum.
 
 ```yaml
-Type: SwitchParameter
+Type: String
 Parameter Sets: Gen2
 Aliases:
 
@@ -209,6 +210,21 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UserName
+UserName value, specified either manually or via input object.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 

--- a/docs/collections/_commands/Set-PASUser.md
+++ b/docs/collections/_commands/Set-PASUser.md
@@ -317,7 +317,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: True (ByPropertyName)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/psPAS/Functions/Accounts/Get-PASAccountPassword.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccountPassword.ps1
@@ -1,77 +1,78 @@
 # .ExternalHelp psPAS-help.xml
 function Get-PASAccountPassword {
-	[CmdletBinding(DefaultParameterSetName = "Gen2")]
+	[CmdletBinding(DefaultParameterSetName = 'Gen2')]
 	param(
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
-		[Alias("id")]
+		[Alias('id')]
 		[string]$AccountID,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $false,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
-		[Alias("UseClassicAPI")]
+		[Alias('UseClassicAPI')]
 		[switch]$UseGen1API,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $false,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[string]$Reason,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $false,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[string]$TicketingSystem,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $false,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[string]$TicketId,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $false,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[int]$Version,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $false,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
-		[ValidateSet("show", "copy", "connect")]
+		[ValidateSet('show', 'copy', 'connect')]
 		[string]$ActionType,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $false,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[boolean]$isUse,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $false,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
-		[switch]$Machine,
+		[string]$Machine,
+
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
@@ -88,19 +89,19 @@ function Get-PASAccountPassword {
 		#Build Request
 		switch ($PSCmdlet.ParameterSetName) {
 
-			"Gen2" {
+			'Gen2' {
 
 				Assert-VersionRequirement -RequiredVersion 10.1
 
 				#For Version 10.1+
 				$Request = @{
 
-					"URI"    = "$Script:BaseURI/api/Accounts/$($AccountID | Get-EscapedString)/Password/Retrieve"
+					'URI'    = "$Script:BaseURI/api/Accounts/$($AccountID | Get-EscapedString)/Password/Retrieve"
 
-					"Method" = "POST"
+					'Method' = 'POST'
 
 					#Get all parameters that will be sent in the request
-					"Body"   = $PSBoundParameters | Get-PASParameter -ParametersToRemove AccountID,UserName | ConvertTo-Json
+					'Body'   = $PSBoundParameters | Get-PASParameter -ParametersToRemove AccountID, UserName | ConvertTo-Json
 
 				}
 
@@ -108,14 +109,14 @@ function Get-PASAccountPassword {
 
 			}
 
-			"Gen1" {
+			'Gen1' {
 
 				#For Version 9.7+
 				$Request = @{
 
-					"URI"    = "$Script:BaseURI/WebServices/PIMServices.svc/Accounts/$($AccountID | Get-EscapedString)/Credentials"
+					'URI'    = "$Script:BaseURI/WebServices/PIMServices.svc/Accounts/$($AccountID | Get-EscapedString)/Credentials"
 
-					"Method" = "GET"
+					'Method' = 'GET'
 
 				}
 
@@ -126,7 +127,7 @@ function Get-PASAccountPassword {
 		}
 
 		#Add default Request parameters
-		$Request.Add("WebSession", $Script:WebSession)
+		$Request.Add('WebSession', $Script:WebSession)
 
 		#splat request to web service
 		$result = Invoke-PASRestMethod @Request
@@ -135,7 +136,7 @@ function Get-PASAccountPassword {
 
 			switch ($PSCmdlet.ParameterSetName) {
 
-				"Gen1" {
+				'Gen1' {
 
 					$result = [System.Text.Encoding]::ASCII.GetString([PSCustomObject]$result.Content)
 
@@ -143,10 +144,18 @@ function Get-PASAccountPassword {
 
 				}
 
-				"Gen2" {
+				'Gen2' {
 
 					#Unescape returned string and remove enclosing quotes.
 					$result = $([System.Text.RegularExpressions.Regex]::Unescape($result) -replace '^"|"$', '')
+
+					#Get UserName if parameter value not provided.
+					if ($PSBoundParameters.Keys -notcontains 'UserName') {
+
+						$UserName = Get-PASAccount -id $AccountID -ErrorAction SilentlyContinue |
+							Select-Object -ExpandProperty UserName
+
+					}
 
 					break
 
@@ -155,9 +164,10 @@ function Get-PASAccountPassword {
 			}
 
 			[PSCustomObject]@{
-					"Password" = $result
-					"UserName" = $UserName
+				'Password' = $result
+				'UserName' = $UserName
 			} | Add-ObjectDetail -typename psPAS.CyberArk.Vault.Credential
+
 		}
 
 	}#process

--- a/psPAS/Functions/Accounts/Get-PASAccountPassword.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccountPassword.ps1
@@ -71,7 +71,12 @@ function Get-PASAccountPassword {
 			ValueFromPipelinebyPropertyName = $false,
 			ParameterSetName = "Gen2"
 		)]
-		[switch]$Machine
+		[switch]$Machine,
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[String]$UserName
 	)
 
 	BEGIN {
@@ -95,7 +100,7 @@ function Get-PASAccountPassword {
 					"Method" = "POST"
 
 					#Get all parameters that will be sent in the request
-					"Body"   = $PSBoundParameters | Get-PASParameter -ParametersToRemove AccountID | ConvertTo-Json
+					"Body"   = $PSBoundParameters | Get-PASParameter -ParametersToRemove AccountID,UserName | ConvertTo-Json
 
 				}
 
@@ -149,8 +154,10 @@ function Get-PASAccountPassword {
 
 			}
 
-			[PSCustomObject] @{"Password" = $result } | Add-ObjectDetail -typename psPAS.CyberArk.Vault.Credential
-
+			[PSCustomObject]@{
+					"Password" = $result
+					"UserName" = $UserName
+			} | Add-ObjectDetail -typename psPAS.CyberArk.Vault.Credential
 		}
 
 	}#process

--- a/psPAS/Functions/User/Set-PASUser.ps1
+++ b/psPAS/Functions/User/Set-PASUser.ps1
@@ -1,24 +1,24 @@
 ﻿# .ExternalHelp psPAS-help.xml
 function Set-PASUser {
-	[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = "Gen2")]
+	[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'Gen2')]
 	param(
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[int]$id,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[ValidateLength(0, 128)]
 		[string]$username,
@@ -26,140 +26,140 @@ function Set-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[securestring]$NewPassword,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[string]$userType,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[boolean]$suspended,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
-		[ValidateSet("PIMSU", "PSM", "PSMP", "PVWA", "WINCLIENT", "PTA", "PACLI", "NAPI", "XAPI", "HTTPGW",
-			"EVD", "PIMSu", "AIMApp", "CPM", "PVWAApp", "PSMApp", "AppPrv", "AIMApp", "PSMPApp")]
+		[ValidateSet('PIMSU', 'PSM', 'PSMP', 'PVWA', 'WINCLIENT', 'PTA', 'PACLI', 'NAPI', 'XAPI', 'HTTPGW',
+			'EVD', 'PIMSu', 'AIMApp', 'CPM', 'PVWAApp', 'PSMApp', 'AppPrv', 'AIMApp', 'PSMPApp')]
 		[string[]]$unAuthorizedInterfaces,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[boolean]$enableUser,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
-		[ValidateSet("AuthTypePass", "AuthTypeLDAP", "AuthTypeRADIUS")]
+		[ValidateSet('AuthTypePass', 'AuthTypeLDAP', 'AuthTypeRADIUS')]
 		[string[]]$authenticationMethod,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[string]$Email,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[boolean]$ChangePassOnNextLogon,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[boolean]$ChangePasswordOnTheNextLogon,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[boolean]$passwordNeverExpires,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[string]$distinguishedName,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
-		[ValidateSet("AddSafes", "AuditUsers", "AddUpdateUsers", "ResetUsersPasswords", "ActivateUsers",
-			"AddNetworkAreas", "ManageDirectoryMapping", "ManageServerFileCategories", "BackupAllSafes",
-			"RestoreAllSafes")]
+		[ValidateSet('AddSafes', 'AuditUsers', 'AddUpdateUsers', 'ResetUsersPasswords', 'ActivateUsers',
+			'AddNetworkAreas', 'ManageDirectoryMapping', 'ManageServerFileCategories', 'BackupAllSafes',
+			'RestoreAllSafes')]
 		[string[]]$vaultAuthorization,
 
 		[parameter(
 			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ValueFromPipelinebyPropertyName = $false,
+			ParameterSetName = 'Gen2'
 		)]
 		[parameter(
 			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ValueFromPipelinebyPropertyName = $false,
+			ParameterSetName = 'Gen1'
 		)]
 		[datetime]$ExpiryDate,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[string]$UserTypeName,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[boolean]$Disabled,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[string]$Location,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 29)]
 		[string]$workStreet,
@@ -167,7 +167,7 @@ function Set-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 19)]
 		[string]$workCity,
@@ -175,7 +175,7 @@ function Set-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 19)]
 		[string]$workState,
@@ -183,7 +183,7 @@ function Set-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 19)]
 		[string]$workZip,
@@ -191,7 +191,7 @@ function Set-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 19)]
 		[string]$workCountry,
@@ -199,7 +199,7 @@ function Set-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 319)]
 		[string]$homePage,
@@ -207,7 +207,7 @@ function Set-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 319)]
 		[string]$homeEmail,
@@ -216,7 +216,7 @@ function Set-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 319)]
 		[string]$businessEmail,
@@ -224,7 +224,7 @@ function Set-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 319)]
 		[string]$otherEmail,
@@ -232,7 +232,7 @@ function Set-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 24)]
 		[string]$homeNumber,
@@ -240,7 +240,7 @@ function Set-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 24)]
 		[string]$businessNumber,
@@ -248,7 +248,7 @@ function Set-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 24)]
 		[string]$cellularNumber,
@@ -256,7 +256,7 @@ function Set-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 24)]
 		[string]$faxNumber,
@@ -264,7 +264,7 @@ function Set-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 24)]
 		[string]$pagerNumber,
@@ -272,7 +272,7 @@ function Set-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 99)]
 		[string]$description,
@@ -281,12 +281,12 @@ function Set-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[ValidateLength(0, 29)]
 		[string]$FirstName,
@@ -294,7 +294,7 @@ function Set-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 29)]
 		[string]$MiddleName,
@@ -302,12 +302,12 @@ function Set-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[ValidateLength(0, 29)]
 		[string]$LastName,
@@ -315,7 +315,7 @@ function Set-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 29)]
 		[string]$street,
@@ -323,7 +323,7 @@ function Set-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 19)]
 		[string]$city,
@@ -331,7 +331,7 @@ function Set-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 19)]
 		[string]$state,
@@ -339,7 +339,7 @@ function Set-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 19)]
 		[string]$zip,
@@ -347,7 +347,7 @@ function Set-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 19)]
 		[string]$country,
@@ -355,7 +355,7 @@ function Set-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 49)]
 		[string]$title,
@@ -363,7 +363,7 @@ function Set-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 49)]
 		[string]$organization,
@@ -371,7 +371,7 @@ function Set-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 49)]
 		[string]$department,
@@ -379,7 +379,7 @@ function Set-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 49)]
 		[string]$profession,
@@ -387,15 +387,15 @@ function Set-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $false,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
-		[Alias("UseClassicAPI")]
+		[Alias('UseClassicAPI')]
 		[switch]$UseGen1API
 	)
 
 	BEGIN {
 
-		If ($PSCmdlet.ParameterSetName -eq "Gen2") {
+		If ($PSCmdlet.ParameterSetName -eq 'Gen2') {
 
 			Assert-VersionRequirement -RequiredVersion 11.1
 
@@ -410,35 +410,35 @@ function Set-PASUser {
 
 		switch ($PSCmdlet.ParameterSetName) {
 
-			"Gen2" {
+			'Gen2' {
 
 				#Create URL for request
 				$URI = "$Script:BaseURI/api/Users/$id"
 
 				$boundParameters = $boundParameters | Format-PASUserObject
 
-				$TypeName = "psPAS.CyberArk.Vault.User.Extended"
+				$TypeName = 'psPAS.CyberArk.Vault.User.Extended'
 
 				break
 
 			}
 
-			"Gen1" {
+			'Gen1' {
 
-				If ($PSBoundParameters.ContainsKey("ExpiryDate")) {
+				If ($PSBoundParameters.ContainsKey('ExpiryDate')) {
 
 					#Convert ExpiryDate to string in Required format
 					$Date = (Get-Date $ExpiryDate -Format MM/dd/yyyy).ToString()
 
 					#Include date string in request
-					$boundParameters["ExpiryDate"] = $Date
+					$boundParameters['ExpiryDate'] = $Date
 
 				}
 
 				#Create URL for request
 				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)"
 
-				$TypeName = "psPAS.CyberArk.Vault.User"
+				$TypeName = 'psPAS.CyberArk.Vault.User'
 
 				#Prepare Request Body
 				$boundParameters = $boundParameters | Get-PASParameter -ParametersToRemove UserName
@@ -450,17 +450,17 @@ function Set-PASUser {
 		}
 
 		#deal with newPassword SecureString
-		If ($PSBoundParameters.ContainsKey("NewPassword")) {
+		If ($PSBoundParameters.ContainsKey('NewPassword')) {
 
 			#Include decoded password in request
-			$boundParameters["NewPassword"] = $(ConvertTo-InsecureString -SecureString $NewPassword)
+			$boundParameters['NewPassword'] = $(ConvertTo-InsecureString -SecureString $NewPassword)
 
 		}
 
 		#Construct Request Body
 		$body = $boundParameters | ConvertTo-Json -Depth 4
 
-		if ($PSCmdlet.ShouldProcess($UserName, "Update User Properties")) {
+		if ($PSCmdlet.ShouldProcess($UserName, 'Update User Properties')) {
 			#send request to web service
 			$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body -WebSession $Script:WebSession
 

--- a/psPAS/Private/ConvertTo-UnixTime.ps1
+++ b/psPAS/Private/ConvertTo-UnixTime.ps1
@@ -28,8 +28,12 @@ Get-Date | ConvertTo-UnixTime
 		)]
 		[switch]$Milliseconds
 	)
+	begin {
+		$currentCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
+	}
+	process {
+		[System.Threading.Thread]::CurrentThread.CurrentCulture = "en-US"
 
-	Process {
 		$UnixTime = [math]::Round($(Get-Date $Date.ToUniversalTime() -UFormat %s))
 
 		If ($Milliseconds) {
@@ -37,5 +41,8 @@ Get-Date | ConvertTo-UnixTime
 		}
 
 		$UnixTime
+	}
+	end {
+		[System.Threading.Thread]::CurrentThread.CurrentCulture = $currentCulture
 	}
 }

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -11021,17 +11021,19 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
             <maml:para>The address of the remote machine to connect to.</maml:para>
             <maml:para>Use of parameter requires version 10.1 at a minimum.</maml:para>
           </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
-            <maml:name>SwitchParameter</maml:name>
+            <maml:name>String</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-		<command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>UserName</maml:name>
           <maml:description>
-            <maml:para>Per default, will pick the UserName of the InputObject, but a user may specify a UserName if wanted.</maml:para>
+            <maml:para>UserName value, specified either manually or via input object.</maml:para>
           </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
             <maml:uri />
@@ -11063,6 +11065,18 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
             <maml:uri />
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>UserName</maml:name>
+          <maml:description>
+            <maml:para>UserName value, specified either manually or via input object.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
       </command:syntaxItem>
     </command:syntax>
@@ -11164,9 +11178,9 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           <maml:para>The address of the remote machine to connect to.</maml:para>
           <maml:para>Use of parameter requires version 10.1 at a minimum.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
-          <maml:name>SwitchParameter</maml:name>
+          <maml:name>String</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
@@ -11182,6 +11196,18 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           <maml:uri />
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>UserName</maml:name>
+        <maml:description>
+          <maml:para>UserName value, specified either manually or via input object.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes />

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -11027,6 +11027,17 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
+		<command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>UserName</maml:name>
+          <maml:description>
+            <maml:para>Per default, will pick the UserName of the InputObject, but a user may specify a UserName if wanted.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Get-PASAccountPassword</maml:name>

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -31194,7 +31194,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ExpiryDate</maml:name>
           <maml:description>
             <maml:para>Expiry Date to set on account.</maml:para>
@@ -31643,7 +31643,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ExpiryDate</maml:name>
           <maml:description>
             <maml:para>Expiry Date to set on account.</maml:para>
@@ -31948,7 +31948,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>ExpiryDate</maml:name>
         <maml:description>
           <maml:para>Expiry Date to set on account.</maml:para>

--- a/psPAS/xml/psPAS.CyberArk.Vault.Credential.Formats.ps1xml
+++ b/psPAS/xml/psPAS.CyberArk.Vault.Credential.Formats.ps1xml
@@ -9,12 +9,16 @@
 			<TableControl>
 				<TableHeaders>
 					<TableColumnHeader />
+					<TableColumnHeader />
 				</TableHeaders>
 				<TableRowEntries>
 					<TableRowEntry>
 						<TableColumnItems>
 							<TableColumnItem>
 								<PropertyName>Password</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<PropertyName>UserName</PropertyName>
 							</TableColumnItem>
 						</TableColumnItems>
 					</TableRowEntry>

--- a/psPAS/xml/psPAS.CyberArk.Vault.Credential.Type.ps1xml
+++ b/psPAS/xml/psPAS.CyberArk.Vault.Credential.Type.ps1xml
@@ -9,6 +9,14 @@
 					$this | Select-Object -ExpandProperty Password | ConvertTo-SecureString -AsPlainText -Force
 				</Script>
 			</ScriptMethod>
+			<ScriptMethod>
+				<Name>ToPsCredential</Name>
+				<Script>
+					param([string]$UserName)
+					if (!$UserName) { $UserName = $this | Select-Object -ExpandProperty UserName }
+					New-Object System.Management.Automation.PSCredential ($UserName,( $this | Select-Object -ExpandProperty Password | ConvertTo-SecureString -AsPlainText -Force))
+				</Script>
+			</ScriptMethod>
 		</Members>
 	</Type>
 </Types>


### PR DESCRIPTION
## Summary

- `ConvertTo-UnixTime`
  - Resolves issue where the function provided invalid values when the culture was not 'en-US'.
- `Set-PASUser`
  - Sets `ValueFromPipelinebyPropertyName = $false` for `ExpiryDate` parameter, avoids parameter validation exception when piping object representing user, such as the output from `Get-PASUSer`, into `Set-PASUser`.
- `Get-PASAccountPassword`
  - MachineName parameter changed to `string` type (previously was incorrectly specified as `switch`)
  - Added `UserName` parameter & `ToPsCredential()` Method to enable return of Credential Object.

## Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes. -->
Closes #363 

<!--
## Code formatting

 See the `CONTRIBUTING` guide.

_Ensure your code adheres to the project's PowerShell Styleguide_
-->