### PR TITLE
psPAS 5.2.52 Release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-.vscode/surrounding.json
-.vscode/settings.json
+.vscode/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@
   - `Revoke-PASJustInTimeAccess`
     - New API function supported from 12.0 (previously missed)
     - Revokes requested JIT access.
+  - `Clear-PASLinkedAccount`
+    - Unlinks associated Logon/Reconcile/ExtraPass accounts
+  - `Get-PASPlatformSummary`
+    - Returns basic platform system type information
 - Other Updates
   - `Get-PASSafe`
     - Implements Get Individual Safe details using Gen2 API feature of PAS 12.2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
       - New method using `Invoke-PASCPMOperation`
     - `GetDetails()`
       - New method using `Get-PASAccountDetail`
-  - Alias Removeal
+  - Alias Removal
     - Removed alias values for previously depreciated command names
 - New Commands
   - `Get-PASAccountDetail`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,55 @@
 - Continued development to encompass any new documented features of the CyberArk API.
 - psPAS v6.0...
 
-## Unreleased
+## Unreleased **5.2.XX (July XX 2021)**
 
-- Updates
+### Module update to cover all CyberArk 12.2 API features
+
+- Breaking Changes
   - `Request-PASJustInTimeAccess`
     - Command renamed from `Request-PASAdHocAccess` in line with CyberArk feature nomenclature.
+  - `Get-PASSafeMember`
+    - Adds capability to get permissions for individual safe member using the Gen2 API from 12.2 onward.
+    - Addition of `UseGen1API` parameter allows operation against Gen1 API if required.
+  - `Set-PASSafeMember`
+    - Adds Gen2 API capability introduced in 12.2.
+    - Default operation is now via Gen2 API.
+    - Addition of `UseGen1API` parameter allows operation against Gen1 API if required.
+  - `Remove-PASSafeMember`
+    - Adds support for operation against Gen2 API introduced in PAS 12.2
+    - Default operation now requires 12.2
+    - `UseGen1API` parameter added to force operation against Gen1 API for earlier PAS versions.
+  - `Set-PASSafe`
+    - Adds Gen2 API capability introduced in 12.2.
+    - Default operation is now via Gen2 API.
+    - Addition of `UseGen1API` parameter allows operation against Gen1 API if required.
+- New Commands
+  - `Get-PASAccountDetail`
+    - New experimental function developed using unofficial documentation
+  - `Revoke-PASJustInTimeAccess`
+    - New API function supported from 12.0 (previously missed)
+    - Revokes requested JIT access.
+- Other Updates
+  - `Get-PASSafe`
+    - Implements Get Individual Safe details using Gen2 API feature of PAS 12.2.
+    - Adds `UseGen1API` parameter to allow backward compatibility when using the `SafeName` parameter.
+    - Changes depreciation of Gen1 API operations from 12.2 to 12.3.
+  - `Get-PASUser`
+    - New `sort` parameter added, supported from 12.2.
+    - Added ability to filter by UserName using Gen2 API.
+    - Gen1 search by UserName now accessible by also specifying the introduced `UseGen1API` parameter.
+  - `Get-PASGroup`
+    - New `sort` parameter added, supported from 12.2.
+  - `Add-PASGroupMember`
+    - Added version check to prevent use of Gen1 API starting from 12.3 in line with documented plan for API depreciation
+  - `New-PASUser`
+    - Added version check to prevent use of Gen1 API starting from 12.3 in line with documented plan for API depreciation
+  - `Remove-PASUser`
+    - Added version check to prevent use of Gen1 API starting from 12.3 in line with documented plan for API depreciation
+  - `Set-PASUser`
+    - Added version check to prevent use of Gen1 API starting from 12.3 in line with documented plan for API depreciation
+  - `Unblock-PASUser`
+    - Added version check to prevent use of Gen1 API starting from 12.3 in line with documented plan for API depreciation
   - Account Methods updated to apply to account details obtained via Gen2 API calls
     - `VerifyPassword()`
       - Updated method to use `Invoke-PASCPMOperation`
@@ -21,12 +65,6 @@
       - New method using `Get-PASAccountDetail`
   - Alias Removal
     - Removed alias values for previously depreciated command names
-- New Commands
-  - `Get-PASAccountDetail`
-    - New experimental function based off of unofficial documentation
-  - `Revoke-PASJustInTimeAccess`
-    - New API function supported from 12.0 (previously missed)
-    - Revokes requested JIT access.
 
 ## **5.1.44 (July 13th 2021)**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@
 - Continued development to encompass any new documented features of the CyberArk API.
 - psPAS v6.0...
 
+## Unreleased
+
+- Updates
+  - `Request-PASJustInTimeAccess`
+    - Command renamed from `Request-PASAdHocAccess` in line with CyberArk feature nomenclature.
+  - Account Methods updated to apply to account details obtained via Gen2 API calls
+    - `VerifyPassword()`
+      - Updated method to use `Invoke-PASCPMOperation`
+    - `ChangePassword()`
+      - Updated method to use `Invoke-PASCPMOperation`
+    - `ReconcilePassword()`
+      - New method using `Invoke-PASCPMOperation`
+    - `GetDetails()`
+      - New method using `Get-PASAccountDetail`
+  - Alias Removeal
+    - Removed alias values for previously depreciated command names
+- New Commands
+  - `Get-PASAccountDetail`
+    - New experimental function based off of unofficial documentation
+  - `Revoke-PASJustInTimeAccess`
+    - New API function supported from 12.0 (previously missed)
+    - Revokes requested JIT access.
+
 ## **5.1.44 (July 13th 2021)**
 
 - Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Continued development to encompass any new documented features of the CyberArk API.
 - psPAS v6.0...
 
-## Unreleased **5.2.XX (July XX 2021)**
+## **5.2.52 (July 27th 2021)**
 
 ### Module update to cover all CyberArk 12.2 API features
 

--- a/README.md
+++ b/README.md
@@ -883,6 +883,7 @@ Click the below dropdown to view the current list of psPAS functions and their m
 [`Get-PASPTARule`][Get-PASPTARule]                                                       |**10.4**            |List Risky Command rules from PTA
 [`Set-PASPTARemediation`][Set-PASPTARemediation]                                         |**10.4**            |Update automaticresponse config in PTA
 [`Set-PASPTARule`][Set-PASPTARule]                                                       |**10.4**            |Update a Risky Commandrule in PTA
+[`Get-PASAccountDetail`][Get-PASAccountDetail]                                           |**10.4**            |Returns information about accounts.
 [`Get-PASGroup`][Get-PASGroup]                                                           |**10.5**            |Return group information
 [`Remove-PASGroupMember`][Remove-PASGroupMember]                                         |**10.5**            |Remove group members
 [`Set-PASOnboardingRule`][Set-PASOnboardingRule]                                         |**10.5**            |Update Onboarding Rules
@@ -893,7 +894,8 @@ Click the below dropdown to view the current list of psPAS functions and their m
 [`Get-PASPSMRecordingActivity`][Get-PASPSMRecordingActivity]                             |**10.6**            |Get activity details from a PSM Recording.
 [`Get-PASPSMRecordingProperty`][Get-PASPSMRecordingProperty]                             |**10.6**            |Get property details from a PSM Recording.
 [`Export-PASPSMRecording`][Export-PASPSMRecording]                                       |**10.6**            |Save PSM Session Recording to a file.
-[`Request-PASAdHocAccess`][Request-PASAdHocAccess]                                       |**10.6**            |Request temporary access to a server.
+[`Request-PASJustInTimeAccess`][Request-PASJustInTimeAccess]                             |**10.6**            |Request temporary access to a server.
+[`Revoke-PASJustInTimeAccess`][Revoke-PASJustInTimeAccess]                               |**12.0**            |Revoke temporary server access.
 [`Get-PASDirectoryMapping`][Get-PASDirectoryMapping]                                     |**10.7**            |Get details of configured directory mappings.
 [`Set-PASDirectoryMapping`][Set-PASDirectoryMapping]                                     |**10.7**            |Update a configured directory mapping.
 [`Remove-PASDirectory`][Remove-PASDirectory]                                             |**10.7**            |Delete a directory configuration.
@@ -976,6 +978,7 @@ Click the below dropdown to view the current list of psPAS functions and their m
 [Add-PASAccount]:/psPAS/Functions/Accounts/Add-PASAccount.ps1
 [Add-PASPendingAccount]:/psPAS/Functions/Accounts/Add-PASPendingAccount.ps1
 [Get-PASAccount]:/psPAS/Functions/Accounts/Get-PASAccount.ps1
+[Get-PASAccountDetail]:/psPAS/Functions/Accounts/Get-PASAccountDetail.ps1
 [Get-PASAccountActivity]:/psPAS/Functions/Accounts/Get-PASAccountActivity.ps1
 [Get-PASAccountPassword]:/psPAS/Functions/Accounts/Get-PASAccountPassword.ps1
 [Remove-PASAccount]:/psPAS/Functions/Accounts/Remove-PASAccount.ps1
@@ -1050,7 +1053,8 @@ Click the below dropdown to view the current list of psPAS functions and their m
 [Get-PASPSMRecordingActivity]:/psPAS/Functions/Monitoring/Get-PASPSMRecordingActivity.ps1
 [Get-PASPSMRecordingProperty]:/psPAS/Functions/Monitoring/Get-PASPSMRecordingProperty.ps1
 [Export-PASPSMRecording]:/psPAS/Functions/Monitoring/Export-PASPSMRecording.ps1
-[Request-PASAdHocAccess]:/psPAS/Functions/Accounts/Request-PASAdHocAccess.ps1
+[Request-PASJustInTimeAccess]:/psPAS/Functions/Accounts/Request-PASJustInTimeAccess.ps1
+[Revoke-PASJustInTimeAccess]:/psPAS/Functions/Accounts/Revoke-PASJustInTimeAccess.ps1
 [Get-PASDirectoryMapping]:/psPAS/Functions/LDAPDirectories/Get-PASDirectoryMapping.ps1
 [Set-PASDirectoryMapping]:/psPAS/Functions/LDAPDirectories/Set-PASDirectoryMapping.ps1
 [Remove-PASDirectory]:/psPAS/Functions/LDAPDirectories/Remove-PASDirectory.ps1

--- a/README.md
+++ b/README.md
@@ -942,12 +942,14 @@ Click the below dropdown to view the current list of psPAS functions and their m
 [`New-PASPrivateSSHKey`][New-PASPrivateSSHKey]                                           |**12.1**            |Generate MFA caching SSH Keys
 [`Remove-PASPrivateSSHKey`][Remove-PASPrivateSSHKey]                                     |**12.1**            |Delete MFA caching SSH Keys
 [`Set-PASGroup`][Set-PASGroup]                                                           |**12.0**            |Update CyberArk groups
+[`Get-PASPlatformSummary`][Get-PASPlatformSummary]                                       |**12.2**            |Get information on platform system types
 
-[Add-PASOpenIDConnectProvider]:/psPAS/Functions/Authentication/Add-PASOpenIDConnectProvider
-[Get-PASOpenIDConnectProvider]:/psPAS/Functions/Authentication/Get-PASOpenIDConnectProvider
-[Remove-PASOpenIDConnectProvider]:/psPAS/Functions/Authentication/Remove-PASOpenIDConnectProvider
-[Set-PASOpenIDConnectProvider]:/psPAS/Functions/Authentication/Set-PASOpenIDConnectProvider
-[Remove-PASAuthenticationMethod]:/psPAS/Functions/Authentication/Remove-PASAuthenticationMethod
+[Get-PASPlatformSummary]:/psPAS/Functions/Platforms/Get-PASPlatformSummary.ps1
+[Add-PASOpenIDConnectProvider]:/psPAS/Functions/Authentication/Add-PASOpenIDConnectProvider.ps1
+[Get-PASOpenIDConnectProvider]:/psPAS/Functions/Authentication/Get-PASOpenIDConnectProvider.ps1
+[Remove-PASOpenIDConnectProvider]:/psPAS/Functions/Authentication/Remove-PASOpenIDConnectProvider.ps1
+[Set-PASOpenIDConnectProvider]:/psPAS/Functions/Authentication/Set-PASOpenIDConnectProvider.ps1
+[Remove-PASAuthenticationMethod]:/psPAS/Functions/Authentication/Remove-PASAuthenticationMethod.ps1
 [Get-PASDiscoveredAccount]:/psPAS/Functions/Accounts/Get-PASDiscoveredAccount.ps1
 [Start-PASAccountImportJob]:/psPAS/Functions/Accounts/Start-PASAccountImportJob.ps1
 [Get-PASAccountImportJob]:/psPAS/Functions/Accounts/Get-PASAccountImportJob.ps1
@@ -1075,15 +1077,15 @@ Click the below dropdown to view the current list of psPAS functions and their m
 [Enable-PASPlatform]:psPAS/Functions/Platforms/Enable-PASPlatform.ps1
 [Remove-PASPlatform]:psPAS/Functions/Platforms/Remove-PASPlatform.ps1
 [Remove-PASGroup]:psPAS/Functions/User/Remove-PASGroup.ps1
-[Clear-PASDiscoveredAccountList]:/psPAS/Functions/Accounts/Clear-PASDiscoveredAccountList
-[Get-PASAccountPasswordVersion]:/psPAS/Functions/Accounts/Get-PASAccountPasswordVersion
-[New-PASAccountPassword]:/psPAS/Functions/Accounts/New-PASAccountPassword
-[Set-PASLinkedAccount]:/psPAS/Functions/Accounts/Set-PASLinkedAccount
-[Clear-PASLinkedAccount]:/psPAS/Functions/Accounts/Clear-PASLinkedAccount
-[Clear-PASPrivateSSHKey]:/psPAS/Functions/Authentication/Clear-PASPrivateSSHKey
-[New-PASPrivateSSHKey]:/psPAS/Functions/Authentication/New-PASPrivateSSHKey
-[Remove-PASPrivateSSHKey]:/psPAS/Functions/Authentication/Remove-PASPrivateSSHKey
-[Set-PASGroup]:/psPAS/Functions/User/Set-PASGroup
+[Clear-PASDiscoveredAccountList]:/psPAS/Functions/Accounts/Clear-PASDiscoveredAccountList.ps1
+[Get-PASAccountPasswordVersion]:/psPAS/Functions/Accounts/Get-PASAccountPasswordVersion.ps1
+[New-PASAccountPassword]:/psPAS/Functions/Accounts/New-PASAccountPassword.ps1
+[Set-PASLinkedAccount]:/psPAS/Functions/Accounts/Set-PASLinkedAccount.ps1
+[Clear-PASLinkedAccount]:/psPAS/Functions/Accounts/Clear-PASLinkedAccount.ps1
+[Clear-PASPrivateSSHKey]:/psPAS/Functions/Authentication/Clear-PASPrivateSSHKey.ps1
+[New-PASPrivateSSHKey]:/psPAS/Functions/Authentication/New-PASPrivateSSHKey.ps1
+[Remove-PASPrivateSSHKey]:/psPAS/Functions/Authentication/Remove-PASPrivateSSHKey.ps1
+[Set-PASGroup]:/psPAS/Functions/User/Set-PASGroup.ps1
 </details>
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -937,6 +937,7 @@ Click the below dropdown to view the current list of psPAS functions and their m
 [`Get-PASAccountPasswordVersion`][Get-PASAccountPasswordVersion]                         |**12.1**            |Get details of previous password versions
 [`New-PASAccountPassword`][New-PASAccountPassword]                                       |**12.0**            |Generate new password values based on platform policy
 [`Set-PASLinkedAccount`][Set-PASLinkedAccount]                                           |**12.1**            |Associate logon and reconcile accounts
+[`Clear-PASLinkedAccount`][Clear-PASLinkedAccount]                                       |**12.2**            |Clear associated linked accounts
 [`Clear-PASPrivateSSHKey`][Clear-PASPrivateSSHKey]                                       |**12.1**            |Remove all MFA caching SSH Keys
 [`New-PASPrivateSSHKey`][New-PASPrivateSSHKey]                                           |**12.1**            |Generate MFA caching SSH Keys
 [`Remove-PASPrivateSSHKey`][Remove-PASPrivateSSHKey]                                     |**12.1**            |Delete MFA caching SSH Keys
@@ -1078,6 +1079,7 @@ Click the below dropdown to view the current list of psPAS functions and their m
 [Get-PASAccountPasswordVersion]:/psPAS/Functions/Accounts/Get-PASAccountPasswordVersion
 [New-PASAccountPassword]:/psPAS/Functions/Accounts/New-PASAccountPassword
 [Set-PASLinkedAccount]:/psPAS/Functions/Accounts/Set-PASLinkedAccount
+[Clear-PASLinkedAccount]:/psPAS/Functions/Accounts/Clear-PASLinkedAccount
 [Clear-PASPrivateSSHKey]:/psPAS/Functions/Authentication/Clear-PASPrivateSSHKey
 [New-PASPrivateSSHKey]:/psPAS/Functions/Authentication/New-PASPrivateSSHKey
 [Remove-PASPrivateSSHKey]:/psPAS/Functions/Authentication/Remove-PASPrivateSSHKey

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Use PowerShell to manage CyberArk via the PVWA REST API.
 
-Contains all published methods of the API up to CyberArk v12.1.
+Contains all published methods of the API up to CyberArk v12.2.
 
 Docs: [https://pspas.pspete.dev](https://pspas.pspete.dev)
 
@@ -613,7 +613,8 @@ $Role2 = [PSCustomObject]@{
   BackupSafe                             = $false
   ViewAuditLog                           = $true
   ViewSafeMembers                        = $true
-  RequestsAuthorizationLevel             = $false
+  requestsAuthorizationLevel1            = $false
+  requestsAuthorizationLevel2            = $false
   AccessWithoutConfirmation              = $true
   CreateFolders                          = $true
   DeleteFolders                          = $true

--- a/Tests/Clear-PASLinkedAccount.Tests.ps1
+++ b/Tests/Clear-PASLinkedAccount.Tests.ps1
@@ -1,0 +1,93 @@
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
+
+    BeforeAll {
+        #Get Current Directory
+        $Here = Split-Path -Parent $PSCommandPath
+
+        #Assume ModuleName from Repository Root folder
+        $ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+        #Resolve Path to Module Directory
+        $ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+        #Define Path to Module Manifest
+        $ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+        if ( -not (Get-Module -Name $ModuleName -All)) {
+
+            Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+        }
+
+        $Script:RequestBody = $null
+        $Script:BaseURI = 'https://SomeURL/SomeApp'
+        $Script:ExternalVersion = '0.0'
+        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+    }
+
+
+    AfterAll {
+
+        $Script:RequestBody = $null
+
+    }
+
+    InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+        BeforeEach {
+            $Script:ExternalVersion = '0.0'
+
+            Mock Invoke-PASRestMethod -MockWith {
+
+            }
+
+            $response = Clear-PASLinkedAccount -AccountID 12_34 -extraPasswordIndex 2
+
+        }
+
+        Context 'Input' {
+
+            It 'sends request' {
+
+                Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+
+            }
+
+            It 'sends request to expected endpoint' {
+
+                Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+                    $URI -eq "$($Script:BaseURI)/api/Accounts/12_34/LinkAccount/2"
+
+                } -Times 1 -Exactly -Scope It
+
+            }
+
+            It 'uses expected method' {
+
+                Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'DELETE' } -Times 1 -Exactly -Scope It
+
+            }
+
+            It 'throws error if version requirement not met' {
+                $Script:ExternalVersion = '1.0'
+                { $InputObject | Clear-PASLinkedAccount -AccountID 12_34 -extraPasswordIndex 2 } | Should -Throw
+                $Script:ExternalVersion = '0.0'
+            }
+
+        }
+
+        Context 'Output' {
+
+            It 'provides no output' {
+
+                $response | Should -BeNullOrEmpty
+
+            }
+
+        }
+
+    }
+
+}

--- a/Tests/Get-PASAccountDetail.Tests.ps1
+++ b/Tests/Get-PASAccountDetail.Tests.ps1
@@ -1,0 +1,130 @@
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
+
+    BeforeAll {
+        #Get Current Directory
+        $Here = Split-Path -Parent $PSCommandPath
+
+        #Assume ModuleName from Repository Root folder
+        $ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+        #Resolve Path to Module Directory
+        $ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+        #Define Path to Module Manifest
+        $ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+        if ( -not (Get-Module -Name $ModuleName -All)) {
+
+            Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+        }
+
+        $Script:RequestBody = $null
+        $Script:BaseURI = 'https://SomeURL/SomeApp'
+        $Script:ExternalVersion = '0.0'
+        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+    }
+
+
+    AfterAll {
+
+        $Script:RequestBody = $null
+
+    }
+
+    InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+        BeforeEach {
+
+            Mock Invoke-PASRestMethod -MockWith {
+                [pscustomobject]@{
+                    'prop1' = 'val1'
+                    'prop2' = 'val2'
+                    'prop3' = 'val3'
+                    'prop4' = 'val4'
+                    'prop5' = 'val5'
+                    'prop6' = 'val6'
+                    'prop7' = 'val7'
+                    'prop8' = 'val8'
+                    'prop9' = 'val9'
+                }
+            }
+
+            $InputObj = [pscustomobject]@{
+                'AccountID' = '66_6'
+
+            }
+
+            $response = $InputObj | Get-PASAccountDetail -Verbose
+        }
+
+        Context 'Mandatory Parameters' {
+
+            $Parameters = @{Parameter = 'id' }
+
+            It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
+
+                param($Parameter)
+
+                (Get-Command Get-PASAccountDetail).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
+
+            }
+
+
+
+        }
+
+
+
+        Context 'Input' {
+
+            It 'sends request' {
+
+                Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+
+            }
+
+            It 'sends request to expected endpoint' {
+
+                Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+                    $URI -eq "$($Script:BaseURI)/api/ExtendedAccounts/66_6/overview"
+
+                } -Times 1 -Exactly -Scope It
+
+            }
+
+            It 'uses expected method' {
+
+                Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
+
+            }
+
+            It 'sends request with no body' {
+
+                Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
+
+            }
+
+        }
+
+        Context 'Output' {
+
+            It 'provides output' {
+
+                $response | Should -Not -Be null
+
+            }
+
+            It 'has output with expected number of properties' {
+
+                ($response | Get-Member -MemberType NoteProperty).length | Should -Be 9
+
+            }
+
+        }
+
+    }
+
+}

--- a/Tests/Get-PASPlatformSummary.Tests.ps1
+++ b/Tests/Get-PASPlatformSummary.Tests.ps1
@@ -1,0 +1,101 @@
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
+
+    BeforeAll {
+        #Get Current Directory
+        $Here = Split-Path -Parent $PSCommandPath
+
+        #Assume ModuleName from Repository Root folder
+        $ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+        #Resolve Path to Module Directory
+        $ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+        #Define Path to Module Manifest
+        $ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+        if ( -not (Get-Module -Name $ModuleName -All)) {
+
+            Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+        }
+
+        $Script:RequestBody = $null
+        $Script:BaseURI = 'https://SomeURL/SomeApp'
+        $Script:ExternalVersion = '0.0'
+        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+    }
+
+
+    AfterAll {
+
+        $Script:RequestBody = $null
+
+    }
+
+    InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+        BeforeEach {
+            Mock Invoke-PASRestMethod -MockWith {
+                @{'SystemTypes' = [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' } }
+            }
+
+            $response = Get-PASPlatformSummary
+        }
+        Context 'Input' {
+
+            It 'sends request' {
+
+                Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+
+            }
+
+            It 'sends request to expected endpoint' {
+
+                Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+                    $URI -eq "$($Script:BaseURI)/API/Platforms/Targets/SystemTypes"
+
+                } -Times 1 -Exactly -Scope It
+
+            }
+
+            It 'uses expected method' {
+
+                Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
+
+            }
+
+            It 'sends request with no body' {
+
+                Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
+
+            }
+
+            It 'throws error if version requirement not met' {
+                $Script:ExternalVersion = '1.0'
+                { Get-PASPlatformSummary } | Should -Throw
+                $Script:ExternalVersion = '0.0'
+            }
+
+        }
+
+        Context 'Output' {
+
+            It 'provides output' {
+
+                $response | Should -Not -BeNullOrEmpty
+
+            }
+
+            It 'has output with expected number of properties' {
+
+                ($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
+
+            }
+
+        }
+
+    }
+
+}

--- a/Tests/Get-PASSafeMember.Tests.ps1
+++ b/Tests/Get-PASSafeMember.Tests.ps1
@@ -68,7 +68,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'sends request to expected endpoint' {
 
-				$response = $InputObj | Get-PASSafeMember -MemberName SomeMember
+				$response = $InputObj | Get-PASSafeMember -MemberName SomeMember -UseGen1API
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -86,16 +86,16 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'uses expected PUT method' {
 
-				$response = Get-PASSafeMember -SafeName SomeSafe -MemberName SomeMember
+				$response = Get-PASSafeMember -SafeName SomeSafe -MemberName SomeMember -UseGen1API
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PUT' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It 'throws for PUT method if version exceeds 12.2' {
+			It 'throws for PUT method if version exceeds 12.3' {
 
-				$Script:ExternalVersion = '12.3'
-				{ Get-PASSafeMember -SafeName SomeSafe -MemberName SomeMember } | Should -Throw
+				$Script:ExternalVersion = '12.4'
+				{ Get-PASSafeMember -SafeName SomeSafe -MemberName SomeMember -UseGen1API } | Should -Throw
 				$Script:ExternalVersion = '0.0'
 
 			}
@@ -139,8 +139,22 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			}
 
+			It 'sends request to expected endpoint' {
+
+				Get-PASSafeMember -SafeName SomeSafe -MemberName SomeMember
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/api/Safes/SomeSafe/Members/SomeMember"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
 			It 'sends expected query' {
+
 				Get-PASSafeMember -SafeName SomeSafe -search SomeMember -memberType user
+
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					($URI -eq "$($Script:BaseURI)/api/Safes/SomeSafe/Members?filter=memberType%20eq%20user&search=SomeMember") -or
@@ -170,6 +184,12 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			It 'throws error if version 12.1 requirement not met' {
 				$Script:ExternalVersion = '12.0'
 				{ Get-PASSafeMember -SafeName SomeSafe -search SomeMember } | Should -Throw
+				$Script:ExternalVersion = '0.0'
+			}
+
+			It 'throws error if version 12.2 requirement not met' {
+				$Script:ExternalVersion = '12.0'
+				{ Get-PASSafeMember -SafeName SomeSafe -MemberName SomeMember } | Should -Throw
 				$Script:ExternalVersion = '0.0'
 			}
 
@@ -294,7 +314,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				}
 
-				$response = $InputObj | Get-PASSafeMember -MemberName SomeMember
+				$response = $InputObj | Get-PASSafeMember -MemberName SomeMember -UseGen1API
 
 				$response.UserName | Should -Be 'SomeMember'
 

--- a/Tests/Get-PASUser.Tests.ps1
+++ b/Tests/Get-PASUser.Tests.ps1
@@ -35,20 +35,6 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context 'Mandatory Parameters' {
-
-			$Parameters = @{Parameter = 'UserName' }
-
-			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
-
-				param($Parameter)
-
-				(Get-Command Get-PASUser).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
-
-			}
-
-		}
-
 		Context 'Input' {
 
 			BeforeEach {
@@ -79,6 +65,8 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'sends request to expected endpoint' {
+
+				$response = $InputObj | Get-PASUser -UseGen1API
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -143,7 +131,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'throws error if version 12.1 requirement not met' {
 				$Script:ExternalVersion = '1.0'
-				{ Get-PASUser -id 123 -extendedDetails $true } | Should -Throw
+				{ Get-PASUser -id 123 -ExtendedDetails $true } | Should -Throw
 				$Script:ExternalVersion = '0.0'
 			}
 
@@ -185,6 +173,8 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'outputs object with expected typename' {
 
+				$response = $InputObj | Get-PASUser -UseGen1API
+
 				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.User
 
 			}
@@ -200,8 +190,6 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.User.Extended
 
 			}
-
-
 
 		}
 

--- a/Tests/Remove-PASSafe.Tests.ps1
+++ b/Tests/Remove-PASSafe.Tests.ps1
@@ -99,7 +99,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			It 'throws if version exceeds 12.2' {
 
 				$Script:ExternalVersion = '12.3'
-				{ Get-PASSafe -SafeName SomeSafe } | Should -Throw
+				{ Get-PASSafe -SafeName SomeSafe -UseGen1API } | Should -Throw
 				$Script:ExternalVersion = '0.0'
 
 			}

--- a/Tests/Remove-PASSafeMember.Tests.ps1
+++ b/Tests/Remove-PASSafeMember.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,25 +35,25 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
+
+			}
+
+			$InputObj = [pscustomobject]@{
+				'MemberName' = 'SomeUser'
+				'SafeName'   = 'SomeSafe'
+
+			}
+
 
 		}
+		Context 'Mandatory Parameters' {
 
-		$InputObj = [pscustomobject]@{
-			"MemberName"   = "SomeUser"
-			"SafeName"     = "SomeSafe"
+			$Parameters = @{Parameter = 'MemberName' },
+			@{Parameter = 'SafeName' }
 
-		}
-
-			$response = $InputObj | Remove-PASSafeMember
-}
-		Context "Mandatory Parameters" {
-
-			$Parameters = @{Parameter = 'MemberName'},
-			@{Parameter = 'SafeName'}
-
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -63,17 +63,59 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
+		Context 'Input-Gen2' {
 
+			BeforeEach {
 
-		Context "Input" {
+				$response = $InputObj | Remove-PASSafeMember
 
-			It "sends request" {
+			}
+
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/api/Safes/SomeSafe/members/SomeUser"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'uses expected method' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'DELETE' } -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'sends request with no body' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
+
+			}
+
+		}
+
+		Context 'Input-Gen1' {
+
+			BeforeEach {
+
+				$response = $InputObj | Remove-PASSafeMember -UseGen1API
+
+			}
+
+			It 'sends request' {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -83,23 +125,45 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output-Gen1' {
 
-			it "provides no output" {
+			BeforeEach {
+
+				$response = $InputObj | Remove-PASSafeMember -UseGen1API
+
+			}
+
+			It 'provides no output' {
+
+				$response | Should -BeNullOrEmpty
+
+			}
+
+		}
+
+		Context 'Output-Gen2' {
+
+			BeforeEach {
+
+				$response = $InputObj | Remove-PASSafeMember
+
+			}
+
+			It 'provides no output' {
 
 				$response | Should -BeNullOrEmpty
 

--- a/Tests/Request-PASJustInTimeAccess.Tests.ps1
+++ b/Tests/Request-PASJustInTimeAccess.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,28 +35,28 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
+
+			}
+
+			$InputObj = [pscustomobject]@{
+				'AccountID' = '22_2'
+
+			}
+
+			$response = $InputObj | Revoke-PASJustInTimeAccess
 
 		}
+		Context 'Mandatory Parameters' {
 
-		$InputObj = [pscustomobject]@{
-"AccountID"    = "22_2"
+			$Parameters = @{Parameter = 'AccountID' }
 
-		}
-
-			$response = $InputObj | Request-PASAdHocAccess
-
-}
-		Context "Mandatory Parameters" {
-
-			$Parameters = @{Parameter = 'AccountID'}
-
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
-				(Get-Command Request-PASAdHocAccess).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
+				(Get-Command Revoke-PASJustInTimeAccess).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
@@ -64,41 +64,41 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Accounts/22_2/grantAdministrativeAccess"
+					$URI -eq "$($Script:BaseURI)/API/Accounts/22_2/RevokeAdministrativeAccess"
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides no output" {
+			It 'provides no output' {
 
 				$response | Should -BeNullOrEmpty
 

--- a/Tests/Revoke-PASJustInTimeAccess.Tests.ps1
+++ b/Tests/Revoke-PASJustInTimeAccess.Tests.ps1
@@ -1,0 +1,111 @@
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
+
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
+
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+		if ( -not (Get-Module -Name $ModuleName -All)) {
+
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+		}
+
+		$Script:RequestBody = $null
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
+		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+	}
+
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
+
+			}
+
+			$InputObj = [pscustomobject]@{
+				'AccountID' = '22_2'
+
+			}
+
+			$response = $InputObj | Revoke-PASJustInTimeAccess
+
+		}
+		Context 'Mandatory Parameters' {
+
+			$Parameters = @{Parameter = 'AccountID' }
+
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
+
+				param($Parameter)
+
+				(Get-Command Revoke-PASJustInTimeAccess).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
+
+			}
+
+		}
+
+
+
+		Context 'Input' {
+
+			It 'sends request' {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'sends request to expected endpoint' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/API/Accounts/22_2/RevokeAdministrativeAccess"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'uses expected method' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'sends request with no body' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
+
+			}
+
+		}
+
+		Context 'Output' {
+
+			It 'provides no output' {
+
+				$response | Should -BeNullOrEmpty
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Set-PASSafe.Tests.ps1
+++ b/Tests/Set-PASSafe.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,24 +35,11 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
-			[PSCustomObject]@{"UpdateSafeResult" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2"}}
-		}
+		Context 'Mandatory Parameters' {
 
-		$InputObj = [pscustomobject]@{
-			"SafeName"     = "SomeName"
+			$Parameters = @{Parameter = 'SafeName' }
 
-		}
-
-			$response = $InputObj | Set-PASSafe -NumberOfDaysRetention 1 -ManagingCPM SomeCPM -NewSafeName SomeNewName
-
-}
-		Context "Mandatory Parameters" {
-
-			$Parameters = @{Parameter = 'SafeName'}
-
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -64,15 +51,29 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input-Gen1' {
 
-			It "sends request" {
+			BeforeEach {
+				Mock Invoke-PASRestMethod -MockWith {
+					[PSCustomObject]@{'UpdateSafeResult' = [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' } }
+				}
+
+				$InputObj = [pscustomobject]@{
+					'SafeName' = 'SomeName'
+
+				}
+
+				$response = $InputObj | Set-PASSafe -NumberOfDaysRetention 1 -ManagingCPM SomeCPM -NewSafeName SomeNewName -UseGen1API
+
+			}
+
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -82,13 +83,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'PUT' } -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PUT' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -100,7 +101,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected number of properties" {
+			It 'has a request body with expected number of properties' {
 
 				($Script:RequestBody.safe | Get-Member -MemberType NoteProperty).length | Should -Be 3
 
@@ -108,23 +109,133 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Output" {
+		Context 'Input-Gen2' {
 
-			it "provides output" {
+			BeforeEach {
+				Mock Invoke-PASRestMethod -MockWith {
+					[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
+				}
+
+				$InputObj = [pscustomobject]@{
+					'SafeName' = 'SomeName'
+
+				}
+
+				$response = $InputObj | Set-PASSafe -NumberOfDaysRetention 1 -ManagingCPM SomeCPM -NewSafeName SomeNewName
+
+			}
+
+			It 'sends request' {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'sends request to expected endpoint' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/api/Safes/SomeName"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'uses expected method' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PUT' } -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'sends request with expected body' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					$Script:RequestBody -ne $null
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'has a request body with expected number of properties' {
+
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 3
+
+			}
+
+		}
+
+		Context 'Output-Gen1' {
+
+			BeforeEach {
+				Mock Invoke-PASRestMethod -MockWith {
+					[PSCustomObject]@{'UpdateSafeResult' = [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' } }
+				}
+
+				$InputObj = [pscustomobject]@{
+					'SafeName' = 'SomeName'
+
+				}
+
+				$response = $InputObj | Set-PASSafe -NumberOfDaysRetention 1 -ManagingCPM SomeCPM -NewSafeName SomeNewName -UseGen1API
+
+			}
+
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Safe
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Safe
+
+			}
+
+
+
+		}
+
+		Context 'Output-Gen2' {
+
+			BeforeEach {
+				Mock Invoke-PASRestMethod -MockWith {
+					[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
+				}
+
+				$InputObj = [pscustomobject]@{
+					'SafeName' = 'SomeName'
+
+				}
+
+				$response = $InputObj | Set-PASSafe -NumberOfDaysRetention 1 -ManagingCPM SomeCPM -NewSafeName SomeNewName
+
+			}
+
+			It 'provides output' {
+
+				$response | Should -Not -BeNullOrEmpty
+
+			}
+
+			It 'has output with expected number of properties' {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
+
+			}
+
+			It 'outputs object with expected typename' {
+
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Safe.Gen2
 
 			}
 

--- a/Tests/Set-PASSafeMember.Tests.ps1
+++ b/Tests/Set-PASSafeMember.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,83 +35,12 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
-			[PSCustomObject]@{
-				"member" = [PSCustomObject]@{
-					"MembershipExpirationDate" = "31/12/2018"
-					"Permissions" = @(
-						[pscustomobject]@{
-							"Key"   = "Key1"
-							"Value" = $true
-						},
-						[pscustomobject]@{
-							"Key"   = "Key2"
-							"Value" = $true
-						},
-						[pscustomobject]@{
-							"Key"   = "TrueKey"
-							"Value" = $true
-						},
-						[pscustomobject]@{
-							"Key"   = "FalseKey"
-							"Value" = $false
-						},
-						[pscustomobject]@{
-							"Key"   = "AnotherKey"
-							"Value" = $true
-						},
-						[pscustomobject]@{
-							"Key"   = "AnotherFalseKey"
-							"Value" = $false
-						}
-						[pscustomobject]@{
-							"Key"   = "IntegerKey"
-							"Value" = 1
-						}
-
-					)
-				}
-			}
-
-		}
-
-		$InputObj = [pscustomobject]@{
-			"SafeName"                               = "SomeSafe"
-			"MemberName"                             = "SomeUser"
-			"UseAccounts"                            = $true
-			"RetrieveAccounts"                       = $true
-			"ListAccounts"                           = $true
-			"AddAccounts"                            = $false
-			"UpdateAccountContent"                   = $false
-			"UpdateAccountProperties"                = $false
-			"InitiateCPMAccountManagementOperations" = $true
-			"SpecifyNextAccountContent"              = $false
-			"RenameAccounts"                         = $false
-			"DeleteAccounts"                         = $false
-			"UnlockAccounts"                         = $true
-			"ManageSafe"                             = $false
-			"ManageSafeMembers"                      = $false
-			"BackupSafe"                             = $false
-			"ViewAuditLog"                           = $true
-			"ViewSafeMembers"                        = $true
-			"RequestsAuthorizationLevel"             = 1
-			"AccessWithoutConfirmation"              = $false
-			"CreateFolders"                          = $false
-			"DeleteFolders"                          = $false
-			"MoveAccountsAndFolders"                 = $false
-
-
-		}
-
-			$response = $InputObj | Set-PASSafeMember -MembershipExpirationDate 12/31/18
-}
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'SafeName' },
 			@{Parameter = 'MemberName' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -123,15 +52,49 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Gen1 Input' {
 
-			It "sends request" {
+			BeforeEach {
+				Mock Invoke-PASRestMethod -MockWith {}
+
+				$InputObj = [pscustomobject]@{
+					'SafeName'                               = 'SomeSafe'
+					'MemberName'                             = 'SomeUser'
+					'UseAccounts'                            = $true
+					'RetrieveAccounts'                       = $true
+					'ListAccounts'                           = $true
+					'AddAccounts'                            = $false
+					'UpdateAccountContent'                   = $false
+					'UpdateAccountProperties'                = $false
+					'InitiateCPMAccountManagementOperations' = $true
+					'SpecifyNextAccountContent'              = $false
+					'RenameAccounts'                         = $false
+					'DeleteAccounts'                         = $false
+					'UnlockAccounts'                         = $true
+					'ManageSafe'                             = $false
+					'ManageSafeMembers'                      = $false
+					'BackupSafe'                             = $false
+					'ViewAuditLog'                           = $true
+					'ViewSafeMembers'                        = $true
+					'RequestsAuthorizationLevel'             = 1
+					'AccessWithoutConfirmation'              = $false
+					'CreateFolders'                          = $false
+					'DeleteFolders'                          = $false
+					'MoveAccountsAndFolders'                 = $false
+
+
+				}
+
+				$response = $InputObj | Set-PASSafeMember -MembershipExpirationDate 12/31/18 -UseGen1API
+			}
+
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -141,19 +104,19 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PUT' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws if invalid date pattern specified" {
+			It 'throws if invalid date pattern specified' {
 
-				{ $InputObj | Set-PASSafeMember -MembershipExpirationDate "31/12/18" } | Should -Throw
+				{ $InputObj | Set-PASSafeMember -MembershipExpirationDate '31/12/18' } | Should -Throw
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -165,13 +128,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected number of properties" {
+			It 'has a request body with expected number of properties' {
 
 				($Script:RequestBody.member | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
-			It "has expected number of nested properties" {
+			It 'has expected number of nested properties' {
 
 				($Script:RequestBody.member.permissions).Count | Should -Be 21
 
@@ -179,66 +142,321 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Output" {
+		Context 'Gen2 Input' {
 
-			it "provides output" {
+			BeforeEach {
+				Mock Invoke-PASRestMethod -MockWith {}
+
+				$InputObj = [pscustomobject]@{
+					'SafeName'                               = 'SomeSafe'
+					'MemberName'                             = 'SomeUser'
+					'UseAccounts'                            = $true
+					'RetrieveAccounts'                       = $true
+					'ListAccounts'                           = $true
+					'AddAccounts'                            = $false
+					'UpdateAccountContent'                   = $false
+					'UpdateAccountProperties'                = $false
+					'InitiateCPMAccountManagementOperations' = $true
+					'SpecifyNextAccountContent'              = $false
+					'RenameAccounts'                         = $false
+					'DeleteAccounts'                         = $false
+					'UnlockAccounts'                         = $true
+					'ManageSafe'                             = $false
+					'ManageSafeMembers'                      = $false
+					'BackupSafe'                             = $false
+					'ViewAuditLog'                           = $true
+					'ViewSafeMembers'                        = $true
+					'AccessWithoutConfirmation'              = $false
+					'CreateFolders'                          = $false
+					'DeleteFolders'                          = $false
+					'MoveAccountsAndFolders'                 = $false
+					'requestsAuthorizationLevel1'            = $true
+				}
+
+				$response = $InputObj | Set-PASSafeMember -MembershipExpirationDate 12/31/18
+			}
+
+			It 'sends request' {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'sends request to expected endpoint' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/api/Safes/SomeSafe/Members/SomeUser"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'uses expected method' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PUT' } -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'sends request with expected body' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody) -ne $null
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'has a request body with expected number of properties' {
+
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 2
+
+			}
+
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '12.1'
+				{ $InputObj | Set-PASSafeMember } | Should -Throw
+				$Script:ExternalVersion = '0.0'
+			}
+
+		}
+
+		Context 'Gen1 Output' {
+
+			BeforeEach {
+				Mock Invoke-PASRestMethod -MockWith {
+					[PSCustomObject]@{
+						'member' = [PSCustomObject]@{
+							'MembershipExpirationDate' = '31/12/2018'
+							'Permissions'              = @(
+								[pscustomobject]@{
+									'Key'   = 'Key1'
+									'Value' = $true
+								},
+								[pscustomobject]@{
+									'Key'   = 'Key2'
+									'Value' = $true
+								},
+								[pscustomobject]@{
+									'Key'   = 'TrueKey'
+									'Value' = $true
+								},
+								[pscustomobject]@{
+									'Key'   = 'FalseKey'
+									'Value' = $false
+								},
+								[pscustomobject]@{
+									'Key'   = 'AnotherKey'
+									'Value' = $true
+								},
+								[pscustomobject]@{
+									'Key'   = 'AnotherFalseKey'
+									'Value' = $false
+								}
+								[pscustomobject]@{
+									'Key'   = 'IntegerKey'
+									'Value' = 1
+								}
+
+							)
+						}
+					}
+
+				}
+
+				$InputObj = [pscustomobject]@{
+					'SafeName'                               = 'SomeSafe'
+					'MemberName'                             = 'SomeUser'
+					'UseAccounts'                            = $true
+					'RetrieveAccounts'                       = $true
+					'ListAccounts'                           = $true
+					'AddAccounts'                            = $false
+					'UpdateAccountContent'                   = $false
+					'UpdateAccountProperties'                = $false
+					'InitiateCPMAccountManagementOperations' = $true
+					'SpecifyNextAccountContent'              = $false
+					'RenameAccounts'                         = $false
+					'DeleteAccounts'                         = $false
+					'UnlockAccounts'                         = $true
+					'ManageSafe'                             = $false
+					'ManageSafeMembers'                      = $false
+					'BackupSafe'                             = $false
+					'ViewAuditLog'                           = $true
+					'ViewSafeMembers'                        = $true
+					'RequestsAuthorizationLevel'             = 1
+					'AccessWithoutConfirmation'              = $false
+					'CreateFolders'                          = $false
+					'DeleteFolders'                          = $false
+					'MoveAccountsAndFolders'                 = $false
+
+
+				}
+
+				$response = $InputObj | Set-PASSafeMember -MembershipExpirationDate 12/31/18 -UseGen1API
+			}
+
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 4
 
 			}
 
-			It "has expected number of nested permission properties" {
+			It 'has expected number of nested permission properties' {
 
 				($response.permissions | Get-Member -MemberType NoteProperty).count | Should -Be 7
 
 			}
 
-			It "has expected boolean false property value" {
+			It 'has expected boolean false property value' {
 
 				$response.permissions.FalseKey | Should -Be $False
 
 
 			}
 
-			It "has expected boolean true property value" {
+			It 'has expected boolean true property value' {
 
 
 				$response.permissions.TrueKey | Should -Be $True
 
 			}
 
-			It "has expected integer property value" {
+			It 'has expected integer property value' {
 
 
 				$response.permissions.IntegerKey | Should -Be 1
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Safe.Member
-
-			}
-
-			it "outputs object with expected safename property" {
-
-				$response.SafeName | Should -Be "SomeSafe"
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Safe.Member
 
 			}
 
-			it "outputs object with expected username property" {
+			It 'outputs object with expected safename property' {
 
-				$response.UserName | Should -Be "SomeUser"
+				$response.SafeName | Should -Be 'SomeSafe'
 
 			}
 
+			It 'outputs object with expected username property' {
 
+				$response.UserName | Should -Be 'SomeUser'
+
+			}
+
+		}
+
+		Context 'Gen2 Output' {
+
+			BeforeEach {
+
+				Mock Invoke-PASRestMethod -MockWith {
+					[PSCustomObject]@{
+						'MemberName'               = 'SomeMember'
+						'MembershipExpirationDate' = '1/1/1970'
+						'SearchIn'                 = 'SomePlace'
+						'Permissions'              = [pscustomobject]@{
+							'Key1'            = 'Value1'
+							'Key2'            = 'Value2'
+							'TrueKey'         = 'true'
+							'FalseKey'        = $false
+							'AnotherKey'      = 'AnotherValue'
+							'AnotherFalseKey' = $false
+							'IntegerKey'      = 1
+						}
+
+					}
+
+				}
+
+				$InputObj = [pscustomobject]@{
+					'SafeName'                               = 'SomeSafe'
+					'MemberName'                             = 'SomeUser'
+					'UseAccounts'                            = $true
+					'RetrieveAccounts'                       = $true
+					'ListAccounts'                           = $true
+					'AddAccounts'                            = $false
+					'UpdateAccountContent'                   = $false
+					'UpdateAccountProperties'                = $false
+					'InitiateCPMAccountManagementOperations' = $true
+					'SpecifyNextAccountContent'              = $false
+					'RenameAccounts'                         = $false
+					'DeleteAccounts'                         = $false
+					'UnlockAccounts'                         = $true
+					'ManageSafe'                             = $false
+					'ManageSafeMembers'                      = $false
+					'BackupSafe'                             = $false
+					'ViewAuditLog'                           = $true
+					'ViewSafeMembers'                        = $true
+					'AccessWithoutConfirmation'              = $false
+					'CreateFolders'                          = $false
+					'DeleteFolders'                          = $false
+					'MoveAccountsAndFolders'                 = $false
+					'requestsAuthorizationLevel1'            = $true
+
+
+
+				}
+
+				$response = $InputObj | Set-PASSafeMember -MembershipExpirationDate '12/31/18'
+
+			}
+
+			It 'provides output' {
+
+				$response | Should -Not -BeNullOrEmpty
+
+			}
+
+			It 'has output with expected number of properties' {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 5
+
+			}
+
+			It 'has expected number of nested permission properties' {
+
+				($response.permissions | Get-Member -MemberType NoteProperty).count | Should -Be 7
+
+			}
+
+			It 'has expected boolean false property value' {
+
+				$response.permissions.FalseKey | Should -Be $False
+
+
+			}
+
+			It 'has expected boolean true property value' {
+
+
+				$response.permissions.TrueKey | Should -Be $True
+
+			}
+
+			It 'has expected integer property value' {
+
+
+				$response.permissions.IntegerKey | Should -Be 1
+
+			}
+
+			It 'outputs object with expected typename' {
+
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Safe.Member.Gen2
+
+			}
 
 		}
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # version format
-version: 5.1.{build}
+version: 5.2.{build}
 
 environment:
   #GIT_TRACE: 1

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -121,6 +121,8 @@ commands:
         url: /commands/New-PASAccountPassword
       - title: "Set-PASLinkedAccount"
         url: /commands/Set-PASLinkedAccount
+      - title: "Clear-PASLinkedAccount"
+        url: /commands/Clear-PASLinkedAccount
 
   - title: "Applications"
     children:

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -97,6 +97,8 @@ commands:
         url: /commands/Invoke-PASCPMOperation
       - title: "Request-PASJustInTimeAccess"
         url: /commands/Request-PASJustInTimeAccess
+      - title: "Revoke-PASJustInTimeAccess"
+        url: /commands/Revoke-PASJustInTimeAccess
       - title: "Enable-PASCPMAutoManagement"
         url: /commands/Enable-PASCPMAutoManagement
       - title: "Disable-PASCPMAutoManagement"

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -253,6 +253,8 @@ commands:
         url: /commands/Get-PASPlatformPSMConfig
       - title: "Set-PASPlatformPSMConfig"
         url: /commands/Set-PASPlatformPSMConfig
+      - title: "Get-PASPlatformSummary"
+        url: /commands/Get-PASPlatformSummary
 
   - title: "Policy ACL"
     children:

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -77,6 +77,8 @@ commands:
         url: /commands/Add-PASAccount
       - title: "Get-PASAccount"
         url: /commands/Get-PASAccount
+      - title: "Get-PASAccountDetail"
+        url: /commands/Get-PASAccountDetail
       - title: "Remove-PASAccount"
         url: /commands/Remove-PASAccount
       - title: "Set-PASAccount"
@@ -93,8 +95,8 @@ commands:
         url: /commands/Add-PASPendingAccount
       - title: "Invoke-PASCPMOperation"
         url: /commands/Invoke-PASCPMOperation
-      - title: "Request-PASAdHocAccess"
-        url: /commands/Request-PASAdHocAccess
+      - title: "Request-PASJustInTimeAccess"
+        url: /commands/Request-PASJustInTimeAccess
       - title: "Enable-PASCPMAutoManagement"
         url: /commands/Enable-PASCPMAutoManagement
       - title: "Disable-PASCPMAutoManagement"

--- a/docs/collections/_commands/Clear-PASLinkedAccount.md
+++ b/docs/collections/_commands/Clear-PASLinkedAccount.md
@@ -1,0 +1,118 @@
+---
+external help file: psPAS-help.xml
+Module Name: psPAS
+online version: https://pspas.pspete.dev/commands/Clear-PASLinkedAccount
+schema: 2.0.0
+title: Clear-PASLinkedAccount
+---
+
+# Clear-PASLinkedAccount
+
+## SYNOPSIS
+
+Clears a linked account association.
+
+## SYNTAX
+
+```
+Clear-PASLinkedAccount [-AccountID] <String> [-extraPasswordIndex] <Int32> [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+Clears the association between a linked account and a source account.
+
+The following Safe authorizations are required on the Safe where the source account is stored to run this command:
+- List accounts
+- Update account properties
+- Manage Safe
+  - Only required when `RequireManageSafeToClearLinkedAccount` is enabled in the configuration.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Clear-PASLinkedAccount -AccountID 12_34 -extraPasswordIndex 3
+```
+
+Clears extraPass3 from account with ID 12_34
+
+## PARAMETERS
+
+### -AccountID
+The id value of the source account
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: id
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -extraPasswordIndex
+The linked account's extra password index.
+
+The index can be for a Reconcile account, Logon account, or other linked account that is defined in the Platform configuration.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: 0
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[https://pspas.pspete.dev/commands/Clear-PASLinkedAccount](https://pspas.pspete.dev/commands/Clear-PASLinkedAccount)
+
+[https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Link-account-unlink.htm](https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Link-account-unlink.htm)

--- a/docs/collections/_commands/Get-PASAccountDetail.md
+++ b/docs/collections/_commands/Get-PASAccountDetail.md
@@ -60,6 +60,7 @@ This is not an officially documented API method and is subject to change.
 It is assumed to require minimum version of 10.4.
 
 ## RELATED LINKS
+
 [https://pspas.pspete.dev/commands/Get-PASAccountActivity](https://pspas.pspete.dev/commands/Get-PASAccountActivity)
 
 [https://documenter.getpostman.com/view/998920/RzZ9Gz1U#d20c01c2-f7fc-4717-bf10-d8c51cb11411](https://documenter.getpostman.com/view/998920/RzZ9Gz1U#d20c01c2-f7fc-4717-bf10-d8c51cb11411)

--- a/docs/collections/_commands/Get-PASAccountDetail.md
+++ b/docs/collections/_commands/Get-PASAccountDetail.md
@@ -1,0 +1,65 @@
+---
+external help file: psPAS-help.xml
+Module Name: psPAS
+online version: https://pspas.pspete.dev/commands/Get-PASAccountActivity
+schema: 2.0.0
+title: Get-PASAccountDetail
+---
+
+# Get-PASAccountDetail
+
+## SYNOPSIS
+
+Gets extended overview of account details
+
+## SYNTAX
+
+```
+Get-PASAccountDetail -id <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+Gets extended details of an account, including data on compliance, activities, dependencies, recordings & platform configuration settings.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Get-PASAccountDetail -id 123_45
+```
+
+Displays extended details of account with id 123_45
+
+## PARAMETERS
+
+### -id
+The Account ID of the account to get extended details for.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: AccountID
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+This is not an officially documented API method and is subject to change.
+
+It is assumed to require minimum version of 10.4.
+
+## RELATED LINKS
+[https://pspas.pspete.dev/commands/Get-PASAccountActivity](https://pspas.pspete.dev/commands/Get-PASAccountActivity)
+
+[https://documenter.getpostman.com/view/998920/RzZ9Gz1U#d20c01c2-f7fc-4717-bf10-d8c51cb11411](https://documenter.getpostman.com/view/998920/RzZ9Gz1U#d20c01c2-f7fc-4717-bf10-d8c51cb11411)

--- a/docs/collections/_commands/Get-PASGroup.md
+++ b/docs/collections/_commands/Get-PASGroup.md
@@ -16,12 +16,14 @@ List groups from the vault
 
 ### groupType (Default)
 ```
-Get-PASGroup [-groupType <String>] [-search <String>] [-includeMembers <Boolean>] [<CommonParameters>]
+Get-PASGroup [-groupType <String>] [-sort <String[]>] [-search <String>] [-includeMembers <Boolean>]
+ [<CommonParameters>]
 ```
 
 ### filter
 ```
-Get-PASGroup [-filter <String>] [-search <String>] [-includeMembers <Boolean>] [<CommonParameters>]
+Get-PASGroup [-filter <String>] [-sort <String[]>] [-search <String>] [-includeMembers <Boolean>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -140,6 +142,28 @@ Requires minimum version of 12.0
 
 ```yaml
 Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -sort
+Property or properties by which to sort returned groups,
+followed by asc (default) or desc to control sort direction.
+
+Cannot sort by a property other than `groupname`, `directory` or `location`.
+
+Separate multiple properties with commas, up to a maximum of three properties.
+
+Requires minimum version of 12.2
+
+```yaml
+Type: String[]
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/collections/_commands/Get-PASPlatformSummary.md
+++ b/docs/collections/_commands/Get-PASPlatformSummary.md
@@ -1,0 +1,46 @@
+---
+external help file: psPAS-help.xml
+Module Name: psPAS
+online version: https://pspas.pspete.dev/commands/Get-PASPlatformSummary
+schema: 2.0.0
+title: Get-PASPlatformSummary
+---
+
+# Get-PASPlatformSummary
+
+## SYNOPSIS
+
+Get list of all platform system types
+
+## SYNTAX
+
+```
+Get-PASPlatformSummary [<CommonParameters>]
+```
+
+## DESCRIPTION
+Retrieve basic information on all existing platform system types.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Get-PASPlatformSummary
+```
+
+Returns list and count of each current platform system types.
+
+## PARAMETERS
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[https://pspas.pspete.dev/commands/Get-PASPlatformSummary](https://pspas.pspete.dev/commands/Get-PASPlatformSummary)

--- a/docs/collections/_commands/Get-PASSafe.md
+++ b/docs/collections/_commands/Get-PASSafe.md
@@ -20,9 +20,15 @@ Get-PASSafe [-search <String>] [-sort <String>] [-includeAccounts <Boolean>] [-e
  [-TimeoutSec <Int32>] [<CommonParameters>]
 ```
 
+### Gen2-byName
+```
+Get-PASSafe [-includeAccounts <Boolean>] -SafeName <String> [-useCache <Boolean>] [-TimeoutSec <Int32>]
+ [<CommonParameters>]
+```
+
 ### Gen1-byName
 ```
-Get-PASSafe [-SafeName <String>] [-TimeoutSec <Int32>] [<CommonParameters>]
+Get-PASSafe [-SafeName <String>] [-UseGen1API] [-TimeoutSec <Int32>] [<CommonParameters>]
 ```
 
 ### Gen1-byQuery
@@ -38,8 +44,9 @@ Get-PASSafe [-FindAll] [-TimeoutSec <Int32>] [<CommonParameters>]
 ## DESCRIPTION
 Gets safe by SafeName, by search query string, or, by default will return all safes.
 - Minimum required version for default operation using Gen2 API is 12.0.
+- Minimum required version for operation using Gen2-byName ParameterSet is 12.2.
 - For PAS versions earlier than 12.0, the Gen1 API parameters must be used.
-- Gen1 API parameters are depreciated for versions higher than 12.2.
+- Gen1 API parameters are depreciated for versions higher than 12.3.
 
 ## EXAMPLES
 
@@ -66,9 +73,9 @@ Minimum required version 12.1
 Get-PASSafe -SafeName SAFE1
 ```
 
-Returns details of "Safe1" using Gen1 API.
+Returns details of "Safe1" using Gen2 API.
 
-Depreciated from version 12.2
+Minimum required version 12.2
 
 ### EXAMPLE 4
 ```
@@ -86,18 +93,29 @@ Get-PASSafe -FindAll
 
 Returns details of all safes using Gen1 API.
 
-Depreciated from version 12.2
+Depreciated from version 12.3
+
+### EXAMPLE 6
+```
+Get-PASSafe -SafeName SAFE1 -UseGen1Api
+```
+
+Returns details of "Safe1" using Gen1 API.
+
+Depreciated from version 12.3
 
 ## PARAMETERS
 
 ### -includeAccounts
 Whether or not to return accounts for each Safe as part of the response.
 
-Minimum required version 12.0
+Minimum required version 12.0 (Default Gen2 Operation)
+
+Minimum required version 12.2 (Gen2-byName Operation)
 
 ```yaml
 Type: Boolean
-Parameter Sets: Gen2
+Parameter Sets: Gen2, Gen2-byName
 Aliases:
 
 Required: False
@@ -159,11 +177,25 @@ Accept wildcard characters: False
 ```
 
 ### -SafeName
-The name of a specific safe to get details of using Gen1 API.
+The name of a specific safe to get details of.
 
-Should be specified for versions earlier than 12.0
+Gen2 API operation requires minimum version 12.2
 
-Depreciated from version 12.2
+When using Gen1 API in versions earlier than 12.0, must be specified with the `-UseGen1API` parameter.
+
+Gen1 operation depreciated from version 12.3
+
+```yaml
+Type: String
+Parameter Sets: Gen2-byName
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
 
 ```yaml
 Type: String
@@ -182,7 +214,7 @@ Query String for safe search in the vault using Gen1 API.
 
 Should be specified for versions earlier than 12.0
 
-Depreciated from version 12.2
+Depreciated from version 12.3
 
 ```yaml
 Type: String
@@ -201,7 +233,7 @@ Specify to find all safes using Gen1 API.
 
 Should be specified for versions earlier than 12.0
 
-Depreciated from version 12.2
+Depreciated from version 12.3
 
 ```yaml
 Type: SwitchParameter
@@ -229,6 +261,36 @@ Required: False
 Position: Named
 Default value: 0
 Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -useCache
+Whether to retrieve from session or not.
+
+```yaml
+Type: Boolean
+Parameter Sets: Gen2-byName
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -UseGen1API
+Specify to force use of the Gen1 API
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Gen1-byName
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 

--- a/docs/collections/_commands/Get-PASSafeMember.md
+++ b/docs/collections/_commands/Get-PASSafeMember.md
@@ -21,7 +21,7 @@ Get-PASSafeMember -SafeName <String> [-TimeoutSec <Int32>] [<CommonParameters>]
 
 ### Gen1-MemberPermissions
 ```
-Get-PASSafeMember -SafeName <String> -MemberName <String> [<CommonParameters>]
+Get-PASSafeMember -SafeName <String> -MemberName <String> [-UseGen1API] [<CommonParameters>]
 ```
 
 ### Gen1-SafeMembers
@@ -36,13 +36,19 @@ Get-PASSafeMember -SafeName <String> [-memberType <String>] [-membershipExpired 
  [<CommonParameters>]
 ```
 
+### Gen2-MemberPermissions
+```
+Get-PASSafeMember -SafeName <String> -MemberName <String> [-useCache <Boolean>] [<CommonParameters>]
+```
+
 ## DESCRIPTION
 Lists the members of a Safe.
 
 - View Safe Members permission is required.
 - Defaults to the Gen 2 API which requires 12.0 or higher.
 - Additional member filter parameters require 12.1 or higher.
-- Versions lower than 12.0 must specify the `UseGen1API` switch to force use of the Gen1 API.
+- MemberName parameter requires 12.2 or higher for use with Gen2 API.
+- Versions lower than 12.0 (or 12.2 when using the MemberName parameter) must specify the `UseGen1API` switch to force use of the Gen1 API.
 
 **Note**
 When using the Gen1 API & querying all members of a safe, the permissions are reported as follows:
@@ -111,9 +117,9 @@ Minimum required version 12.0
 Get-PASSafeMember -SafeName Target_Safe -MemberName SomeUser
 ```
 
-Lists all permissions for member SomeUser on Target_Safe
+Lists all permissions for member SomeUser on Target_Safe using Gen2 API
 
-Depreciated from CyberArk Version 12.3
+Requires minimum CyberArk Version of 12.2
 
 ### EXAMPLE 3
 ```
@@ -121,6 +127,15 @@ Get-PASSafeMember -SafeName Target_Safe -UseGen1API
 ```
 
 Lists all members with permissions on Target_Safe using the Gen1 API.
+
+### EXAMPLE 4
+```
+Get-PASSafeMember -SafeName Target_Safe -MemberName SomeUser -UseGen1API
+```
+
+Lists all permissions for member SomeUser on Target_Safe using Gen1 API
+
+Depreciated from CyberArk Version 12.3
 
 ## PARAMETERS
 
@@ -142,14 +157,17 @@ Accept wildcard characters: False
 ### -MemberName
 Specify the name of a safe member to return their safe permissions in full.
 
-**NOTE**: An empty PUT request (update) is sent to retrieve full safe permissions for a user:
+Operation against Gen2 API requires minimum version of 12.2
+
+**NOTE for Gen1 Operation**: An empty PUT request (update) is sent to retrieve full safe permissions for a user:
+- `-UseGen1API` parameter must be specified.
 - You cannot report on the permissions of the user authenticated to the API.
 - Reporting on the permissions of the Quota Owner is expected to fail.
 - Depreciated from CyberArk Version 12.3
 
 ```yaml
 Type: String
-Parameter Sets: Gen1-MemberPermissions
+Parameter Sets: Gen1-MemberPermissions, Gen2-MemberPermissions
 Aliases: UserName
 
 Required: True
@@ -266,6 +284,20 @@ Force use of the Gen1 API.
 
 Should be specified for versions earlier than 12.0.
 
+Should be specified for versions earlier than 12.2 when querying by MemberName
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Gen1-MemberPermissions
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
 ```yaml
 Type: SwitchParameter
 Parameter Sets: Gen1-SafeMembers
@@ -274,7 +306,22 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: False
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -useCache
+Whether or not to retrieve the cache from a session.
+
+```yaml
+Type: Boolean
+Parameter Sets: Gen2-MemberPermissions
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 

--- a/docs/collections/_commands/Get-PASUser.md
+++ b/docs/collections/_commands/Get-PASUser.md
@@ -16,7 +16,8 @@ Returns details of vault users
 
 ### Gen2 (Default)
 ```
-Get-PASUser [-Search <String>] [-UserType <String>] [-ComponentUser <Boolean>] [<CommonParameters>]
+Get-PASUser [-Search <String>] [-UserType <String>] [-ComponentUser <Boolean>] [-sort <String[]>]
+ [-UserName <String>] [<CommonParameters>]
 ```
 
 ### Gen2ID
@@ -26,13 +27,13 @@ Get-PASUser -id <Int32> [<CommonParameters>]
 
 ### Gen2-ExtendedDetails
 ```
-Get-PASUser [-Search <String>] [-UserType <String>] [-ComponentUser <Boolean>] [-ExtendedDetails <Boolean>]
- [<CommonParameters>]
+Get-PASUser [-Search <String>] [-UserType <String>] [-ComponentUser <Boolean>] [-sort <String[]>]
+ [-ExtendedDetails <Boolean>] [-UserName <String>] [<CommonParameters>]
 ```
 
 ### Gen1
 ```
-Get-PASUser -UserName <String> [<CommonParameters>]
+Get-PASUser -UserName <String> [-UseGen1API] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -158,6 +159,21 @@ Accept wildcard characters: False
 ### -UserName
 The user's name
 
+Default operation targets the Gen2 API & requires minimum version of 12.2.
+
+For operation against versions earlier than 12.2, the `UseGen1API` parameter should also be specified.
+```yaml
+Type: String
+Parameter Sets: Gen2, Gen2-ExtendedDetails
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
 ```yaml
 Type: String
 Parameter Sets: Gen1
@@ -184,6 +200,43 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -sort
+Property or properties by which to sort returned accounts,
+followed by asc (default) or desc to control sort direction.
+
+Cannot sort by a property other than `username`, `usertype`, `firstname`, `lastname`, `location`, `middlename` or `source`.
+
+Separate multiple properties with commas, up to a maximum of three properties.
+
+Requires minimum version of 12.2
+
+```yaml
+Type: String[]
+Parameter Sets: Gen2, Gen2-ExtendedDetails
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -UseGen1API
+Forces use of the Gen1 API endpoint
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Gen1
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/collections/_commands/New-PASAccountGroup.md
+++ b/docs/collections/_commands/New-PASAccountGroup.md
@@ -57,7 +57,9 @@ Accept wildcard characters: False
 ### -GroupPlatformID
 The name of the platform for the group.
 
-The associated platform must be set to "PolicyType=Group"
+The associated platform must be set to "PolicyType=Group" or "PolicyType=RotationalGroup"
+
+To add Account Group with Policy Type of Rotational Group requires minimum version of 12.2
 
 ```yaml
 Type: String

--- a/docs/collections/_commands/Remove-PASSafeMember.md
+++ b/docs/collections/_commands/Remove-PASSafeMember.md
@@ -15,13 +15,16 @@ Removes a member from a safe
 ## SYNTAX
 
 ```
-Remove-PASSafeMember [-SafeName] <String> [-MemberName] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+Remove-PASSafeMember [-SafeName] <String> [-MemberName] <String> [-UseGen1API] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 Removes a specific member from a Safe.
 
 The user who runs this function requires the ManageSafeMembers permission.
+
+Default operation against Gen2 API requires minimum version of 12.2
 
 ## EXAMPLES
 
@@ -30,7 +33,16 @@ The user who runs this function requires the ManageSafeMembers permission.
 Remove-PASSafeMember -SafeName TargetSafe -MemberName TargetUser
 ```
 
-Removes TargetUser as safe member from TargetSafe
+Removes TargetUser as safe member from TargetSafe using Gen2 API
+
+Requires minimum version 12.2
+
+### EXAMPLE 2
+```
+Remove-PASSafeMember -SafeName TargetSafe -MemberName TargetUser -UseGen1API
+```
+
+Removes TargetUser as safe member from TargetSafe using Gen1 API
 
 ## PARAMETERS
 
@@ -92,6 +104,23 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UseGen1API
+Specify to force usage the Gen1 API endpoint.
+
+Should be specified for versions earlier than 12.2
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 

--- a/docs/collections/_commands/Request-PASJustInTimeAccess.md
+++ b/docs/collections/_commands/Request-PASJustInTimeAccess.md
@@ -2,20 +2,20 @@
 category: PSPAS
 external help file: psPAS-help.xml
 Module Name: psPAS
-online version: https://pspas.pspete.dev/commands/Request-PASAdHocAccess
+online version: https://pspas.pspete.dev/commands/Request-PASJustInTimeAccess
 schema: 2.0.0
-title: Request-PASAdHocAccess
+title: Request-PASJustInTimeAccess
 ---
 
-# Request-PASAdHocAccess
+# Request-PASJustInTimeAccess
 
 ## SYNOPSIS
-Requests access to a target Windows machine
+Requests JIT access to a target Windows machine
 
 ## SYNTAX
 
 ```
-Request-PASAdHocAccess [-AccountID] <String> [<CommonParameters>]
+Request-PASJustInTimeAccess [-AccountID] <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -26,10 +26,10 @@ The domain user who requests access will be added to the local Administrators gr
 
 ### EXAMPLE 1
 ```
-Request-PASAdHocAccess -AccountID 36_3
+Request-PASJustInTimeAccess -AccountID 36_3
 ```
 
-Requests "ad hoc" access on the server for which the account with id 36_3 is a local account with local admin membership.
+Requests JIT access on the server for which the account with id 36_3 is a local account with local admin membership.
 
 ## PARAMETERS
 
@@ -59,6 +59,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[https://pspas.pspete.dev/commands/Request-PASAdHocAccess](https://pspas.pspete.dev/commands/Request-PASAdHocAccess)
+[https://pspas.pspete.dev/commands/Request-PASJustInTimeAccess](https://pspas.pspete.dev/commands/Request-PASJustInTimeAccess)
 
 [https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/GetAccess.htm](https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/GetAccess.htm)

--- a/docs/collections/_commands/Revoke-PASJustInTimeAccess.md
+++ b/docs/collections/_commands/Revoke-PASJustInTimeAccess.md
@@ -1,0 +1,64 @@
+---
+category: PSPAS
+external help file: psPAS-help.xml
+Module Name: psPAS
+online version: https://pspas.pspete.dev/commands/Revoke-PASJustInTimeAccess
+schema: 2.0.0
+title: Revoke-PASJustInTimeAccess
+---
+
+# Revoke-PASJustInTimeAccess
+
+## SYNOPSIS
+Revoke JIT access to a target Windows machine
+
+## SYNTAX
+
+```
+Revoke-PASJustInTimeAccess [-AccountID] <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+Requests and receives access, with administrative rights, to a target Windows machine.
+The domain user who issuing the command will be removed from the local Administrators group of the target machine.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Revoke-PASJustInTimeAccess -AccountID 36_3
+```
+
+Revokes JIT access on the server for which the account with id 36_3 is a local account with local admin membership.
+
+## PARAMETERS
+
+### -AccountID
+The ID of the local account that will be used to remove the authenticated user from the Administrators group on the target machine.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: id
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[https://pspas.pspete.dev/commands/Revoke-PASJustInTimeAccess](https://pspas.pspete.dev/commands/Revoke-PASJustInTimeAccess)
+
+[https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/GetAccess.htm](https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/GetAccess.htm)

--- a/docs/collections/_commands/Set-PASSafe.md
+++ b/docs/collections/_commands/Set-PASSafe.md
@@ -14,22 +14,32 @@ Updates a safe in the Vault
 
 ## SYNTAX
 
-### Update (Default)
+### Gen2-NumberOfDaysRetention (Default)
 ```
-Set-PASSafe -SafeName <String> [-NewSafeName <String>] [-Description <String>] [-OLACEnabled <Boolean>]
- [-ManagingCPM <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
-```
-
-### Versions
-```
-Set-PASSafe -SafeName <String> [-NewSafeName <String>] [-Description <String>] [-OLACEnabled <Boolean>]
- [-ManagingCPM <String>] [-NumberOfVersionsRetention <Int32>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Set-PASSafe -SafeName <String> [-NewSafeName <String>] [-Description <String>] [-location <String>]
+ [-OLACEnabled <Boolean>] [-ManagingCPM <String>] -NumberOfDaysRetention <Int32> [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
-### Days
+### Gen2-NumberOfVersionsRetention
+```
+Set-PASSafe -SafeName <String> [-NewSafeName <String>] [-Description <String>] [-location <String>]
+ [-OLACEnabled <Boolean>] [-ManagingCPM <String>] -NumberOfVersionsRetention <Int32> [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+### Gen1-NumberOfVersionsRetention
 ```
 Set-PASSafe -SafeName <String> [-NewSafeName <String>] [-Description <String>] [-OLACEnabled <Boolean>]
- [-ManagingCPM <String>] [-NumberOfDaysRetention <Int32>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-ManagingCPM <String>] [-NumberOfVersionsRetention <Int32>] [-UseGen1API] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+### Gen1-NumberOfDaysRetention
+```
+Set-PASSafe -SafeName <String> [-NewSafeName <String>] [-Description <String>] [-OLACEnabled <Boolean>]
+ [-ManagingCPM <String>] [-NumberOfDaysRetention <Int32>] [-UseGen1API] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -43,7 +53,16 @@ Manage Safe permission is required.
 Set-PASSafe -SafeName SAFE -Description "New-Description" -NumberOfVersionsRetention 10
 ```
 
-Updates description and version retention on SAFE
+Updates description and version retention on SAFE using Gen2 API
+
+Minimum required version 12.2
+
+### EXAMPLE 2
+```
+Set-PASSafe -SafeName SAFE -Description "New-Description" -NumberOfDaysRetention 10 -UseGen1API
+```
+
+Updates description and number of days retention on SAFE using Gen1 API
 
 ## PARAMETERS
 
@@ -139,13 +158,25 @@ Specify either this parameter or NumberOfDaysRetention.
 
 ```yaml
 Type: Int32
-Parameter Sets: Versions
+Parameter Sets: Gen2-NumberOfVersionsRetention
+Aliases:
+
+Required: True
+Position: Named
+Default value: 0
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+```yaml
+Type: Int32
+Parameter Sets: Gen1-NumberOfVersionsRetention
 Aliases:
 
 Required: False
 Position: Named
 Default value: 0
-Accept pipeline input: False
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
@@ -158,13 +189,25 @@ Specify either this parameter or NumberOfVersionsRetention
 
 ```yaml
 Type: Int32
-Parameter Sets: Days
+Parameter Sets: Gen2-NumberOfDaysRetention
+Aliases:
+
+Required: True
+Position: Named
+Default value: 0
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+```yaml
+Type: Int32
+Parameter Sets: Gen1-NumberOfDaysRetention
 Aliases:
 
 Required: False
 Position: Named
 Default value: 0
-Accept pipeline input: False
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
@@ -196,6 +239,40 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -location
+The vault location to set for the safe
+
+Minimum required version 12.2
+
+```yaml
+Type: String
+Parameter Sets: Gen2-NumberOfDaysRetention, Gen2-NumberOfVersionsRetention
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -UseGen1API
+Specify to force usage the Gen1 API endpoint.
+
+Should be specified for versions earlier than 12.2
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Gen1-NumberOfVersionsRetention, Gen1-NumberOfDaysRetention
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 

--- a/docs/collections/_commands/Set-PASSafeMember.md
+++ b/docs/collections/_commands/Set-PASSafeMember.md
@@ -14,6 +14,20 @@ Updates a Safe Member
 
 ## SYNTAX
 
+### Gen2 (Default)
+```
+Set-PASSafeMember -SafeName <String> -MemberName <String> [-MembershipExpirationDate <DateTime>]
+ [-UseAccounts <Boolean>] [-RetrieveAccounts <Boolean>] [-ListAccounts <Boolean>] [-AddAccounts <Boolean>]
+ [-UpdateAccountContent <Boolean>] [-UpdateAccountProperties <Boolean>]
+ [-InitiateCPMAccountManagementOperations <Boolean>] [-SpecifyNextAccountContent <Boolean>]
+ [-RenameAccounts <Boolean>] [-DeleteAccounts <Boolean>] [-UnlockAccounts <Boolean>] [-ManageSafe <Boolean>]
+ [-ManageSafeMembers <Boolean>] [-BackupSafe <Boolean>] [-ViewAuditLog <Boolean>] [-ViewSafeMembers <Boolean>]
+ [-requestsAuthorizationLevel1 <Boolean>] [-requestsAuthorizationLevel2 <Boolean>]
+ [-AccessWithoutConfirmation <Boolean>] [-CreateFolders <Boolean>] [-DeleteFolders <Boolean>]
+ [-MoveAccountsAndFolders <Boolean>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### Gen1
 ```
 Set-PASSafeMember -SafeName <String> -MemberName <String> [-MembershipExpirationDate <DateTime>]
  [-UseAccounts <Boolean>] [-RetrieveAccounts <Boolean>] [-ListAccounts <Boolean>] [-AddAccounts <Boolean>]
@@ -22,13 +36,16 @@ Set-PASSafeMember -SafeName <String> -MemberName <String> [-MembershipExpiration
  [-RenameAccounts <Boolean>] [-DeleteAccounts <Boolean>] [-UnlockAccounts <Boolean>] [-ManageSafe <Boolean>]
  [-ManageSafeMembers <Boolean>] [-BackupSafe <Boolean>] [-ViewAuditLog <Boolean>] [-ViewSafeMembers <Boolean>]
  [-RequestsAuthorizationLevel <Int32>] [-AccessWithoutConfirmation <Boolean>] [-CreateFolders <Boolean>]
- [-DeleteFolders <Boolean>] [-MoveAccountsAndFolders <Boolean>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-DeleteFolders <Boolean>] [-MoveAccountsAndFolders <Boolean>] [-UseGen1API] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 Updates an existing Safe Member's permissions on a safe.
 
 Manage Safe Members permission is required.
+
+Default operation against the Gen2 API requires a minimum version of 12.2
 
 ## EXAMPLES
 
@@ -37,7 +54,16 @@ Manage Safe Members permission is required.
 Set-PASSafeMember -SafeName TargetSafe -MemberName TargetUser -AddAccounts $true
 ```
 
-Updates TargetUser's permissions as safe member on TargetSafe to include "Add Accounts"
+Updates TargetUser's permissions as safe member on TargetSafe to include "Add Accounts" using the Gen2 API.
+
+Minimum required version 12.2
+
+### EXAMPLE 2
+```
+Set-PASSafeMember -SafeName TargetSafe -MemberName TargetUser -AddAccounts $true -UseGen1API
+```
+
+Updates TargetUser's permissions as safe member on TargetSafe to include "Add Accounts" using the Gen1 API.
 
 ## PARAMETERS
 
@@ -93,7 +119,7 @@ safe member on safe.
 ```yaml
 Type: Boolean
 Parameter Sets: (All)
-Aliases:
+Aliases: RestrictedRetrieve
 
 Required: False
 Position: Named
@@ -109,7 +135,7 @@ to safe member on safe.
 ```yaml
 Type: Boolean
 Parameter Sets: (All)
-Aliases:
+Aliases: Retrieve
 
 Required: False
 Position: Named
@@ -125,7 +151,7 @@ safe member on safe.
 ```yaml
 Type: Boolean
 Parameter Sets: (All)
-Aliases:
+Aliases: ListContent
 
 Required: False
 Position: Named
@@ -143,7 +169,7 @@ Includes UpdateAccountProperties (when adding or removing permission).
 ```yaml
 Type: Boolean
 Parameter Sets: (All)
-Aliases:
+Aliases: Add
 
 Required: False
 Position: Named
@@ -159,7 +185,7 @@ member on safe.
 ```yaml
 Type: Boolean
 Parameter Sets: (All)
-Aliases:
+Aliases: Update
 
 Required: False
 Position: Named
@@ -175,7 +201,7 @@ to safe member on safe.
 ```yaml
 Type: Boolean
 Parameter Sets: (All)
-Aliases:
+Aliases: UpdateMetadata
 
 Required: False
 Position: Named
@@ -223,7 +249,7 @@ member on safe.
 ```yaml
 Type: Boolean
 Parameter Sets: (All)
-Aliases:
+Aliases: Rename
 
 Required: False
 Position: Named
@@ -239,7 +265,7 @@ member on safe.
 ```yaml
 Type: Boolean
 Parameter Sets: (All)
-Aliases:
+Aliases: Delete
 
 Required: False
 Position: Named
@@ -255,7 +281,7 @@ member on safe.
 ```yaml
 Type: Boolean
 Parameter Sets: (All)
-Aliases:
+Aliases: Unlock
 
 Required: False
 Position: Named
@@ -319,7 +345,7 @@ on safe.
 ```yaml
 Type: Boolean
 Parameter Sets: (All)
-Aliases:
+Aliases: ViewAudit
 
 Required: False
 Position: Named
@@ -335,7 +361,7 @@ on safe.
 ```yaml
 Type: Boolean
 Parameter Sets: (All)
-Aliases:
+Aliases: ViewMembers
 
 Required: False
 Position: Named
@@ -351,7 +377,7 @@ Valid Values: 0, 1 or 2
 
 ```yaml
 Type: Int32
-Parameter Sets: (All)
+Parameter Sets: Gen1
 Aliases:
 
 Required: False
@@ -384,7 +410,7 @@ on safe.
 ```yaml
 Type: Boolean
 Parameter Sets: (All)
-Aliases:
+Aliases: AddRenameFolder
 
 Required: False
 Position: Named
@@ -416,7 +442,7 @@ member on safe.
 ```yaml
 Type: Boolean
 Parameter Sets: (All)
-Aliases:
+Aliases: MoveFilesAndFolders
 
 Required: False
 Position: Named
@@ -450,6 +476,57 @@ Parameter Sets: (All)
 Aliases: cf
 
 Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -requestsAuthorizationLevel1
+Boolean value defining if requestsAuthorizationLevel1 permission will be granted to safe member on safe.
+
+Minimum required version 12.2
+
+```yaml
+Type: Boolean
+Parameter Sets: Gen2
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -requestsAuthorizationLevel2
+Boolean value defining if requestsAuthorizationLevel2 permission will be granted to safe member on safe.
+
+Minimum required version 12.2
+
+```yaml
+Type: Boolean
+Parameter Sets: Gen2
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -UseGen1API
+Specify to force usage the Gen1 API endpoint.
+
+Should be specified for versions earlier than 12.2
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Gen1
+Aliases:
+
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/docs/collections/_docs/10-compatibility.md
+++ b/docs/collections/_docs/10-compatibility.md
@@ -41,6 +41,7 @@ If you are using version 9.7+, and the function being invoked requires version 9
 [`Add-PASAccount`][Add-PASAccount]                                                       |**9.0** ([Notes](#add-pasaccount))                  |Adds a new account.
 [`Add-PASPendingAccount`][Add-PASPendingAccount]                                         |**9.7**                                             |Adds discovered account or SSH key as a pending account.
 [`Get-PASAccount`][Get-PASAccount]                                                       |**9.3** ([Notes](#get-pasaccount))                  |Returns information about accounts.
+[`Get-PASAccountDetail`][Get-PASAccountDetail]                                           |**10.4**                                            |Returns information about accounts.
 [`Get-PASAccountActivity`][Get-PASAccountActivity]                                       |**9.7**                                             |Returns activities for an account.
 [`Get-PASAccountPassword`][Get-PASAccountPassword]                                       |**9.7** ([Notes](#get-pasaccountpassword))          |Returns password for an account.
 [`Remove-PASAccount`][Remove-PASAccount]                                                 |**9.3** ([Notes](#remove-pasaccount))               |Deletes an account
@@ -116,7 +117,8 @@ If you are using version 9.7+, and the function being invoked requires version 9
 [`Get-PASPSMRecordingActivity`][Get-PASPSMRecordingActivity]                             | **10.6**                                           |Get activity details from a PSM Recording.
 [`Get-PASPSMRecordingProperty`][Get-PASPSMRecordingProperty]                             | **10.6**                                           |Get property details from a PSM Recording.
 [`Export-PASPSMRecording`][Export-PASPSMRecording]                                       | **10.6**                                           |Save PSM Session Recording to a file.
-[`Request-PASAdHocAccess`][Request-PASAdHocAccess]                                       | **10.6**                                           |Request temporary access to a server.
+[`Request-PASJustInTimeAccess`][Request-PASJustInTimeAccess]                             | **10.6**                                           |Request temporary access to a server.
+[`Revoke-PASJustInTimeAccess`][Revoke-PASJustInTimeAccess]                               | **12.0**                                           |Revoke temporary server access.
 [`Get-PASDirectoryMapping`][Get-PASDirectoryMapping]                                     | **10.7**                                           |Get details of configured directory mappings.
 [`Set-PASDirectoryMapping`][Set-PASDirectoryMapping]                                     | **10.7** ([Notes](#set-pasdirectorymapping))       |Update a configured directory mapping.
 [`Remove-PASDirectory`][Remove-PASDirectory]                                             | **10.7**                                           |Delete a directory configuration.
@@ -282,7 +284,8 @@ If you are using version 9.7+, and the function being invoked requires version 9
 [Get-PASPSMRecordingActivity]:/commands/Get-PASPSMRecordingActivity
 [Get-PASPSMRecordingProperty]:/commands/Get-PASPSMRecordingProperty
 [Export-PASPSMRecording]:/commands/Export-PASPSMRecording
-[Request-PASAdHocAccess]:/commands/Request-PASAdHocAccess
+[Request-PASJustInTimeAccess]:/commands/Request-PASJustInTimeAccess
+[Revoke-PASJustInTimeAccess]:/commands/Revoke-PASJustInTimeAccess
 [Get-PASDirectoryMapping]:/commands/Get-PASDirectoryMapping
 [Set-PASDirectoryMapping]:/commands/Set-PASDirectoryMapping
 [Remove-PASDirectory]:/commands/Remove-PASDirectory
@@ -301,6 +304,7 @@ If you are using version 9.7+, and the function being invoked requires version 9
 [Enable-PASPlatform]:/commands/Enable-PASPlatform
 [Remove-PASPlatform]:/commands/Remove-PASPlatform
 [Remove-PASGroup]:/commands/Remove-PASGroup
+[Get-PASAccountDetail]:/commands/Get-PASAccountDetail
 
 ## Notes
 

--- a/docs/collections/_docs/10-compatibility.md
+++ b/docs/collections/_docs/10-compatibility.md
@@ -2,7 +2,7 @@
 title: "Compatibility"
 permalink: /docs/compatibility/
 excerpt: "Module Compatibility"
-last_modified_at: 2021-07-04zT01:33:52-00:00
+last_modified_at: 2021-07-25zT01:33:52-00:00
 toc: false
 ---
 
@@ -76,14 +76,14 @@ If you are using version 9.7+, and the function being invoked requires version 9
 [`Get-PASRequestDetail`][Get-PASRequestDetail]                                           |**9.10** ([Notes](#-pasrequestdetail))              |Get request details
 [`New-PASRequest`][New-PASRequest]                                                       |**9.10** ([Notes](#-pasrequest))                    |Creates an access request for an account
 [`Remove-PASRequest`][Remove-PASRequest]                                                 |**9.10** ([Notes](#-pasrequest))                    |Deletes a request
-[`Add-PASSafeMember`][Add-PASSafeMember]                                                 |**9.3** ([Notes](#add-passafemember))                |Adds a Safe Member to a safe
-[`Get-PASSafeMember`][Get-PASSafeMember]                                                 |**9.7** ([Notes](#get-passafemember))                |Lists the members of a Safe
-[`Remove-PASSafeMember`][Remove-PASSafeMember]                                           |**9.3**                                             |Removes a member from a safe
-[`Set-PASSafeMember`][Set-PASSafeMember]                                                 |**9.3**                                             |Updates a Safe Member's Permissions
-[`Add-PASSafe`][Add-PASSafe]                                                             | **9.2** ([Notes](#add-passafe))                     |Adds a new safe
-[`Get-PASSafe`][Get-PASSafe]                                                             | **9.7** ([Notes](#get-passafe))                     |Returns safe details
-[`Remove-PASSafe`][Remove-PASSafe]                                                       | **9.3** ([Notes](#remove-passafe))                  |Deletes a safe
-[`Set-PASSafe`][Set-PASSafe]                                                             | **9.3**                                            |Updates a safe
+[`Add-PASSafeMember`][Add-PASSafeMember]                                                 |**9.3** ([Notes](#add-passafemember))               |Adds a Safe Member to a safe
+[`Get-PASSafeMember`][Get-PASSafeMember]                                                 |**9.7** ([Notes](#get-passafemember))               |Lists the members of a Safe
+[`Remove-PASSafeMember`][Remove-PASSafeMember]                                           |**9.3** ([Notes](#remove-passafemember)             |Removes a member from a safe
+[`Set-PASSafeMember`][Set-PASSafeMember]                                                 |**9.3** ([Notes](#set-passafemember)                |Updates a Safe Member's Permissions
+[`Add-PASSafe`][Add-PASSafe]                                                             | **9.2** ([Notes](#add-passafe))                    |Adds a new safe
+[`Get-PASSafe`][Get-PASSafe]                                                             | **9.7** ([Notes](#get-passafe))                    |Returns safe details
+[`Remove-PASSafe`][Remove-PASSafe]                                                       | **9.3** ([Notes](#remove-passafe))                 |Deletes a safe
+[`Set-PASSafe`][Set-PASSafe]                                                             | **9.3** ([Notes](#set-passafe))                    |Updates a safe
 [`Get-PASSafeShareLogo`][Get-PASSafeShareLogo]                                           | **9.7**                                            |Returns details of SafeShare Logo
 [`Get-PASServer`][Get-PASServer]                                                         | **9.7**                                            |Returns details of the Web Service Server
 [`Get-PASServerWebService`][Get-PASServerWebService]                                     | **9.7**                                            |Returns details of the Web Service
@@ -427,6 +427,7 @@ If you are using version 9.7+, and the function being invoked requires version 9
     - `GroupID`
     - `memberID`
 - The Gen1 API endpoint can be used by using the `GroupName` & `UserName` parameters.
+- Gen1 API depreciated from 12.3
 
 ### Get-PASUser
 
@@ -438,12 +439,14 @@ If you are using version 9.7+, and the function being invoked requires version 9
     - Get user by ID.
 - Version 11.5 returns additional group membership  detail for user accounts.
 - Version 12.1 introduced new parameter to request `ExtendedDetails` for a user.
+- Version 12.2 introduced new `sort` parameter and ability to filter by UserName.
 
 ### New-PASUser
 
 - Version 10.9 introduced a new API endpoint.
   - Supports:
     - Additional property parameters.
+- Gen1 API depreciated from 12.3
 
 ### Unblock-PASUser
 
@@ -451,6 +454,7 @@ If you are using version 9.7+, and the function being invoked requires version 9
   - Requires Parameters:
     - `userID`
 - The Gen1 API endpoint can be used by using the `userName` parameter.
+- Gen1 API depreciated from 12.3
 
 ### Get-PASDirectory
 
@@ -508,12 +512,14 @@ If you are using version 9.7+, and the function being invoked requires version 9
 - Version 11.1 introduced a new API endpoint.
   - Supports:
     - Delete User by ID
+- Gen1 API depreciated from 12.3
 
 ### Set-PASUser
 
 - Version 11.1 introduced a new API endpoint.
   - Supports:
     - Additional parameters for updating users.
+- Gen1 API depreciated from 12.3
 
 ### Get-PASPTAEvent
 
@@ -529,6 +535,15 @@ If you are using version 9.7+, and the function being invoked requires version 9
 
 - Version 12.0 introduced a new API endpoint.
 - Version 12.1 introduced new filter parameters.
+- Version 12.2 introduces capability to get permissions of individual safe member.
+
+### Set-PASSafeMember
+
+- Version 12.2 introduced a new API endpoint.
+
+### Remove-PASSafeMember
+
+- Version 12.2 introduced a new API endpoint.
 
 ### Add-PASSafeMember
 
@@ -542,6 +557,7 @@ If you are using version 9.7+, and the function being invoked requires version 9
 
 - Version 12.0 introduced a new API endpoint.
 - Version 12.1 introduced a new parameter `extendedDetails`.
+- Version 12.1 introduces capability to get details of individual safe using the Gen2 API.
 
 ### Remove-PASSafe
 
@@ -555,3 +571,8 @@ If you are using version 9.7+, and the function being invoked requires version 9
 ### Get-PASGroup
 
 - Version 12.0 introduced `includeMembers` parameter.
+- Version 12.2 introduced new `sort` parameter.
+
+### Set-PASSafe
+
+- Version 12.2 introduced new API endpoint

--- a/docs/collections/_docs/10-compatibility.md
+++ b/docs/collections/_docs/10-compatibility.md
@@ -159,6 +159,7 @@ If you are using version 9.7+, and the function being invoked requires version 9
 [`Get-PASAccountPasswordVersion`][Get-PASAccountPasswordVersion]                         |**12.1**                                            |Get details of previous password versions
 [`New-PASAccountPassword`][New-PASAccountPassword]                                       |**12.0**                                            |Generate new password values based on platform policy
 [`Set-PASLinkedAccount`][Set-PASLinkedAccount]                                           |**12.1**                                            |Associate logon and reconcile accounts
+[`Clear-PASLinkedAccount`][Clear-PASLinkedAccount]                                       |**12.2**                                            |Clear associated linked accounts
 [`Clear-PASPrivateSSHKey`][Clear-PASPrivateSSHKey]                                       |**12.1**                                            |Remove all MFA caching SSH Keys
 [`New-PASPrivateSSHKey`][New-PASPrivateSSHKey]                                           |**12.1**                                            |Generate MFA caching SSH Keys
 [`Remove-PASPrivateSSHKey`][Remove-PASPrivateSSHKey]                                     |**12.1**                                            |Delete MFA caching SSH Keys
@@ -169,6 +170,7 @@ If you are using version 9.7+, and the function being invoked requires version 9
 [Get-PASAccountPasswordVersion]:/commands/Get-PASAccountPasswordVersion
 [New-PASAccountPassword]:/commands/New-PASAccountPassword
 [Set-PASLinkedAccount]:/commands/Set-PASLinkedAccount
+[Clear-PASLinkedAccount]:/commands/Clear-PASLinkedAccount
 [Clear-PASPrivateSSHKey]:/commands/Clear-PASPrivateSSHKey
 [New-PASPrivateSSHKey]:/commands/New-PASPrivateSSHKey
 [Remove-PASPrivateSSHKey]:/commands/Remove-PASPrivateSSHKey

--- a/docs/collections/_docs/10-compatibility.md
+++ b/docs/collections/_docs/10-compatibility.md
@@ -164,8 +164,9 @@ If you are using version 9.7+, and the function being invoked requires version 9
 [`New-PASPrivateSSHKey`][New-PASPrivateSSHKey]                                           |**12.1**                                            |Generate MFA caching SSH Keys
 [`Remove-PASPrivateSSHKey`][Remove-PASPrivateSSHKey]                                     |**12.1**                                            |Delete MFA caching SSH Keys
 [`Set-PASGroup`][Set-PASGroup]                                                           |**12.0**                                            |Update CyberArk groups
+[`Get-PASPlatformSummary`][Get-PASPlatformSummary]                                       |**12.2**                                            |Get basic information on current platform system types
 
-
+[Get-PASPlatformSummary]:/commands/Get-PASPlatformSummary
 [Clear-PASDiscoveredAccountList]:/commands/Clear-PASDiscoveredAccountList
 [Get-PASAccountPasswordVersion]:/commands/Get-PASAccountPasswordVersion
 [New-PASAccountPassword]:/commands/New-PASAccountPassword

--- a/docs/collections/_docs/18-troubleshooting.md
+++ b/docs/collections/_docs/18-troubleshooting.md
@@ -16,6 +16,9 @@ A lot of issues reported to the project stem from sources outside of the psPAS c
 
 Use the resources on this page to help navigate the project and information in the public domain to find resolutions for any challenge with psPAS you may face.
 
+The details on this site always relate to the latest module version. If you are using an older version of the module consult the module help, accessed via the PowerShell Get-Help CmdLet, to get details relevant to the version you use.
+{: .notice--info}
+
 ## Previous Issues
 
 Check the historic [issues](https://github.com/pspete/psPAS/issues?q=is%3Aissue) logged for the module; it is possible an answer, reason or resolution has already been provided for any observed behaviour.

--- a/docs/collections/_docs/32-safe-permissions.md
+++ b/docs/collections/_docs/32-safe-permissions.md
@@ -2,7 +2,7 @@
 title: "Safe Permissions"
 permalink: /docs/safe-permissions/
 excerpt: "psPAS Safe Permissions"
-last_modified_at: 2021-04-10T01:33:52-00:00
+last_modified_at: 2021-07-25T01:33:52-00:00
 ---
 
 - Define Safe Roles and assign to safe members:
@@ -32,7 +32,8 @@ $Role2 = [PSCustomObject]@{
   BackupSafe                             = $false
   ViewAuditLog                           = $true
   ViewSafeMembers                        = $true
-  RequestsAuthorizationLevel             = $false
+  requestsAuthorizationLevel1            = $false
+  requestsAuthorizationLevel2            = $false
   AccessWithoutConfirmation              = $true
   CreateFolders                          = $true
   DeleteFolders                          = $true

--- a/docs/collections/_pages/commands.md
+++ b/docs/collections/_pages/commands.md
@@ -191,6 +191,7 @@ A psPAS command may not appear in the below list due to it not being explicitly 
 [Get Secret Versions][Get Secret Versions]                                                     | [Get-PASAccountPasswordVersion][Get-PASAccountPasswordVersion]
 [Generate Password][Generate Password]                                                         | [New-PASAccountPassword][New-PASAccountPassword]
 [Link an Account][Link an Account]                                                             | [Set-PASLinkedAccount][Set-PASLinkedAccount]
+[Unlink an Account][Unlink an Account]                                                         | [Clear-PASLinkedAccount][Clear-PASLinkedAccount]
 [Delete all MFA caching SSH keys][Delete all MFA caching SSH keys]                             | [Clear-PASPrivateSSHKey][Clear-PASPrivateSSHKey]
 [Generate an MFA caching SSH key][Generate an MFA caching SSH key]                                   | [New-PASPrivateSSHKey][New-PASPrivateSSHKey]
 [Generate an MFA caching SSH key for another user][Generate an MFA caching SSH key for another user] | [New-PASPrivateSSHKey][New-PASPrivateSSHKey]
@@ -334,6 +335,7 @@ A psPAS command may not appear in the below list due to it not being explicitly 
 [Get-PASAccountPasswordVersion]:/commands/Get-PASAccountPasswordVersion
 [New-PASAccountPassword]:/commands/New-PASAccountPassword
 [Set-PASLinkedAccount]:/commands/Set-PASLinkedAccount
+[Clear-PASLinkedAccount]:/commands/Clear-PASLinkedAccount
 [Clear-PASPrivateSSHKey]:/commands/Clear-PASPrivateSSHKey
 [New-PASPrivateSSHKey]:/commands/New-PASPrivateSSHKey
 [Remove-PASPrivateSSHKey]:/commands/Remove-PASPrivateSSHKey
@@ -345,6 +347,7 @@ A psPAS command may not appear in the below list due to it not being explicitly 
 [Get Secret Versions]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/Secrets-Get-versions.htm
 [Generate Password]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/Secrets-Generate-Password.htm
 [Link an Account]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Link-account.htm
+[Unlink an Account]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Link-account-unlink.htm
 [Delete all MFA caching SSH keys]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Delete%20all%20MFA%20caching%20SSH%20keys.htm
 [Generate an MFA caching SSH key]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Generate%20MFA%20caching%20SSH%20key.htm
 [Generate an MFA caching SSH key for another user]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Generate%20MFA%20caching%20SSH%20key%20for%20another%20user.htm

--- a/docs/collections/_pages/commands.md
+++ b/docs/collections/_pages/commands.md
@@ -49,7 +49,8 @@ A psPAS command may not appear in the below list due to it not being explicitly 
 [Get bulk account upload result][Get bulk account upload result]                            | [Get-PASAccountImportJob][Get-PASAccountImportJob]
 [Get password value][Get password value]                                                    | [Get-PASAccountPassword][Get-PASAccountPassword]
 [Retrieve private SSH key account][Retrieve private SSH key account]                        | [Get-PASAccountSSHKey][Get-PASAccountSSHKey]
-[Get Just in Time access][Get Just in Time access]                                          | [Request-PASAdHocAccess][Request-PASAdHocAccess]
+[Get Just in Time access][Get Just in Time access]                                          | [Request-PASJustInTimeAccess][Request-PASJustInTimeAccess]
+[Revoke Just in Time access][Revoke Just in Time access]                                    | [Revoke-PASJustInTimeAccess][Revke-PASJustInTimeAccess]
 [Add allowed referrer][Add allowed referrer]                                                | [Add-PASAllowedReferrer][Add-PASAllowedReferrer]
 [Get allowed referrer][Get allowed referrer]                                                | [Get-PASAllowedReferrer][Get-PASAllowedReferrer]
 [Get applications][Get applications]                                                        | [Get-PASApplication][Get-PASApplication]
@@ -196,6 +197,7 @@ A psPAS command may not appear in the below list due to it not being explicitly 
 [Delete an MFA caching SSH key][Delete an MFA caching SSH key]                                       | [Remove-PASPrivateSSHKey][Remove-PASPrivateSSHKey]
 [Delete an MFA caching SSH key for another user][Delete an MFA caching SSH key for another user]     | [Remove-PASPrivateSSHKey][Remove-PASPrivateSSHKey]
 [Update Group][Update Group]                                                                         | [Set-PASGroup][Set-PASGroup]
+[Extended Account Overview][Extended Account Overview]                                               | [Get-PASAccountDetail][Get-PASAccountDetail]
 
 [Get-PASDiscoveredAccount]:/commands/Get-PASDiscoveredAccount
 [Start-PASAccountImportJob]:/commands/Start-PASAccountImportJob
@@ -303,7 +305,8 @@ A psPAS command may not appear in the below list due to it not being explicitly 
 [Get-PASPSMRecordingActivity]:/commands/Get-PASPSMRecordingActivity
 [Get-PASPSMRecordingProperty]:/commands/Get-PASPSMRecordingProperty
 [Export-PASPSMRecording]:/commands/Export-PASPSMRecording
-[Request-PASAdHocAccess]:/commands/Request-PASAdHocAccess
+[Request-PASJustInTimeAccess]:/commands/Request-PASJustInTimeAccess
+[Revoke-PASJustInTimeAccess]:/commands/Revoke-PASJustInTimeAccess
 [Get-PASDirectoryMapping]:/commands/Get-PASDirectoryMapping
 [Set-PASDirectoryMapping]:/commands/Set-PASDirectoryMapping
 [Remove-PASDirectory]:/commands/Remove-PASDirectory
@@ -335,7 +338,9 @@ A psPAS command may not appear in the below list due to it not being explicitly 
 [New-PASPrivateSSHKey]:/commands/New-PASPrivateSSHKey
 [Remove-PASPrivateSSHKey]:/commands/Remove-PASPrivateSSHKey
 [Set-PASGroup]:/commands/Set-PASGroup
+[Get-PASAccountDetail]:/commands/Get-PASAccountDetail
 
+[Extended Account Overview]:https://documenter.getpostman.com/view/998920/RzZ9Gz1U#d20c01c2-f7fc-4717-bf10-d8c51cb11411
 [Delete discovered accounts]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Delete-Discovered-accounts.htm
 [Get Secret Versions]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/Secrets-Get-versions.htm
 [Generate Password]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/Secrets-Generate-Password.htm
@@ -491,6 +496,7 @@ A psPAS command may not appear in the below list due to it not being explicitly 
 [Add member to account group]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Add-account-to-account-group.htm
 [Delete member from account group]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/DeleteMemberFromAccountGroup.htm
 [Get Just in Time access]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/GetAccess.htm
+[Revoke Just in Time access]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Revoke-access.htm
 [Connect using PSM]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/ConnectThroughPSM.htm
 [Ad hoc connect using PSM]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/SecureConnectPSM.htm
 [Get password value]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/GetPasswordValueV10.htm

--- a/psPAS/Functions/Accounts/Clear-PASLinkedAccount.ps1
+++ b/psPAS/Functions/Accounts/Clear-PASLinkedAccount.ps1
@@ -1,0 +1,42 @@
+# .ExternalHelp psPAS-help.xml
+Function Clear-PASLinkedAccount {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [parameter(
+            Mandatory = $true,
+            ValueFromPipelinebyPropertyName = $true
+        )]
+        [Alias('id')]
+        [string]$AccountID,
+
+        [parameter(
+            Mandatory = $true,
+            ValueFromPipelinebyPropertyName = $true
+        )]
+        [int]$extraPasswordIndex
+
+    )
+
+    BEGIN {
+
+        Assert-VersionRequirement -RequiredVersion 12.2
+
+    }#begin
+
+    PROCESS {
+
+        #Create URL for Request
+        $URI = "$Script:BaseURI/api/Accounts/$AccountID/LinkAccount/$extraPasswordIndex"
+
+        if ($PSCmdlet.ShouldProcess($AccountID, "Clear extraPass$extraPasswordIndex Linked Account")) {
+
+            #Send request to web service
+            Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+
+        }
+
+    }#process
+
+    END { }#end
+
+}

--- a/psPAS/Functions/Accounts/Get-PASAccountDetail.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccountDetail.ps1
@@ -1,0 +1,35 @@
+# .ExternalHelp psPAS-help.xml
+function Get-PASAccountDetail {
+    [CmdletBinding()]
+    param(
+        [parameter(
+            Mandatory = $true,
+            ValueFromPipelinebyPropertyName = $true,
+            ParameterSetName = 'Gen2ID'
+        )]
+        [Alias('AccountID')]
+        [string]$id
+    )
+
+    BEGIN {
+        #check minimum version (10.4 assumed)
+        Assert-VersionRequirement -RequiredVersion 10.4
+    }#begin
+
+    PROCESS {
+
+        #define base URL
+        $URI = "$Script:BaseURI/api/ExtendedAccounts/$id/overview"
+
+        #Send request to web service
+        $result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+
+        If ($null -ne $result) {
+            $result
+        }
+
+    }#process
+
+    END { }#end
+
+}

--- a/psPAS/Functions/Accounts/Request-PASJustInTimeAccess.ps1
+++ b/psPAS/Functions/Accounts/Request-PASJustInTimeAccess.ps1
@@ -1,5 +1,5 @@
 # .ExternalHelp psPAS-help.xml
-function Request-PASAdHocAccess {
+function Request-PASJustInTimeAccess {
 	[CmdletBinding()]
 	param(
 		[parameter(
@@ -7,7 +7,7 @@ function Request-PASAdHocAccess {
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateNotNullOrEmpty()]
-		[Alias("id")]
+		[Alias('id')]
 		[string]$AccountID
 	)
 
@@ -27,4 +27,5 @@ function Request-PASAdHocAccess {
 	}#process
 
 	END { }#end
+
 }

--- a/psPAS/Functions/Accounts/Revoke-PASJustInTimeAccess.ps1
+++ b/psPAS/Functions/Accounts/Revoke-PASJustInTimeAccess.ps1
@@ -1,0 +1,31 @@
+# .ExternalHelp psPAS-help.xml
+function Revoke-PASJustInTimeAccess {
+    [CmdletBinding()]
+    param(
+        [parameter(
+            Mandatory = $true,
+            ValueFromPipelinebyPropertyName = $true
+        )]
+        [ValidateNotNullOrEmpty()]
+        [Alias('id')]
+        [string]$AccountID
+    )
+
+    BEGIN {
+        #check minimum version
+        Assert-VersionRequirement -RequiredVersion 12.0
+    }#begin
+
+    PROCESS {
+
+        #Create URL for request
+        $URI = "$Script:BaseURI/api/Accounts/$AccountID/RevokeAdministrativeAccess"
+
+        #Send request to webservice
+        Invoke-PASRestMethod -Uri $URI -Method POST -WebSession $Script:WebSession
+
+    }#process
+
+    END { }#end
+
+}

--- a/psPAS/Functions/Connections/New-PASPSMSession.ps1
+++ b/psPAS/Functions/Connections/New-PASPSMSession.ps1
@@ -1,13 +1,12 @@
 # .ExternalHelp psPAS-help.xml
 function New-PASPSMSession {
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'PSMConnectPrerequisites', Justification = "False Positive")]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'PSMConnectPrerequisites', Justification = 'False Positive')]
 	[CmdletBinding(SupportsShouldProcess)]
-	[Alias("Get-PASPSMConnectionParameter")]
 	param(
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "PSMConnect"
+			ParameterSetName = 'PSMConnect'
 		)]
 		[ValidateNotNullOrEmpty()]
 		[string]$AccountID,
@@ -15,173 +14,173 @@ function New-PASPSMSession {
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AdHocConnect"
+			ParameterSetName = 'AdHocConnect'
 		)]
 		[string]$userName,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AdHocConnect"
+			ParameterSetName = 'AdHocConnect'
 		)]
 		[securestring]$secret,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AdHocConnect"
+			ParameterSetName = 'AdHocConnect'
 		)]
 		[string]$address,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AdHocConnect"
+			ParameterSetName = 'AdHocConnect'
 		)]
 		[string]$platformID,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AdHocConnect"
+			ParameterSetName = 'AdHocConnect'
 		)]
 		[string]$extraFields,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "PSMConnect"
+			ParameterSetName = 'PSMConnect'
 		)]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AdHocConnect"
+			ParameterSetName = 'AdHocConnect'
 		)]
 		[string]$reason,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "PSMConnect"
+			ParameterSetName = 'PSMConnect'
 		)]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AdHocConnect"
+			ParameterSetName = 'AdHocConnect'
 		)]
 		[string]$TicketingSystemName,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "PSMConnect"
+			ParameterSetName = 'PSMConnect'
 		)]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AdHocConnect"
+			ParameterSetName = 'AdHocConnect'
 		)]
 		[string]$TicketId,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "PSMConnect"
+			ParameterSetName = 'PSMConnect'
 		)]
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AdHocConnect"
+			ParameterSetName = 'AdHocConnect'
 		)]
 		[string]$ConnectionComponent,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "PSMConnect"
+			ParameterSetName = 'PSMConnect'
 		)]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AdHocConnect"
+			ParameterSetName = 'AdHocConnect'
 		)]
-		[ValidateSet("Yes", "No")]
+		[ValidateSet('Yes', 'No')]
 		[string]$AllowMappingLocalDrives,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "PSMConnect"
+			ParameterSetName = 'PSMConnect'
 		)]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AdHocConnect"
+			ParameterSetName = 'AdHocConnect'
 		)]
-		[ValidateSet("Yes", "No")]
+		[ValidateSet('Yes', 'No')]
 		[string]$AllowConnectToConsole,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "PSMConnect"
+			ParameterSetName = 'PSMConnect'
 		)]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AdHocConnect"
+			ParameterSetName = 'AdHocConnect'
 		)]
-		[ValidateSet("Yes", "No")]
+		[ValidateSet('Yes', 'No')]
 		[string]$RedirectSmartCards,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "PSMConnect"
+			ParameterSetName = 'PSMConnect'
 		)]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AdHocConnect"
+			ParameterSetName = 'AdHocConnect'
 		)]
 		[string]$PSMRemoteMachine,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "PSMConnect"
+			ParameterSetName = 'PSMConnect'
 		)]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AdHocConnect"
+			ParameterSetName = 'AdHocConnect'
 		)]
 		[string]$LogonDomain,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "PSMConnect"
+			ParameterSetName = 'PSMConnect'
 		)]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AdHocConnect"
+			ParameterSetName = 'AdHocConnect'
 		)]
-		[ValidateSet("Yes", "No")]
+		[ValidateSet('Yes', 'No')]
 		[string]$AllowSelectHTML5,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "PSMConnect"
+			ParameterSetName = 'PSMConnect'
 		)]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AdHocConnect"
+			ParameterSetName = 'AdHocConnect'
 		)]
-		[ValidateSet("RDP", "PSMGW")]
+		[ValidateSet('RDP', 'PSMGW')]
 		[string]$ConnectionMethod,
 
 		[parameter(
@@ -194,7 +193,7 @@ function New-PASPSMSession {
 
 	BEGIN {
 
-		$AdHocParameters = [Collections.Generic.List[String]]@("ConnectionComponent", "reason", "ticketingSystemName", "ticketId", "ConnectionParams")
+		$AdHocParameters = [Collections.Generic.List[String]]@('ConnectionComponent', 'reason', 'ticketingSystemName', 'ticketId', 'ConnectionParams')
 
 	}#begin
 
@@ -209,7 +208,7 @@ function New-PASPSMSession {
 
 		switch ($PSCmdlet.ParameterSetName) {
 
-			"PSMConnect" {
+			'PSMConnect' {
 				Assert-VersionRequirement -RequiredVersion 9.10
 
 				#Create URL for Request
@@ -224,14 +223,14 @@ function New-PASPSMSession {
 
 			}
 
-			"AdHocConnect" {
+			'AdHocConnect' {
 				Assert-VersionRequirement -RequiredVersion 10.5
 
 				#Create URL for Request
 				$URI = "$Script:BaseURI/API/Accounts/AdHocConnect"
 
 				#Include decoded password in request
-				$boundParameters["secret"] = $(ConvertTo-InsecureString -SecureString $secret)
+				$boundParameters['secret'] = $(ConvertTo-InsecureString -SecureString $secret)
 
 				#Connection parameters are included under the PSMConnectPrerequisites property of the JSON body, for each one specified
 				$boundParameters.keys | Where-Object { $AdHocParameters -contains $PSItem } | ForEach-Object {
@@ -247,7 +246,7 @@ function New-PASPSMSession {
 					if ($PSMConnectPrerequisites.keys.count -gt 0) {
 
 						#If PSMConnectPrerequisites have been specified, add PSMConnectPrerequisites to boundParameters
-						$boundParameters["PSMConnectPrerequisites"] = $PSMConnectPrerequisites
+						$boundParameters['PSMConnectPrerequisites'] = $PSMConnectPrerequisites
 
 					}
 				}
@@ -266,30 +265,29 @@ function New-PASPSMSession {
 		$ThisSession = $Script:WebSession
 
 		#if a connection method is specified
-		If ($PSBoundParameters.ContainsKey("ConnectionMethod")) {
+		If ($PSBoundParameters.ContainsKey('ConnectionMethod')) {
 
 			#The information needs to passed in the header
-			if ($PSBoundParameters["ConnectionMethod"] -eq "RDP") {
+			if ($PSBoundParameters['ConnectionMethod'] -eq 'RDP') {
 
 				#RDP accept "application/json" response
-				$Accept = "application/octet-stream"
+				$Accept = 'application/octet-stream'
 
-			}
-			elseif ($PSBoundParameters["ConnectionMethod"] -eq "PSMGW") {
+			} elseif ($PSBoundParameters['ConnectionMethod'] -eq 'PSMGW') {
 
 				Assert-VersionRequirement -RequiredVersion 10.2
 
 				#PSMGW accept * / * response
-				$Accept = "* / *"
+				$Accept = '* / *'
 
 			}
 
 			#add detail to header
-			$ThisSession.Headers["Accept"] = $Accept
+			$ThisSession.Headers['Accept'] = $Accept
 
 		}
 
-		if ($PSCmdlet.ShouldProcess($ShouldProcess, "New PSM Session")) {
+		if ($PSCmdlet.ShouldProcess($ShouldProcess, 'New PSM Session')) {
 
 			#send request to PAS web service
 			$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $body -WebSession $ThisSession
@@ -298,13 +296,12 @@ function New-PASPSMSession {
 
 		If ($null -ne $result) {
 
-			If (($result | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name) -contains "PSMGWRequest") {
+			If (($result | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name) -contains 'PSMGWRequest') {
 
 				#Return PSM GW URL Details
 				$result
 
-			}
-			Else {
+			} Else {
 
 				#Save the RDP file to disk
 				Out-PASFile -InputObject $result -Path $Path

--- a/psPAS/Functions/Platforms/Get-PASPlatformSummary.ps1
+++ b/psPAS/Functions/Platforms/Get-PASPlatformSummary.ps1
@@ -1,0 +1,30 @@
+# .ExternalHelp psPAS-help.xml
+function Get-PASPlatformSummary {
+    [CmdletBinding()]
+    param()
+
+    BEGIN {
+        Assert-VersionRequirement -RequiredVersion 12.2
+    }#begin
+
+    PROCESS {
+
+        #Create request URL
+        $URI = "$Script:BaseURI/API/Platforms/Targets/SystemTypes"
+
+        #Send request to web service
+        $result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+
+        #$result
+        If ($null -ne $result) {
+
+            #Return Results
+            $result.SystemTypes
+
+        }
+
+    }#process
+
+    END { }#end
+
+}

--- a/psPAS/Functions/SafeMembers/Remove-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Remove-PASSafeMember.ps1
@@ -1,5 +1,6 @@
 # .ExternalHelp psPAS-help.xml
 function Remove-PASSafeMember {
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'UseGen1API', Justification = 'False Positive')]
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
 		[parameter(
@@ -9,23 +10,47 @@ function Remove-PASSafeMember {
 		[ValidateNotNullOrEmpty()]
 		[string]$SafeName,
 
-		[Alias("UserName")]
+		[Alias('UserName')]
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateNotNullOrEmpty()]
-		[string]$MemberName
+		[string]$MemberName,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'Gen1'
+		)]
+		[switch]$UseGen1API
 	)
 
 	BEGIN { }#begin
 
 	PROCESS {
 
-		#Create URL for request
-		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Safes/$($SafeName |
+		switch ($PSCmdlet.ParameterSetName) {
 
-            Get-EscapedString)/Members/$($MemberName | Get-EscapedString)"
+			'Gen1' {
+
+				#Create URL for request
+				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Safes/$($SafeName |
+					Get-EscapedString)/Members/$($MemberName | Get-EscapedString)"
+
+			}
+
+			default {
+
+				Assert-VersionRequirement -RequiredVersion 12.2
+
+				#Create URL for request
+				$URI = "$Script:BaseURI/api/Safes/$($SafeName |
+					Get-EscapedString)/members/$($MemberName | Get-EscapedString)"
+
+			}
+
+		}
 
 		if ($PSCmdlet.ShouldProcess($SafeName, "Remove Safe Member '$MemberName'")) {
 

--- a/psPAS/Functions/SafeMembers/Set-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Set-PASSafeMember.ps1
@@ -1,6 +1,6 @@
 # .ExternalHelp psPAS-help.xml
 function Set-PASSafeMember {
-	[CmdletBinding(SupportsShouldProcess)]
+	[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'Gen2')]
 	param(
 		[parameter(
 			Mandatory = $true,
@@ -15,6 +15,7 @@ function Set-PASSafeMember {
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateNotNullOrEmpty()]
+		[ValidateScript( { $_ -notmatch '.*(\?|\&).*' })]
 		[string]$MemberName,
 
 		[parameter(
@@ -27,49 +28,53 @@ function Set-PASSafeMember {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[Alias('RestrictedRetrieve')]
 		[boolean]$UseAccounts,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[Alias('Retrieve')]
 		[boolean]$RetrieveAccounts,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[Alias('ListContent')]
 		[boolean]$ListAccounts,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[Alias('Add')]
 		[boolean]$AddAccounts,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[Alias('Update')]
 		[boolean]$UpdateAccountContent,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[Alias('UpdateMetadata')]
 		[boolean]$UpdateAccountProperties,
 
 		[parameter(
 			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = 'CPM'
+			ValueFromPipelinebyPropertyName = $true
 		)]
 		[boolean]$InitiateCPMAccountManagementOperations,
 
 		[parameter(
 			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = 'CPM'
+			ValueFromPipelinebyPropertyName = $true
 		)]
 		[boolean]$SpecifyNextAccountContent,
 
@@ -77,18 +82,21 @@ function Set-PASSafeMember {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[Alias('Rename')]
 		[boolean]$RenameAccounts,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[Alias('Delete')]
 		[boolean]$DeleteAccounts,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[Alias('Unlock')]
 		[boolean]$UnlockAccounts,
 
 		[parameter(
@@ -113,20 +121,38 @@ function Set-PASSafeMember {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[Alias('ViewAudit')]
 		[boolean]$ViewAuditLog,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[Alias('ViewMembers')]
 		[boolean]$ViewSafeMembers,
 
 		[parameter(
 			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'Gen1'
 		)]
 		[ValidateRange(0, 2)]
 		[int]$RequestsAuthorizationLevel,
+
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'Gen2'
+		)]
+		[boolean]$requestsAuthorizationLevel1,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'Gen2'
+		)]
+		[boolean]$requestsAuthorizationLevel2,
 
 		[parameter(
 			Mandatory = $false,
@@ -138,6 +164,7 @@ function Set-PASSafeMember {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[Alias('AddRenameFolder')]
 		[boolean]$CreateFolders,
 
 		[parameter(
@@ -150,7 +177,16 @@ function Set-PASSafeMember {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[boolean]$MoveAccountsAndFolders
+		[Alias('MoveFilesAndFolders')]
+		[boolean]$MoveAccountsAndFolders,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $false,
+			ParameterSetName = 'Gen1'
+		)]
+		[switch]$UseGen1API
+
 	)
 
 	BEGIN {
@@ -164,34 +200,73 @@ function Set-PASSafeMember {
 
 	PROCESS {
 
-		#Create URL for request
-		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Safes/$($SafeName |
-
-            Get-EscapedString)/Members/$($MemberName | Get-EscapedString)"
-
 		#Get passed parameters to include in request body
 		$boundParameters = $PSBoundParameters | Get-PASParameter
 
-		If ($PSBoundParameters.ContainsKey('MembershipExpirationDate')) {
+		switch ($PSCmdlet.ParameterSetName) {
 
-			#Convert ExpiryDate to string in Required format
-			$Date = (Get-Date $MembershipExpirationDate -Format MM/dd/yyyy).ToString()
+			'Gen1' {
 
-			#Include date string in request
-			$boundParameters['MembershipExpirationDate'] = $Date
+				#check required version
+				Assert-VersionRequirement -MaximumVersion 12.3
+
+				#Create URL for request
+				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Safes/$($SafeName |
+					Get-EscapedString)/Members/$($MemberName | Get-EscapedString)"
+
+				If ($PSBoundParameters.ContainsKey('MembershipExpirationDate')) {
+
+					#Convert ExpiryDate to string in Required format
+					$Date = (Get-Date $MembershipExpirationDate -Format MM/dd/yyyy).ToString()
+
+					#Include date string in request
+					$boundParameters['MembershipExpirationDate'] = $Date
+
+				}
+
+				#Add permissions array to request in correct order
+				[array]$boundParameters['Permissions'] = $boundParameters | ConvertTo-SortedPermission -Gen1
+
+				#Create JSON for body of request
+				$body = @{
+
+					'member' = $boundParameters | Get-PASParameter -ParametersToKeep $keysToKeep
+
+					#Ensure all levels of object are output
+				} | ConvertTo-Json -Depth 3
+
+				break
+
+			}
+
+			'Gen2' {
+
+				Assert-VersionRequirement -RequiredVersion 12.2
+
+				#Create URL for request
+				$URI = "$Script:BaseURI/api/Safes/$($SafeName | Get-EscapedString)/Members/$($MemberName | Get-EscapedString)"
+
+				If ($PSBoundParameters.ContainsKey('MembershipExpirationDate')) {
+
+					#Convert MembershipExpirationDate to string in Required format
+					$Date = Get-Date $MembershipExpirationDate | ConvertTo-UnixTime
+
+					#Include date string in request
+					$boundParameters['MembershipExpirationDate'] = $Date
+
+				}
+
+				#Add permissions array to request in correct order
+				$boundParameters['Permissions'] = $boundParameters | ConvertTo-SortedPermission -Gen2
+
+				#Create required request object
+				$body = $boundParameters | Get-PASParameter -ParametersToKeep $keysToKeep | ConvertTo-Json
+
+				break
+
+			}
 
 		}
-
-		#Add permissions array to request in correct order
-		[array]$boundParameters['Permissions'] = $boundParameters | ConvertTo-SortedPermission -Gen1
-
-		#Create JSON for body of request
-		$body = @{
-
-			'member' = $boundParameters | Get-PASParameter -ParametersToKeep $keysToKeep
-
-			#Ensure all levels of object are output
-		} | ConvertTo-Json -Depth 3
 
 		if ($PSCmdlet.ShouldProcess($SafeName, "Update Safe Permissions for '$MemberName'")) {
 
@@ -200,17 +275,37 @@ function Set-PASSafeMember {
 
 			If ($null -ne $result) {
 
-				#format output
-				$result.member | Select-Object MembershipExpirationDate,
+				switch ($PSCmdlet.ParameterSetName) {
 
-				@{Name = 'Permissions'; 'Expression' = {
+					'Gen1' {
 
-						$result.member.permissions | ConvertFrom-KeyValuePair }
+						#format output
+						$result.member | Select-Object MembershipExpirationDate,
 
-				} | Add-ObjectDetail -typename psPAS.CyberArk.Vault.Safe.Member -PropertyToAdd @{
+						@{Name = 'Permissions'; 'Expression' = {
 
-					'UserName' = $MemberName
-					'SafeName' = $SafeName
+								$result.member.permissions | ConvertFrom-KeyValuePair }
+
+						} | Add-ObjectDetail -typename psPAS.CyberArk.Vault.Safe.Member -PropertyToAdd @{
+
+							'UserName' = $MemberName
+							'SafeName' = $SafeName
+
+						}
+
+						break
+
+					}
+
+					'Gen2' {
+
+						$result |
+							Select-Object *, @{Name = 'UserName'; 'Expression' = { $PSItem.MemberName } } |
+							Add-ObjectDetail -typename psPAS.CyberArk.Vault.Safe.Member.Gen2
+
+						break
+
+					}
 
 				}
 

--- a/psPAS/Functions/User/Add-PASGroupMember.ps1
+++ b/psPAS/Functions/User/Add-PASGroupMember.ps1
@@ -1,47 +1,47 @@
 # .ExternalHelp psPAS-help.xml
 function Add-PASGroupMember {
-	[CmdletBinding(DefaultParameterSetName = "Gen2")]
+	[CmdletBinding(DefaultParameterSetName = 'Gen2')]
 	param(
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[int]$groupId,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[string]$memberId,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
-		[ValidateSet("domain", "vault")]
+		[ValidateSet('domain', 'vault')]
 		[string]$memberType,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[string]$domainName,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[string]$GroupName,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[string]$UserName
 	)
@@ -54,7 +54,9 @@ function Add-PASGroupMember {
 
 		switch ($PSCmdlet.ParameterSetName) {
 
-			"Gen1" {
+			'Gen1' {
+
+				Assert-VersionRequirement -MaximumVersion 12.3
 
 				#Create URL for request
 				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Groups/$($GroupName | Get-EscapedString)/Users"
@@ -63,7 +65,7 @@ function Add-PASGroupMember {
 
 			}
 
-			"Gen2" {
+			'Gen2' {
 
 				Assert-VersionRequirement -RequiredVersion 10.6
 

--- a/psPAS/Functions/User/Get-PASGroup.ps1
+++ b/psPAS/Functions/User/Get-PASGroup.ps1
@@ -20,6 +20,18 @@ function Get-PASGroup {
 
 		[parameter(
 			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'groupType'
+		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'filter'
+		)]
+		[string[]]$sort,
+
+		[parameter(
+			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[string]$search,
@@ -37,9 +49,23 @@ function Get-PASGroup {
 
 	PROCESS {
 
-		If ($PSBoundParameters.ContainsKey('includeMembers')) {
+		switch ($PSBoundParameters.Keys) {
 
-			Assert-VersionRequirement -RequiredVersion 12.0
+			{ $_ -match 'includeMembers' } {
+
+				#includeMembers parameter require 12.0
+				Assert-VersionRequirement -RequiredVersion 12.0
+
+				continue
+
+			}
+
+			{ $_ -match 'sort' } {
+
+				#Sort parameter require 12.2
+				Assert-VersionRequirement -RequiredVersion 12.2
+
+			}
 
 		}
 

--- a/psPAS/Functions/User/Get-PASUser.ps1
+++ b/psPAS/Functions/User/Get-PASUser.ps1
@@ -34,7 +34,6 @@ function Get-PASUser {
 		)]
 		[string]$UserType,
 
-
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
@@ -47,6 +46,17 @@ function Get-PASUser {
 		)]
 		[boolean]$ComponentUser,
 
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'Gen2'
+		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'Gen2-ExtendedDetails'
+		)]
+		[string[]]$sort,
 
 		[parameter(
 			Mandatory = $false,
@@ -56,11 +66,28 @@ function Get-PASUser {
 		[boolean]$ExtendedDetails,
 
 		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'Gen2'
+		)]
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'Gen2-ExtendedDetails'
+		)]
+		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Gen1'
 		)]
-		[string]$UserName
+		[string]$UserName,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $false,
+			ParameterSetName = 'Gen1'
+		)]
+		[switch]$UseGen1API
 	)
 
 	BEGIN { }#begin
@@ -75,6 +102,7 @@ function Get-PASUser {
 			'Gen2ID' {
 
 				Assert-VersionRequirement -RequiredVersion 10.10
+
 				#Create URL for request
 				$URI = "$URI/$id"
 
@@ -90,7 +118,19 @@ function Get-PASUser {
 
 			( { $PSItem -match '^Gen2' } ) {
 
+				switch ($PSBoundParameters.Keys) {
+
+					{ $_ -match 'UserName|sort' } {
+
+						#Gen2 UserName & Sort parameters require 12.2
+						Assert-VersionRequirement -RequiredVersion 12.2
+
+					}
+
+				}
+
 				Assert-VersionRequirement -RequiredVersion 10.9
+
 				#Get Parameters to include in request
 				$boundParameters = $PSBoundParameters | Get-PASParameter
 
@@ -109,6 +149,8 @@ function Get-PASUser {
 			}
 
 			'Gen1' {
+
+				Assert-VersionRequirement -MaximumVersion 12.3
 
 				#Create URL for request
 				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)"

--- a/psPAS/Functions/User/New-PASUser.ps1
+++ b/psPAS/Functions/User/New-PASUser.ps1
@@ -1,16 +1,16 @@
 ﻿# .ExternalHelp psPAS-help.xml
 function New-PASUser {
-	[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = "Gen2")]
+	[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'Gen2')]
 	param(
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[ValidateLength(0, 128)]
 		[string]$UserName,
@@ -18,133 +18,133 @@ function New-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[securestring]$InitialPassword,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[string]$userType,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
-		[ValidateSet("PIMSU", "PSM", "PSMP", "PVWA", "WINCLIENT", "PTA", "PACLI", "NAPI", "XAPI", "HTTPGW",
-			"EVD", "PIMSu", "AIMApp", "CPM", "PVWAApp", "PSMApp", "AppPrv", "AIMApp", "PSMPApp")]
+		[ValidateSet('PIMSU', 'PSM', 'PSMP', 'PVWA', 'WINCLIENT', 'PTA', 'PACLI', 'NAPI', 'XAPI', 'HTTPGW',
+			'EVD', 'PIMSu', 'AIMApp', 'CPM', 'PVWAApp', 'PSMApp', 'AppPrv', 'AIMApp', 'PSMPApp')]
 		[string[]]$unAuthorizedInterfaces,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[boolean]$enableUser,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
-		[ValidateSet("AuthTypePass", "AuthTypeLDAP", "AuthTypeRADIUS")]
+		[ValidateSet('AuthTypePass', 'AuthTypeLDAP', 'AuthTypeRADIUS')]
 		[string[]]$authenticationMethod,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[string]$Email,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[boolean]$ChangePassOnNextLogon,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[boolean]$ChangePasswordOnTheNextLogon,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[boolean]$passwordNeverExpires,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[string]$distinguishedName,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
-		[ValidateSet("AddSafes", "AuditUsers", "AddUpdateUsers", "ResetUsersPasswords", "ActivateUsers",
-			"AddNetworkAreas", "ManageDirectoryMapping", "ManageServerFileCategories", "BackupAllSafes",
-			"RestoreAllSafes")]
+		[ValidateSet('AddSafes', 'AuditUsers', 'AddUpdateUsers', 'ResetUsersPasswords', 'ActivateUsers',
+			'AddNetworkAreas', 'ManageDirectoryMapping', 'ManageServerFileCategories', 'BackupAllSafes',
+			'RestoreAllSafes')]
 		[string[]]$vaultAuthorization,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[datetime]$ExpiryDate,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[string]$UserTypeName,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[boolean]$Disabled,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[string]$Location,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 29)]
 		[string]$workStreet,
@@ -152,7 +152,7 @@ function New-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 19)]
 		[string]$workCity,
@@ -160,7 +160,7 @@ function New-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 19)]
 		[string]$workState,
@@ -168,7 +168,7 @@ function New-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 19)]
 		[string]$workZip,
@@ -176,7 +176,7 @@ function New-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 19)]
 		[string]$workCountry,
@@ -184,7 +184,7 @@ function New-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 319)]
 		[string]$homePage,
@@ -192,7 +192,7 @@ function New-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 319)]
 		[string]$homeEmail,
@@ -201,7 +201,7 @@ function New-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 319)]
 		[string]$businessEmail,
@@ -209,7 +209,7 @@ function New-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 319)]
 		[string]$otherEmail,
@@ -217,7 +217,7 @@ function New-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 24)]
 		[string]$homeNumber,
@@ -225,7 +225,7 @@ function New-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 24)]
 		[string]$businessNumber,
@@ -233,7 +233,7 @@ function New-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 24)]
 		[string]$cellularNumber,
@@ -241,7 +241,7 @@ function New-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 24)]
 		[string]$faxNumber,
@@ -249,7 +249,7 @@ function New-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 24)]
 		[string]$pagerNumber,
@@ -257,7 +257,7 @@ function New-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 99)]
 		[string]$description,
@@ -266,12 +266,12 @@ function New-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[ValidateLength(0, 29)]
 		[string]$FirstName,
@@ -279,7 +279,7 @@ function New-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 29)]
 		[string]$MiddleName,
@@ -288,12 +288,12 @@ function New-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[ValidateLength(0, 29)]
 		[string]$LastName,
@@ -301,7 +301,7 @@ function New-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 29)]
 		[string]$street,
@@ -309,7 +309,7 @@ function New-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 19)]
 		[string]$city,
@@ -317,7 +317,7 @@ function New-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 19)]
 		[string]$state,
@@ -325,7 +325,7 @@ function New-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 19)]
 		[string]$zip,
@@ -333,7 +333,7 @@ function New-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 19)]
 		[string]$country,
@@ -341,7 +341,7 @@ function New-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 49)]
 		[string]$title,
@@ -349,7 +349,7 @@ function New-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 49)]
 		[string]$organization,
@@ -357,7 +357,7 @@ function New-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 49)]
 		[string]$department,
@@ -365,7 +365,7 @@ function New-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(0, 49)]
 		[string]$profession,
@@ -373,9 +373,9 @@ function New-PASUser {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $false,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
-		[Alias("UseClassicAPI")]
+		[Alias('UseClassicAPI')]
 		[switch]$UseGen1API
 	)
 
@@ -386,16 +386,16 @@ function New-PASUser {
 		#Get request parameters
 		$boundParameters = $PSBoundParameters | Get-PASParameter
 
-		If ($PSBoundParameters.ContainsKey("InitialPassword")) {
+		If ($PSBoundParameters.ContainsKey('InitialPassword')) {
 
 			#Include decoded password in request
-			$boundParameters["InitialPassword"] = $(ConvertTo-InsecureString -SecureString $InitialPassword)
+			$boundParameters['InitialPassword'] = $(ConvertTo-InsecureString -SecureString $InitialPassword)
 
 		}
 
 		switch ($PSCmdlet.ParameterSetName) {
 
-			"Gen2" {
+			'Gen2' {
 
 				Assert-VersionRequirement -RequiredVersion 10.9
 
@@ -404,28 +404,30 @@ function New-PASUser {
 
 				$boundParameters = $boundParameters | Format-PASUserObject
 
-				$TypeName = "psPAS.CyberArk.Vault.User.Extended"
+				$TypeName = 'psPAS.CyberArk.Vault.User.Extended'
 
 				break
 
 			}
 
-			"Gen1" {
+			'Gen1' {
+
+				Assert-VersionRequirement -MaximumVersion 12.3
 
 				#Create URL for request
 				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Users"
 
-				If ($PSBoundParameters.ContainsKey("ExpiryDate")) {
+				If ($PSBoundParameters.ContainsKey('ExpiryDate')) {
 
 					#Convert ExpiryDate to string in Required format
 					$Date = (Get-Date $ExpiryDate -Format MM/dd/yyyy).ToString()
 
 					#Include date string in request
-					$boundParameters["ExpiryDate"] = $Date
+					$boundParameters['ExpiryDate'] = $Date
 
 				}
 
-				$TypeName = "psPAS.CyberArk.Vault.User"
+				$TypeName = 'psPAS.CyberArk.Vault.User'
 
 				break
 
@@ -436,7 +438,7 @@ function New-PASUser {
 		#Construct Request Body
 		$body = $boundParameters | ConvertTo-Json -Depth 4
 
-		if ($PSCmdlet.ShouldProcess($UserName, "Create User")) {
+		if ($PSCmdlet.ShouldProcess($UserName, 'Create User')) {
 
 			#send request to web service
 			$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession

--- a/psPAS/Functions/User/Remove-PASUser.ps1
+++ b/psPAS/Functions/User/Remove-PASUser.ps1
@@ -1,26 +1,26 @@
 # .ExternalHelp psPAS-help.xml
 function Remove-PASUser {
-	[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = "Gen2")]
+	[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'Gen2')]
 	param(
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[int]$id,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[string]$UserName
 	)
 
 	BEGIN {
 
-		If ($PSCmdlet.ParameterSetName -eq "Gen2") {
+		If ($PSCmdlet.ParameterSetName -eq 'Gen2') {
 
 			Assert-VersionRequirement -RequiredVersion 11.1
 
@@ -32,7 +32,7 @@ function Remove-PASUser {
 
 		switch ($PSCmdlet.ParameterSetName) {
 
-			"Gen2" {
+			'Gen2' {
 
 				$URI = "$Script:BaseURI/api/Users/$id"
 
@@ -41,6 +41,8 @@ function Remove-PASUser {
 			}
 
 			default {
+
+				Assert-VersionRequirement -MaximumVersion 12.3
 
 				#Create URL for request
 				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)"
@@ -51,7 +53,7 @@ function Remove-PASUser {
 
 		}
 
-		if ($PSCmdlet.ShouldProcess($UserName, "Delete User")) {
+		if ($PSCmdlet.ShouldProcess($UserName, 'Delete User')) {
 
 			#send request to web service
 			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession

--- a/psPAS/Functions/User/Set-PASUser.ps1
+++ b/psPAS/Functions/User/Set-PASUser.ps1
@@ -425,6 +425,8 @@ function Set-PASUser {
 
 			'Gen1' {
 
+				Assert-VersionRequirement -MaximumVersion 12.3
+
 				If ($PSBoundParameters.ContainsKey('ExpiryDate')) {
 
 					#Convert ExpiryDate to string in Required format

--- a/psPAS/Functions/User/Unblock-PASUser.ps1
+++ b/psPAS/Functions/User/Unblock-PASUser.ps1
@@ -1,26 +1,26 @@
 # .ExternalHelp psPAS-help.xml
 function Unblock-PASUser {
 
-	[CmdletBinding(DefaultParameterSetName = "Gen2")]
+	[CmdletBinding(DefaultParameterSetName = 'Gen2')]
 	param(
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[int]$id,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[string]$UserName,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $false,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[ValidateSet($false)]
 		[boolean]$Suspended
@@ -28,7 +28,7 @@ function Unblock-PASUser {
 
 	BEGIN {
 
-		$Request = @{"WebSession" = $Script:WebSession }
+		$Request = @{'WebSession' = $Script:WebSession }
 
 	}#begin
 
@@ -36,24 +36,26 @@ function Unblock-PASUser {
 
 		switch ($PSCmdlet.ParameterSetName) {
 
-			"Gen2" {
+			'Gen2' {
 
 				Assert-VersionRequirement -RequiredVersion 10.10
 
 				#Create request
-				$Request["URI"] = "$Script:BaseURI/api/Users/$id/Activate"
-				$Request["Method"] = "POST"
+				$Request['URI'] = "$Script:BaseURI/api/Users/$id/Activate"
+				$Request['Method'] = 'POST'
 
 				break
 
 			}
 
-			"Gen1" {
+			'Gen1' {
+
+				Assert-VersionRequirement -MaximumVersion 12.3
 
 				#Create request
-				$Request["URI"] = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)"
-				$Request["Method"] = "PUT"
-				$Request["Body"] = $PSBoundParameters | Get-PASParameter -ParametersToRemove UserName | ConvertTo-Json
+				$Request['URI'] = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)"
+				$Request['Method'] = 'PUT'
+				$Request['Body'] = $PSBoundParameters | Get-PASParameter -ParametersToRemove UserName | ConvertTo-Json
 
 				break
 

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -10936,6 +10936,77 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
+      <command:name>Get-PASAccountDetail</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>PASAccountDetail</command:noun>
+      <maml:description>
+        <maml:para>Gets extended overview of account details</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Gets extended details of an account, including data on compliance, activities, dependencies, recordings &amp; platform configuration settings.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Get-PASAccountDetail</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="AccountID">
+          <maml:name>id</maml:name>
+          <maml:description>
+            <maml:para>The Account ID of the account to get extended details for.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="AccountID">
+        <maml:name>id</maml:name>
+        <maml:description>
+          <maml:para>The Account ID of the account to get extended details for.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>This is not an officially documented API method and is subject to change.</maml:para>
+        <maml:para>It is assumed to require minimum version of 10.4.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; Get-PASAccountDetail -id 123_45</dev:code>
+        <dev:remarks>
+          <maml:para>Displays extended details of account with id 123_45</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>https://pspas.pspete.dev/commands/Get-PASAccountActivity</maml:linkText>
+        <maml:uri>https://pspas.pspete.dev/commands/Get-PASAccountActivity</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>https://documenter.getpostman.com/view/998920/RzZ9Gz1U#d20c01c2-f7fc-4717-bf10-d8c51cb11411</maml:linkText>
+        <maml:uri>https://documenter.getpostman.com/view/998920/RzZ9Gz1U#d20c01c2-f7fc-4717-bf10-d8c51cb11411</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
       <command:name>Get-PASAccountGroup</command:name>
       <command:verb>Get</command:verb>
       <command:noun>PASAccountGroup</command:noun>
@@ -27405,11 +27476,11 @@ New-PASSession -SAMLAuth -concurrentSession $true -BaseURI $baseURL -SAMLRespons
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
-      <command:name>Request-PASAdHocAccess</command:name>
+      <command:name>Request-PASJustInTimeAccess</command:name>
       <command:verb>Request</command:verb>
-      <command:noun>PASAdHocAccess</command:noun>
+      <command:noun>PASJustInTimeAccess</command:noun>
       <maml:description>
-        <maml:para>Requests access to a target Windows machine</maml:para>
+        <maml:para>Requests JIT access to a target Windows machine</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
@@ -27417,7 +27488,7 @@ New-PASSession -SAMLAuth -concurrentSession $true -BaseURI $baseURL -SAMLRespons
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
-        <maml:name>Request-PASAdHocAccess</maml:name>
+        <maml:name>Request-PASJustInTimeAccess</maml:name>
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="id">
           <maml:name>AccountID</maml:name>
           <maml:description>
@@ -27456,16 +27527,16 @@ New-PASSession -SAMLAuth -concurrentSession $true -BaseURI $baseURL -SAMLRespons
     <command:examples>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
-        <dev:code>Request-PASAdHocAccess -AccountID 36_3</dev:code>
+        <dev:code>Request-PASJustInTimeAccess -AccountID 36_3</dev:code>
         <dev:remarks>
-          <maml:para>Requests "ad hoc" access on the server for which the account with id 36_3 is a local account with local admin membership.</maml:para>
+          <maml:para>Requests JIT access on the server for which the account with id 36_3 is a local account with local admin membership.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
     <command:relatedLinks>
       <maml:navigationLink>
-        <maml:linkText>https://pspas.pspete.dev/commands/Request-PASAdHocAccess</maml:linkText>
-        <maml:uri>https://pspas.pspete.dev/commands/Request-PASAdHocAccess</maml:uri>
+        <maml:linkText>https://pspas.pspete.dev/commands/Request-PASJustInTimeAccess</maml:linkText>
+        <maml:uri>https://pspas.pspete.dev/commands/Request-PASJustInTimeAccess</maml:uri>
       </maml:navigationLink>
       <maml:navigationLink>
         <maml:linkText>https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/GetAccess.htm</maml:linkText>
@@ -27586,6 +27657,76 @@ New-PASSession -SAMLAuth -concurrentSession $true -BaseURI $baseURL -SAMLRespons
       <maml:navigationLink>
         <maml:linkText>https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Suspend-ResumeSession.htm</maml:linkText>
         <maml:uri>https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Suspend-ResumeSession.htm</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Revoke-PASJustInTimeAccess</command:name>
+      <command:verb>Revoke</command:verb>
+      <command:noun>PASJustInTimeAccess</command:noun>
+      <maml:description>
+        <maml:para>Revoke JIT access to a target Windows machine</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Requests and receives access, with administrative rights, to a target Windows machine. The domain user who issuing the command will be removed from the local Administrators group of the target machine.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Revoke-PASJustInTimeAccess</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="id">
+          <maml:name>AccountID</maml:name>
+          <maml:description>
+            <maml:para>The ID of the local account that will be used to remove the authenticated user from the Administrators group on the target machine.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="id">
+        <maml:name>AccountID</maml:name>
+        <maml:description>
+          <maml:para>The ID of the local account that will be used to remove the authenticated user from the Administrators group on the target machine.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+        <dev:code>Revoke-PASJustInTimeAccess -AccountID 36_3</dev:code>
+        <dev:remarks>
+          <maml:para>Revokes JIT access on the server for which the account with id 36_3 is a local account with local admin membership.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>https://pspas.pspete.dev/commands/Revoke-PASJustInTimeAccess</maml:linkText>
+        <maml:uri>https://pspas.pspete.dev/commands/Revoke-PASJustInTimeAccess</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/GetAccess.htm</maml:linkText>
+        <maml:uri>https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/GetAccess.htm</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -13034,6 +13034,21 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>sort</maml:name>
+          <maml:description>
+            <maml:para>Property or properties by which to sort returned groups, followed by asc (default) or desc to control sort direction.</maml:para>
+            <maml:para>Cannot sort by a property other than `groupname`, `directory` or `location`.</maml:para>
+            <maml:para>Separate multiple properties with commas, up to a maximum of three properties.</maml:para>
+            <maml:para>Requires minimum version of 12.2</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Get-PASGroup</maml:name>
@@ -13072,6 +13087,21 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
           <dev:type>
             <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>sort</maml:name>
+          <maml:description>
+            <maml:para>Property or properties by which to sort returned groups, followed by asc (default) or desc to control sort direction.</maml:para>
+            <maml:para>Cannot sort by a property other than `groupname`, `directory` or `location`.</maml:para>
+            <maml:para>Separate multiple properties with commas, up to a maximum of three properties.</maml:para>
+            <maml:para>Requires minimum version of 12.2</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -13126,6 +13156,21 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
         <dev:type>
           <maml:name>Boolean</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>sort</maml:name>
+        <maml:description>
+          <maml:para>Property or properties by which to sort returned groups, followed by asc (default) or desc to control sort direction.</maml:para>
+          <maml:para>Cannot sort by a property other than `groupname`, `directory` or `location`.</maml:para>
+          <maml:para>Separate multiple properties with commas, up to a maximum of three properties.</maml:para>
+          <maml:para>Requires minimum version of 12.2</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -15677,8 +15722,9 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
     </command:details>
     <maml:description>
       <maml:para>Gets safe by SafeName, by search query string, or, by default will return all safes. - Minimum required version for default operation using Gen2 API is 12.0.</maml:para>
+      <maml:para>- Minimum required version for operation using Gen2-byName ParameterSet is 12.2.</maml:para>
       <maml:para>- For PAS versions earlier than 12.0, the Gen1 API parameters must be used.</maml:para>
-      <maml:para>- Gen1 API parameters are depreciated for versions higher than 12.2.</maml:para>
+      <maml:para>- Gen1 API parameters are depreciated for versions higher than 12.3.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -15687,7 +15733,8 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           <maml:name>includeAccounts</maml:name>
           <maml:description>
             <maml:para>Whether or not to return accounts for each Safe as part of the response.</maml:para>
-            <maml:para>Minimum required version 12.0</maml:para>
+            <maml:para>Minimum required version 12.0 (Default Gen2 Operation)</maml:para>
+            <maml:para>Minimum required version 12.2 (Gen2-byName Operation)</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
           <dev:type>
@@ -15752,11 +15799,26 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
       <command:syntaxItem>
         <maml:name>Get-PASSafe</maml:name>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>includeAccounts</maml:name>
+          <maml:description>
+            <maml:para>Whether or not to return accounts for each Safe as part of the response.</maml:para>
+            <maml:para>Minimum required version 12.0 (Default Gen2 Operation)</maml:para>
+            <maml:para>Minimum required version 12.2 (Gen2-byName Operation)</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>SafeName</maml:name>
           <maml:description>
-            <maml:para>The name of a specific safe to get details of using Gen1 API.</maml:para>
-            <maml:para>Should be specified for versions earlier than 12.0</maml:para>
-            <maml:para>Depreciated from version 12.2</maml:para>
+            <maml:para>The name of a specific safe to get details of.</maml:para>
+            <maml:para>Gen2 API operation requires minimum version 12.2</maml:para>
+            <maml:para>When using Gen1 API in versions earlier than 12.0, must be specified with the `-UseGen1API` parameter.</maml:para>
+            <maml:para>Gen1 operation depreciated from version 12.3</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -15778,6 +15840,60 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           </dev:type>
           <dev:defaultValue>0</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>useCache</maml:name>
+          <maml:description>
+            <maml:para>Whether to retrieve from session or not.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Get-PASSafe</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>SafeName</maml:name>
+          <maml:description>
+            <maml:para>The name of a specific safe to get details of.</maml:para>
+            <maml:para>Gen2 API operation requires minimum version 12.2</maml:para>
+            <maml:para>When using Gen1 API in versions earlier than 12.0, must be specified with the `-UseGen1API` parameter.</maml:para>
+            <maml:para>Gen1 operation depreciated from version 12.3</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>TimeoutSec</maml:name>
+          <maml:description>
+            <maml:para>See Invoke-WebRequest</maml:para>
+            <maml:para>Specify a timeout value in seconds</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>0</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>UseGen1API</maml:name>
+          <maml:description>
+            <maml:para>Specify to force use of the Gen1 API</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Get-PASSafe</maml:name>
@@ -15786,7 +15902,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           <maml:description>
             <maml:para>Query String for safe search in the vault using Gen1 API.</maml:para>
             <maml:para>Should be specified for versions earlier than 12.0</maml:para>
-            <maml:para>Depreciated from version 12.2</maml:para>
+            <maml:para>Depreciated from version 12.3</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -15816,7 +15932,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           <maml:description>
             <maml:para>Specify to find all safes using Gen1 API.</maml:para>
             <maml:para>Should be specified for versions earlier than 12.0</maml:para>
-            <maml:para>Depreciated from version 12.2</maml:para>
+            <maml:para>Depreciated from version 12.3</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -15844,7 +15960,8 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <maml:name>includeAccounts</maml:name>
         <maml:description>
           <maml:para>Whether or not to return accounts for each Safe as part of the response.</maml:para>
-          <maml:para>Minimum required version 12.0</maml:para>
+          <maml:para>Minimum required version 12.0 (Default Gen2 Operation)</maml:para>
+          <maml:para>Minimum required version 12.2 (Gen2-byName Operation)</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
         <dev:type>
@@ -15892,12 +16009,13 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>SafeName</maml:name>
         <maml:description>
-          <maml:para>The name of a specific safe to get details of using Gen1 API.</maml:para>
-          <maml:para>Should be specified for versions earlier than 12.0</maml:para>
-          <maml:para>Depreciated from version 12.2</maml:para>
+          <maml:para>The name of a specific safe to get details of.</maml:para>
+          <maml:para>Gen2 API operation requires minimum version 12.2</maml:para>
+          <maml:para>When using Gen1 API in versions earlier than 12.0, must be specified with the `-UseGen1API` parameter.</maml:para>
+          <maml:para>Gen1 operation depreciated from version 12.3</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -15911,7 +16029,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <maml:description>
           <maml:para>Query String for safe search in the vault using Gen1 API.</maml:para>
           <maml:para>Should be specified for versions earlier than 12.0</maml:para>
-          <maml:para>Depreciated from version 12.2</maml:para>
+          <maml:para>Depreciated from version 12.3</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -15925,7 +16043,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <maml:description>
           <maml:para>Specify to find all safes using Gen1 API.</maml:para>
           <maml:para>Should be specified for versions earlier than 12.0</maml:para>
-          <maml:para>Depreciated from version 12.2</maml:para>
+          <maml:para>Depreciated from version 12.3</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -15946,6 +16064,30 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           <maml:uri />
         </dev:type>
         <dev:defaultValue>0</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>useCache</maml:name>
+        <maml:description>
+          <maml:para>Whether to retrieve from session or not.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+        <dev:type>
+          <maml:name>Boolean</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>UseGen1API</maml:name>
+        <maml:description>
+          <maml:para>Specify to force use of the Gen1 API</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes />
@@ -15976,8 +16118,8 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <maml:title>-------------------------- EXAMPLE 3 --------------------------</maml:title>
         <dev:code>Get-PASSafe -SafeName SAFE1</dev:code>
         <dev:remarks>
-          <maml:para>Returns details of "Safe1" using Gen1 API.</maml:para>
-          <maml:para>Depreciated from version 12.2</maml:para>
+          <maml:para>Returns details of "Safe1" using Gen2 API.</maml:para>
+          <maml:para>Minimum required version 12.2</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
@@ -15993,7 +16135,15 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <dev:code>Get-PASSafe -FindAll</dev:code>
         <dev:remarks>
           <maml:para>Returns details of all safes using Gen1 API.</maml:para>
-          <maml:para>Depreciated from version 12.2</maml:para>
+          <maml:para>Depreciated from version 12.3</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 6 --------------------------</maml:title>
+        <dev:code>Get-PASSafe -SafeName SAFE1 -UseGen1Api</dev:code>
+        <dev:remarks>
+          <maml:para>Returns details of "Safe1" using Gen1 API.</maml:para>
+          <maml:para>Depreciated from version 12.3</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -16030,7 +16180,8 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
       <maml:para>- View Safe Members permission is required.</maml:para>
       <maml:para>- Defaults to the Gen 2 API which requires 12.0 or higher.</maml:para>
       <maml:para>- Additional member filter parameters require 12.1 or higher.</maml:para>
-      <maml:para>- Versions lower than 12.0 must specify the `UseGen1API` switch to force use of the Gen1 API. Note When using the Gen1 API &amp; querying all members of a safe, the permissions are reported as follows:</maml:para>
+      <maml:para>- MemberName parameter requires 12.2 or higher for use with Gen2 API.</maml:para>
+      <maml:para>- Versions lower than 12.0 (or 12.2 when using the MemberName parameter) must specify the `UseGen1API` switch to force use of the Gen1 API. Note When using the Gen1 API &amp; querying all members of a safe, the permissions are reported as follows:</maml:para>
       <maml:para>- List accounts (ListContent)</maml:para>
       <maml:para>- Retrieve accounts	(Retrieve)</maml:para>
       <maml:para>- Add accounts, including update properties (Add)</maml:para>
@@ -16096,13 +16247,71 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="UserName">
           <maml:name>MemberName</maml:name>
           <maml:description>
-            <maml:para>Specify the name of a safe member to return their safe permissions in full. NOTE : An empty PUT request (update) is sent to retrieve full safe permissions for a user: - You cannot report on the permissions of the user authenticated to the API.</maml:para>
+            <maml:para>Specify the name of a safe member to return their safe permissions in full.</maml:para>
+            <maml:para>Operation against Gen2 API requires minimum version of 12.2 NOTE for Gen1 Operation : An empty PUT request (update) is sent to retrieve full safe permissions for a user: - `-UseGen1API` parameter must be specified.</maml:para>
+            <maml:para>- You cannot report on the permissions of the user authenticated to the API.</maml:para>
             <maml:para>- Reporting on the permissions of the Quota Owner is expected to fail.</maml:para>
             <maml:para>- Depreciated from CyberArk Version 12.3</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>UseGen1API</maml:name>
+          <maml:description>
+            <maml:para>Force use of the Gen1 API.</maml:para>
+            <maml:para>Should be specified for versions earlier than 12.0.</maml:para>
+            <maml:para>Should be specified for versions earlier than 12.2 when querying by MemberName</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Get-PASSafeMember</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>SafeName</maml:name>
+          <maml:description>
+            <maml:para>The name of the safe to get the members of</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="UserName">
+          <maml:name>MemberName</maml:name>
+          <maml:description>
+            <maml:para>Specify the name of a safe member to return their safe permissions in full.</maml:para>
+            <maml:para>Operation against Gen2 API requires minimum version of 12.2 NOTE for Gen1 Operation : An empty PUT request (update) is sent to retrieve full safe permissions for a user: - `-UseGen1API` parameter must be specified.</maml:para>
+            <maml:para>- You cannot report on the permissions of the user authenticated to the API.</maml:para>
+            <maml:para>- Reporting on the permissions of the Quota Owner is expected to fail.</maml:para>
+            <maml:para>- Depreciated from CyberArk Version 12.3</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>useCache</maml:name>
+          <maml:description>
+            <maml:para>Whether or not to retrieve the cache from a session.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -16243,11 +16452,12 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>UseGen1API</maml:name>
           <maml:description>
             <maml:para>Force use of the Gen1 API.</maml:para>
             <maml:para>Should be specified for versions earlier than 12.0.</maml:para>
+            <maml:para>Should be specified for versions earlier than 12.2 when querying by MemberName</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -16273,7 +16483,9 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="UserName">
         <maml:name>MemberName</maml:name>
         <maml:description>
-          <maml:para>Specify the name of a safe member to return their safe permissions in full. NOTE : An empty PUT request (update) is sent to retrieve full safe permissions for a user: - You cannot report on the permissions of the user authenticated to the API.</maml:para>
+          <maml:para>Specify the name of a safe member to return their safe permissions in full.</maml:para>
+          <maml:para>Operation against Gen2 API requires minimum version of 12.2 NOTE for Gen1 Operation : An empty PUT request (update) is sent to retrieve full safe permissions for a user: - `-UseGen1API` parameter must be specified.</maml:para>
+          <maml:para>- You cannot report on the permissions of the user authenticated to the API.</maml:para>
           <maml:para>- Reporting on the permissions of the Quota Owner is expected to fail.</maml:para>
           <maml:para>- Depreciated from CyberArk Version 12.3</maml:para>
         </maml:description>
@@ -16362,11 +16574,12 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>UseGen1API</maml:name>
         <maml:description>
           <maml:para>Force use of the Gen1 API.</maml:para>
           <maml:para>Should be specified for versions earlier than 12.0.</maml:para>
+          <maml:para>Should be specified for versions earlier than 12.2 when querying by MemberName</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -16374,6 +16587,18 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           <maml:uri />
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>useCache</maml:name>
+        <maml:description>
+          <maml:para>Whether or not to retrieve the cache from a session.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+        <dev:type>
+          <maml:name>Boolean</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes />
@@ -16396,8 +16621,8 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
         <dev:code>Get-PASSafeMember -SafeName Target_Safe -MemberName SomeUser</dev:code>
         <dev:remarks>
-          <maml:para>Lists all permissions for member SomeUser on Target_Safe</maml:para>
-          <maml:para>Depreciated from CyberArk Version 12.3</maml:para>
+          <maml:para>Lists all permissions for member SomeUser on Target_Safe using Gen2 API</maml:para>
+          <maml:para>Requires minimum CyberArk Version of 12.2</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
@@ -16405,6 +16630,14 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <dev:code>Get-PASSafeMember -SafeName Target_Safe -UseGen1API</dev:code>
         <dev:remarks>
           <maml:para>Lists all members with permissions on Target_Safe using the Gen1 API.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 4 --------------------------</maml:title>
+        <dev:code>Get-PASSafeMember -SafeName Target_Safe -MemberName SomeUser -UseGen1API</dev:code>
+        <dev:remarks>
+          <maml:para>Lists all permissions for member SomeUser on Target_Safe using Gen1 API</maml:para>
+          <maml:para>Depreciated from CyberArk Version 12.3</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -16796,6 +17029,35 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>UserName</maml:name>
+          <maml:description>
+            <maml:para>The user's name</maml:para>
+            <maml:para>Default operation targets the Gen2 API &amp; requires minimum version of 12.2.</maml:para>
+            <maml:para>For operation against versions earlier than 12.2, the `UseGen1API` parameter should also be specified.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>sort</maml:name>
+          <maml:description>
+            <maml:para>Property or properties by which to sort returned accounts, followed by asc (default) or desc to control sort direction.</maml:para>
+            <maml:para>Cannot sort by a property other than `username`, `usertype`, `firstname`, `lastname`, `location`, `middlename` or `source`.</maml:para>
+            <maml:para>Separate multiple properties with commas, up to a maximum of three properties.</maml:para>
+            <maml:para>Requires minimum version of 12.2</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Get-PASUser</maml:name>
@@ -16839,6 +17101,20 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>UserName</maml:name>
+          <maml:description>
+            <maml:para>The user's name</maml:para>
+            <maml:para>Default operation targets the Gen2 API &amp; requires minimum version of 12.2.</maml:para>
+            <maml:para>For operation against versions earlier than 12.2, the `UseGen1API` parameter should also be specified.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>ExtendedDetails</maml:name>
           <maml:description>
             <maml:para>Returns user groups and userDN for LDAP users.</maml:para>
@@ -16851,6 +17127,21 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>sort</maml:name>
+          <maml:description>
+            <maml:para>Property or properties by which to sort returned accounts, followed by asc (default) or desc to control sort direction.</maml:para>
+            <maml:para>Cannot sort by a property other than `username`, `usertype`, `firstname`, `lastname`, `location`, `middlename` or `source`.</maml:para>
+            <maml:para>Separate multiple properties with commas, up to a maximum of three properties.</maml:para>
+            <maml:para>Requires minimum version of 12.2</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Get-PASUser</maml:name>
@@ -16858,6 +17149,8 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
           <maml:name>UserName</maml:name>
           <maml:description>
             <maml:para>The user's name</maml:para>
+            <maml:para>Default operation targets the Gen2 API &amp; requires minimum version of 12.2.</maml:para>
+            <maml:para>For operation against versions earlier than 12.2, the `UseGen1API` parameter should also be specified.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -16865,6 +17158,17 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>UseGen1API</maml:name>
+          <maml:description>
+            <maml:para>Forces use of the Gen1 API endpoint</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
       </command:syntaxItem>
     </command:syntax>
@@ -16921,10 +17225,12 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>UserName</maml:name>
         <maml:description>
           <maml:para>The user's name</maml:para>
+          <maml:para>Default operation targets the Gen2 API &amp; requires minimum version of 12.2.</maml:para>
+          <maml:para>For operation against versions earlier than 12.2, the `UseGen1API` parameter should also be specified.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -16945,6 +17251,33 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>sort</maml:name>
+        <maml:description>
+          <maml:para>Property or properties by which to sort returned accounts, followed by asc (default) or desc to control sort direction.</maml:para>
+          <maml:para>Cannot sort by a property other than `username`, `usertype`, `firstname`, `lastname`, `location`, `middlename` or `source`.</maml:para>
+          <maml:para>Separate multiple properties with commas, up to a maximum of three properties.</maml:para>
+          <maml:para>Requires minimum version of 12.2</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>UseGen1API</maml:name>
+        <maml:description>
+          <maml:para>Forces use of the Gen1 API endpoint</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes />
@@ -18027,7 +18360,8 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
           <maml:name>GroupPlatformID</maml:name>
           <maml:description>
             <maml:para>The name of the platform for the group.</maml:para>
-            <maml:para>The associated platform must be set to "PolicyType=Group"</maml:para>
+            <maml:para>The associated platform must be set to "PolicyType=Group" or "PolicyType=RotationalGroup"</maml:para>
+            <maml:para>To add Account Group with Policy Type of Rotational Group requires minimum version of 12.2</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -18089,7 +18423,8 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
         <maml:name>GroupPlatformID</maml:name>
         <maml:description>
           <maml:para>The name of the platform for the group.</maml:para>
-          <maml:para>The associated platform must be set to "PolicyType=Group"</maml:para>
+          <maml:para>The associated platform must be set to "PolicyType=Group" or "PolicyType=RotationalGroup"</maml:para>
+          <maml:para>To add Account Group with Policy Type of Rotational Group requires minimum version of 12.2</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -27164,6 +27499,7 @@ New-PASSession -SAMLAuth -concurrentSession $true -BaseURI $baseURL -SAMLRespons
     <maml:description>
       <maml:para>Removes a specific member from a Safe.</maml:para>
       <maml:para>The user who runs this function requires the ManageSafeMembers permission.</maml:para>
+      <maml:para>Default operation against Gen2 API requires minimum version of 12.2</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -27207,6 +27543,18 @@ New-PASSession -SAMLAuth -concurrentSession $true -BaseURI $baseURL -SAMLRespons
           <maml:name>Confirm</maml:name>
           <maml:description>
             <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>UseGen1API</maml:name>
+          <maml:description>
+            <maml:para>Specify to force usage the Gen1 API endpoint.</maml:para>
+            <maml:para>Should be specified for versions earlier than 12.2</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -27265,6 +27613,19 @@ New-PASSession -SAMLAuth -concurrentSession $true -BaseURI $baseURL -SAMLRespons
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>UseGen1API</maml:name>
+        <maml:description>
+          <maml:para>Specify to force usage the Gen1 API endpoint.</maml:para>
+          <maml:para>Should be specified for versions earlier than 12.2</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
     </command:parameters>
     <command:inputTypes />
     <command:returnValues />
@@ -27278,7 +27639,15 @@ New-PASSession -SAMLAuth -concurrentSession $true -BaseURI $baseURL -SAMLRespons
         <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
         <dev:code>Remove-PASSafeMember -SafeName TargetSafe -MemberName TargetUser</dev:code>
         <dev:remarks>
-          <maml:para>Removes TargetUser as safe member from TargetSafe</maml:para>
+          <maml:para>Removes TargetUser as safe member from TargetSafe using Gen2 API</maml:para>
+          <maml:para>Requires minimum version 12.2</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
+        <dev:code>Remove-PASSafeMember -SafeName TargetSafe -MemberName TargetUser -UseGen1API</dev:code>
+        <dev:remarks>
+          <maml:para>Removes TargetUser as safe member from TargetSafe using Gen1 API</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -31228,7 +31597,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>NumberOfVersionsRetention</maml:name>
           <maml:description>
             <maml:para>The number of retained versions of every password that is stored in the Safe. - Max value = 999 Specify either this parameter or NumberOfDaysRetention.</maml:para>
@@ -31255,6 +31624,134 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           <maml:name>Confirm</maml:name>
           <maml:description>
             <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>location</maml:name>
+          <maml:description>
+            <maml:para>The vault location to set for the safe</maml:para>
+            <maml:para>Minimum required version 12.2</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Set-PASSafe</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>SafeName</maml:name>
+          <maml:description>
+            <maml:para>The name of the safe to update. - Max Length 28 characters.</maml:para>
+            <maml:para>- Cannot start with a space.</maml:para>
+            <maml:para>- Cannot contain: '\','/',':','*','&lt;','&gt;','"','.' or '|'</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>NewSafeName</maml:name>
+          <maml:description>
+            <maml:para>A name to rename the safe to - Max Length 28 characters.</maml:para>
+            <maml:para>- Cannot start with a space.</maml:para>
+            <maml:para>- Cannot contain: '\','/',':','*','&lt;','&gt;','"','.' or '|'</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Description</maml:name>
+          <maml:description>
+            <maml:para>Updated Description for safe.</maml:para>
+            <maml:para>Max 100 characters.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>OLACEnabled</maml:name>
+          <maml:description>
+            <maml:para>Boolean value, dictating whether or not to enable Object Level Access Control on the safe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ManagingCPM</maml:name>
+          <maml:description>
+            <maml:para>The Name of the CPM user to manage the safe.</maml:para>
+            <maml:para>Specify "" to prevent CPM management.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>NumberOfVersionsRetention</maml:name>
+          <maml:description>
+            <maml:para>The number of retained versions of every password that is stored in the Safe. - Max value = 999 Specify either this parameter or NumberOfDaysRetention.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>0</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>UseGen1API</maml:name>
+          <maml:description>
+            <maml:para>Specify to force usage the Gen1 API endpoint.</maml:para>
+            <maml:para>Should be specified for versions earlier than 12.2</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -31331,7 +31828,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>NumberOfDaysRetention</maml:name>
           <maml:description>
             <maml:para>The number of days for which password versions are saved in the Safe.</maml:para>
@@ -31361,6 +31858,137 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           <maml:name>Confirm</maml:name>
           <maml:description>
             <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>location</maml:name>
+          <maml:description>
+            <maml:para>The vault location to set for the safe</maml:para>
+            <maml:para>Minimum required version 12.2</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Set-PASSafe</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>SafeName</maml:name>
+          <maml:description>
+            <maml:para>The name of the safe to update. - Max Length 28 characters.</maml:para>
+            <maml:para>- Cannot start with a space.</maml:para>
+            <maml:para>- Cannot contain: '\','/',':','*','&lt;','&gt;','"','.' or '|'</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>NewSafeName</maml:name>
+          <maml:description>
+            <maml:para>A name to rename the safe to - Max Length 28 characters.</maml:para>
+            <maml:para>- Cannot start with a space.</maml:para>
+            <maml:para>- Cannot contain: '\','/',':','*','&lt;','&gt;','"','.' or '|'</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Description</maml:name>
+          <maml:description>
+            <maml:para>Updated Description for safe.</maml:para>
+            <maml:para>Max 100 characters.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>OLACEnabled</maml:name>
+          <maml:description>
+            <maml:para>Boolean value, dictating whether or not to enable Object Level Access Control on the safe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ManagingCPM</maml:name>
+          <maml:description>
+            <maml:para>The Name of the CPM user to manage the safe.</maml:para>
+            <maml:para>Specify "" to prevent CPM management.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>NumberOfDaysRetention</maml:name>
+          <maml:description>
+            <maml:para>The number of days for which password versions are saved in the Safe.</maml:para>
+            <maml:para>- Minimum Value: 1</maml:para>
+            <maml:para>- Maximum Value: 3650</maml:para>
+            <maml:para>Specify either this parameter or NumberOfVersionsRetention</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>0</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>UseGen1API</maml:name>
+          <maml:description>
+            <maml:para>Specify to force usage the Gen1 API endpoint.</maml:para>
+            <maml:para>Should be specified for versions earlier than 12.2</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -31437,7 +32065,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>NumberOfVersionsRetention</maml:name>
         <maml:description>
           <maml:para>The number of retained versions of every password that is stored in the Safe. - Max value = 999 Specify either this parameter or NumberOfDaysRetention.</maml:para>
@@ -31449,7 +32077,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>0</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>NumberOfDaysRetention</maml:name>
         <maml:description>
           <maml:para>The number of days for which password versions are saved in the Safe.</maml:para>
@@ -31488,6 +32116,32 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>location</maml:name>
+        <maml:description>
+          <maml:para>The vault location to set for the safe</maml:para>
+          <maml:para>Minimum required version 12.2</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>UseGen1API</maml:name>
+        <maml:description>
+          <maml:para>Specify to force usage the Gen1 API endpoint.</maml:para>
+          <maml:para>Should be specified for versions earlier than 12.2</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
     </command:parameters>
     <command:inputTypes />
     <command:returnValues />
@@ -31501,7 +32155,15 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
         <dev:code>Set-PASSafe -SafeName SAFE -Description "New-Description" -NumberOfVersionsRetention 10</dev:code>
         <dev:remarks>
-          <maml:para>Updates description and version retention on SAFE</maml:para>
+          <maml:para>Updates description and version retention on SAFE using Gen2 API</maml:para>
+          <maml:para>Minimum required version 12.2</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
+        <dev:code>Set-PASSafe -SafeName SAFE -Description "New-Description" -NumberOfDaysRetention 10 -UseGen1API</dev:code>
+        <dev:remarks>
+          <maml:para>Updates description and number of days retention on SAFE using Gen1 API</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -31528,6 +32190,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
     <maml:description>
       <maml:para>Updates an existing Safe Member's permissions on a safe.</maml:para>
       <maml:para>Manage Safe Members permission is required.</maml:para>
+      <maml:para>Default operation against the Gen2 API requires a minimum version of 12.2</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -31568,7 +32231,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="RestrictedRetrieve">
           <maml:name>UseAccounts</maml:name>
           <maml:description>
             <maml:para>Boolean value defining if UseAccounts permission will be granted to safe member on safe.</maml:para>
@@ -31580,7 +32243,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Retrieve">
           <maml:name>RetrieveAccounts</maml:name>
           <maml:description>
             <maml:para>Boolean value defining if RetrieveAccounts permission will be granted to safe member on safe.</maml:para>
@@ -31592,7 +32255,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="ListContent">
           <maml:name>ListAccounts</maml:name>
           <maml:description>
             <maml:para>Boolean value defining if ListAccounts permission will be granted to safe member on safe.</maml:para>
@@ -31604,7 +32267,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Add">
           <maml:name>AddAccounts</maml:name>
           <maml:description>
             <maml:para>Boolean value defining if permission will be granted to safe member on safe.</maml:para>
@@ -31617,7 +32280,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Update">
           <maml:name>UpdateAccountContent</maml:name>
           <maml:description>
             <maml:para>Boolean value defining if AddAccounts permission will be granted to safe member on safe.</maml:para>
@@ -31629,7 +32292,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="UpdateMetadata">
           <maml:name>UpdateAccountProperties</maml:name>
           <maml:description>
             <maml:para>Boolean value defining if UpdateAccountProperties permission will be granted to safe member on safe.</maml:para>
@@ -31665,7 +32328,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Rename">
           <maml:name>RenameAccounts</maml:name>
           <maml:description>
             <maml:para>Boolean value defining if RenameAccounts permission will be granted to safe member on safe.</maml:para>
@@ -31677,7 +32340,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Delete">
           <maml:name>DeleteAccounts</maml:name>
           <maml:description>
             <maml:para>Boolean value defining if DeleteAccounts permission will be granted to safe member on safe.</maml:para>
@@ -31689,7 +32352,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Unlock">
           <maml:name>UnlockAccounts</maml:name>
           <maml:description>
             <maml:para>Boolean value defining if UnlockAccounts permission will be granted to safe member on safe.</maml:para>
@@ -31737,7 +32400,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="ViewAudit">
           <maml:name>ViewAuditLog</maml:name>
           <maml:description>
             <maml:para>Boolean value defining if ViewAuditLog permission will be granted to safe member on safe.</maml:para>
@@ -31749,7 +32412,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="ViewMembers">
           <maml:name>ViewSafeMembers</maml:name>
           <maml:description>
             <maml:para>Boolean value defining if ViewSafeMembers permission will be granted to safe member on safe.</maml:para>
@@ -31786,7 +32449,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="AddRenameFolder">
           <maml:name>CreateFolders</maml:name>
           <maml:description>
             <maml:para>Boolean value defining if CreateFolders permission will be granted to safe member on safe.</maml:para>
@@ -31810,7 +32473,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="MoveFilesAndFolders">
           <maml:name>MoveAccountsAndFolders</maml:name>
           <maml:description>
             <maml:para>Boolean value defining if MoveAccountsAndFolders permission will be granted to safe member on safe.</maml:para>
@@ -31843,6 +32506,346 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
             <maml:uri />
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>UseGen1API</maml:name>
+          <maml:description>
+            <maml:para>Specify to force usage the Gen1 API endpoint.</maml:para>
+            <maml:para>Should be specified for versions earlier than 12.2</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Set-PASSafeMember</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>SafeName</maml:name>
+          <maml:description>
+            <maml:para>The name of the safe to which the safe member belong</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="UserName">
+          <maml:name>MemberName</maml:name>
+          <maml:description>
+            <maml:para>Vault or Domain User, or Group, safe member to update.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>MembershipExpirationDate</maml:name>
+          <maml:description>
+            <maml:para>Defines when the member's Safe membership expires.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">DateTime</command:parameterValue>
+          <dev:type>
+            <maml:name>DateTime</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="RestrictedRetrieve">
+          <maml:name>UseAccounts</maml:name>
+          <maml:description>
+            <maml:para>Boolean value defining if UseAccounts permission will be granted to safe member on safe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Retrieve">
+          <maml:name>RetrieveAccounts</maml:name>
+          <maml:description>
+            <maml:para>Boolean value defining if RetrieveAccounts permission will be granted to safe member on safe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="ListContent">
+          <maml:name>ListAccounts</maml:name>
+          <maml:description>
+            <maml:para>Boolean value defining if ListAccounts permission will be granted to safe member on safe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Add">
+          <maml:name>AddAccounts</maml:name>
+          <maml:description>
+            <maml:para>Boolean value defining if permission will be granted to safe member on safe.</maml:para>
+            <maml:para>Includes UpdateAccountProperties (when adding or removing permission).</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Update">
+          <maml:name>UpdateAccountContent</maml:name>
+          <maml:description>
+            <maml:para>Boolean value defining if AddAccounts permission will be granted to safe member on safe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="UpdateMetadata">
+          <maml:name>UpdateAccountProperties</maml:name>
+          <maml:description>
+            <maml:para>Boolean value defining if UpdateAccountProperties permission will be granted to safe member on safe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>InitiateCPMAccountManagementOperations</maml:name>
+          <maml:description>
+            <maml:para>Boolean value defining if InitiateCPMAccountManagementOperations permission will be granted to safe member on safe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>SpecifyNextAccountContent</maml:name>
+          <maml:description>
+            <maml:para>Boolean value defining if SpecifyNextAccountContent permission will be granted to safe member on safe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Rename">
+          <maml:name>RenameAccounts</maml:name>
+          <maml:description>
+            <maml:para>Boolean value defining if RenameAccounts permission will be granted to safe member on safe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Delete">
+          <maml:name>DeleteAccounts</maml:name>
+          <maml:description>
+            <maml:para>Boolean value defining if DeleteAccounts permission will be granted to safe member on safe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Unlock">
+          <maml:name>UnlockAccounts</maml:name>
+          <maml:description>
+            <maml:para>Boolean value defining if UnlockAccounts permission will be granted to safe member on safe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>ManageSafe</maml:name>
+          <maml:description>
+            <maml:para>Boolean value defining if ManageSafe permission will be granted to safe member on safe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>ManageSafeMembers</maml:name>
+          <maml:description>
+            <maml:para>Boolean value defining if ManageSafeMembers permission will be granted to safe member on safe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>BackupSafe</maml:name>
+          <maml:description>
+            <maml:para>Boolean value defining if BackupSafe permission will be granted to safe member on safe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="ViewAudit">
+          <maml:name>ViewAuditLog</maml:name>
+          <maml:description>
+            <maml:para>Boolean value defining if ViewAuditLog permission will be granted to safe member on safe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="ViewMembers">
+          <maml:name>ViewSafeMembers</maml:name>
+          <maml:description>
+            <maml:para>Boolean value defining if ViewSafeMembers permission will be granted to safe member on safe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>AccessWithoutConfirmation</maml:name>
+          <maml:description>
+            <maml:para>Boolean value defining if AccessWithoutConfirmation permission will be granted to safe member on safe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="AddRenameFolder">
+          <maml:name>CreateFolders</maml:name>
+          <maml:description>
+            <maml:para>Boolean value defining if CreateFolders permission will be granted to safe member on safe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>DeleteFolders</maml:name>
+          <maml:description>
+            <maml:para>Boolean value defining if DeleteFolders permission will be granted to safe member on safe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="MoveFilesAndFolders">
+          <maml:name>MoveAccountsAndFolders</maml:name>
+          <maml:description>
+            <maml:para>Boolean value defining if MoveAccountsAndFolders permission will be granted to safe member on safe.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>requestsAuthorizationLevel1</maml:name>
+          <maml:description>
+            <maml:para>Boolean value defining if requestsAuthorizationLevel1 permission will be granted to safe member on safe.</maml:para>
+            <maml:para>Minimum required version 12.2</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>requestsAuthorizationLevel2</maml:name>
+          <maml:description>
+            <maml:para>Boolean value defining if requestsAuthorizationLevel2 permission will be granted to safe member on safe.</maml:para>
+            <maml:para>Minimum required version 12.2</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
       </command:syntaxItem>
     </command:syntax>
@@ -31883,7 +32886,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="RestrictedRetrieve">
         <maml:name>UseAccounts</maml:name>
         <maml:description>
           <maml:para>Boolean value defining if UseAccounts permission will be granted to safe member on safe.</maml:para>
@@ -31895,7 +32898,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Retrieve">
         <maml:name>RetrieveAccounts</maml:name>
         <maml:description>
           <maml:para>Boolean value defining if RetrieveAccounts permission will be granted to safe member on safe.</maml:para>
@@ -31907,7 +32910,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="ListContent">
         <maml:name>ListAccounts</maml:name>
         <maml:description>
           <maml:para>Boolean value defining if ListAccounts permission will be granted to safe member on safe.</maml:para>
@@ -31919,7 +32922,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Add">
         <maml:name>AddAccounts</maml:name>
         <maml:description>
           <maml:para>Boolean value defining if permission will be granted to safe member on safe.</maml:para>
@@ -31932,7 +32935,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Update">
         <maml:name>UpdateAccountContent</maml:name>
         <maml:description>
           <maml:para>Boolean value defining if AddAccounts permission will be granted to safe member on safe.</maml:para>
@@ -31944,7 +32947,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="UpdateMetadata">
         <maml:name>UpdateAccountProperties</maml:name>
         <maml:description>
           <maml:para>Boolean value defining if UpdateAccountProperties permission will be granted to safe member on safe.</maml:para>
@@ -31980,7 +32983,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Rename">
         <maml:name>RenameAccounts</maml:name>
         <maml:description>
           <maml:para>Boolean value defining if RenameAccounts permission will be granted to safe member on safe.</maml:para>
@@ -31992,7 +32995,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Delete">
         <maml:name>DeleteAccounts</maml:name>
         <maml:description>
           <maml:para>Boolean value defining if DeleteAccounts permission will be granted to safe member on safe.</maml:para>
@@ -32004,7 +33007,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="Unlock">
         <maml:name>UnlockAccounts</maml:name>
         <maml:description>
           <maml:para>Boolean value defining if UnlockAccounts permission will be granted to safe member on safe.</maml:para>
@@ -32052,7 +33055,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="ViewAudit">
         <maml:name>ViewAuditLog</maml:name>
         <maml:description>
           <maml:para>Boolean value defining if ViewAuditLog permission will be granted to safe member on safe.</maml:para>
@@ -32064,7 +33067,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="ViewMembers">
         <maml:name>ViewSafeMembers</maml:name>
         <maml:description>
           <maml:para>Boolean value defining if ViewSafeMembers permission will be granted to safe member on safe.</maml:para>
@@ -32101,7 +33104,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="AddRenameFolder">
         <maml:name>CreateFolders</maml:name>
         <maml:description>
           <maml:para>Boolean value defining if CreateFolders permission will be granted to safe member on safe.</maml:para>
@@ -32125,7 +33128,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="MoveFilesAndFolders">
         <maml:name>MoveAccountsAndFolders</maml:name>
         <maml:description>
           <maml:para>Boolean value defining if MoveAccountsAndFolders permission will be granted to safe member on safe.</maml:para>
@@ -32161,6 +33164,45 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>requestsAuthorizationLevel1</maml:name>
+        <maml:description>
+          <maml:para>Boolean value defining if requestsAuthorizationLevel1 permission will be granted to safe member on safe.</maml:para>
+          <maml:para>Minimum required version 12.2</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+        <dev:type>
+          <maml:name>Boolean</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>requestsAuthorizationLevel2</maml:name>
+        <maml:description>
+          <maml:para>Boolean value defining if requestsAuthorizationLevel2 permission will be granted to safe member on safe.</maml:para>
+          <maml:para>Minimum required version 12.2</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+        <dev:type>
+          <maml:name>Boolean</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>UseGen1API</maml:name>
+        <maml:description>
+          <maml:para>Specify to force usage the Gen1 API endpoint.</maml:para>
+          <maml:para>Should be specified for versions earlier than 12.2</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
     </command:parameters>
     <command:inputTypes />
     <command:returnValues />
@@ -32174,7 +33216,15 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
         <dev:code>Set-PASSafeMember -SafeName TargetSafe -MemberName TargetUser -AddAccounts $true</dev:code>
         <dev:remarks>
-          <maml:para>Updates TargetUser's permissions as safe member on TargetSafe to include "Add Accounts"</maml:para>
+          <maml:para>Updates TargetUser's permissions as safe member on TargetSafe to include "Add Accounts" using the Gen2 API.</maml:para>
+          <maml:para>Minimum required version 12.2</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
+        <dev:code>Set-PASSafeMember -SafeName TargetSafe -MemberName TargetUser -AddAccounts $true -UseGen1API</dev:code>
+        <dev:remarks>
+          <maml:para>Updates TargetUser's permissions as safe member on TargetSafe to include "Add Accounts" using the Gen1 API.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -14292,6 +14292,47 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
+      <command:name>Get-PASPlatformSummary</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>PASPlatformSummary</command:noun>
+      <maml:description>
+        <maml:para>Get list of all platform system types</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Retrieve basic information on all existing platform system types.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Get-PASPlatformSummary</maml:name>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters />
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; Get-PASPlatformSummary</dev:code>
+        <dev:remarks>
+          <maml:para>Returns list and count of each current platform system types.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>https://pspas.pspete.dev/commands/Get-PASPlatformSummary</maml:linkText>
+        <maml:uri>https://pspas.pspete.dev/commands/Get-PASPlatformSummary</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
       <command:name>Get-PASPolicyACL</command:name>
       <command:verb>Get</command:verb>
       <command:noun>PASPolicyACL</command:noun>

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -8279,6 +8279,152 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
+      <command:name>Clear-PASLinkedAccount</command:name>
+      <command:verb>Clear</command:verb>
+      <command:noun>PASLinkedAccount</command:noun>
+      <maml:description>
+        <maml:para>Clears a linked account association.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Clears the association between a linked account and a source account.</maml:para>
+      <maml:para>The following Safe authorizations are required on the Safe where the source account is stored to run this command: - List accounts</maml:para>
+      <maml:para>- Update account properties</maml:para>
+      <maml:para>- Manage Safe</maml:para>
+      <maml:para>  - Only required when `RequireManageSafeToClearLinkedAccount` is enabled in the configuration.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Clear-PASLinkedAccount</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="id">
+          <maml:name>AccountID</maml:name>
+          <maml:description>
+            <maml:para>The id value of the source account</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
+          <maml:name>extraPasswordIndex</maml:name>
+          <maml:description>
+            <maml:para>The linked account's extra password index.</maml:para>
+            <maml:para>The index can be for a Reconcile account, Logon account, or other linked account that is defined in the Platform configuration.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>0</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="id">
+        <maml:name>AccountID</maml:name>
+        <maml:description>
+          <maml:para>The id value of the source account</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
+        <maml:name>extraPasswordIndex</maml:name>
+        <maml:description>
+          <maml:para>The linked account's extra password index.</maml:para>
+          <maml:para>The index can be for a Reconcile account, Logon account, or other linked account that is defined in the Platform configuration.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>0</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+        <maml:name>WhatIf</maml:name>
+        <maml:description>
+          <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; Clear-PASLinkedAccount -AccountID 12_34 -extraPasswordIndex 3</dev:code>
+        <dev:remarks>
+          <maml:para>Clears extraPass3 from account with ID 12_34</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>https://pspas.pspete.dev/commands/Clear-PASLinkedAccount</maml:linkText>
+        <maml:uri>https://pspas.pspete.dev/commands/Clear-PASLinkedAccount</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Link-account-unlink.htm</maml:linkText>
+        <maml:uri>https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Link-account-unlink.htm</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
       <command:name>Clear-PASPrivateSSHKey</command:name>
       <command:verb>Clear</command:verb>
       <command:noun>PASPrivateSSHKey</command:noun>

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -217,7 +217,8 @@
 		'Clear-PASPrivateSSHKey',
 		'Revoke-PASJustInTimeAccess',
 		'Get-PASAccountDetail',
-		'Clear-PASLinkedAccount'
+		'Clear-PASLinkedAccount',
+		'Get-PASPlatformSummary'
 	)
 
 	#AliasesToExport   = @()

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -214,12 +214,12 @@
 		'Get-PASAccountPasswordVersion',
 		'New-PASPrivateSSHKey',
 		'Remove-PASPrivateSSHKey',
-		'Clear-PASPrivateSSHKey'
+		'Clear-PASPrivateSSHKey',
+		'Revoke-PASJustInTimeAccess',
+		'Get-PASAccountDetail'
 	)
 
-	AliasesToExport   = @(
-		'Get-PASPSMConnectionParameter'
-	)
+	#AliasesToExport   = @()
 
 	# Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
 	PrivateData       = @{

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -216,7 +216,8 @@
 		'Remove-PASPrivateSSHKey',
 		'Clear-PASPrivateSSHKey',
 		'Revoke-PASJustInTimeAccess',
-		'Get-PASAccountDetail'
+		'Get-PASAccountDetail',
+		'Clear-PASLinkedAccount'
 	)
 
 	#AliasesToExport   = @()

--- a/psPAS/xml/psPAS.CyberArk.Vault.Account.Type.ps1xml
+++ b/psPAS/xml/psPAS.CyberArk.Vault.Account.Type.ps1xml
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Types>
 	<Type>
-		<Name>psPAS.CyberArk.Vault.Account</Name>
+		<Name>psPAS.CyberArk.Vault.Account.V10</Name>
 		<Members>
 			<ScriptMethod>
 				<Name>GetActivity</Name>
 				<Script>
 					$this | Get-PASAccountActivity
+				</Script>
+			</ScriptMethod>
+			<ScriptMethod>
+				<Name>GetDetails</Name>
+				<Script>
+					$this | Get-PASAccountDetail
 				</Script>
 			</ScriptMethod>
 			<ScriptMethod>
@@ -18,13 +24,19 @@
 			<ScriptMethod>
 				<Name>VerifyPassword</Name>
 				<Script>
-					$this | Start-PASCredVerify
+					$this | Invoke-PASCPMOperation -VerifyTask
 				</Script>
 			</ScriptMethod>
 			<ScriptMethod>
 				<Name>ChangePassword</Name>
 				<Script>
-					$this | Start-PASCredChange -ImmediateChangeByCPM Yes
+					$this | Invoke-PASCPMOperation -ChangeTask
+				</Script>
+			</ScriptMethod>
+			<ScriptMethod>
+				<Name>ReconcilePassword</Name>
+				<Script>
+					$this | Invoke-PASCPMOperation -ReconcileTask
 				</Script>
 			</ScriptMethod>
 			<ScriptMethod>


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
<!--
Please include a summary of the change and which issue is fixed & relevant motivation and context.
Put `Fixes #XXX` in your comment to link the issue that your PR fixes.
-->
- Breaking Changes
  - `Request-PASJustInTimeAccess`
    - Command renamed from `Request-PASAdHocAccess` in line with CyberArk feature nomenclature.
  - `Get-PASSafeMember`
    - Adds capability to get permissions for individual safe member using the Gen2 API from 12.2 onward.
    - Addition of `UseGen1API` parameter allows operation against Gen1 API if required.
  - `Set-PASSafeMember`
    - Adds Gen2 API capability introduced in 12.2.
    - Default operation is now via Gen2 API.
    - Addition of `UseGen1API` parameter allows operation against Gen1 API if required.
  - `Remove-PASSafeMember`
    - Adds support for operation against Gen2 API introduced in PAS 12.2
    - Default operation now requires 12.2
    - `UseGen1API` parameter added to force operation against Gen1 API for earlier PAS versions.
  - `Set-PASSafe`
    - Adds Gen2 API capability introduced in 12.2.
    - Default operation is now via Gen2 API.
    - Addition of `UseGen1API` parameter allows operation against Gen1 API if required.
- New Commands
  - `Get-PASAccountDetail`
    - New experimental function developed using unofficial documentation
  - `Revoke-PASJustInTimeAccess`
    - New API function supported from 12.0 (previously missed)
    - Revokes requested JIT access.
  - `Clear-PASLinkedAccount`
    - Unlinks associated Logon/Reconcile/ExtraPass accounts
  - `Get-PASPlatformSummary`
    - Returns basic platform system type information
- Other Updates
  - `Get-PASSafe`
    - Implements Get Individual Safe details using Gen2 API feature of PAS 12.2.
    - Adds `UseGen1API` parameter to allow backward compatibility when using the `SafeName` parameter.
    - Changes depreciation of Gen1 API operations from 12.2 to 12.3.
  - `Get-PASUser`
    - New `sort` parameter added, supported from 12.2.
    - Added ability to filter by UserName using Gen2 API.
    - Gen1 search by UserName now accessible by also specifying the introduced `UseGen1API` parameter.
  - `Get-PASGroup`
    - New `sort` parameter added, supported from 12.2.
  - `Add-PASGroupMember`
    - Added version check to prevent use of Gen1 API starting from 12.3 in line with documented plan for API depreciation
  - `New-PASUser`
    - Added version check to prevent use of Gen1 API starting from 12.3 in line with documented plan for API depreciation
  - `Remove-PASUser`
    - Added version check to prevent use of Gen1 API starting from 12.3 in line with documented plan for API depreciation
  - `Set-PASUser`
    - Added version check to prevent use of Gen1 API starting from 12.3 in line with documented plan for API depreciation
  - `Unblock-PASUser`
    - Added version check to prevent use of Gen1 API starting from 12.3 in line with documented plan for API depreciation
  - Account Methods updated to apply to account details obtained via Gen2 API calls
    - `VerifyPassword()`
      - Updated method to use `Invoke-PASCPMOperation`
    - `ChangePassword()`
      - Updated method to use `Invoke-PASCPMOperation`
    - `ReconcilePassword()`
      - New method using `Invoke-PASCPMOperation`
    - `GetDetails()`
      - New method using `Get-PASAccountDetail`
  - Alias Removal
    - Removed alias values for previously depreciated command names

Fixes #

## Type of change
<!--
Please select all relevant options:
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that makes existing functionality work differently)
- [X] Documentation update (psPAS website or command help content)
- [X] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [X] Pester test(s) updated
- [X] Pester test(s) passing

**Test Configuration**:
- PowerShell version: 5 & 7
- CyberArk PAS version: 12.2
- OS Version: Win 10

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [X] My code follows the style guidelines of this project
- [X] I have followed the contributing guidelines.
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new test failures or errors
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [ ] I have linked a related issue