### PR TITLE
Release 5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,24 @@
 - Continued development to encompass any new documented features of the CyberArk API.
 - psPAS v6.0...
 
-## **vNext 5.2.## (TBC)**
+## **vNext 5.3.## (TBC)**
 
+### Module update to cover all CyberArk 12.6 API features
+
+- New Commands
+  - `Enable-PASUser`
+    - New command, supported from 12.6
+  - `Disable-PASUser`
+    - New command, supported from 12.6
 - Updates
+  - `Get-PASAccount`
+    - Added `savedFilter` parameter, supported from 12.6
   - `Get-PASGroup`
+    - Added `id` parameter, supported from 12.6
     - Added `groupName` parameter, supported from 12.2.
+  - `Get-PASAccountGroup`
+    - Depreciated use of "Get Safe account groups" API
+    - Makes ParameterSet based on `Get account group by Safe` API the default.
   - Updated documentation and help text.
 
 ## **5.2.59 (November 7th 2021)**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 - Continued development to encompass any new documented features of the CyberArk API.
 - psPAS v6.0...
 
-## **vNext 5.3.## (TBC)**
+## **vNext (TBC)** ##
+
+## **5.3.69 (July 26th 2022)**
 
 ### Module update to cover all CyberArk 12.6 API features
 
@@ -23,6 +25,7 @@
   - `Get-PASAccountGroup`
     - Depreciated use of "Get Safe account groups" API
     - Makes ParameterSet based on `Get account group by Safe` API the default.
+  - Updates URL formatting to include a forward slash (/) to end of URL for functions which may include a dot (.) via provided parameter values.
   - Updated documentation and help text.
 
 ## **5.2.59 (November 7th 2021)**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 - Continued development to encompass any new documented features of the CyberArk API.
 - psPAS v6.0...
 
+## **vNext 5.2.## (TBC)**
+
+- Updates
+  - `Get-PASGroup`
+    - Added `groupName` parameter, supported from 12.2.
+  - Updated documentation and help text.
+
 ## **5.2.59 (November 7th 2021)**
 
 - Fix

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2021 Pete Maan
+Copyright (c) 2017-2022 Pete Maan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Use PowerShell to manage CyberArk via the PVWA REST API.
 
-Contains all published methods of the API up to CyberArk v12.2.
+Contains all published methods of the API up to CyberArk v12.6.
 
 Docs: [https://pspas.pspete.dev](https://pspas.pspete.dev)
 
@@ -943,6 +943,8 @@ Click the below dropdown to view the current list of psPAS functions and their m
 [`Remove-PASPrivateSSHKey`][Remove-PASPrivateSSHKey]                                     |**12.1**            |Delete MFA caching SSH Keys
 [`Set-PASGroup`][Set-PASGroup]                                                           |**12.0**            |Update CyberArk groups
 [`Get-PASPlatformSummary`][Get-PASPlatformSummary]                                       |**12.2**            |Get information on platform system types
+[`Enable-PASUser`][Enable-PASUser]                                                       |**12.6**            |Enable CyberArk Users
+[`Disable-PASUser`][Enable-PASUser]                                                      |**12.6**            |Disable CyberArk Users
 
 [Get-PASPlatformSummary]:/psPAS/Functions/Platforms/Get-PASPlatformSummary.ps1
 [Add-PASOpenIDConnectProvider]:/psPAS/Functions/Authentication/Add-PASOpenIDConnectProvider.ps1
@@ -1094,7 +1096,7 @@ Click the below dropdown to view the current list of psPAS functions and their m
 
 ### Prerequisites
 
-- Powershell v5 (minimum), or PowerShell Core
+- PowerShell Core, or Windows Powershell v5 (minimum)
 - CyberArk PAS REST API/Web Service
 - A user with which to authenticate, with appropriate Vault/Safe permissions.
 

--- a/Tests/Add-PASAccount.Tests.ps1
+++ b/Tests/Add-PASAccount.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,11 +35,11 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'password' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -47,79 +47,79 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "specifies parameter userName as mandatory for ParameterSet Gen1" {
+			It 'specifies parameter userName as mandatory for ParameterSet Gen1' {
 
-				(Get-Command Add-PASAccount).Parameters["UserName"].ParameterSets["Gen1"].IsMandatory | Should -Be $true
-
-			}
-			It "specifies parameter SafeName as mandatory for ParameterSet Gen1" {
-
-				(Get-Command Add-PASAccount).Parameters["SafeName"].ParameterSets["Gen1"].IsMandatory | Should -Be $true
+				(Get-Command Add-PASAccount).Parameters['UserName'].ParameterSets['Gen1'].IsMandatory | Should -Be $true
 
 			}
-			It "specifies parameter SafeName as mandatory for ParameterSet Gen2" {
+			It 'specifies parameter SafeName as mandatory for ParameterSet Gen1' {
 
-				(Get-Command Add-PASAccount).Parameters["SafeName"].ParameterSets["Gen2"].IsMandatory | Should -Be $true
-
-			}
-			It "specifies parameter platformID as mandatory for ParameterSet Gen1" {
-
-				(Get-Command Add-PASAccount).Parameters["platformID"].ParameterSets["Gen1"].IsMandatory | Should -Be $true
+				(Get-Command Add-PASAccount).Parameters['SafeName'].ParameterSets['Gen1'].IsMandatory | Should -Be $true
 
 			}
-			It "specifies parameter platformID as mandatory for ParameterSet Gen2" {
+			It 'specifies parameter SafeName as mandatory for ParameterSet Gen2' {
 
-				(Get-Command Add-PASAccount).Parameters["platformID"].ParameterSets["Gen2"].IsMandatory | Should -Be $true
+				(Get-Command Add-PASAccount).Parameters['SafeName'].ParameterSets['Gen2'].IsMandatory | Should -Be $true
+
+			}
+			It 'specifies parameter platformID as mandatory for ParameterSet Gen1' {
+
+				(Get-Command Add-PASAccount).Parameters['platformID'].ParameterSets['Gen1'].IsMandatory | Should -Be $true
+
+			}
+			It 'specifies parameter platformID as mandatory for ParameterSet Gen2' {
+
+				(Get-Command Add-PASAccount).Parameters['platformID'].ParameterSets['Gen2'].IsMandatory | Should -Be $true
 
 			}
 
 		}
 
-		Context "Input" {
+		Context 'Input' {
 
 			BeforeEach {
 
-				$secureString = $("P_Password" | ConvertTo-SecureString -AsPlainText -Force)
+				$secureString = $('P_Password' | ConvertTo-SecureString -AsPlainText -Force)
 				Mock Invoke-PASRestMethod -MockWith {
 					Write-Output @{ }
 				}
 
 				$InputObj = [pscustomobject]@{
-					"safeName"              = "P_Safe"
-					"platformID"            = "P_Platform"
-					"password"              = $secureString
-					"userName"              = "P_UserName"
-					"Port"                  = 1234
-					"ExtraPass1Name"        = "P_ExtP1"
-					"DynamicProperties"     = @{"TestKey" = "TestVal"; "TestKey1" = "TestVal"; "TestKey2" = "TestVal" }
-					"address"               = "10.10.10.10"
-					"accountName"           = "SomeName"
-					"disableAutoMgmt"       = $true
-					"disableAutoMgmtReason" = "SomeReason"
-					"groupName"             = "SomeGroup"
-					"groupPlatformID"       = "GPlatform"
-					"ExtraPass1Folder"      = "Root"
-					"ExtraPass1Safe"        = "Safe1"
-					"ExtraPass3Name"        = "SomeName"
-					"ExtraPass3Folder"      = "Root"
-					"ExtraPass3Safe"        = "SomeSafe"
+					'safeName'              = 'P_Safe'
+					'platformID'            = 'P_Platform'
+					'password'              = $secureString
+					'userName'              = 'P_UserName'
+					'Port'                  = 1234
+					'ExtraPass1Name'        = 'P_ExtP1'
+					'DynamicProperties'     = @{'TestKey' = 'TestVal'; 'TestKey1' = 'TestVal'; 'TestKey2' = 'TestVal' }
+					'address'               = '10.10.10.10'
+					'accountName'           = 'SomeName'
+					'disableAutoMgmt'       = $true
+					'disableAutoMgmtReason' = 'SomeReason'
+					'groupName'             = 'SomeGroup'
+					'groupPlatformID'       = 'GPlatform'
+					'ExtraPass1Folder'      = 'Root'
+					'ExtraPass1Safe'        = 'Safe1'
+					'ExtraPass3Name'        = 'SomeName'
+					'ExtraPass3Folder'      = 'Root'
+					'ExtraPass3Safe'        = 'SomeSafe'
 				}
 
 				$InputObjV10 = [pscustomobject]@{
-					"address"                          = "someaddress"
-					"SafeName"                         = "SomeSafe"
-					"PlatformID"                       = "SomePlatform"
-					"userName"                         = "SomeUser"
-					"secret"                           = $secureString
-					"automaticManagementEnabled"       = $true
-					"remoteMachines"                   = "someMachine"
-					"accessRestrictedToRemoteMachines" = $false
+					'address'                          = 'someaddress'
+					'SafeName'                         = 'SomeSafe'
+					'PlatformID'                       = 'SomePlatform'
+					'userName'                         = 'SomeUser'
+					'secret'                           = $secureString
+					'automaticManagementEnabled'       = $true
+					'remoteMachines'                   = 'someMachine'
+					'accessRestrictedToRemoteMachines' = $false
 				}
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 
 				$InputObj | Add-PASAccount
 
@@ -127,7 +127,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected endpoint - V9 ParameterSet" {
+			It 'sends request to expected endpoint - V9 ParameterSet' {
 
 				$InputObj | Add-PASAccount
 
@@ -139,7 +139,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected endpoint - V10 ParameterSet" {
+			It 'sends request to expected endpoint - V10 ParameterSet' {
 
 				$InputObjV10 | Add-PASAccount
 
@@ -151,7 +151,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				$InputObj | Add-PASAccount
 
@@ -159,7 +159,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request with expected body - V9 ParameterSet" {
+			It 'sends request with expected body - V9 ParameterSet' {
 
 				$InputObj | Add-PASAccount
 
@@ -171,7 +171,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected number of properties - V9 ParameterSet" {
+			It 'has a request body with expected number of properties - V9 ParameterSet' {
 
 				$InputObj | Add-PASAccount
 
@@ -180,7 +180,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 				} -Times 1 -Exactly -Scope It
 			}
 
-			It "has expected number of nested properties - V9 ParameterSet" {
+			It 'has expected number of nested properties - V9 ParameterSet' {
 				$InputObj | Add-PASAccount
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
@@ -190,7 +190,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 				} -Times 1 -Exactly -Scope It
 			}
 
-			It "sends request with expected body - V10 ParameterSet" {
+			It 'sends request with expected body - V10 ParameterSet' {
 
 				$InputObjV10 | Add-PASAccount
 
@@ -202,7 +202,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected number of properties - V10 ParameterSet" {
+			It 'has a request body with expected number of properties - V10 ParameterSet' {
 
 				$InputObjV10 | Add-PASAccount
 
@@ -212,7 +212,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has expected number of RemoteMachine nested properties - V10 ParameterSet" {
+			It 'has expected number of RemoteMachine nested properties - V10 ParameterSet' {
 				$InputObjV10 | Add-PASAccount
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
@@ -223,7 +223,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has expected number of secretManagement nested properties - V10 ParameterSet" {
+			It 'has expected number of secretManagement nested properties - V10 ParameterSet' {
 
 				$InputObjV10 | Add-PASAccount
 
@@ -235,82 +235,82 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "throws error if version requirement not met" {
+			It 'throws error if version requirement not met' {
 
-				$Script:ExternalVersion = "1.0"
+				$Script:ExternalVersion = '1.0'
 				{ $InputObjV10 | Add-PASAccount } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
 			BeforeEach {
 
-				$secureString = $("P_Password" | ConvertTo-SecureString -AsPlainText -Force)
+				$secureString = $('P_Password' | ConvertTo-SecureString -AsPlainText -Force)
 				Mock Invoke-PASRestMethod -MockWith {
 					$result = [pscustomobject]@{
-						"Prop1" = "Val1"
-						"Prop2" = "Val2"
-						"Prop3" = "Val3"
+						'Prop1' = 'Val1'
+						'Prop2' = 'Val2'
+						'Prop3' = 'Val3'
 					}
 
 					$result
 				}
 
 				$InputObj = [pscustomobject]@{
-					"address"                    = "someaddress"
-					"SafeName"                   = "SomeSafe"
-					"PlatformID"                 = "SomePlatform"
-					"userName"                   = "SomeUser"
-					"secret"                     = $secureString
-					"automaticManagementEnabled" = $true
-					"remoteMachines"             = "someMachine"
+					'address'                    = 'someaddress'
+					'SafeName'                   = 'SomeSafe'
+					'PlatformID'                 = 'SomePlatform'
+					'userName'                   = 'SomeUser'
+					'secret'                     = $secureString
+					'automaticManagementEnabled' = $true
+					'remoteMachines'             = 'someMachine'
 				}
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 
 			}
 
-			It "provides no output - V9 ParameterSet" {
+			It 'provides no output - V9 ParameterSet' {
 
 				$InputObj = [pscustomobject]@{
-					"safeName"              = "P_Safe"
-					"platformID"            = "P_Platform"
-					"password"              = $secureString
-					"userName"              = "P_UserName"
-					"Port"                  = 1234
-					"ExtraPass1Name"        = "P_ExtP1"
-					"DynamicProperties"     = @{"TestKey" = "TestVal"; "TestKey1" = "TestVal"; "TestKey2" = "TestVal" }
-					"address"               = "10.10.10.10"
-					"accountName"           = "SomeName"
-					"disableAutoMgmt"       = $true
-					"disableAutoMgmtReason" = "SomeReason"
-					"groupName"             = "SomeGroup"
-					"groupPlatformID"       = "GPlatform"
-					"ExtraPass1Folder"      = "Root"
-					"ExtraPass1Safe"        = "Safe1"
-					"ExtraPass3Name"        = "SomeName"
-					"ExtraPass3Folder"      = "Root"
-					"ExtraPass3Safe"        = "SomeSafe"
+					'safeName'              = 'P_Safe'
+					'platformID'            = 'P_Platform'
+					'password'              = $secureString
+					'userName'              = 'P_UserName'
+					'Port'                  = 1234
+					'ExtraPass1Name'        = 'P_ExtP1'
+					'DynamicProperties'     = @{'TestKey' = 'TestVal'; 'TestKey1' = 'TestVal'; 'TestKey2' = 'TestVal' }
+					'address'               = '10.10.10.10'
+					'accountName'           = 'SomeName'
+					'disableAutoMgmt'       = $true
+					'disableAutoMgmtReason' = 'SomeReason'
+					'groupName'             = 'SomeGroup'
+					'groupPlatformID'       = 'GPlatform'
+					'ExtraPass1Folder'      = 'Root'
+					'ExtraPass1Safe'        = 'Safe1'
+					'ExtraPass3Name'        = 'SomeName'
+					'ExtraPass3Folder'      = 'Root'
+					'ExtraPass3Safe'        = 'SomeSafe'
 				}
 				$response = $InputObj | Add-PASAccount
 				$response | Should -BeNullOrEmpty
 
 			}
 
-			It "provides output - V10 ParameterSet" {
+			It 'provides output - V10 ParameterSet' {
 				$response = $InputObj | Add-PASAccount
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "outputs object with expected typename - v10 parameterset" {
+			It 'outputs object with expected typename - v10 parameterset' {
 				Mock Invoke-PASRestMethod -MockWith {
 					[pscustomobject]@{
-						"Count" = 30
-						"Value" = [pscustomobject]@{"Prop1" = "Val1" }
+						'Count' = 30
+						'Value' = [pscustomobject]@{'Prop1' = 'Val1' }
 					}
 				}
 				$response = $InputObj | Add-PASAccount

--- a/Tests/Add-PASAccountACL.Tests.ps1
+++ b/Tests/Add-PASAccountACL.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,23 +35,23 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
+		BeforeEach {
 
 			Mock Invoke-PASRestMethod -MockWith {
-			[pscustomobject]@{"AddAccountPrivilegedCommandResult" = [pscustomobject]@{"some" = "thing" } }
+				[pscustomobject]@{'AddAccountPrivilegedCommandResult' = [pscustomobject]@{'some' = 'thing' } }
+
+			}
+
+			$InputObj = [pscustomobject]@{
+				'AccountPolicyID' = 'UNIXSSH'
+				'AccountAddress'  = 'ServerA.domain.com'
+			}
+
+			$response = $InputObj | Add-PASAccountACL -AccountUserName 'root' -Command 'some command' -CommandGroup $false -PermissionType Deny -UserName 'TestUser'
 
 		}
 
-		$InputObj = [pscustomobject]@{
-			"AccountPolicyID" = "UNIXSSH"
-			"AccountAddress"  = "ServerA.domain.com"
-		}
-
-		$response = $InputObj | Add-PASAccountACL -AccountUserName "root" -Command 'some command' -CommandGroup $false -PermissionType Deny -UserName "TestUser"
-
-		}
-
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'AccountPolicyId' },
 			@{Parameter = 'AccountAddress' },
@@ -62,7 +62,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 			@{Parameter = 'UserName' }
 
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -72,31 +72,31 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Account/ServerA.domain.com|root|UNIXSSH/PrivilegedCommands"
+					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Account/ServerA.domain.com|root|UNIXSSH/PrivilegedCommands/"
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PUT' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -108,7 +108,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected number of properties" {
+			It 'has a request body with expected number of properties' {
 
 				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 4
 
@@ -116,23 +116,23 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.ACL.Account
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.ACL.Account
 
 			}
 

--- a/Tests/Add-PASAccountGroupMember.Tests.ps1
+++ b/Tests/Add-PASAccountGroupMember.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,15 +35,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
+		BeforeEach {
 			Mock Invoke-PASRestMethod -MockWith {
 
 			}
 
 			$InputObj = [pscustomobject]@{
 
-				"AccountID" = "99_9"
-				"GroupID"   = "88_8"
+				'AccountID' = '99_9'
+				'GroupID'   = '88_8'
 
 			}
 
@@ -51,12 +51,12 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'AccountID' },
 			@{Parameter = 'GroupID' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -68,15 +68,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -86,13 +86,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -104,24 +104,24 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected number of properties" {
+			It 'has a request body with expected number of properties' {
 
 				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
 			}
 
-			It "throws error if version requirement not met" {
-$Script:ExternalVersion = "1.0"
-				$Script:ExternalVersion = "1.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
+				$Script:ExternalVersion = '1.0'
 				{ $InputObj | Add-PASAccountGroupMember } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides no output" {
+			It 'provides no output' {
 
 				$response | Should -BeNullOrEmpty
 

--- a/Tests/Add-PASAllowedReferrer.Tests.ps1
+++ b/Tests/Add-PASAllowedReferrer.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -37,20 +37,20 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		BeforeEach {
 			Mock Invoke-PASRestMethod -MockWith {
-				[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+				[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
 			}
 
-			$response = Add-PASAllowedReferrer -referrerURL "SomeURLValue"
+			$response = Add-PASAllowedReferrer -referrerURL 'SomeURLValue'
 		}
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -60,39 +60,39 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					($Body | ConvertFrom-Json).referrerURL -eq "SomeURLValue"
+					($Body | ConvertFrom-Json).referrerURL -eq 'SomeURLValue'
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
-				{ Add-PASAllowedReferrer  -referrerURL "SomeURLValue" } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
+				{ Add-PASAllowedReferrer -referrerURL 'SomeURLValue' } | Should -Throw
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 

--- a/Tests/Add-PASApplication.Tests.ps1
+++ b/Tests/Add-PASApplication.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,15 +35,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
+		BeforeEach {
 			Mock Invoke-PASRestMethod -MockWith {
 
 			}
 
 			$InputObj = [pscustomobject]@{
 
-				"AppID"        = "SomeApplication"
-				"Location"     = "\SomeLocation\"
+				'AppID'    = 'SomeApplication'
+				'Location' = '\SomeLocation\'
 
 			}
 
@@ -52,12 +52,12 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
-			$Parameters = @{Parameter = 'AppID'},
-			@{Parameter = 'Location'}
+			$Parameters = @{Parameter = 'AppID' },
+			@{Parameter = 'Location' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -69,21 +69,21 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "validates expiration date pattern" {
+			It 'validates expiration date pattern' {
 
-				{$InputObj | Add-PASApplication -ExpirationDate 20-04-2019} | Should -Throw
+				{ $InputObj | Add-PASApplication -ExpirationDate 20-04-2019 } | Should -Throw
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -93,13 +93,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -111,7 +111,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected number of properties" {
+			It 'has a request body with expected number of properties' {
 
 				($Script:RequestBody.application | Get-Member -MemberType NoteProperty).length | Should -Be 3
 
@@ -119,9 +119,9 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides no output" {
+			It 'provides no output' {
 
 				$response | Should -BeNullOrEmpty
 

--- a/Tests/Add-PASApplicationAuthenticationMethod.Tests.ps1
+++ b/Tests/Add-PASApplicationAuthenticationMethod.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,143 +35,143 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
 
+			}
+
+			$InputObj = [pscustomobject]@{
+
+				'AppID' = 'SomeApplication'
+
+			}
 		}
+		Context 'Mandatory Parameters' {
 
-		$InputObj = [pscustomobject]@{
-
-			"AppID"        = "SomeApplication"
-
-		}
-}
-		Context "Mandatory Parameters" {
-
-			$Parameters = @{Parameter = 'AppID'},
+			$Parameters = @{Parameter = 'AppID' },
 			@{Parameter = 'path' },
 			@{Parameter = 'hash' },
 			@{Parameter = 'osUser' },
 			@{Parameter = 'machineAddress' },
 			@{Parameter = 'certificateserialnumber' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
-				(Get-Command Add-PASApplicationAuthenticationMethod).Parameters["$Parameter"].Attributes.Mandatory | Select-Object -Unique |  Should -Be $true
+				(Get-Command Add-PASApplicationAuthenticationMethod).Parameters["$Parameter"].Attributes.Mandatory | Select-Object -Unique | Should -Be $true
 
 			}
 
 		}
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
-				$InputObj | Add-PASApplicationAuthenticationMethod -path "SomePath" -IsFolder $true -AllowInternalScripts $true
+			It 'sends request' {
+				$InputObj | Add-PASApplicationAuthenticationMethod -path 'SomePath' -IsFolder $true -AllowInternalScripts $true
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
-				$InputObj | Add-PASApplicationAuthenticationMethod -path "SomePath" -IsFolder $true -AllowInternalScripts $true
+				$InputObj | Add-PASApplicationAuthenticationMethod -path 'SomePath' -IsFolder $true -AllowInternalScripts $true
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Applications/SomeApplication/Authentications"
+					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Applications/SomeApplication/Authentications/"
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
-				$InputObj | Add-PASApplicationAuthenticationMethod -path "SomePath" -IsFolder $true -AllowInternalScripts $true
+				$InputObj | Add-PASApplicationAuthenticationMethod -path 'SomePath' -IsFolder $true -AllowInternalScripts $true
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected AuthType for path authentication" {
+			It 'sends request with expected AuthType for path authentication' {
 
-				$InputObj | Add-PASApplicationAuthenticationMethod -path "SomePath" -IsFolder $true -AllowInternalScripts $true
+				$InputObj | Add-PASApplicationAuthenticationMethod -path 'SomePath' -IsFolder $true -AllowInternalScripts $true
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$Script:RequestBody = $Body | ConvertFrom-Json
 
-					($Script:RequestBody.authentication.AuthType) -eq "path"
+					($Script:RequestBody.authentication.AuthType) -eq 'path'
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected AuthType for hash authentication" {
+			It 'sends request with expected AuthType for hash authentication' {
 
-				$InputObj | Add-PASApplicationAuthenticationMethod -hash "SomeHash"
+				$InputObj | Add-PASApplicationAuthenticationMethod -hash 'SomeHash'
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$Script:RequestBody = $Body | ConvertFrom-Json
 
-					($Script:RequestBody.authentication.AuthType) -eq "hash"
+					($Script:RequestBody.authentication.AuthType) -eq 'hash'
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected AuthType for osUser authentication" {
+			It 'sends request with expected AuthType for osUser authentication' {
 
-				$InputObj | Add-PASApplicationAuthenticationMethod -osUser "SomeUser"
+				$InputObj | Add-PASApplicationAuthenticationMethod -osUser 'SomeUser'
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$Script:RequestBody = $Body | ConvertFrom-Json
 
-					($Script:RequestBody.authentication.AuthType) -eq "osUser"
+					($Script:RequestBody.authentication.AuthType) -eq 'osUser'
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected AuthType for machineAddress authentication" {
+			It 'sends request with expected AuthType for machineAddress authentication' {
 
-				$InputObj | Add-PASApplicationAuthenticationMethod -machineAddress "machineAddress"
+				$InputObj | Add-PASApplicationAuthenticationMethod -machineAddress 'machineAddress'
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$Script:RequestBody = $Body | ConvertFrom-Json
 
-					($Script:RequestBody.authentication.AuthType) -eq "machineAddress"
+					($Script:RequestBody.authentication.AuthType) -eq 'machineAddress'
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected AuthType for certificateserialnumber authentication" {
+			It 'sends request with expected AuthType for certificateserialnumber authentication' {
 
-				$InputObj | Add-PASApplicationAuthenticationMethod -certificateserialnumber "certificateserialnumber"
+				$InputObj | Add-PASApplicationAuthenticationMethod -certificateserialnumber 'certificateserialnumber'
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$Script:RequestBody = $Body | ConvertFrom-Json
 
-					($Script:RequestBody.authentication.AuthType) -eq "certificateserialnumber"
+					($Script:RequestBody.authentication.AuthType) -eq 'certificateserialnumber'
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected AuthType for certificateattr authentication" {
+			It 'sends request with expected AuthType for certificateattr authentication' {
 
-				Add-PASApplicationAuthenticationMethod -AppID AppWebService -SubjectAlternativeName "DNS Name=application.service"
+				Add-PASApplicationAuthenticationMethod -AppID AppWebService -SubjectAlternativeName 'DNS Name=application.service'
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$Script:RequestBody = $Body | ConvertFrom-Json
 
-					($Script:RequestBody.authentication.AuthType) -eq "certificateattr"
+					($Script:RequestBody.authentication.AuthType) -eq 'certificateattr'
 
 				} -Times 1 -Exactly -Scope It
 
@@ -179,11 +179,11 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides no output" {
+			It 'provides no output' {
 
-				$response = $InputObj | Add-PASApplicationAuthenticationMethod -path "SomePath"  -IsFolder $true -AllowInternalScripts $true
+				$response = $InputObj | Add-PASApplicationAuthenticationMethod -path 'SomePath' -IsFolder $true -AllowInternalScripts $true
 
 				$response | Should -BeNullOrEmpty
 

--- a/Tests/Add-PASAuthenticationMethod.Tests.ps1
+++ b/Tests/Add-PASAuthenticationMethod.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -37,20 +37,20 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		BeforeEach {
 			Mock Invoke-PASRestMethod -MockWith {
-				[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+				[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
 			}
 
 			$response = Add-PASAuthenticationMethod -id SomeID
 		}
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -60,37 +60,37 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-					$($Body | ConvertFrom-Json | Select-Object -ExpandProperty id) -eq "SomeID"
+					$($Body | ConvertFrom-Json | Select-Object -ExpandProperty id) -eq 'SomeID'
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
 				{ Add-PASAuthenticationMethod -id SomeID } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 

--- a/Tests/Add-PASDirectory.Tests.ps1
+++ b/Tests/Add-PASDirectory.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,20 +35,20 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Input" {
+		Context 'Input' {
 
 			BeforeEach {
 				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+					[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
 				}
 
 				$InputObj = [pscustomobject]@{
-					"DirectoryType"     = "SomeType.ini"
-					"HostAddresses"     = "1.1.1.1", "2.2.2.2", "3.3.3.3"
-					"DomainName"        = "SomeDomain"
-					"DomainBaseContext" = "DC=Some,DC=Domain"
-					"BindPassword"      = $(ConvertTo-SecureString "SomeNewPassword" -AsPlainText -Force)
-					"BindUsername"      = "SomeUser"
+					'DirectoryType'     = 'SomeType.ini'
+					'HostAddresses'     = '1.1.1.1', '2.2.2.2', '3.3.3.3'
+					'DomainName'        = 'SomeDomain'
+					'DomainBaseContext' = 'DC=Some,DC=Domain'
+					'BindPassword'      = $(ConvertTo-SecureString 'SomeNewPassword' -AsPlainText -Force)
+					'BindUsername'      = 'SomeUser'
 
 				}
 
@@ -56,13 +56,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -72,13 +72,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -90,56 +90,56 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected number of properties" {
+			It 'has a request body with expected number of properties' {
 
 				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 6
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
-				$Script:ExternalVersion = "1.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
+				$Script:ExternalVersion = '1.0'
 				{ $InputObj | Add-PASDirectory } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
 			BeforeEach {
 				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+					[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
 				}
 
 				$InputObj = [pscustomobject]@{
-					"DirectoryType"     = "SomeType.ini"
-					"DomainName"        = "SomeDomain"
-					"DomainBaseContext" = "DC=Some,DC=Domain"
-					"BindPassword"      = $(ConvertTo-SecureString "SomeNewPassword" -AsPlainText -Force)
-					"BindUsername"      = "SomeUser"
+					'DirectoryType'     = 'SomeType.ini'
+					'DomainName'        = 'SomeDomain'
+					'DomainBaseContext' = 'DC=Some,DC=Domain'
+					'BindPassword'      = $(ConvertTo-SecureString 'SomeNewPassword' -AsPlainText -Force)
+					'BindUsername'      = 'SomeUser'
 
 				}
 
-				$response = $InputObj | Add-PASDirectory -DCList @{"Name" = "SomeName"; }
+				$response = $InputObj | Add-PASDirectory -DCList @{'Name' = 'SomeName'; }
 
 			}
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Directory.Extended
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Directory.Extended
 
 			}
 

--- a/Tests/Add-PASDiscoveredAccount.Tests.ps1
+++ b/Tests/Add-PASDiscoveredAccount.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,7 +35,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'UserName' },
 			@{Parameter = 'Address' },
@@ -43,7 +43,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 			@{Parameter = 'AccountEnabled' },
 			@{Parameter = 'fingerprint' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -53,29 +53,29 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input" {
+		Context 'Input' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith { }
 
 				$InputObj = [pscustomobject]@{
-					"UserName"       = "SomeUser"
-					"Address"        = "SomeDomain"
-					"discoveryDate"  = "$(Get-Date 1/1/1971)"
-					"AccountEnabled" = $true
+					'UserName'       = 'SomeUser'
+					'Address'        = 'SomeDomain'
+					'discoveryDate'  = "$(Get-Date 1/1/1971)"
+					'AccountEnabled' = $true
 
 				}
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 				$InputObj | Add-PASDiscoveredAccount
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 				$InputObj | Add-PASDiscoveredAccount
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -85,13 +85,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 				$InputObj | Add-PASDiscoveredAccount
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 				$InputObj | Add-PASDiscoveredAccount
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 					($Body) -ne $null
@@ -99,7 +99,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected number of properties" {
+			It 'has a request body with expected number of properties' {
 				$InputObj | Add-PASDiscoveredAccount
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -108,7 +108,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 				} -Times 1 -Exactly -Scope It
 			}
 
-			It "converts date to expected UNIX time" {
+			It 'converts date to expected UNIX time' {
 				$InputObj | Add-PASDiscoveredAccount
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -117,68 +117,68 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 				} -Times 1 -Exactly -Scope It
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.2"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.2'
 
 				{ $InputObj | Add-PASDiscoveredAccount } | Should -Throw
 
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 
 			}
 
-			It "has a request body with expected platformTypeAccountProperties property for Windows" {
-				$InputObj | Add-PASDiscoveredAccount -sid 1234
+			It 'has a request body with expected platformTypeAccountProperties property for Windows' {
+				$InputObj | Add-PASDiscoveredAccount -SID 1234
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					($Body | ConvertFrom-Json).platformTypeAccountProperties.SID -eq "1234"
+					($Body | ConvertFrom-Json).platformTypeAccountProperties.SID -eq '1234'
 
 				} -Times 1 -Exactly -Scope It
 			}
 
-			It "has a request body with expected platformTypeAccountProperties property for UNIX" {
+			It 'has a request body with expected platformTypeAccountProperties property for UNIX' {
 				$InputObj | Add-PASDiscoveredAccount -uid 1234 -gid 1
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					($Body | ConvertFrom-Json).platformTypeAccountProperties.UID -eq "1234"
-					($Body | ConvertFrom-Json).platformTypeAccountProperties.GID -eq "1"
+					($Body | ConvertFrom-Json).platformTypeAccountProperties.UID -eq '1234'
+					($Body | ConvertFrom-Json).platformTypeAccountProperties.GID -eq '1'
 
 				} -Times 1 -Exactly -Scope It
 			}
 
-			It "has a request body with expected platformTypeAccountProperties property for UNIXSSHKey" {
-				$InputObj | Add-PASDiscoveredAccount -uid 1234 -gid 1 -fingerprint "SomePrint" -Path "SomePath" -format "SomeFormat"
+			It 'has a request body with expected platformTypeAccountProperties property for UNIXSSHKey' {
+				$InputObj | Add-PASDiscoveredAccount -uid 1234 -gid 1 -fingerprint 'SomePrint' -path 'SomePath' -format 'SomeFormat'
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					($Body | ConvertFrom-Json).platformTypeAccountProperties.UID -eq "1234"
-					($Body | ConvertFrom-Json).platformTypeAccountProperties.GID -eq "1"
-					($Body | ConvertFrom-Json).platformTypeAccountProperties.fingerprint -eq "SomePrint"
-					($Body | ConvertFrom-Json).platformTypeAccountProperties.Path -eq "SomePath"
-					($Body | ConvertFrom-Json).platformTypeAccountProperties.format -eq "SomeFormat"
+					($Body | ConvertFrom-Json).platformTypeAccountProperties.UID -eq '1234'
+					($Body | ConvertFrom-Json).platformTypeAccountProperties.GID -eq '1'
+					($Body | ConvertFrom-Json).platformTypeAccountProperties.fingerprint -eq 'SomePrint'
+					($Body | ConvertFrom-Json).platformTypeAccountProperties.Path -eq 'SomePath'
+					($Body | ConvertFrom-Json).platformTypeAccountProperties.format -eq 'SomeFormat'
 
 				} -Times 1 -Exactly -Scope It
 			}
 
-			It "has a request body with expected platformTypeAccountProperties property for AWS" {
+			It 'has a request body with expected platformTypeAccountProperties property for AWS' {
 				$InputObj | Add-PASDiscoveredAccount -awsAccountID 123456777889 -awsAccessKeyID SomeAccessKey
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					($Body | ConvertFrom-Json).platformTypeAccountProperties.awsAccountID -eq "123456777889"
-					($Body | ConvertFrom-Json).platformTypeAccountProperties.awsAccessKeyID -eq "SomeAccessKey"
+					($Body | ConvertFrom-Json).platformTypeAccountProperties.awsAccountID -eq '123456777889'
+					($Body | ConvertFrom-Json).platformTypeAccountProperties.awsAccessKeyID -eq 'SomeAccessKey'
 
 				} -Times 1 -Exactly -Scope It
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
 
 					[pscustomobject]@{
-						"id"     = "Value1"
-						"status" = "Value2"
+						'id'     = 'Value1'
+						'status' = 'Value2'
 					}
 
 
@@ -187,16 +187,16 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 				$InputObj = [pscustomobject]@{
-					"UserName"       = "SomeUser"
-					"Address"        = "SomeDomain"
-					"discoveryDate"  = "$(Get-Date 1/1/1971)"
-					"AccountEnabled" = $true
+					'UserName'       = 'SomeUser'
+					'Address'        = 'SomeDomain'
+					'discoveryDate'  = "$(Get-Date 1/1/1971)"
+					'AccountEnabled' = $true
 
 				}
 
 			}
 
-			it "provides output" {
+			It 'provides output' {
 				$response = $InputObj | Add-PASDiscoveredAccount
 				$response | Should -Not -BeNullOrEmpty
 

--- a/Tests/Add-PASGroupMember.Tests.ps1
+++ b/Tests/Add-PASGroupMember.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,31 +35,31 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
-			Write-Output "Added"
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
+				Write-Output 'Added'
+			}
+
+			$InputObj = [pscustomobject]@{
+				'GroupName' = 'SomeGroup'
+				'UserName'  = 'SomeUser'
+
+			}
+
+			$InputObjV10 = [pscustomobject]@{
+				'memberId'   = 'someName'
+				'memberType' = 'domain'
+				'domainName' = 'SomeDomain'
+				'groupId'    = '1234'
+
+			}
 		}
-
-		$InputObj = [pscustomobject]@{
-			"GroupName" = "SomeGroup"
-			"UserName"  = "SomeUser"
-
-		}
-
-		$InputObjV10 = [pscustomobject]@{
-			"memberId"   = "someName"
-			"memberType" = "domain"
-			"domainName" = "SomeDomain"
-			"groupId"    = "1234"
-
-		}
-}
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'GroupName' },
 			@{Parameter = 'UserName' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -69,9 +69,9 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				$InputObj | Add-PASGroupMember
 
@@ -79,19 +79,19 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				$InputObj | Add-PASGroupMember
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Groups/SomeGroup/Users"
+					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Groups/SomeGroup/Users/"
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint - V10" {
+			It 'sends request to expected endpoint - V10' {
 
 				$InputObjV10 | Add-PASGroupMember
 
@@ -103,7 +103,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				$InputObj | Add-PASGroupMember
 
@@ -111,7 +111,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method - V10" {
+			It 'uses expected method - V10' {
 
 				$InputObjV10 | Add-PASGroupMember
 
@@ -119,7 +119,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				$InputObj | Add-PASGroupMember
 
@@ -133,13 +133,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected number of properties" {
+			It 'has a request body with expected number of properties' {
 
 				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
 			}
 
-			It "sends request with expected body - v10" {
+			It 'sends request with expected body - v10' {
 
 				$InputObjV10 | Add-PASGroupMember
 
@@ -153,28 +153,28 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected number of properties - V10" {
+			It 'has a request body with expected number of properties - V10' {
 
 				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 3
 
 			}
 
-			It "throws error if version requirement not met" {
-$Script:ExternalVersion = "1.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
 
-				$Script:ExternalVersion = "1.0"
+				$Script:ExternalVersion = '1.0'
 
 				{ $InputObjV10 | Add-PASGroupMember } | Should -Throw
 
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 				$response = $InputObj | Add-PASGroupMember
 				$response | Should -Not -BeNullOrEmpty
 

--- a/Tests/Add-PASOpenIDConnectProvider.Tests.ps1
+++ b/Tests/Add-PASOpenIDConnectProvider.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -36,21 +36,21 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		BeforeEach {
-			$Script:ExternalVersion = "0.0"
+			$Script:ExternalVersion = '0.0'
 
 			Mock Invoke-PASRestMethod -MockWith {
-				[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+				[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
 			}
 
-			$clientSecret = $("SomeClientSecret" | ConvertTo-SecureString -AsPlainText -Force)
+			$clientSecret = $('SomeClientSecret' | ConvertTo-SecureString -AsPlainText -Force)
 
 			$InputObject = [PSCustomObject]@{
 
-				id                   = "idValue"
-				authenticationFlow   = "Code"
-				discoveryEndpointUrl = "https://SomeValue"
-				clientId             = "00000159875dgjut02f5"
-				clientSecretMethod   = "Post"
+				id                   = 'idValue'
+				authenticationFlow   = 'Code'
+				discoveryEndpointUrl = 'https://SomeValue'
+				clientId             = '00000159875dgjut02f5'
+				clientSecretMethod   = 'Post'
 				clientSecret         = $clientSecret
 			}
 
@@ -58,15 +58,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -76,13 +76,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 					$($Body | ConvertFrom-Json) -ne $null
@@ -90,27 +90,27 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "throws error if userNameClaim contains invalid characters" {
-				{ $InputObject | Add-PASOpenIDConnectProvider -userNameClaim "abc_123-456" } | Should -Throw
+			It 'throws error if userNameClaim contains invalid characters' {
+				{ $InputObject | Add-PASOpenIDConnectProvider -userNameClaim 'abc_123-456' } | Should -Throw
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
 				{ $InputObject | Add-PASOpenIDConnectProvider } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			It "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 

--- a/Tests/Add-PASPendingAccount.Tests.ps1
+++ b/Tests/Add-PASPendingAccount.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,49 +35,49 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
+		BeforeEach {
 
 			Mock Invoke-PASRestMethod -MockWith {
 				Write-Output @{ }
 			}
 
 			$InputObj = [pscustomobject]@{
-				"UserName"                = "SomeUser"
-				"Address"                 = "SomeAddress"
-				"AccountDiscoveryDate"    = "2018-02-22T22:22:22Z"
-				"OSType"                  = "Windows"
-				"AccountEnabled"          = "enabled"
-				"AccountOSGroups"         = "SomeGroup"
-				"AccountType"             = "local"
-				"DiscoveryPlatformType"   = "SomePlatform"
-				"Domain"                  = "SomeDomain"
-				"LastLogonDate"           = "2017-12-31T23:59:59Z"
-				"LastPasswordSet"         = "1995-05-06T20:20:00Z"
-				"PasswordNeverExpires"    = $true
-				"OSVersion"               = "SomeValue"
-				"OU"                      = "SomeOU"
-				"AccountCategory"         = "privileged"
-				"AccountCategoryCriteria" = "some;category"
-				"UserDisplayName"         = "DisplayThis"
-				"AccountDescription"      = "SomeDescription"
-				"AccountExpirationDate"   = "2020-01-01T00:00:00Z"
-				"UID"                     = "0"
-				"GID"                     = "0"
-				"MachineOSFamily"         = "Workstation"
+				'UserName'                = 'SomeUser'
+				'Address'                 = 'SomeAddress'
+				'AccountDiscoveryDate'    = '2018-02-22T22:22:22Z'
+				'OSType'                  = 'Windows'
+				'AccountEnabled'          = 'enabled'
+				'AccountOSGroups'         = 'SomeGroup'
+				'AccountType'             = 'local'
+				'DiscoveryPlatformType'   = 'SomePlatform'
+				'Domain'                  = 'SomeDomain'
+				'LastLogonDate'           = '2017-12-31T23:59:59Z'
+				'LastPasswordSet'         = '1995-05-06T20:20:00Z'
+				'PasswordNeverExpires'    = $true
+				'OSVersion'               = 'SomeValue'
+				'OU'                      = 'SomeOU'
+				'AccountCategory'         = 'privileged'
+				'AccountCategoryCriteria' = 'some;category'
+				'UserDisplayName'         = 'DisplayThis'
+				'AccountDescription'      = 'SomeDescription'
+				'AccountExpirationDate'   = '2020-01-01T00:00:00Z'
+				'UID'                     = '0'
+				'GID'                     = '0'
+				'MachineOSFamily'         = 'Workstation'
 			}
 
-			$response = $InputObj | Add-PASPendingAccount -verbose
+			$response = $InputObj | Add-PASPendingAccount -Verbose
 
 		}
 
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 			$Parameters = @{Parameter = 'UserName' },
 			@{Parameter = 'Address' },
 			@{Parameter = 'AccountDiscoveryDate' },
 			@{Parameter = 'AccountEnabled' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 				param($Parameter)
 
 				(Get-Command Add-PASPendingAccount).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
@@ -86,15 +86,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled 'Invoke-PASRestMethod' -ParameterFilter {
 
@@ -104,13 +104,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request using expected method" {
+			It 'sends request using expected method' {
 
 				Assert-MockCalled 'Invoke-PASRestMethod' -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -122,7 +122,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected number of properties" {
+			It 'has a request body with expected number of properties' {
 
 				($Script:RequestBody.pendingAccount | Get-Member -MemberType NoteProperty).length | Should -Be 21
 
@@ -130,9 +130,9 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides no output" {
+			It 'provides no output' {
 
 				$response | Should -BeNullOrEmpty
 

--- a/Tests/Add-PASPolicyACL.Tests.ps1
+++ b/Tests/Add-PASPolicyACL.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -36,33 +36,33 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 
-		BeforeEach{
+		BeforeEach {
 
 			Mock Invoke-PASRestMethod -MockWith {
-				[pscustomobject]@{"AddPolicyPrivilegedCommandResult" = [pscustomobject]@{"some" = "thing" } }
+				[pscustomobject]@{'AddPolicyPrivilegedCommandResult' = [pscustomobject]@{'some' = 'thing' } }
 
 			}
 
 			$InputObj = [pscustomobject]@{
-				"PolicyID" = "UNIXSSH"
+				'PolicyID' = 'UNIXSSH'
 			}
 
-			$response = $InputObj | Add-PASPolicyACL -UserName "root" -Command 'some command' -CommandGroup $false -PermissionType Deny
+			$response = $InputObj | Add-PASPolicyACL -UserName 'root' -Command 'some command' -CommandGroup $false -PermissionType Deny
 
 
 		}
 
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
-			$Parameters = @{Parameter = 'Command'},
-			@{Parameter = 'CommandGroup'},
-			@{Parameter = 'PermissionType'},
-			@{Parameter = 'PolicyID'},
-			@{Parameter = 'UserName'}
+			$Parameters = @{Parameter = 'Command' },
+			@{Parameter = 'CommandGroup' },
+			@{Parameter = 'PermissionType' },
+			@{Parameter = 'PolicyID' },
+			@{Parameter = 'UserName' }
 
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -73,31 +73,31 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Policy/UNIXSSH/PrivilegedCommands"
+					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Policy/UNIXSSH/PrivilegedCommands/"
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'PUT' } -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PUT' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -109,7 +109,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected number of properties" {
+			It 'has a request body with expected number of properties' {
 
 				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 4
 
@@ -117,23 +117,23 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.ACL.Policy
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.ACL.Policy
 
 			}
 

--- a/Tests/Add-PASPublicSSHKey.Tests.ps1
+++ b/Tests/Add-PASPublicSSHKey.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -38,26 +38,26 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		BeforeEach {
 
 			Mock Invoke-PASRestMethod -MockWith {
-				[PSCustomObject]@{"AddUserAuthorizedKeyResult" = [PSCustomObject]@{"PublicSSHKey" = "SomeSSHKey" } }
+				[PSCustomObject]@{'AddUserAuthorizedKeyResult' = [PSCustomObject]@{'PublicSSHKey' = 'SomeSSHKey' } }
 			}
 
 			$InputObj = [pscustomobject]@{
-				"UserName" = "SomeUser"
+				'UserName' = 'SomeUser'
 
 			}
 
-			$response = $InputObj | Add-PASPublicSSHKey -PublicSSHKey "SomeSSHKey"
+			$response = $InputObj | Add-PASPublicSSHKey -PublicSSHKey 'SomeSSHKey'
 
 		}
 
 
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'UserName' },
 			@{Parameter = 'PublicSSHKey' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -68,31 +68,31 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/SomeUser/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys"
+					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/SomeUser/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys/"
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -104,7 +104,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected number of properties" {
+			It 'has a request body with expected number of properties' {
 
 				($Script:RequestBody.PublicSSHKey).count | Should -Be 1
 
@@ -112,31 +112,31 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PublicSSHKey
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PublicSSHKey
 
 			}
 
 
 
-			It "returns expected UserName property in response" {
+			It 'returns expected UserName property in response' {
 
-				$response.UserName | Should -Be "SomeUser"
+				$response.UserName | Should -Be 'SomeUser'
 
 			}
 

--- a/Tests/Approve-PASRequest.Tests.ps1
+++ b/Tests/Approve-PASRequest.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,28 +35,28 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
+		BeforeEach {
 			$InputObj = [pscustomobject]@{
-				"RequestID" = "24_68"
-				"Reason"    = "Some Reason"
+				'RequestID' = '24_68'
+				'Reason'    = 'Some Reason'
 
 			}
 
-				Mock Invoke-PASRestMethod -MockWith {
+			Mock Invoke-PASRestMethod -MockWith {
 
 			}
-			$Script:ExternalVersion = "9.10"
+			$Script:ExternalVersion = '9.10'
 			$response = $InputObj | Approve-PASRequest
 		}
 
 
 
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'RequestID' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -68,15 +68,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -86,13 +86,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -104,23 +104,23 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected number of properties" {
+			It 'has a request body with expected number of properties' {
 
 				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
-				{ $InputObj | Approve-PASRequest  } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
+				{ $InputObj | Approve-PASRequest } | Should -Throw
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides no output" {
+			It 'provides no output' {
 
 				$response | Should -BeNullOrEmpty
 

--- a/Tests/Close-PASSession.Tests.ps1
+++ b/Tests/Close-PASSession.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,8 +35,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-				Mock Invoke-PASRestMethod -MockWith {
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
 
 			}
 
@@ -44,19 +44,19 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			$response = Close-PASSession -UseClassicAPI -verbose
+			$response = Close-PASSession -UseClassicAPI -Verbose
 
 		}
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -66,19 +66,19 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected v10 URL" {
+			It 'sends request to expected v10 URL' {
 
 				$response = Close-PASSession
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
@@ -89,7 +89,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected SAML Auth URL" {
+			It 'sends request to expected SAML Auth URL' {
 
 				$response = Close-PASSession -SAMLAuthentication
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
@@ -100,7 +100,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected Shared Auth URL" {
+			It 'sends request to expected Shared Auth URL' {
 
 				$response = Close-PASSession -SharedAuthentication
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
@@ -113,9 +113,9 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides no output" {
+			It 'provides no output' {
 
 				$response | Should -BeNullOrEmpty
 

--- a/Tests/Compare-MinimumVersion.Tests.ps1
+++ b/Tests/Compare-MinimumVersion.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -36,16 +36,16 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		It 'returns TRUE if version is greater than minimum version' {
-			Compare-MinimumVersion -Version "9.8.0" -MinimumVersion "8.9.0" | Should -Be $true
+			Compare-MinimumVersion -Version '9.8.0' -MinimumVersion '8.9.0' | Should -Be $true
 		}
 
 		It 'returns FALSE if version is less than minimum version' {
-			Compare-MinimumVersion -Version "9.8.0" -MinimumVersion "9.9.0" | Should -Be $false
+			Compare-MinimumVersion -Version '9.8.0' -MinimumVersion '9.9.0' | Should -Be $false
 		}
 
 		It 'returns TRUE if version is 0.0' {
 
-			Compare-MinimumVersion -Version "0.0" -MinimumVersion "1.1.0" | Should -Be $true
+			Compare-MinimumVersion -Version '0.0' -MinimumVersion '1.1.0' | Should -Be $true
 
 		}
 

--- a/Tests/Connect-PASPSMSession.Tests.ps1
+++ b/Tests/Connect-PASPSMSession.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,12 +35,12 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'SessionId' },
 			@{Parameter = 'ConnectionMethod' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -50,35 +50,35 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input" {
+		Context 'Input' {
 
 			BeforeEach {
 
-				$Script:BaseURI = "https://SomeURL/SomeApp"
-				$Script:ExternalVersion = "0.0"
+				$Script:BaseURI = 'https://SomeURL/SomeApp'
+				$Script:ExternalVersion = '0.0'
 				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 				Mock Invoke-PASRestMethod -MockWith {
 
-					[PSCustomObject]@{"Prop1" = "VAL1"; "Prop2" = "Val2"; "Prop3" = "Val3" }
+					[PSCustomObject]@{'Prop1' = 'VAL1'; 'Prop2' = 'Val2'; 'Prop3' = 'Val3' }
 				}
 
 				$InputObj = [pscustomobject]@{
 
-					"SessionId"        = "SomeSession"
-					"ConnectionMethod" = "RDP"
+					'SessionId'        = 'SomeSession'
+					'ConnectionMethod' = 'RDP'
 
 				}
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 				$InputObj | Connect-PASPSMSession
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint for PSMConnect" {
+			It 'sends request to expected endpoint for PSMConnect' {
 				$InputObj | Connect-PASPSMSession
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -88,13 +88,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 				$InputObj | Connect-PASPSMSession
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 				$InputObj | Connect-PASPSMSession
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -104,73 +104,73 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has expected Accept key in header" {
+			It 'has expected Accept key in header' {
 				$InputObj | Connect-PASPSMSession
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$WebSession.Headers["Accept"] -eq 'application/json'
+					$WebSession.Headers['Accept'] -eq 'application/json'
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "specifies expected Accept key in header for PSMGW requests" {
+			It 'specifies expected Accept key in header for PSMGW requests' {
 
 				$InputObj | Connect-PASPSMSession -ConnectionMethod PSMGW
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$WebSession.Headers["Accept"] -eq '* / *'
+					$WebSession.Headers['Accept'] -eq '* / *'
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "9.8"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '9.8'
 				{ $InputObj | Connect-PASPSMSession -ConnectionMethod RDP } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
 			BeforeEach {
 
-				$Script:BaseURI = "https://SomeURL/SomeApp"
-				$Script:ExternalVersion = "0.0"
+				$Script:BaseURI = 'https://SomeURL/SomeApp'
+				$Script:ExternalVersion = '0.0'
 				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 				Mock Invoke-PASRestMethod -MockWith {
 
-					[PSCustomObject]@{"Prop1" = "VAL1"; "Prop2" = "Val2"; "Prop3" = "Val3" }
+					[PSCustomObject]@{'Prop1' = 'VAL1'; 'Prop2' = 'Val2'; 'Prop3' = 'Val3' }
 				}
 
 				$InputObj = [pscustomobject]@{
 
-					"SessionId"        = "SomeSession"
-					"ConnectionMethod" = "RDP"
+					'SessionId'        = 'SomeSession'
+					'ConnectionMethod' = 'RDP'
 
 				}
 
 			}
 
-			it "provides output" {
+			It 'provides output' {
 
 				$InputObj | Connect-PASPSMSession | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($InputObj | Connect-PASPSMSession | Get-Member -MemberType NoteProperty).length | Should -Be 3
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$InputObj | Connect-PASPSMSession | get-member | select-object -expandproperty typename -Unique | Should -Be System.Management.Automation.PSCustomObject
+				$InputObj | Connect-PASPSMSession | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be System.Management.Automation.PSCustomObject
 
 			}
 

--- a/Tests/ConvertFrom-KeyValuePair.Tests.ps1
+++ b/Tests/ConvertFrom-KeyValuePair.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,7 +35,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "General" {
+		Context 'General' {
 
 			BeforeEach {
 
@@ -43,46 +43,46 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 				$Permissions = @(
 					[pscustomobject]@{
-						"Key"   = "Key1"
-						"Value" = $true
+						'Key'   = 'Key1'
+						'Value' = $true
 					},
 					[pscustomobject]@{
-						"Key"   = "Key2"
-						"Value" = $true
+						'Key'   = 'Key2'
+						'Value' = $true
 					},
 					[pscustomobject]@{
-						"Key"   = "TrueKey"
-						"Value" = $true
+						'Key'   = 'TrueKey'
+						'Value' = $true
 					},
 					[pscustomobject]@{
-						"Key"   = "FalseKey"
-						"Value" = $false
+						'Key'   = 'FalseKey'
+						'Value' = $false
 					},
 					[pscustomobject]@{
-						"Key"   = "AnotherKey"
-						"Value" = 1
+						'Key'   = 'AnotherKey'
+						'Value' = 1
 					},
 					[pscustomobject]@{
-						"Key"   = "AnotherFalseKey"
-						"Value" = $false
+						'Key'   = 'AnotherFalseKey'
+						'Value' = $false
 					}
 
 				)
 			}
 
-			It "does not throw" {
+			It 'does not throw' {
 
 				{ $InputObj | ConvertFrom-KeyValuePair } | Should -Not -Throw
 
 			}
 
-			It "produces no output if given no input" {
+			It 'produces no output if given no input' {
 
 				$InputObj | ConvertFrom-KeyValuePair | Should -BeNullOrEmpty
 
 			}
 
-			It "outputs expected properties" {
+			It 'outputs expected properties' {
 
 				$Result = $Permissions | ConvertFrom-KeyValuePair
 				$Result.Key1 | Should -Be $true

--- a/Tests/ConvertTo-ConnectionParam.Tests.ps1
+++ b/Tests/ConvertTo-ConnectionParam.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,51 +35,51 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "General" {
+		Context 'General' {
 
 			BeforeEach {
 
 				$InputObj = @{
-					PSMRemoteMachine = "RemoteMachineValue"
-					LogonDomain      = "LogonDomainValue"
-					SomeProperty     = "SomeValue"
+					PSMRemoteMachine = 'RemoteMachineValue'
+					LogonDomain      = 'LogonDomainValue'
+					SomeProperty     = 'SomeValue'
 				}
 
 			}
 
-			It "does not throw" {
+			It 'does not throw' {
 
 				{ ConvertTo-ConnectionParam } | Should -Not -Throw
 
 			}
 
-			It "produces no output if given no input" {
+			It 'produces no output if given no input' {
 
 				ConvertTo-ConnectionParam | Should -BeNullOrEmpty
 
 			}
 
-			It "outputs expected ConnectionParams properties" {
+			It 'outputs expected ConnectionParams properties' {
 
 				$result = $InputObj | ConvertTo-ConnectionParam
-				$result["ConnectionParams"]["PSMRemoteMachine"]["Value"] | Should -Be "RemoteMachineValue"
-				$result["ConnectionParams"]["LogonDomain"]["Value"] | Should -Be "LogonDomainValue"
-				$result["SomeProperty"] | Should -Be "SomeValue"
+				$result['ConnectionParams']['PSMRemoteMachine']['Value'] | Should -Be 'RemoteMachineValue'
+				$result['ConnectionParams']['LogonDomain']['Value'] | Should -Be 'LogonDomainValue'
+				$result['SomeProperty'] | Should -Be 'SomeValue'
 
 			}
 
-			It "returns expected hashtable if no ConnectionParams are specified" {
+			It 'returns expected hashtable if no ConnectionParams are specified' {
 
 				$InputObj = @{
-					Property1 = "SomeValue"
-					Property2 = "SomeOtherValue"
+					Property1 = 'SomeValue'
+					Property2 = 'SomeOtherValue'
 				}
 
 				$result = $InputObj | ConvertTo-ConnectionParam
 
-				$result["Property1"] | Should -Be "SomeValue"
-				$result["Property2"] | Should -Be "SomeOtherValue"
-				$result["ConnectionParams"] | Should -BeNullOrEmpty
+				$result['Property1'] | Should -Be 'SomeValue'
+				$result['Property2'] | Should -Be 'SomeOtherValue'
+				$result['ConnectionParams'] | Should -BeNullOrEmpty
 
 			}
 

--- a/Tests/ConvertTo-FilterString.Tests.ps1
+++ b/Tests/ConvertTo-FilterString.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,38 +35,38 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "General" {
+		Context 'General' {
 
 			BeforeEach {
 
 				$InputObj = @{
-					Property1        = "Value"
-					Property2        = "Another Value"
+					Property1        = 'Value'
+					Property2        = 'Another Value'
 					modificationTime = $(Get-Date 1/1/2020)
 				}
 
 			}
 
-			It "does not throw" {
+			It 'does not throw' {
 
 				{ ConvertTo-FilterString } | Should -Not -Throw
 
 			}
 
-			It "produces no output if given no input" {
+			It 'produces no output if given no input' {
 
 				ConvertTo-FilterString | Should -BeNullOrEmpty
 
 			}
 
-			It "converts hashtable to expected filter string" {
+			It 'converts hashtable to expected filter string' {
 
 				$Value = $InputObj | ConvertTo-FilterString
 
-				$Value["filter"] | Should -Match " AND "
-				$Value["filter"] | Should -Match "Property1 eq Value"
-				$Value["filter"] | Should -Match "Property2 eq Another Value"
-				$Value["filter"] | Should -Match "modificationTime gte 1577836800"
+				$Value['filter'] | Should -Match ' AND '
+				$Value['filter'] | Should -Match 'Property1 eq Value'
+				$Value['filter'] | Should -Match 'Property2 eq Another Value'
+				$Value['filter'] | Should -Match 'modificationTime gte 1577836800'
 
 			}
 

--- a/Tests/ConvertTo-InsecureString.Tests.ps1
+++ b/Tests/ConvertTo-InsecureString.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,11 +35,11 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
-			$Parameters = @{Parameter = 'SecureString'}
+			$Parameters = @{Parameter = 'SecureString' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -49,7 +49,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "General" {
+		Context 'General' {
 
 			BeforeEach {
 
@@ -59,9 +59,9 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "converts securestring to plaintext" {
+			It 'converts securestring to plaintext' {
 
-				ConvertTo-InsecureString -SecureString $InputObj.SecureString| Should -Be "SomeSecureString"
+				ConvertTo-InsecureString -SecureString $InputObj.SecureString | Should -Be 'SomeSecureString'
 
 			}
 

--- a/Tests/ConvertTo-QueryString.Tests.ps1
+++ b/Tests/ConvertTo-QueryString.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,42 +35,42 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "General" {
+		Context 'General' {
 
 			BeforeEach {
 
 				$InputObj = @{
-					Property1 = "Value"
-					Property2 = "Another Value"
+					Property1 = 'Value'
+					Property2 = 'Another Value'
 				}
 
 			}
 
-			It "does not throw" {
+			It 'does not throw' {
 
 				{ ConvertTo-QueryString } | Should -Not -Throw
 
 			}
 
-			It "produces no output if given no input" {
+			It 'produces no output if given no input' {
 
 				ConvertTo-QueryString | Should -BeNullOrEmpty
 
 			}
 
-			It "converts hashtable to expected query string" {
+			It 'converts hashtable to expected query string' {
 
-				$InputObj | ConvertTo-QueryString | Should -Match "Value&Property"
-				$InputObj | ConvertTo-QueryString | Should -Match "Property1=Value"
-				$InputObj | ConvertTo-QueryString | Should -Match "Property2=Another%20Value"
+				$InputObj | ConvertTo-QueryString | Should -Match 'Value&Property'
+				$InputObj | ConvertTo-QueryString | Should -Match 'Property1=Value'
+				$InputObj | ConvertTo-QueryString | Should -Match 'Property2=Another%20Value'
 
 			}
 
-			It "returns expected unescaped string" {
+			It 'returns expected unescaped string' {
 				$InputObj = @{
-					Property1 = "Value,Value,Value,Value"
+					Property1 = 'Value,Value,Value,Value'
 				}
-				$InputObj | ConvertTo-QueryString -NoEscape | Should -Match "Property1=Value,Value,Value,Value"
+				$InputObj | ConvertTo-QueryString -NoEscape | Should -Match 'Property1=Value,Value,Value,Value'
 			}
 
 		}

--- a/Tests/Copy-PASPlatform.Tests.ps1
+++ b/Tests/Copy-PASPlatform.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "11.4"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '11.4'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,7 +35,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'TargetPlatform' },
 			@{Parameter = 'DependentPlatform' },
@@ -44,7 +44,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 			@{Parameter = 'ID' },
 			@{Parameter = 'name' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -54,29 +54,29 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input" {
+		Context 'Input' {
 
 			BeforeEach {
 				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+					[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
 				}
 
 				$InputObj = [pscustomobject]@{
-					"name" = "SomeName"
-					"ID"   = 1234
+					'name' = 'SomeName'
+					'ID'   = 1234
 				}
 
 				$response = $InputObj | Copy-PASPlatform -TargetPlatform
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint - TargetPlatform" {
+			It 'sends request to expected endpoint - TargetPlatform' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -86,7 +86,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected endpoint - DependentPlatform" {
+			It 'sends request to expected endpoint - DependentPlatform' {
 				$response = $InputObj | Copy-PASPlatform -DependentPlatform
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -96,7 +96,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected endpoint - RotationalGroup" {
+			It 'sends request to expected endpoint - RotationalGroup' {
 
 				$response = $InputObj | Copy-PASPlatform -RotationalGroup
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
@@ -107,7 +107,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected endpoint - GroupPlatform" {
+			It 'sends request to expected endpoint - GroupPlatform' {
 
 				$response = $InputObj | Copy-PASPlatform -GroupPlatform
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
@@ -118,13 +118,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -136,39 +136,39 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected number of properties" {
+			It 'has a request body with expected number of properties' {
 
 				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "11.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '11.0'
 				{ $InputObj | Copy-PASPlatform -GroupPlatform } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
 			BeforeEach {
 
-				$Script:ExternalVersion = "11.4"
+				$Script:ExternalVersion = '11.4'
 				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+					[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
 				}
 
 				$InputObj = [pscustomobject]@{
-					"name" = "SomeName"
-					"ID"   = 1234
+					'name' = 'SomeName'
+					'ID'   = 1234
 				}
 
 				$response = $InputObj | Copy-PASPlatform -TargetPlatform
 
 			}
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 

--- a/Tests/Deny-PASRequest.Tests.ps1
+++ b/Tests/Deny-PASRequest.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,7 +35,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
+		BeforeEach {
 
 			Mock Invoke-PASRestMethod -MockWith {
 
@@ -43,19 +43,19 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			$InputObj = [pscustomobject]@{
 
-				"RequestID" = "24_68"
-				"Reason"    = "Some Reason"
+				'RequestID' = '24_68'
+				'Reason'    = 'Some Reason'
 
 			}
 
 			$response = $InputObj | Deny-PASRequest
 
 		}
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'RequestID' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -67,15 +67,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -85,13 +85,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -103,23 +103,23 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected number of properties" {
+			It 'has a request body with expected number of properties' {
 
 				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
 			}
 
-			It "throws error if version requirement not met" {
-$Script:ExternalVersion = "1.0"
-				{ $InputObj | Deny-PASRequest  } | Should -Throw
-$Script:ExternalVersion = "0.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
+				{ $InputObj | Deny-PASRequest } | Should -Throw
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides no output" {
+			It 'provides no output' {
 
 				$response | Should -BeNullOrEmpty
 

--- a/Tests/Disable-PASCPMAutoManagement.Tests.ps1
+++ b/Tests/Disable-PASCPMAutoManagement.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,11 +35,11 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'AccountID' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -49,33 +49,33 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input" {
+		Context 'Input' {
 
 			BeforeEach {
 
 				Mock Set-PASAccount -MockWith { }
 
 				$InputObj = [pscustomobject]@{
-					"AccountID"   = "12_3"
+					'AccountID' = '12_3'
 
 				}
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 
-				$InputObj | Disable-PASCPMAutoManagement -Reason "Pester Test"
+				$InputObj | Disable-PASCPMAutoManagement -Reason 'Pester Test'
 				Assert-MockCalled Set-PASAccount -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
+			It 'throws error if version requirement not met' {
 
-				$Script:ExternalVersion = "1.2"
+				$Script:ExternalVersion = '1.2'
 
 				{ $InputObj | Disable-PASCPMAutoManagement } | Should -Throw
 
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 
 			}
 

--- a/Tests/Disable-PASPlatform.Tests.ps1
+++ b/Tests/Disable-PASPlatform.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -41,19 +41,19 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 			}
 
 			$InputObj = [pscustomobject]@{
-				"ID" = 1234
+				'ID' = 1234
 
 			}
 		}
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'ID' },
 			@{Parameter = 'TargetPlatform' },
 			@{Parameter = 'GroupPlatform' },
 			@{Parameter = 'RotationalGroup' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -65,15 +65,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 				$InputObj | Disable-PASPlatform -TargetPlatform
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint - TargetPlatform" {
+			It 'sends request to expected endpoint - TargetPlatform' {
 				$InputObj | Disable-PASPlatform -TargetPlatform
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -83,7 +83,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected endpoint - GroupPlatform" {
+			It 'sends request to expected endpoint - GroupPlatform' {
 				$InputObj | Disable-PASPlatform -GroupPlatform
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -93,7 +93,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected endpoint - RotationalGroup" {
+			It 'sends request to expected endpoint - RotationalGroup' {
 				$InputObj | Disable-PASPlatform -RotationalGroup
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -103,13 +103,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 				$InputObj | Disable-PASPlatform -GroupPlatform
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 				$InputObj | Disable-PASPlatform -RotationalGroup
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
@@ -117,9 +117,9 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides no output" {
+			It 'provides no output' {
 				$response = $InputObj | Disable-PASPlatform -TargetPlatform
 				$response | Should -BeNullOrEmpty
 

--- a/Tests/Disable-PASUser.Tests.ps1
+++ b/Tests/Disable-PASUser.Tests.ps1
@@ -74,7 +74,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
                 Enable-PASUser -id 1234
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/API/Users/1234/disable"
+                    $URI -eq "$($Script:BaseURI)/API/Users/1234/disable/"
 
                 } -Times 1 -Exactly -Scope It
 

--- a/Tests/Disable-PASUser.Tests.ps1
+++ b/Tests/Disable-PASUser.Tests.ps1
@@ -1,0 +1,109 @@
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
+
+    BeforeAll {
+        #Get Current Directory
+        $Here = Split-Path -Parent $PSCommandPath
+
+        #Assume ModuleName from Repository Root folder
+        $ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+        #Resolve Path to Module Directory
+        $ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+        #Define Path to Module Manifest
+        $ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+        if ( -not (Get-Module -Name $ModuleName -All)) {
+
+            Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+        }
+
+        $Script:RequestBody = $null
+        $Script:BaseURI = 'https://SomeURL/SomeApp'
+        $Script:ExternalVersion = '0.0'
+        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+    }
+
+
+    AfterAll {
+
+        $Script:RequestBody = $null
+
+    }
+
+    InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+        BeforeEach {
+            Mock Invoke-PASRestMethod -MockWith {
+
+            }
+
+            $InputObj = [pscustomobject]@{
+                'id' = 1234
+
+            }
+        }
+
+        Context 'Mandatory Parameters' {
+
+            $Parameters = @{Parameter = 'id' }
+
+            It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
+
+                param($Parameter)
+
+				(Get-Command Enable-PASUser).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
+
+            }
+
+        }
+
+
+
+        Context 'Input' {
+
+            It 'sends request' {
+                $InputObj | Enable-PASUser
+                Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+
+            }
+
+            It 'sends request to expected endpoint' {
+                Enable-PASUser -id 1234
+                Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+                    $URI -eq "$($Script:BaseURI)/API/Users/1234/disable"
+
+                } -Times 1 -Exactly -Scope It
+
+            }
+
+            It 'uses expected method' {
+                $InputObj | Enable-PASUser
+                Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
+
+            }
+
+            It 'sends request with no body' {
+                $InputObj | Enable-PASUser
+                Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
+
+            }
+
+        }
+
+        Context 'Output' {
+
+            It 'provides no output' {
+                $response = $InputObj | Disable-PASUser
+                $response | Should -BeNullOrEmpty
+
+            }
+
+        }
+
+    }
+
+}

--- a/Tests/Disable-PASUser.Tests.ps1
+++ b/Tests/Disable-PASUser.Tests.ps1
@@ -54,7 +54,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 param($Parameter)
 
-				(Get-Command Enable-PASUser).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
+				(Get-Command Disable-PASUser).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
             }
 
@@ -65,13 +65,13 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         Context 'Input' {
 
             It 'sends request' {
-                $InputObj | Enable-PASUser
+                $InputObj | Disable-PASUser
                 Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
             }
 
             It 'sends request to expected endpoint' {
-                Enable-PASUser -id 1234
+                Disable-PASUser -id 1234
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
                     $URI -eq "$($Script:BaseURI)/API/Users/1234/disable/"
@@ -81,13 +81,13 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             }
 
             It 'uses expected method' {
-                $InputObj | Enable-PASUser
+                $InputObj | Disable-PASUser
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
             }
 
             It 'sends request with no body' {
-                $InputObj | Enable-PASUser
+                $InputObj | Disable-PASUser
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
             }

--- a/Tests/Enable-PASCPMAutoManagement.Tests.ps1
+++ b/Tests/Enable-PASCPMAutoManagement.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,11 +35,11 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'AccountID' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -49,30 +49,30 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input" {
+		Context 'Input' {
 
 			BeforeEach {
 
 				Mock Set-PASAccount -MockWith { }
 
 				$InputObj = [pscustomobject]@{
-					"AccountID"   = "12_3"
+					'AccountID' = '12_3'
 
 				}
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 				$InputObj | Enable-PASCPMAutoManagement
 				Assert-MockCalled Set-PASAccount -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.2"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.2'
 
 				{ $InputObj | Enable-PASCPMAutoManagement } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Enable-PASPlatform.Tests.ps1
+++ b/Tests/Enable-PASPlatform.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -41,19 +41,19 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 			}
 
 			$InputObj = [pscustomobject]@{
-				"ID" = 1234
+				'ID' = 1234
 
 			}
 		}
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'ID' },
 			@{Parameter = 'TargetPlatform' },
 			@{Parameter = 'GroupPlatform' },
 			@{Parameter = 'RotationalGroup' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -65,15 +65,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 				$InputObj | Enable-PASPlatform -TargetPlatform
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint - TargetPlatform" {
+			It 'sends request to expected endpoint - TargetPlatform' {
 				$InputObj | Enable-PASPlatform -TargetPlatform
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -83,7 +83,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected endpoint - GroupPlatform" {
+			It 'sends request to expected endpoint - GroupPlatform' {
 				$InputObj | Enable-PASPlatform -GroupPlatform
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -93,7 +93,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected endpoint - RotationalGroup" {
+			It 'sends request to expected endpoint - RotationalGroup' {
 				$InputObj | Enable-PASPlatform -RotationalGroup
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -103,13 +103,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 				$InputObj | Enable-PASPlatform -GroupPlatform
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 				$InputObj | Enable-PASPlatform -RotationalGroup
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
@@ -117,9 +117,9 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides no output" {
+			It 'provides no output' {
 				$response = $InputObj | Enable-PASPlatform -TargetPlatform
 				$response | Should -BeNullOrEmpty
 

--- a/Tests/Enable-PASUser.Tests.ps1
+++ b/Tests/Enable-PASUser.Tests.ps1
@@ -74,7 +74,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
                 Enable-PASUser -id 1234
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/API/Users/1234/enable"
+                    $URI -eq "$($Script:BaseURI)/API/Users/1234/enable/"
 
                 } -Times 1 -Exactly -Scope It
 

--- a/Tests/Enable-PASUser.Tests.ps1
+++ b/Tests/Enable-PASUser.Tests.ps1
@@ -1,0 +1,109 @@
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
+
+    BeforeAll {
+        #Get Current Directory
+        $Here = Split-Path -Parent $PSCommandPath
+
+        #Assume ModuleName from Repository Root folder
+        $ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+        #Resolve Path to Module Directory
+        $ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+        #Define Path to Module Manifest
+        $ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+        if ( -not (Get-Module -Name $ModuleName -All)) {
+
+            Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+        }
+
+        $Script:RequestBody = $null
+        $Script:BaseURI = 'https://SomeURL/SomeApp'
+        $Script:ExternalVersion = '0.0'
+        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+    }
+
+
+    AfterAll {
+
+        $Script:RequestBody = $null
+
+    }
+
+    InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+        BeforeEach {
+            Mock Invoke-PASRestMethod -MockWith {
+
+            }
+
+            $InputObj = [pscustomobject]@{
+                'id' = 1234
+
+            }
+        }
+
+        Context 'Mandatory Parameters' {
+
+            $Parameters = @{Parameter = 'id' }
+
+            It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
+
+                param($Parameter)
+
+				(Get-Command Enable-PASUser).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
+
+            }
+
+        }
+
+
+
+        Context 'Input' {
+
+            It 'sends request' {
+                $InputObj | Enable-PASUser
+                Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+
+            }
+
+            It 'sends request to expected endpoint' {
+                Enable-PASUser -id 1234
+                Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+                    $URI -eq "$($Script:BaseURI)/API/Users/1234/enable"
+
+                } -Times 1 -Exactly -Scope It
+
+            }
+
+            It 'uses expected method' {
+                $InputObj | Enable-PASUser
+                Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
+
+            }
+
+            It 'sends request with no body' {
+                $InputObj | Enable-PASUser
+                Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
+
+            }
+
+        }
+
+        Context 'Output' {
+
+            It 'provides no output' {
+                $response = $InputObj | Enable-PASUser
+                $response | Should -BeNullOrEmpty
+
+            }
+
+        }
+
+    }
+
+}

--- a/Tests/Export-PASPSMRecording.Tests.ps1
+++ b/Tests/Export-PASPSMRecording.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,12 +35,12 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'RecordingID' },
 			@{Parameter = 'path' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -50,20 +50,20 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input" {
+		Context 'Input' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
 					[PSCustomObject]@{
 						Content = New-Object Byte[] 512
-						Headers = @{"Content-Disposition" = "attachment; filename=FILENAME.zip" }
+						Headers = @{'Content-Disposition' = 'attachment; filename=FILENAME.zip' }
 					}
 				}
 
 				$InputObj = [pscustomobject]@{
-					"RecordingID" = "SomeID"
-					"path"        = "$env:Temp"
+					'RecordingID' = 'SomeID'
+					'path'        = "$env:Temp"
 
 				}
 
@@ -71,28 +71,28 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "throws if path is invalid" {
+			It 'throws if path is invalid' {
 				{ $InputObj | Export-PASPSMRecording -PlatformID SomePlatform -path A:\test.avi } | Should -Throw
 			}
 
-			It "throws if InputFile resolves to a file" {
+			It 'throws if InputFile resolves to a file' {
 
 				$InputObj = [pscustomobject]@{
-					"RecordingID" = "SomeID"
-					"path"        = "$env:Temp\test.avi"
+					'RecordingID' = 'SomeID'
+					'path'        = "$env:Temp\test.avi"
 
 				}
 
 				{ $InputObj | Export-PASPSMRecording -PlatformID SomePlatform -path $pwd } | Should -Throw
 			}
 
-			It "sends request" {
+			It 'sends request' {
 				$InputObj | Export-PASPSMRecording
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 				$InputObj | Export-PASPSMRecording
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -102,23 +102,23 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 				$InputObj | Export-PASPSMRecording
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 				$InputObj | Export-PASPSMRecording
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "10.5"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '10.5'
 
 				{ $InputObj | Export-PASPSMRecording } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Export-PASPlatform.Tests.ps1
+++ b/Tests/Export-PASPlatform.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,24 +35,24 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
+		BeforeEach {
 			Mock Invoke-PASRestMethod -MockWith {
 
-			New-Object Byte[] 512
+				New-Object Byte[] 512
 
+			}
+
+			Mock Out-PASFile -MockWith { }
+
+			$response = Export-PASPlatform -PlatformID SomePlatform -path "$env:Temp\testExport.zip"
 		}
 
-		Mock Out-PASFile -MockWith { }
-
-		$response = Export-PASPlatform -PlatformID SomePlatform -path "$env:Temp\testExport.zip"
-		}
-
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'PlatformID' },
 			@{Parameter = 'path' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -64,19 +64,19 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "throws if path is invalid" {
+			It 'throws if path is invalid' {
 				{ Export-PASPlatform -PlatformID SomePlatform -path A:\test.txt } | Should -Throw
 			}
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Scope It -Times 1 -Exactly
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -86,16 +86,16 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
 				{ Export-PASPlatform -PlatformID SomePlatform -path "$env:Temp\testExport.zip" } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Format-PASUserObject.Tests.ps1
+++ b/Tests/Format-PASUserObject.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,66 +35,66 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "General" {
+		Context 'General' {
 
 			BeforeEach {
 
 				$InputObj = @{
-					"UserName"   = "SomeUser"
-					"FirstName"  = "Some"
-					"LastName"   = "User"
-					"ExpiryDate" = "10/31/2018"
-					"workStreet" = "SomeStreet"
-					"homePage"   = "www.geocities.com"
-					"faxNumber"  = "1979"
-					"city"       = "Tombouctou"
+					'UserName'   = 'SomeUser'
+					'FirstName'  = 'Some'
+					'LastName'   = 'User'
+					'ExpiryDate' = '10/31/2018'
+					'workStreet' = 'SomeStreet'
+					'homePage'   = 'www.geocities.com'
+					'faxNumber'  = '1979'
+					'city'       = 'Tombouctou'
 				}
 
 			}
 
-			It "does not throw" {
+			It 'does not throw' {
 
 				{ $InputObj | Format-PASUserObject } | Should -Not -Throw
 
 			}
 
-			It "outputs expected object type" {
+			It 'outputs expected object type' {
 				$InputObj | Format-PASUserObject | Should -BeOfType Hashtable
 			}
 
-			It "has output with expected number of keys" {
+			It 'has output with expected number of keys' {
 				$result = $InputObj | Format-PASUserObject
 				$result.keys.count | Should -Be 6
 			}
 
-			It "has expected value for remoteMachinesAccess" {
+			It 'has expected value for remoteMachinesAccess' {
 				$result = $InputObj | Format-PASUserObject
-				$result["personalDetails"].keys | Should -Contain FirstName
-				$result["personalDetails"].keys | Should -Contain LastName
-				$result["personalDetails"].keys | Should -Contain city
+				$result['personalDetails'].keys | Should -Contain FirstName
+				$result['personalDetails'].keys | Should -Contain LastName
+				$result['personalDetails'].keys | Should -Contain city
 			}
 
-			It "has expected value for businessAddress" {
+			It 'has expected value for businessAddress' {
 				$result = $InputObj | Format-PASUserObject
-				$result["businessAddress"].keys | Should -Contain workStreet
+				$result['businessAddress'].keys | Should -Contain workStreet
 			}
 
-			It "has expected value for phones" {
+			It 'has expected value for phones' {
 				$result = $InputObj | Format-PASUserObject
-				$result["phones"].keys | Should -Contain faxNumber
+				$result['phones'].keys | Should -Contain faxNumber
 			}
 
-			It "has expected value for internet" {
+			It 'has expected value for internet' {
 				$result = $InputObj | Format-PASUserObject
-				$result["internet"].keys | Should -Contain homePage
+				$result['internet'].keys | Should -Contain homePage
 			}
 
-			It "has expected value for ExpiryDate" {
+			It 'has expected value for ExpiryDate' {
 				$result = $InputObj | Format-PASUserObject
-				$result["ExpiryDate"] | Should -Be "1540944000"
+				$result['ExpiryDate'] | Should -Be '1540944000'
 			}
 
-			It "does not include unexpected keys in result" {
+			It 'does not include unexpected keys in result' {
 				$result = $InputObj | Format-PASUserObject
 				$result.keys | Should -Not -Contain FirstName
 				$result.keys | Should -Not -Contain LastName

--- a/Tests/Get-ByteArray.Tests.ps1
+++ b/Tests/Get-ByteArray.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 
@@ -21,8 +21,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -36,11 +36,11 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
-			$Parameters = @{Parameter = 'Path'}
+			$Parameters = @{Parameter = 'Path' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -50,15 +50,14 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "General" {
+		Context 'General' {
 
-			It "outputs byte array of expected size" {
+			It 'outputs byte array of expected size' {
 
-				if($IsCoreCLR){
+				if ($IsCoreCLR) {
 
 					$(Get-ByteArray -Path "$PSCommandPath").Count | Should -Be (Get-Content "$PSCommandPath" -ReadCount 0 -AsByteStream).Count
-				}
-				Else { Set-ItResult -Inconclusive }
+				} Else { Set-ItResult -Inconclusive }
 			}
 
 		}

--- a/Tests/Get-EscapedString.Tests.ps1
+++ b/Tests/Get-EscapedString.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -37,13 +37,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		It 'outputs a string' {
 
-			"+ & %" | Get-EscapedString | Should -BeOfType System.String
+			'+ & %' | Get-EscapedString | Should -BeOfType System.String
 
 		}
 
 		It 'outputs an escaped string' {
 
-			"+ & %" | Get-EscapedString | Should -BeExactly "%2B%20%26%20%25"
+			'+ & %' | Get-EscapedString | Should -BeExactly '%2B%20%26%20%25'
 
 		}
 

--- a/Tests/Get-NextLink.Tests.ps1
+++ b/Tests/Get-NextLink.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,29 +35,28 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "General" {
+		Context 'General' {
 
 			BeforeEach {
 
 				$InputObj = [pscustomobject]@{
-					"Count"    = 30
-					"nextLink" = "SomeLink"
-					"Value"    = @([pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" })
+					'Count'    = 30
+					'nextLink' = 'SomeLink'
+					'Value'    = @([pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' })
 				}
 
 				Mock Invoke-PASRestMethod -MockWith {
 					if ($script:iteration -lt 10) {
 						[pscustomobject]@{
-							"Count"    = 30
-							"nextLink" = "SomeLink"
-							"Value"    = @([pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" })
+							'Count'    = 30
+							'nextLink' = 'SomeLink'
+							'Value'    = @([pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' })
 						}
 						$script:iteration++
-					}
-					else {
+					} else {
 						[pscustomobject]@{
-							"Count" = 30
-							"Value" = @([pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" })
+							'Count' = 30
+							'Value' = @([pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' })
 						}
 					}
 				}
@@ -65,29 +64,29 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "does not throw" {
+			It 'does not throw' {
 
 				{ Get-NextLink } | Should -Not -Throw
 
 			}
 
-			It "produces no output if given no input" {
+			It 'produces no output if given no input' {
 
 				Get-NextLink | Should -BeNullOrEmpty
 
 			}
 
-			It "processes NextLink" {
+			It 'processes NextLink' {
 
 				$InputObj | Get-NextLink
 				Assert-MockCalled Invoke-PASRestMethod -Times 10 -Exactly -Scope It
 
 			}
 
-			It "outputs expected number of results" {
+			It 'outputs expected number of results' {
 
 				$results = $InputObj | Get-NextLink
-				$results.count | should -Be 99
+				$results.count | Should -Be 99
 
 			}
 

--- a/Tests/Get-PASAccount.Tests.ps1
+++ b/Tests/Get-PASAccount.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,7 +35,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Request Input" {
+		Context 'Request Input' {
 
 			BeforeEach {
 
@@ -45,15 +45,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request - v10ByID parameterset" {
+			It 'sends request - v10ByID parameterset' {
 
-				Get-PASAccount -ID "SomeID"
+				Get-PASAccount -id 'SomeID'
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request - v10ByQuery parameterset" {
+			It 'sends request - v10ByQuery parameterset' {
 
 				Get-PASAccount -search SearchTerm -searchType contains
 
@@ -61,7 +61,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request - legacy parameterset" {
+			It 'sends request - legacy parameterset' {
 
 				Get-PASAccount -Keywords SomeValue -Safe SomeSafe
 
@@ -69,7 +69,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected endpoint - v10ByQuery parameterset" {
+			It 'sends request to expected endpoint - v10ByQuery parameterset' {
 
 				Get-PASAccount -search SearchTerm
 
@@ -81,7 +81,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends expected filter - v10ByFilter parameterset" {
+			It 'sends expected filter - v10ByFilter parameterset' {
 
 				Get-PASAccount -safeName SomeSafe
 
@@ -93,7 +93,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends expected unix time - v10ByFilter parameterset" {
+			It 'sends expected unix time - v10ByFilter parameterset' {
 
 				Get-PASAccount -modificationTime $(Get-Date -Month 01 -Day 01 -Year 2020 -Hour 0 -Minute 0 -Second 0 -Millisecond 0)
 
@@ -105,7 +105,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends expected filters - v10ByFilter parameterset" {
+			It 'sends expected filters - v10ByFilter parameterset' {
 
 				Get-PASAccount -modificationTime $(Get-Date -Month 01 -Day 01 -Year 2020 -Hour 0 -Minute 0 -Second 0 -Millisecond 0) -safeName SomeSafe
 
@@ -118,9 +118,9 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected endpoint - v10ByID parameterset" {
+			It 'sends request to expected endpoint - v10ByID parameterset' {
 
-				Get-PASAccount -ID "SomeID"
+				Get-PASAccount -id 'SomeID'
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 					$URI -eq "$($Script:BaseURI)/api/Accounts/SomeID"
@@ -129,7 +129,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected endpoint - legacy parameterset" {
+			It 'sends request to expected endpoint - legacy parameterset' {
 
 				Get-PASAccount -Keywords SomeValue -Safe SomeSafe
 
@@ -141,7 +141,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request using expected method" {
+			It 'sends request using expected method' {
 
 				Get-PASAccount -Keywords SomeValue -Safe SomeSafe
 
@@ -149,7 +149,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Get-PASAccount -Keywords SomeValue -Safe SomeSafe
 
@@ -157,86 +157,88 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
-				{ Get-PASAccount -ID "SomeID" } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+			It 'throws error if version requirement not met' {
+
+				$Script:ExternalVersion = '1.0'
+				{ Get-PASAccount -id 'SomeID' } | Should -Throw
+				$Script:ExternalVersion = '0.0'
+
 			}
 
 		}
 
-		Context "Response Output" {
+		Context 'Response Output' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
 
 					$result = [pscustomobject]@{
-						"Count"    = 30
-						"Accounts" = [pscustomobject]@{
-							"AccountID"          = "66_6"
-							"Properties"         = @(
+						'Count'    = 30
+						'Accounts' = [pscustomobject]@{
+							'AccountID'          = '66_6'
+							'Properties'         = @(
 								[pscustomobject]@{
-									"Key"   = "Safe"
-									"Value" = "zzTestSafe1"
+									'Key'   = 'Safe'
+									'Value' = 'zzTestSafe1'
 								},
 								[pscustomobject]@{
-									"Key"   = "Folder"
-									"Value" = "Root"
+									'Key'   = 'Folder'
+									'Value' = 'Root'
 								},
 								[pscustomobject]@{
-									"Key"   = "Name"
-									"Value" = "Operating System-_Test_WinDomain-VIRTUALREAL.IT-user01"
+									'Key'   = 'Name'
+									'Value' = 'Operating System-_Test_WinDomain-VIRTUALREAL.IT-user01'
 								},
 								[pscustomobject]@{
-									"Key"   = "UserName"
-									"Value" = "user01"
+									'Key'   = 'UserName'
+									'Value' = 'user01'
 								},
 								[pscustomobject]@{
-									"Key"   = "PolicyID"
-									"Value" = "_Test_WinDomain"
+									'Key'   = 'PolicyID'
+									'Value' = '_Test_WinDomain'
 								},
 								[pscustomobject]@{
-									"Key"   = "LogonDomain"
-									"Value" = "VIRTUALREAL"
+									'Key'   = 'LogonDomain'
+									'Value' = 'VIRTUALREAL'
 								},
 								[pscustomobject]@{
-									"Key"   = "LastSuccessVerification"
-									"Value" = "1511973510"
+									'Key'   = 'LastSuccessVerification'
+									'Value' = '1511973510'
 								},
 								[pscustomobject]@{
-									"Key"   = "Address"
-									"Value" = "VIRTUALREAL.IT"
+									'Key'   = 'Address'
+									'Value' = 'VIRTUALREAL.IT'
 								},
 								[pscustomobject]@{
-									"Key"   = "DeviceType"
-									"Value" = "Operating System"
+									'Key'   = 'DeviceType'
+									'Value' = 'Operating System'
 								}
 							)
-							"InternalProperties" = @(
+							'InternalProperties' = @(
 								[pscustomobject]@{
-									"Key"   = "CPMStatus"
-									"Value" = "success"
+									'Key'   = 'CPMStatus'
+									'Value' = 'success'
 								},
 								[pscustomobject]@{
-									"Key"   = "SequenceID"
-									"Value" = "1"
+									'Key'   = 'SequenceID'
+									'Value' = '1'
 								},
 								[pscustomobject]@{
-									"Key"   = "CreationMethod"
-									"Value" = "PVWA"
+									'Key'   = 'CreationMethod'
+									'Value' = 'PVWA'
 								},
 								[pscustomobject]@{
-									"Key"   = "RetriesCount"
-									"Value" = "-1"
+									'Key'   = 'RetriesCount'
+									'Value' = '-1'
 								},
 								[pscustomobject]@{
-									"Key"   = "LastSuccessChange"
-									"Value" = "1516127648"
+									'Key'   = 'LastSuccessChange'
+									'Value' = '1516127648'
 								},
 								[pscustomobject]@{
-									"Key"   = "LastTask"
-									"Value" = "ChangeTask"
+									'Key'   = 'LastTask'
+									'Value' = 'ChangeTask'
 								}
 							)
 						}
@@ -248,50 +250,49 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "provides output - legacy parameterset" {
+			It 'provides output - legacy parameterset' {
 				$response = Get-PASAccount -Keywords SomeValue -Safe SomeSafe -WarningAction SilentlyContinue
 				$response | Should -Not -Be Null
 
 			}
 
-			It "provides output - V10ByID parameterset" {
+			It 'provides output - V10ByID parameterset' {
 				Mock Invoke-PASRestMethod -MockWith {
 					[pscustomobject]@{
-						"Count" = 30
-						"Value" = [pscustomobject]@{"Prop1" = "Val1" }
+						'Count' = 30
+						'Value' = [pscustomobject]@{'Prop1' = 'Val1' }
 					}
 				}
-				$response = Get-PASAccount -id "SomeID"
-				$response | Should -not -be null
+				$response = Get-PASAccount -id 'SomeID'
+				$response | Should -Not -Be null
 
 			}
 
-			It "provides output - V10ByQuery parameterset" {
+			It 'provides output - V10ByQuery parameterset' {
 				Mock Invoke-PASRestMethod -MockWith {
 					[pscustomobject]@{
-						"Count" = 30
-						"Value" = @([pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" })
+						'Count' = 30
+						'Value' = @([pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' })
 					}
 				}
 				$response = Get-PASAccount -search SomeSearchTerm
-				$response | Should -not -be null
+				$response | Should -Not -Be null
 
 			}
 
-			It "processes NextLink" {
+			It 'processes NextLink' {
 				Mock Invoke-PASRestMethod -MockWith {
 					if ($script:iteration -lt 10) {
 						[pscustomobject]@{
-							"Count"    = 30
-							"nextLink" = "SomeLink"
-							"Value"    = @([pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" })
+							'Count'    = 30
+							'nextLink' = 'SomeLink'
+							'Value'    = @([pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' })
 						}
 						$script:iteration++
-					}
-					else {
+					} else {
 						[pscustomobject]@{
-							"Count" = 30
-							"Value" = @([pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" })
+							'Count' = 30
+							'Value' = @([pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' })
 						}
 					}
 				}
@@ -301,33 +302,33 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has output with expected number of properties - legacy parameterset" {
+			It 'has output with expected number of properties - legacy parameterset' {
 				$response = Get-PASAccount -Keywords SomeValue -Safe SomeSafe -WarningAction SilentlyContinue
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 11
 
 			}
 
-			It "outputs object with expected typename - legacy parameterset" {
+			It 'outputs object with expected typename - legacy parameterset' {
 				$response = Get-PASAccount -Keywords SomeValue -Safe SomeSafe -WarningAction SilentlyContinue
-				$response | Get-Member | Select-Object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Account
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Account
 
 			}
 
-			It "outputs object with expected typename - v10 parameterset" {
+			It 'outputs object with expected typename - v10 parameterset' {
 				Mock Invoke-PASRestMethod -MockWith {
 					[pscustomobject]@{
-						"Count" = 30
-						"Value" = @([pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" }, [pscustomobject]@{"Prop1" = "Val1" })
+						'Count' = 30
+						'Value' = @([pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' }, [pscustomobject]@{'Prop1' = 'Val1' })
 					}
 				}
 				$response = Get-PASAccount -search SomeSearch
-				$response | Get-Member | Select-Object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Account.V10
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Account.V10
 
 			}
 
-			It "writes warning that more than 1 account returned from the search - legacy parameterset" {
+			It 'writes warning that more than 1 account returned from the search - legacy parameterset' {
 				$response = Get-PASAccount -Keywords SomeValue -Safe SomeSafe -WarningVariable warning -WarningAction SilentlyContinue
-				$warning | Should -Be "30 matching accounts found. Only the first result will be returned"
+				$warning | Should -Be '30 matching accounts found. Only the first result will be returned'
 
 			}
 

--- a/Tests/Get-PASAccountACL.Tests.ps1
+++ b/Tests/Get-PASAccountACL.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,17 +35,17 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
+		BeforeEach {
 
 			Mock Invoke-PASRestMethod -MockWith {
-				[pscustomobject]@{"ListAccountPrivilegedCommandsResult" = [pscustomobject]@{"some" = "thing"; "other" = "thing" } }
+				[pscustomobject]@{'ListAccountPrivilegedCommandsResult' = [pscustomobject]@{'some' = 'thing'; 'other' = 'thing' } }
 
 			}
 
 			$InputObj = [pscustomobject]@{
-				"AccountPolicyID" = "UNIXSSH"
-				"AccountAddress"  = "ServerA.domain.com"
-				"AccountUserName" = "root"
+				'AccountPolicyID' = 'UNIXSSH'
+				'AccountAddress'  = 'ServerA.domain.com'
+				'AccountUserName' = 'root'
 			}
 
 			$response = $InputObj | Get-PASAccountACL
@@ -53,14 +53,14 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
-			$Parameters = @{Parameter = 'AccountPolicyId'},
-			@{Parameter = 'AccountAddress'},
-			@{Parameter = 'AccountUserName'}
+			$Parameters = @{Parameter = 'AccountPolicyId' },
+			@{Parameter = 'AccountAddress' },
+			@{Parameter = 'AccountUserName' }
 
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -72,55 +72,55 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Account/ServerA.domain.com|root|UNIXSSH/PrivilegedCommands"
+					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Account/ServerA.domain.com|root|UNIXSSH/PrivilegedCommands/"
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.ACL.Account
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.ACL.Account
 
 			}
 

--- a/Tests/Get-PASAccountActivity.Tests.ps1
+++ b/Tests/Get-PASAccountActivity.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,30 +35,30 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
+		BeforeEach {
 
 			Mock Invoke-PASRestMethod -MockWith {
-				[pscustomobject]@{"GetAccountActivitiesResult" = [pscustomobject]@{
-						"prop1" = "val1"
-						"prop2" = "val2"
-						"prop3" = "val3"
+				[pscustomobject]@{'GetAccountActivitiesResult' = [pscustomobject]@{
+						'prop1' = 'val1'
+						'prop2' = 'val2'
+						'prop3' = 'val3'
 					}
 				}
 			}
 
 			$InputObj = [pscustomobject]@{
-				"AccountID" = "66_6"
+				'AccountID' = '66_6'
 
 			}
 
-			$response = $InputObj | Get-PASAccountActivity -verbose
+			$response = $InputObj | Get-PASAccountActivity -Verbose
 		}
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'AccountID' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -72,15 +72,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -90,13 +90,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
@@ -104,23 +104,23 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
-				$response | Should -not -be null
+				$response | Should -Not -Be null
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 3
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Account.Activity
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Account.Activity
 
 			}
 

--- a/Tests/Get-PASAccountGroup.Tests.ps1
+++ b/Tests/Get-PASAccountGroup.Tests.ps1
@@ -46,7 +46,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				'Safe' = 'SomeSafe'
 			}
 
-			$response = $InputObj | Get-PASAccountGroup -UseClassicAPI -Verbose
+			$response = $InputObj | Get-PASAccountGroup -Verbose
 
 		}
 
@@ -90,9 +90,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$Script:ExternalVersion = '0.0'
 			}
 
-			It 'sends request to expected endpoint - V10 ParameterSet' {
+			It 'sends request to expected endpoint - Gen1 ParameterSet' {
 
-				$InputObj | Get-PASAccountGroup
+				$InputObj | Get-PASAccountGroup -UseGen1API
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 

--- a/Tests/Get-PASAccountGroupMember.Tests.ps1
+++ b/Tests/Get-PASAccountGroupMember.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,26 +35,26 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
+		BeforeEach {
 
 			Mock Invoke-PASRestMethod -MockWith {
-				[pscustomobject]@{"Prop1" = "Val1" }
+				[pscustomobject]@{'Prop1' = 'Val1' }
 			}
 
 			$InputObj = [pscustomobject]@{
-				"GroupID" = "32_1"
+				'GroupID' = '32_1'
 
 			}
 
-			$response = $InputObj | Get-PASAccountGroupMember -verbose
+			$response = $InputObj | Get-PASAccountGroupMember -Verbose
 		}
 
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
-			$Parameters = @{Parameter = 'GroupID'}
+			$Parameters = @{Parameter = 'GroupID' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -66,15 +66,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -84,43 +84,43 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope It
-
-			}
-
-			It "sends request with no body" {
-
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-$Script:ExternalVersion = "1.0"
-				{$InputObj | Get-PASAccountGroupMember } | Should -Throw
-$Script:ExternalVersion = "0.0"
+			It 'sends request with no body' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
+				{ $InputObj | Get-PASAccountGroupMember } | Should -Throw
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Account.Group.Member
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Account.Group.Member
 
 			}
 

--- a/Tests/Get-PASAccountImportJob.Tests.ps1
+++ b/Tests/Get-PASAccountImportJob.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,7 +35,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "General" {
+		Context 'General' {
 
 			BeforeEach {
 
@@ -44,18 +44,18 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "does not throw" {
+			It 'does not throw' {
 
 				{ Get-PASAccountImportJob } | Should -Not -Throw
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 				Get-PASAccountImportJob
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 				Get-PASAccountImportJob
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -64,7 +64,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 				} -Times 1 -Exactly -Scope It
 			}
 
-			It "sends request to expected endpoint - byID" {
+			It 'sends request to expected endpoint - byID' {
 				Get-PASAccountImportJob -id 1234
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -73,16 +73,16 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 				} -Times 1 -Exactly -Scope It
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 				Get-PASAccountImportJob
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "11.5"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '11.5'
 
 				{ $InputObj | Get-PASAccountImportJob } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Get-PASAccountSSHKey.Tests.ps1
+++ b/Tests/Get-PASAccountSSHKey.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,13 +35,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Standard Operation" {
+		Context 'Standard Operation' {
 
 			BeforeEach {
 
 				$Script:ExternalVersion = 11.5
 
-				Mock Invoke-PASRestMethod -MockWith { "PrivateSSHKey!" }
+				Mock Invoke-PASRestMethod -MockWith { 'PrivateSSHKey!' }
 
 				$InputObject = [PSCustomObject]@{
 					AccountID = 1234
@@ -49,14 +49,14 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "does not throw" {
+			It 'does not throw' {
 
 				{ $InputObject | Get-PASAccountSSHKey } | Should -Not -Throw
 
 
 			}
 
-			It "throws if version requirement not met" {
+			It 'throws if version requirement not met' {
 				$Script:ExternalVersion = 1.1
 
 				{ $InputObject | Get-PASAccountSSHKey } | Should -Throw
@@ -64,11 +64,11 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "Returns expected response" {
+			It 'Returns expected response' {
 
 				$result = $InputObject | Get-PASAccountSSHKey
 
-				$result | Should -Be "PrivateSSHKey!"
+				$result | Should -Be 'PrivateSSHKey!'
 
 			}
 

--- a/Tests/Get-PASAllowedReferrer.Tests.ps1
+++ b/Tests/Get-PASAllowedReferrer.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -37,20 +37,20 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		BeforeEach {
 			Mock Invoke-PASRestMethod -MockWith {
-				[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+				[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
 			}
 
 			$response = Get-PASAllowedReferrer
 		}
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -60,35 +60,35 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
 				{ Get-PASAllowedReferrer } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 

--- a/Tests/Get-PASApplication.Tests.ps1
+++ b/Tests/Get-PASApplication.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,14 +35,14 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
+		BeforeEach {
 
 			Mock Invoke-PASRestMethod -MockWith {
-				[PSCustomObject]@{"application" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" } }
+				[PSCustomObject]@{'application' = [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' } }
 			}
 
 			$InputObj = [pscustomobject]@{
-				"AppID" = "SomeApplication"
+				'AppID' = 'SomeApplication'
 
 			}
 
@@ -52,37 +52,37 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint (byAppID ParameterSet)" {
+			It 'sends request to expected endpoint (byAppID ParameterSet)' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Applications/SomeApplication"
+					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Applications/SomeApplication/"
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint (byQuery ParameterSet)" {
+			It 'sends request to expected endpoint (byQuery ParameterSet)' {
 				$InputObj | Get-PASApplication
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -94,23 +94,23 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Application
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Application
 
 			}
 

--- a/Tests/Get-PASApplicationAuthenticationMethod.Tests.ps1
+++ b/Tests/Get-PASApplicationAuthenticationMethod.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,14 +35,14 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
+		BeforeEach {
 
 			Mock Invoke-PASRestMethod -MockWith {
-				[PSCustomObject]@{"authentication" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" } }
+				[PSCustomObject]@{'authentication' = [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' } }
 			}
 
 			$InputObj = [pscustomobject]@{
-				"AppID" = "SomeApplication"
+				'AppID' = 'SomeApplication'
 
 			}
 
@@ -52,11 +52,11 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
-			$Parameters = @{Parameter = 'AppID'}
+			$Parameters = @{Parameter = 'AppID' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -68,55 +68,55 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint (byAppID ParameterSet)" {
+			It 'sends request to expected endpoint (byAppID ParameterSet)' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Applications/SomeApplication/Authentications"
+					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Applications/SomeApplication/Authentications/"
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.ApplicationAuth
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.ApplicationAuth
 
 			}
 

--- a/Tests/Get-PASAuthenticationMethod.Tests.ps1
+++ b/Tests/Get-PASAuthenticationMethod.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -37,20 +37,20 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		BeforeEach {
 			Mock Invoke-PASRestMethod -MockWith {
-				[PSCustomObject]@{"Methods" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" } }
+				[PSCustomObject]@{'Methods' = [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' } }
 			}
 
 			$response = Get-PASAuthenticationMethod
 		}
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint - get all method" {
+			It 'sends request to expected endpoint - get all method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -60,7 +60,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected endpoint - get specific method" {
+			It 'sends request to expected endpoint - get specific method' {
 
 				Get-PASAuthenticationMethod -ID SomeMethod
 
@@ -72,35 +72,35 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
 				{ Get-PASAuthenticationMethod } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			It "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 

--- a/Tests/Get-PASComponentDetail.Tests.ps1
+++ b/Tests/Get-PASComponentDetail.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,21 +35,21 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
+		BeforeEach {
 			Mock Invoke-PASRestMethod -MockWith {
-				[PSCustomObject]@{"ComponentsDetails" = [PSCustomObject]@{"SomeProp" = "SomValue"; "OtherProp" = "OtherValue" }}
+				[PSCustomObject]@{'ComponentsDetails' = [PSCustomObject]@{'SomeProp' = 'SomValue'; 'OtherProp' = 'OtherValue' } }
 
-		}
+			}
 
 			$response = Get-PASComponentDetail -ComponentID PVWA
-	}
+		}
 
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'ComponentID' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -61,15 +61,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -79,35 +79,35 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
-				{ Get-PASComponentDetail -ComponentID PVWA  } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
+				{ Get-PASComponentDetail -ComponentID PVWA } | Should -Throw
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 

--- a/Tests/Get-PASComponentSummary.Tests.ps1
+++ b/Tests/Get-PASComponentSummary.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,25 +35,25 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
-			[PSCustomObject]@{
-				"Components" = [PSCustomObject]@{"ComponentID" = "SomValue"; "ComponentName" = "OtherValue"; "Role" = "SomValue"; "IP" = "OtherValue"; "IsLoggedOn" = "OtherValue" }
-				"Vaults"     = [PSCustomObject]@{"Role" = "SomValue"; "IP" = "OtherValue"; "IsLoggedOn" = "OtherValue" }
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
+				[PSCustomObject]@{
+					'Components' = [PSCustomObject]@{'ComponentID' = 'SomValue'; 'ComponentName' = 'OtherValue'; 'Role' = 'SomValue'; 'IP' = 'OtherValue'; 'IsLoggedOn' = 'OtherValue' }
+					'Vaults'     = [PSCustomObject]@{'Role' = 'SomValue'; 'IP' = 'OtherValue'; 'IsLoggedOn' = 'OtherValue' }
+				}
 			}
+
+			$response = Get-PASComponentSummary
 		}
+		Context 'Input' {
 
-		$response = Get-PASComponentSummary
-}
-		Context "Input" {
-
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -63,27 +63,27 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-$Script:ExternalVersion = "1.0"
-				{ Get-PASComponentSummary  } | Should -Throw
-$Script:ExternalVersion = "0.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
+				{ Get-PASComponentSummary } | Should -Throw
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
 
 

--- a/Tests/Get-PASConnectionComponent.Tests.ps1
+++ b/Tests/Get-PASConnectionComponent.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -37,20 +37,20 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		BeforeEach {
 			Mock Invoke-PASRestMethod -MockWith {
-				[PSCustomObject]@{"PSMConnectors" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" } }
+				[PSCustomObject]@{'PSMConnectors' = [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' } }
 			}
 
 			$response = Get-PASConnectionComponent
 		}
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -60,35 +60,35 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
 				{ Get-PASConnectionComponent } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 

--- a/Tests/Get-PASDirectory.Tests.ps1
+++ b/Tests/Get-PASDirectory.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,25 +35,25 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Input" {
+		Context 'Input' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+					[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
 				}
 
 				$response = Get-PASDirectory -id SomeDir
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -63,61 +63,61 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-$Script:ExternalVersion = "1.0"
-				{ Get-PASDirectory  } | Should -Throw
-$Script:ExternalVersion = "0.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
+				{ Get-PASDirectory } | Should -Throw
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+					[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
 				}
 
 				$response = Get-PASDirectory -id SomeDir
 
 			}
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Directory.Extended
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Directory.Extended
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
 				$response = Get-PASDirectory
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Directory
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Directory
 
 			}
 

--- a/Tests/Get-PASDirectoryMapping.Tests.ps1
+++ b/Tests/Get-PASDirectoryMapping.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,32 +35,32 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'DirectoryName' },
 			@{Parameter = 'MappingID' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
-				(Get-Command Get-PASDirectoryMapping).Parameters["$Parameter"].Attributes.Mandatory | Select-object -Unique | Should -Be $true
+				(Get-Command Get-PASDirectoryMapping).Parameters["$Parameter"].Attributes.Mandatory | Select-Object -Unique | Should -Be $true
 
 			}
 
 		}
 
-		Context "Input" {
+		Context 'Input' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+					[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
 				}
 
 				$InputObj = [pscustomobject]@{
 
-					"DirectoryName" = "SomeDirectory"
+					'DirectoryName' = 'SomeDirectory'
 
 				}
 
@@ -68,54 +68,54 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/LDAP/Directories/SomeDirectory/Mappings/SomeMapping"
+					$URI -eq "$($Script:BaseURI)/api/Configuration/LDAP/Directories/SomeDirectory/Mappings/SomeMapping/"
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-$Script:ExternalVersion = "1.0"
-				{ $InputObj | Get-PASDirectoryMapping  } | Should -Throw
-$Script:ExternalVersion = "0.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
+				{ $InputObj | Get-PASDirectoryMapping } | Should -Throw
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+					[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
 				}
 
 				$InputObj = [pscustomobject]@{
 
-					"DirectoryName" = "SomeDirectory"
-					"MappingID"     = "SomeMapping"
+					'DirectoryName' = 'SomeDirectory'
+					'MappingID'     = 'SomeMapping'
 
 				}
 
@@ -123,21 +123,21 @@ $Script:ExternalVersion = "0.0"
 
 			}
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Directory.Mapping
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Directory.Mapping
 
 			}
 

--- a/Tests/Get-PASDiscoveredAccount.Tests.ps1
+++ b/Tests/Get-PASDiscoveredAccount.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,28 +35,28 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "General" {
+		Context 'General' {
 
 			BeforeEach {
 
-				Mock Invoke-PASRestMethod -MockWith { "Data" }
+				Mock Invoke-PASRestMethod -MockWith { 'Data' }
 				Mock Get-NextLink -MockWith {  }
 
 
 			}
 
-			It "does not throw" {
+			It 'does not throw' {
 
 				{ Get-PASDiscoveredAccount } | Should -Not -Throw
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 				Get-PASDiscoveredAccount
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 				Get-PASDiscoveredAccount
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -65,7 +65,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 				} -Times 1 -Exactly -Scope It
 			}
 
-			It "sends request to expected endpoint - byID" {
+			It 'sends request to expected endpoint - byID' {
 				Get-PASDiscoveredAccount -id 456
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -74,48 +74,48 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 				} -Times 1 -Exactly -Scope It
 			}
 
-			It "sends expected filter" {
-				Get-PASDiscoveredAccount -privileged $true -accountEnabled $true
+			It 'sends expected filter' {
+				Get-PASDiscoveredAccount -privileged $true -AccountEnabled $true
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 					($URI -eq "$($Script:BaseURI)/api/DiscoveredAccounts?filter=privileged%20eq%20True%20AND%20AccountEnabled%20eq%20True" -or
-						$URI -eq "$($Script:BaseURI)/api/DiscoveredAccounts?filter=AccountEnabled%20eq%20True%20AND%20privileged%20eq%20True")
+					$URI -eq "$($Script:BaseURI)/api/DiscoveredAccounts?filter=AccountEnabled%20eq%20True%20AND%20privileged%20eq%20True")
 
 				} -Times 1 -Exactly -Scope It
 			}
 
-			It "sends expected query" {
+			It 'sends expected query' {
 				Get-PASDiscoveredAccount -search something -searchType startswith
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 					($URI -eq "$($Script:BaseURI)/api/DiscoveredAccounts?search=something&searchType=startswith" -or
-						$URI -eq "$($Script:BaseURI)/api/DiscoveredAccounts?searchType=startswith&search=something")
+					$URI -eq "$($Script:BaseURI)/api/DiscoveredAccounts?searchType=startswith&search=something")
 
 				} -Times 1 -Exactly -Scope It
 			}
 
-			It "sends expected query & filter" {
+			It 'sends expected query & filter' {
 				Get-PASDiscoveredAccount -search something -privileged $true
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 					($URI -eq "$($Script:BaseURI)/api/DiscoveredAccounts?search=something&filter=privileged%20eq%20True" -or
-						$URI -eq "$($Script:BaseURI)/api/DiscoveredAccounts?filter=privileged%20eq%20True&search=something")
+					$URI -eq "$($Script:BaseURI)/api/DiscoveredAccounts?filter=privileged%20eq%20True&search=something")
 
 				} -Times 1 -Exactly -Scope It
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 				Get-PASDiscoveredAccount
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 			}
 
-			It "invokes Get-NextLink" {
+			It 'invokes Get-NextLink' {
 				Get-PASDiscoveredAccount
 				Assert-MockCalled Get-NextLink -Times 1 -Exactly -Scope It
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "11.5"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '11.5'
 
 				{ Get-PASDiscoveredAccount } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Get-PASGroup.Tests.ps1
+++ b/Tests/Get-PASGroup.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,7 +35,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Input" {
+		Context 'Input' {
 
 			BeforeEach {
 
@@ -43,13 +43,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 				Get-PASGroup
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 				Get-PASGroup
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -59,8 +59,18 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request with expected query - filter ParameterSet" {
-				Get-PASGroup -filter "groupType eq Directory" -search "Search Term"
+			It 'sends request to expected endpoint' {
+				Get-PASGroup -id 666
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/API/UserGroups/666/"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'sends request with expected query - filter ParameterSet' {
+				Get-PASGroup -filter 'groupType eq Directory' -search 'Search Term'
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					($URI -eq "$($Script:BaseURI)/API/UserGroups?search=Search%20Term&filter=groupType%20eq%20Directory") -or ($URI -eq "$($Script:BaseURI)/API/UserGroups?filter=groupType%20eq%20Directory&search=Search%20Term")
@@ -69,8 +79,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request with expected query - groupType ParameterSet" {
-				Get-PASGroup -groupType Vault -search "Search Term"
+			It 'sends request with expected query - groupType ParameterSet' {
+				Get-PASGroup -groupType Vault -search 'Search Term'
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					($URI -eq "$($Script:BaseURI)/API/UserGroups?search=Search%20Term&filter=groupType%20eq%20Vault") -or ($URI -eq "$($Script:BaseURI)/API/UserGroups?filter=groupType%20eq%20Vault&search=Search%20Term")
@@ -79,53 +89,53 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 				Get-PASGroup
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 				Get-PASGroup
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.2"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.2'
 
 				{ Get-PASGroup } | Should -Throw
 
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
 					[pscustomobject]@{
-						"value" = [pscustomobject]@{
-							"Prop1" = "Value1"
-							"Prop2" = "Value2"
-							"Prop3" = "Value3"
-							"Prop4" = "Value4"
+						'value' = [pscustomobject]@{
+							'Prop1' = 'Value1'
+							'Prop2' = 'Value2'
+							'Prop3' = 'Value3'
+							'Prop4' = 'Value4'
 						}
 					}
 				}
 
 			}
 
-			it "provides output" {
+			It 'provides output' {
 				$response = Get-PASGroup
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 				$response = Get-PASGroup
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 4
 

--- a/Tests/Get-PASLoggedOnUser.Tests.ps1
+++ b/Tests/Get-PASLoggedOnUser.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,24 +35,24 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
-			[PSCustomObject]@{"Detail1" = "Detail"; "Detail2" = "Detail" }
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
+				[PSCustomObject]@{'Detail1' = 'Detail'; 'Detail2' = 'Detail' }
+			}
+
+
+
+			$response = Get-PASLoggedOnUser
 		}
+		Context 'Input' {
 
-
-
-		$response = Get-PASLoggedOnUser
-}
-		Context "Input" {
-
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -62,13 +62,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
@@ -76,23 +76,23 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.User
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.User
 
 			}
 

--- a/Tests/Get-PASOnboardingRule.Tests.ps1
+++ b/Tests/Get-PASOnboardingRule.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -37,26 +37,26 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		BeforeEach {
 			Mock Invoke-PASRestMethod -MockWith {
-				[PSCustomObject]@{"AutomaticOnboardingRules" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" } }
+				[PSCustomObject]@{'AutomaticOnboardingRules' = [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' } }
 			}
 
 			$InputObj = [pscustomobject]@{
-				"AccountID" = "99_9"
-				"Names"     = "SomeRule,SomeRule2"
+				'AccountID' = '99_9'
+				'Names'     = 'SomeRule,SomeRule2'
 
 			}
 
 			$response = $InputObj | Get-PASOnboardingRule
 		}
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -66,43 +66,43 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
 				{ $InputObj | Get-PASOnboardingRule } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.OnboardingRule
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.OnboardingRule
 
 			}
 

--- a/Tests/Get-PASOpenIDConnectProvider.Tests.ps1
+++ b/Tests/Get-PASOpenIDConnectProvider.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -36,11 +36,11 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		BeforeEach {
-			$Script:ExternalVersion = "0.0"
+			$Script:ExternalVersion = '0.0'
 
 			Mock Invoke-PASRestMethod -MockWith {
 
-				[PSCustomObject]@{"Providers" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" } }
+				[PSCustomObject]@{'Providers' = [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' } }
 
 			}
 
@@ -48,15 +48,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint - get all method" {
+			It 'sends request to expected endpoint - get all method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -66,7 +66,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected endpoint - get specific method" {
+			It 'sends request to expected endpoint - get specific method' {
 
 				Get-PASOpenIDConnectProvider -id idValue
 
@@ -78,35 +78,35 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
 				{ $InputObject | Get-PASOpenIDConnectProvider } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			It "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 

--- a/Tests/Get-PASPSMRecording.Tests.ps1
+++ b/Tests/Get-PASPSMRecording.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,31 +35,31 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Input" {
+		Context 'Input' {
 
 			BeforeEach {
 				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{"Recordings" = [PSCustomObject]@{"Prop1" = "VAL1"; "Prop2" = "Val2"; "Prop3" = "Val3" } }
+					[PSCustomObject]@{'Recordings' = [PSCustomObject]@{'Prop1' = 'VAL1'; 'Prop2' = 'Val2'; 'Prop3' = 'Val3' } }
 				}
 
 				$InputObj = [pscustomobject]@{
 
-					"Limit" = 9
+					'Limit' = 9
 
 				}
 
-				$Script:BaseURI = "https://SomeURL/SomeApp"
-				$Script:ExternalVersion = "0.0"
+				$Script:BaseURI = 'https://SomeURL/SomeApp'
+				$Script:ExternalVersion = '0.0'
 				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 			}
 
-			It "sends request" {
+			It 'sends request' {
 				$InputObj | Get-PASPSMRecording
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 				$InputObj | Get-PASPSMRecording
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -69,21 +69,21 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 				$InputObj | Get-PASPSMRecording
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 				$InputObj | Get-PASPSMRecording
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint when querying by ID" {
+			It 'sends request to expected endpoint when querying by ID' {
 
-				Get-PASPSMRecording -RecordingId SomeID
+				Get-PASPSMRecording -RecordingID SomeID
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -93,51 +93,51 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
 				{ $InputObj | Get-PASPSMRecording } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
-			It "throws error if version requirement not met when querying by ID" {
-				$Script:ExternalVersion = "10.5"
-				{ Get-PASPSMRecording -RecordingId SomeID } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+			It 'throws error if version requirement not met when querying by ID' {
+				$Script:ExternalVersion = '10.5'
+				{ Get-PASPSMRecording -RecordingID SomeID } | Should -Throw
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 			BeforeEach {
 				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{"Recordings" = [PSCustomObject]@{"Prop1" = "VAL1"; "Prop2" = "Val2"; "Prop3" = "Val3" } }
+					[PSCustomObject]@{'Recordings' = [PSCustomObject]@{'Prop1' = 'VAL1'; 'Prop2' = 'Val2'; 'Prop3' = 'Val3' } }
 				}
 
 				$InputObj = [pscustomobject]@{
 
-					"Limit" = 9
+					'Limit' = 9
 
 				}
 
-				$Script:BaseURI = "https://SomeURL/SomeApp"
-				$Script:ExternalVersion = "0.0"
+				$Script:BaseURI = 'https://SomeURL/SomeApp'
+				$Script:ExternalVersion = '0.0'
 				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 			}
-			it "provides output" {
+			It 'provides output' {
 
 				$InputObj | Get-PASPSMRecording | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($InputObj | Get-PASPSMRecording | Get-Member -MemberType NoteProperty).length | Should -Be 3
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$InputObj | Get-PASPSMRecording | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PSM.Recording
+				$InputObj | Get-PASPSMRecording | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PSM.Recording
 
 			}
 

--- a/Tests/Get-PASPSMRecordingActivity.Tests.ps1
+++ b/Tests/Get-PASPSMRecordingActivity.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,11 +35,11 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'RecordingID' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -49,26 +49,26 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input" {
+		Context 'Input' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith { }
 
 				$InputObj = [pscustomobject]@{
-					"RecordingID" = "SomeID"
+					'RecordingID' = 'SomeID'
 
 				}
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 				$InputObj | Get-PASPSMRecordingActivity
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 				$InputObj | Get-PASPSMRecordingActivity
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -78,63 +78,63 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 				$InputObj | Get-PASPSMRecordingActivity
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 				$InputObj | Get-PASPSMRecordingActivity
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "10.5"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '10.5'
 
 				{ $InputObj | Get-PASPSMRecordingActivity } | Should -Throw
 
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
 					[pscustomobject]@{
-						"Activities" = [pscustomobject]@{
-							"Prop1" = "Value1"
-							"Prop2" = "Value2"
-							"Prop3" = "Value3"
-							"Prop4" = "Value4"
+						'Activities' = [pscustomobject]@{
+							'Prop1' = 'Value1'
+							'Prop2' = 'Value2'
+							'Prop3' = 'Value3'
+							'Prop4' = 'Value4'
 						}
 					}
 				}
 
 				$InputObj = [pscustomobject]@{
-					"RecordingID" = "SomeID"
+					'RecordingID' = 'SomeID'
 				}
 
 			}
 
-			it "provides output" {
+			It 'provides output' {
 				$response = $InputObj | Get-PASPSMRecordingActivity
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 				$response = $InputObj | Get-PASPSMRecordingActivity
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PSM.Recording.Activity
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PSM.Recording.Activity
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 				$response = $InputObj | Get-PASPSMRecordingActivity
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 4
 

--- a/Tests/Get-PASPSMRecordingProperty.Tests.ps1
+++ b/Tests/Get-PASPSMRecordingProperty.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,11 +35,11 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'RecordingID' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -49,26 +49,26 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input" {
+		Context 'Input' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith { }
 
 				$InputObj = [pscustomobject]@{
-					"RecordingID" = "SomeID"
+					'RecordingID' = 'SomeID'
 
 				}
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 				$InputObj | Get-PASPSMRecordingProperty
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 				$InputObj | Get-PASPSMRecordingProperty
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -78,59 +78,59 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 				$InputObj | Get-PASPSMRecordingProperty
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 				$InputObj | Get-PASPSMRecordingProperty
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "10.5"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '10.5'
 
 				{ $InputObj | Get-PASPSMRecordingProperty } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
 					[pscustomobject]@{
-						"Prop1" = "Value1"
-						"Prop2" = "Value2"
-						"Prop3" = "Value3"
-						"Prop4" = "Value4"
+						'Prop1' = 'Value1'
+						'Prop2' = 'Value2'
+						'Prop3' = 'Value3'
+						'Prop4' = 'Value4'
 					}
 				}
 
 				$InputObj = [pscustomobject]@{
-					"RecordingID" = "SomeID"
+					'RecordingID' = 'SomeID'
 				}
 
 			}
 
-			it "provides output" {
+			It 'provides output' {
 				$response = $InputObj | Get-PASPSMRecordingProperty
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 				$response = $InputObj | Get-PASPSMRecordingProperty
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PSM.Recording.Property
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PSM.Recording.Property
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 				$response = $InputObj | Get-PASPSMRecordingProperty
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 4
 

--- a/Tests/Get-PASPSMServer.Tests.ps1
+++ b/Tests/Get-PASPSMServer.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -37,20 +37,20 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		BeforeEach {
 			Mock Invoke-PASRestMethod -MockWith {
-				[PSCustomObject]@{"PSMServers" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" } }
+				[PSCustomObject]@{'PSMServers' = [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' } }
 			}
 
 			$response = Get-PASPSMServer
 		}
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -60,35 +60,35 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
 				{ Get-PASPSMServer } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 

--- a/Tests/Get-PASPSMSession.Tests.ps1
+++ b/Tests/Get-PASPSMSession.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,33 +35,33 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Input" {
+		Context 'Input' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{"LiveSessions" = [PSCustomObject]@{"Prop1" = "VAL1"; "Prop2" = "Val2"; "Prop3" = "Val3" } }
+					[PSCustomObject]@{'LiveSessions' = [PSCustomObject]@{'Prop1' = 'VAL1'; 'Prop2' = 'Val2'; 'Prop3' = 'Val3' } }
 				}
 
 				$InputObj = [pscustomobject]@{
 
-					"Limit" = 9
+					'Limit' = 9
 
 				}
 
-				$Script:BaseURI = "https://SomeURL/SomeApp"
-				$Script:ExternalVersion = "0.0"
+				$Script:BaseURI = 'https://SomeURL/SomeApp'
+				$Script:ExternalVersion = '0.0'
 				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 				$InputObj | Get-PASPSMSession
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 				$InputObj | Get-PASPSMSession
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -71,19 +71,19 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 				$InputObj | Get-PASPSMSession
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 				$InputObj | Get-PASPSMSession
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint when querying by ID" {
+			It 'sends request to expected endpoint when querying by ID' {
 
 				Get-PASPSMSession -liveSessionId SomeID
 
@@ -95,54 +95,54 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
 				{ $InputObj | Get-PASPSMSession } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
-			It "throws error if version requirement not met when querying by ID" {
-				$Script:ExternalVersion = "10.5"
+			It 'throws error if version requirement not met when querying by ID' {
+				$Script:ExternalVersion = '10.5'
 				{ Get-PASPSMSession -liveSessionId SomeID } | Should -Throw
 
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{"LiveSessions" = [PSCustomObject]@{"Prop1" = "VAL1"; "Prop2" = "Val2"; "Prop3" = "Val3" } }
+					[PSCustomObject]@{'LiveSessions' = [PSCustomObject]@{'Prop1' = 'VAL1'; 'Prop2' = 'Val2'; 'Prop3' = 'Val3' } }
 				}
 
 				$InputObj = [pscustomobject]@{
 
-					"Limit" = 9
+					'Limit' = 9
 
 				}
 
-				$Script:BaseURI = "https://SomeURL/SomeApp"
-				$Script:ExternalVersion = "0.0"
+				$Script:BaseURI = 'https://SomeURL/SomeApp'
+				$Script:ExternalVersion = '0.0'
 				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 			}
-			it "provides output" {
+			It 'provides output' {
 
 				$InputObj | Get-PASPSMSession | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($InputObj | Get-PASPSMSession | Get-Member -MemberType NoteProperty).length | Should -Be 3
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$InputObj | Get-PASPSMSession | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PSM.Session
+				$InputObj | Get-PASPSMSession | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PSM.Session
 
 			}
 

--- a/Tests/Get-PASPSMSessionActivity.Tests.ps1
+++ b/Tests/Get-PASPSMSessionActivity.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,11 +35,11 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'liveSessionId' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -49,26 +49,26 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input" {
+		Context 'Input' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith { }
 
 				$InputObj = [pscustomobject]@{
-					"liveSessionId" = "SomeID"
+					'liveSessionId' = 'SomeID'
 
 				}
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 				$InputObj | Get-PASPSMSessionActivity
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 				$InputObj | Get-PASPSMSessionActivity
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -78,62 +78,62 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 				$InputObj | Get-PASPSMSessionActivity
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 				$InputObj | Get-PASPSMSessionActivity
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "10.5"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '10.5'
 
 				{ $InputObj | Get-PASPSMSessionActivity } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
 					[pscustomobject]@{
-						"Activities" = [pscustomobject]@{
-							"Prop1" = "Value1"
-							"Prop2" = "Value2"
-							"Prop3" = "Value3"
-							"Prop4" = "Value4"
+						'Activities' = [pscustomobject]@{
+							'Prop1' = 'Value1'
+							'Prop2' = 'Value2'
+							'Prop3' = 'Value3'
+							'Prop4' = 'Value4'
 						}
 					}
 				}
 
 				$InputObj = [pscustomobject]@{
-					"liveSessionId" = "SomeID"
+					'liveSessionId' = 'SomeID'
 				}
 
 			}
 
-			it "provides output" {
+			It 'provides output' {
 				$response = $InputObj | Get-PASPSMSessionActivity
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 				$response = $InputObj | Get-PASPSMSessionActivity
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PSM.Session.Activity
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PSM.Session.Activity
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 				$response = $InputObj | Get-PASPSMSessionActivity
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 4
 

--- a/Tests/Get-PASPSMSessionProperty.Tests.ps1
+++ b/Tests/Get-PASPSMSessionProperty.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,11 +35,11 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'liveSessionId' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -49,26 +49,26 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input" {
+		Context 'Input' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith { }
 
 				$InputObj = [pscustomobject]@{
-					"liveSessionId" = "SomeID"
+					'liveSessionId' = 'SomeID'
 
 				}
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 				$InputObj | Get-PASPSMSessionProperty
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 				$InputObj | Get-PASPSMSessionProperty
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -78,62 +78,62 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 				$InputObj | Get-PASPSMSessionProperty
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 				$InputObj | Get-PASPSMSessionProperty
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "10.5"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '10.5'
 
 				{ $InputObj | Get-PASPSMSessionProperty } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
 					[pscustomobject]@{
 
-						"Prop1" = "Value1"
-						"Prop2" = "Value2"
-						"Prop3" = "Value3"
-						"Prop4" = "Value4"
+						'Prop1' = 'Value1'
+						'Prop2' = 'Value2'
+						'Prop3' = 'Value3'
+						'Prop4' = 'Value4'
 
 					}
 				}
 
 				$InputObj = [pscustomobject]@{
-					"liveSessionId" = "SomeID"
+					'liveSessionId' = 'SomeID'
 				}
 
 			}
 
-			it "provides output" {
+			It 'provides output' {
 				$response = $InputObj | Get-PASPSMSessionProperty
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 				$response = $InputObj | Get-PASPSMSessionProperty
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PSM.Session.Property
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PSM.Session.Property
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 				$response = $InputObj | Get-PASPSMSessionProperty
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 4
 

--- a/Tests/Get-PASPTAEvent.Tests.ps1
+++ b/Tests/Get-PASPTAEvent.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,27 +35,27 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Input" {
+		Context 'Input' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{"addsaferesult" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" } }
+					[PSCustomObject]@{'addsaferesult' = [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' } }
 				}
 
-				$Script:BaseURI = "https://SomeURL/SomeApp"
-				$Script:ExternalVersion = "0.0"
+				$Script:BaseURI = 'https://SomeURL/SomeApp'
+				$Script:ExternalVersion = '0.0'
 				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 				Get-PASPTAEvent -fromUpdateDate 1-1-1979
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 				Get-PASPTAEvent -fromUpdateDate 1-1-1979
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -65,23 +65,23 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 				Get-PASPTAEvent -fromUpdateDate 1-1-1979
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected header" {
+			It 'sends request with expected header' {
 				Get-PASPTAEvent -lastUpdatedEventDate 1-1-1979
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$($Websession.headers["lastUpdatedEventDate"]) -eq "283996800"
+					$($Websession.headers['lastUpdatedEventDate']) -eq '283996800'
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 				Get-PASPTAEvent -fromUpdateDate 1-1-1979
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -91,41 +91,41 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
 				{ Get-PASPTAEvent } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{"addsaferesult" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" } }
+					[PSCustomObject]@{'addsaferesult' = [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' } }
 				}
 
-				$Script:BaseURI = "https://SomeURL/SomeApp"
-				$Script:ExternalVersion = "0.0"
+				$Script:BaseURI = 'https://SomeURL/SomeApp'
+				$Script:ExternalVersion = '0.0'
 				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 			}
-			it "provides output" {
+			It 'provides output' {
 
 				Get-PASPTAEvent -fromUpdateDate 1-1-1979 | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				(Get-PASPTAEvent -fromUpdateDate 1-1-1979 | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				Get-PASPTAEvent -fromUpdateDate 1-1-1979 | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PTA.Event
+				Get-PASPTAEvent -fromUpdateDate 1-1-1979 | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PTA.Event
 
 			}
 

--- a/Tests/Get-PASPTARemediation.Tests.ps1
+++ b/Tests/Get-PASPTARemediation.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,22 +35,22 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
-			[PSCustomObject]@{"automaticRemediation" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" } }
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
+				[PSCustomObject]@{'automaticRemediation' = [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' } }
+			}
+
+			$response = Get-PASPTARemediation
 		}
+		Context 'Input' {
 
-		$response = Get-PASPTARemediation
-}
-		Context "Input" {
-
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -60,13 +60,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -76,31 +76,31 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "throws error if version requirement not met" {
-$Script:ExternalVersion = "1.0"
-				{ Get-PASPTARemediation  } | Should -Throw
-$Script:ExternalVersion = "0.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
+				{ Get-PASPTARemediation } | Should -Throw
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PTA.Remediation
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PTA.Remediation
 
 			}
 

--- a/Tests/Get-PASPTARule.Tests.ps1
+++ b/Tests/Get-PASPTARule.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -34,22 +34,22 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 	}
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
-BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
-			[PSCustomObject]@{"riskyActivities" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" } }
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
+				[PSCustomObject]@{'riskyActivities' = [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' } }
+			}
+
+			$response = Get-PASPTARule
 		}
+		Context 'Input' {
 
-		$response = Get-PASPTARule
-}
-		Context "Input" {
-
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -59,13 +59,13 @@ BeforeEach{
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -75,31 +75,31 @@ BeforeEach{
 
 			}
 
-			It "throws error if version requirement not met" {
-$Script:ExternalVersion = "1.0"
-				{ Get-PASPTARule  } | Should -Throw
-$Script:ExternalVersion = "0.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
+				{ Get-PASPTARule } | Should -Throw
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PTA.Rule
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PTA.Rule
 
 			}
 

--- a/Tests/Get-PASParameter.Tests.ps1
+++ b/Tests/Get-PASParameter.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,15 +35,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "General Tests"{
+		Context 'General Tests' {
 
-			BeforeEach{
+			BeforeEach {
 
 				[array]$CommonParameters = [System.Management.Automation.PSCmdlet]::CommonParameters
 				[array]$CommonParameters += [System.Management.Automation.PSCmdlet]::OptionalCommonParameters
 				[array]$CommonParameters = $CommonParameters | Select-Object -Unique
-				[hashtable]$InputParams = @{"KeepThis" = "Kept"; "RemoveThis" = "Removed" }
-				$CommonParameters | ForEach-Object { $InputParams.Add($PSItem, "something") }
+				[hashtable]$InputParams = @{'KeepThis' = 'Kept'; 'RemoveThis' = 'Removed' }
+				$CommonParameters | ForEach-Object { $InputParams.Add($PSItem, 'something') }
 				$ReturnData = $InputParams | Get-PASParameter -ParametersToRemove RemoveThis
 
 			}
@@ -64,11 +64,11 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 			}
 
 			It 'does not return additional specified parameters' {
-				$ReturnData["RemoveThis"] | Should -BeNullOrEmpty
+				$ReturnData['RemoveThis'] | Should -BeNullOrEmpty
 			}
 
 			It 'returns expected value' {
-				$ReturnData["KeepThis"] | Should -Be "Kept"
+				$ReturnData['KeepThis'] | Should -Be 'Kept'
 			}
 
 		}

--- a/Tests/Get-PASPlatform.Tests.ps1
+++ b/Tests/Get-PASPlatform.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,118 +35,118 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Input - Legacy" {
+		Context 'Input - Legacy' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
 
-					[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = 123 }
+					[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2'; 'Prop3' = 123 }
 
 				}
 
 				$InputObj = [pscustomobject]@{
-					"Name" = "SomeName"
+					'Name' = 'SomeName'
 
 				}
 
-				$response = $InputObj | Get-PASPlatform -verbose
+				$response = $InputObj | Get-PASPlatform -Verbose
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Platforms/SomeName"
+					$URI -eq "$($Script:BaseURI)/API/Platforms/SomeName/"
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
 				{ $InputObj | Get-PASPlatform } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Input - 11.1" {
+		Context 'Input - 11.1' {
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
 
 					[PSCustomObject]@{
-						"Platforms" = [PSCustomObject]@{
-							"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = 123
+						'Platforms' = [PSCustomObject]@{
+							'Prop1' = 'Val1'; 'Prop2' = 'Val2'; 'Prop3' = 123
 						}
 					}
 
 				}
 
 				$InputObj = [pscustomobject]@{
-					"Search"       = "SomeName"
-					"Active"       = $true
-					"PlatformType" = "Regular"
+					'Search'       = 'SomeName'
+					'Active'       = $true
+					'PlatformType' = 'Regular'
 				}
 
 				$response = $InputObj | Get-PASPlatform
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "10.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '10.0'
 				{ $InputObj | Get-PASPlatform } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Input - 11.4" {
+		Context 'Input - 11.4' {
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
 
 					[PSCustomObject]@{
-						"Platforms" = [PSCustomObject]@{
-							"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = 123
+						'Platforms' = [PSCustomObject]@{
+							'Prop1' = 'Val1'; 'Prop2' = 'Val2'; 'Prop3' = 123
 						}
 					}
 
@@ -156,19 +156,19 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint - target" {
+			It 'sends request to expected endpoint - target' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -178,7 +178,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected endpoint - dependent" {
+			It 'sends request to expected endpoint - dependent' {
 
 				Get-PASPlatform -DependentPlatform
 
@@ -190,7 +190,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected endpoint - group" {
+			It 'sends request to expected endpoint - group' {
 
 				Get-PASPlatform -GroupPlatform
 
@@ -202,7 +202,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected endpoint - rotational group" {
+			It 'sends request to expected endpoint - rotational group' {
 
 				Get-PASPlatform -RotationalGroup
 
@@ -214,58 +214,58 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "11.3"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '11.3'
 				{ Get-PASPlatform } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
 
-					[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = 123 }
+					[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2'; 'Prop3' = 123 }
 
 				}
 
 				$InputObj = [pscustomobject]@{
-					"Name" = "SomeName"
+					'Name' = 'SomeName'
 
 				}
 
-				$response = $InputObj | Get-PASPlatform -verbose
+				$response = $InputObj | Get-PASPlatform -Verbose
 
 			}
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties - legacy" {
+			It 'has output with expected number of properties - legacy' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 3
 
 			}
 
-			It "has output with expected number of properties - 11.1" {
+			It 'has output with expected number of properties - 11.1' {
 
 				Mock Invoke-PASRestMethod -MockWith {
 
 					[PSCustomObject]@{
-						"Platforms" = [PSCustomObject]@{
-							"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = 123
+						'Platforms' = [PSCustomObject]@{
+							'Prop1' = 'Val1'; 'Prop2' = 'Val2'; 'Prop3' = 123
 						}
 					}
 
@@ -277,13 +277,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has output with expected number of properties - 11.4" {
+			It 'has output with expected number of properties - 11.4' {
 
 				Mock Invoke-PASRestMethod -MockWith {
 
 					[PSCustomObject]@{
-						"Platforms" = [PSCustomObject]@{
-							"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = 123
+						'Platforms' = [PSCustomObject]@{
+							'Prop1' = 'Val1'; 'Prop2' = 'Val2'; 'Prop3' = 123
 						}
 					}
 
@@ -295,9 +295,9 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Platform
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Platform
 
 			}
 

--- a/Tests/Get-PASPlatformPSMConfig.Tests.ps1
+++ b/Tests/Get-PASPlatformPSMConfig.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -37,20 +37,20 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		BeforeEach {
 			Mock Invoke-PASRestMethod -MockWith {
-				[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+				[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
 			}
 
 			$response = Get-PASPlatformPSMConfig -ID 42
 		}
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -60,35 +60,35 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
-				{ Get-PASPlatformPSMConfig  -ID 42 } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
+				{ Get-PASPlatformPSMConfig -ID 42 } | Should -Throw
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 

--- a/Tests/Get-PASPlatformSafe.Tests.ps1
+++ b/Tests/Get-PASPlatformSafe.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,11 +35,11 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
-			$Parameters = @{Parameter = 'PlatformID'}
+			$Parameters = @{Parameter = 'PlatformID' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -49,100 +49,100 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input - 11.1" {
+		Context 'Input - 11.1' {
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
 
 					[PSCustomObject]@{
-						"count" = 2
-						"value" = [array] "value1","value2","value3"
-						}
+						'count' = 2
+						'value' = [array] 'value1', 'value2', 'value3'
 					}
+				}
 
 
 				$InputObj = [pscustomobject]@{
-					"PlatformID" = "SomeName"
+					'PlatformID' = 'SomeName'
 				}
 
 				$response = $InputObj | Get-PASPlatformSafe
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Platforms/SomeName/Safes"
+					$URI -eq "$($Script:BaseURI)/API/Platforms/SomeName/Safes/"
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "10.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '10.0'
 				{ $InputObj | Get-PASPlatformSafe } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
 
-					[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = 123 }
+					[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2'; 'Prop3' = 123 }
 
 				}
 
 				$InputObj = [pscustomobject]@{
-					"Name" = "SomeName"
+					'Name' = 'SomeName'
 
 				}
 
-				$response = $InputObj | Get-PASPlatform -verbose
+				$response = $InputObj | Get-PASPlatform -Verbose
 
 			}
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties - legacy" {
+			It 'has output with expected number of properties - legacy' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 3
 
 			}
 
-			It "has output with expected number of properties - 11.1" {
+			It 'has output with expected number of properties - 11.1' {
 
 				Mock Invoke-PASRestMethod -MockWith {
 
 					[PSCustomObject]@{
-						"Platforms" = [PSCustomObject]@{
-							"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = 123
+						'Platforms' = [PSCustomObject]@{
+							'Prop1' = 'Val1'; 'Prop2' = 'Val2'; 'Prop3' = 123
 						}
 					}
 
@@ -154,9 +154,9 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Platform
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Platform
 
 			}
 

--- a/Tests/Get-PASPolicyACL.Tests.ps1
+++ b/Tests/Get-PASPolicyACL.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,24 +35,24 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
-			[pscustomobject]@{"ListPolicyPrivilegedCommandsResult" = [pscustomobject]@{"some" = "thing"; "other" = "thing"}}
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
+				[pscustomobject]@{'ListPolicyPrivilegedCommandsResult' = [pscustomobject]@{'some' = 'thing'; 'other' = 'thing' } }
 
-		}
+			}
 
-		$InputObj = [pscustomobject]@{
-		"PolicyID"     = "UNIXSSH"
-		}
+			$InputObj = [pscustomobject]@{
+				'PolicyID' = 'UNIXSSH'
+			}
 			$response = $InputObj | Get-PASPolicyACL
 
-	}
-		Context "Mandatory Parameters" {
+		}
+		Context 'Mandatory Parameters' {
 
-			$Parameters = @{Parameter = 'PolicyId'}
+			$Parameters = @{Parameter = 'PolicyId' }
 
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -64,55 +64,55 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Policy/UNIXSSH/PrivilegedCommands"
+					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Policy/UNIXSSH/PrivilegedCommands/"
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'GET' } -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.ACL.Policy
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.ACL.Policy
 
 			}
 

--- a/Tests/Get-PASPublicSSHKey.Tests.ps1
+++ b/Tests/Get-PASPublicSSHKey.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,22 +35,23 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
-			[PSCustomObject]@{"GetUserAuthorizedKeysResult" = [PSCustomObject]@{"KeyID" = "SomeID"; "PublicSSHKey" = "SomeKey" } }
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
+				[PSCustomObject]@{'GetUserAuthorizedKeysResult' = [PSCustomObject]@{'KeyID' = 'SomeID'; 'PublicSSHKey' = 'SomeKey' } }
+			}
+
+			$InputObj = [pscustomobject]@{
+				'UserName' = 'SomeUser'
+
+			}
+			$response = $InputObj | Get-PASPublicSSHKey
 		}
 
-		$InputObj = [pscustomobject]@{
-		"UserName" = "SomeUser"
-
-				}
-					$response = $InputObj | Get-PASPublicSSHKey
-		}
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'UserName' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -62,31 +63,31 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/SomeUser/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys"
+					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/SomeUser/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys/"
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
@@ -94,29 +95,29 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 3
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PublicSSHKey
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PublicSSHKey
 
 			}
 
 
 
-			It "returns username property in response" {
+			It 'returns username property in response' {
 
 				$response.UserName | Should -Be SomeUser
 

--- a/Tests/Get-PASRequest.Tests.ps1
+++ b/Tests/Get-PASRequest.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -38,18 +38,18 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		BeforeEach {
 			Mock Invoke-PASRestMethod -MockWith {
 				[PSCustomObject]@{
-					"MyRequests"       = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "val2" }
-					"IncomingRequests" = [PSCustomObject]@{"PropA" = "ValA"; "PropB" = "ValB"; "PropC" = "ValC" }
+					'MyRequests'       = [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'val2' }
+					'IncomingRequests' = [PSCustomObject]@{'PropA' = 'ValA'; 'PropB' = 'ValB'; 'PropC' = 'ValC' }
 				}
 			}
 		}
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'RequestType' },
 			@{Parameter = 'OnlyWaiting' },
 			@{Parameter = 'Expired' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -59,18 +59,18 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input - MyRequests" {
+		Context 'Input - MyRequests' {
 
 			BeforeEach {
 				Get-PASRequest -RequestType MyRequests -OnlyWaiting $true -Expired $true
 			}
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -81,37 +81,37 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
 				{ Get-PASRequest -RequestType MyRequests -OnlyWaiting $true -Expired $true } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Input - IncomingRequests" {
+		Context 'Input - IncomingRequests' {
 			BeforeEach {
 				Get-PASRequest -RequestType IncomingRequests -OnlyWaiting $true -Expired $true
 			}
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -122,13 +122,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
@@ -136,25 +136,25 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Output - MyRequests" {
+		Context 'Output - MyRequests' {
 			BeforeEach {
 				$response = Get-PASRequest -RequestType MyRequests -OnlyWaiting $true -Expired $false
 			}
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Request.Details
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Request.Details
 
 			}
 
@@ -162,25 +162,25 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Output - IncomingRequests" {
+		Context 'Output - IncomingRequests' {
 			BeforeEach {
 				$response = Get-PASRequest -RequestType IncomingRequests -OnlyWaiting $true -Expired $false
 			}
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 3
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Request.Details
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Request.Details
 
 			}
 

--- a/Tests/Get-PASRequestDetail.Tests.ps1
+++ b/Tests/Get-PASRequestDetail.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,21 +35,21 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
-			[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "val2"; "PropA" = "ValA"; "PropB" = "ValB"; "PropC" = "ValC" }
-		}
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
+				[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'val2'; 'PropA' = 'ValA'; 'PropB' = 'ValB'; 'PropC' = 'ValC' }
+			}
 
-		$InputObj = [pscustomobject]@{
-"RequestID" = "SomeID"
+			$InputObj = [pscustomobject]@{
+				'RequestID' = 'SomeID'
+			}
 		}
-}
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'RequestType' },
 			@{Parameter = 'RequestID' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -59,17 +59,17 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input - MyRequests" {
-			BeforeEach{
-			$InputObj | Get-PASRequestDetail -RequestType MyRequests
-}
-			It "sends request" {
+		Context 'Input - MyRequests' {
+			BeforeEach {
+				$InputObj | Get-PASRequestDetail -RequestType MyRequests
+			}
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -79,37 +79,37 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-$Script:ExternalVersion = "1.0"
-				{ $InputObj | Get-PASRequestDetail -RequestType MyRequests  } | Should -Throw
-$Script:ExternalVersion = "0.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
+				{ $InputObj | Get-PASRequestDetail -RequestType MyRequests } | Should -Throw
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Input - IncomingRequests" {
-			BeforeEach{
-			$InputObj | Get-PASRequestDetail -RequestType IncomingRequests
-}
-			It "sends request" {
+		Context 'Input - IncomingRequests' {
+			BeforeEach {
+				$InputObj | Get-PASRequestDetail -RequestType IncomingRequests
+			}
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -119,13 +119,13 @@ $Script:ExternalVersion = "0.0"
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
@@ -133,25 +133,25 @@ $Script:ExternalVersion = "0.0"
 
 		}
 
-		Context "Output" {
-			BeforeEach{
-			$response = $InputObj | Get-PASRequestDetail -RequestType MyRequests
-}
-			it "provides output" {
+		Context 'Output' {
+			BeforeEach {
+				$response = $InputObj | Get-PASRequestDetail -RequestType MyRequests
+			}
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 5
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Request.Extended
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Request.Extended
 
 			}
 

--- a/Tests/Get-PASResponse.Tests.ps1
+++ b/Tests/Get-PASResponse.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,63 +35,63 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Standard Operation" {
+		Context 'Standard Operation' {
 
 			BeforeEach {
 
 				$JSONResponse = New-MockObject -Type Microsoft.PowerShell.Commands.WebResponseObject
 				$JSONResponse | Add-Member -MemberType NoteProperty -Name StatusCode -Value 200 -Force
-				$JSONResponse | Add-Member -MemberType NoteProperty -Name Headers -Value @{ "Content-Type" = 'application/json; charset=utf-8' } -Force
+				$JSONResponse | Add-Member -MemberType NoteProperty -Name Headers -Value @{ 'Content-Type' = 'application/json; charset=utf-8' } -Force
 				$JSONResponse | Add-Member -MemberType NoteProperty -Name Content -Value (@{
-						"prop1"   = "value1";
-						"prop2"   = "value2";
-						"prop123" = 123
-						"test"    = 321
+						'prop1'   = 'value1';
+						'prop2'   = 'value2';
+						'prop123' = 123
+						'test'    = 321
 					} | ConvertTo-Json) -Force
 
 				$TextResponse = New-MockObject -Type Microsoft.PowerShell.Commands.WebResponseObject
 				$TextResponse | Add-Member -MemberType NoteProperty -Name StatusCode -Value 200 -Force
-				$TextResponse | Add-Member -MemberType NoteProperty -Name Headers -Value @{ "Content-Type" = 'text/html; charset=utf-8' } -Force
+				$TextResponse | Add-Member -MemberType NoteProperty -Name Headers -Value @{ 'Content-Type' = 'text/html; charset=utf-8' } -Force
 				$TextResponse | Add-Member -MemberType NoteProperty -Name Content -Value '"Value"' -Force
 
 				$HTMLResponse = New-MockObject -Type Microsoft.PowerShell.Commands.WebResponseObject
 				$HTMLResponse | Add-Member -MemberType NoteProperty -Name StatusCode -Value 200 -Force
-				$HTMLResponse | Add-Member -MemberType NoteProperty -Name Headers -Value @{ "Content-Type" = 'text/html; charset=utf-8' } -Force
+				$HTMLResponse | Add-Member -MemberType NoteProperty -Name Headers -Value @{ 'Content-Type' = 'text/html; charset=utf-8' } -Force
 				$HTMLResponse | Add-Member -MemberType NoteProperty -Name Content -Value '<HTML><HEAD><BODY><P>Test</P></BODY></HEAD></HTML>' -Force
 
 				$ApplicationSave = New-MockObject -Type Microsoft.PowerShell.Commands.WebResponseObject
 				$ApplicationSave | Add-Member -MemberType NoteProperty -Name StatusCode -Value 200 -Force
-				$ApplicationSave | Add-Member -MemberType NoteProperty -Name Headers -Value @{ "Content-Type" = 'application/save' ; "Content-Disposition" = "attachment; filename=FILENAME.zip" } -Force
-				$ApplicationSave | Add-Member -MemberType NoteProperty -Name Content -Value $([System.Text.Encoding]::Ascii.GetBytes("Expected")) -Force
+				$ApplicationSave | Add-Member -MemberType NoteProperty -Name Headers -Value @{ 'Content-Type' = 'application/save' ; 'Content-Disposition' = 'attachment; filename=FILENAME.zip' } -Force
+				$ApplicationSave | Add-Member -MemberType NoteProperty -Name Content -Value $([System.Text.Encoding]::Ascii.GetBytes('Expected')) -Force
 
 				$OctetStream = New-MockObject -Type Microsoft.PowerShell.Commands.WebResponseObject
 				$OctetStream | Add-Member -MemberType NoteProperty -Name StatusCode -Value 200 -Force
-				$OctetStream | Add-Member -MemberType NoteProperty -Name Headers -Value @{ "Content-Type" = 'application/octet-stream' ; "Content-Disposition" = "attachment; filename=FILENAME.zip" } -Force
-				$OctetStream | Add-Member -MemberType NoteProperty -Name Content -Value $([System.Text.Encoding]::Ascii.GetBytes("Expected")) -Force
+				$OctetStream | Add-Member -MemberType NoteProperty -Name Headers -Value @{ 'Content-Type' = 'application/octet-stream' ; 'Content-Disposition' = 'attachment; filename=FILENAME.zip' } -Force
+				$OctetStream | Add-Member -MemberType NoteProperty -Name Content -Value $([System.Text.Encoding]::Ascii.GetBytes('Expected')) -Force
 
 			}
 
-			It "returns expected number of properties" {
+			It 'returns expected number of properties' {
 				$result = Get-PASResponse -APIResponse $JSONResponse
 				($result | Get-Member -MemberType NoteProperty).length | Should -Be 4
 			}
 
-			It "returns expected text value" {
+			It 'returns expected text value' {
 				Get-PASResponse -APIResponse $TextResponse | Should -Be '"Value"'
 			}
 
-			It "throws if HTML received" {
+			It 'throws if HTML received' {
 				{ Get-PASResponse -APIResponse $HTMLResponse } | Should -Throw
 			}
 
-			It "returns expected application-save value" {
+			It 'returns expected application-save value' {
 				$result = Get-PASResponse -APIResponse $ApplicationSave
-				$([System.Text.Encoding]::ASCII.GetString($result.Content)) | Should -Be "Expected"
+				$([System.Text.Encoding]::ASCII.GetString($result.Content)) | Should -Be 'Expected'
 			}
 
-			It "returns expected octet-stream value" {
+			It 'returns expected octet-stream value' {
 				$result = Get-PASResponse -APIResponse $OctetStream
-				$([System.Text.Encoding]::ASCII.GetString($result.Content)) | Should -Be "Expected"
+				$([System.Text.Encoding]::ASCII.GetString($result.Content)) | Should -Be 'Expected'
 			}
 
 		}

--- a/Tests/Get-PASSAMLResponse.Tests.ps1
+++ b/Tests/Get-PASSAMLResponse.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -30,24 +30,24 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
+		BeforeEach {
 
 			Mock Invoke-WebRequest -MockWith {
 
 				[pscustomobject]@{
 
-					"Links"       = [pscustomobject]@{
+					'Links'       = [pscustomobject]@{
 
-						"href" = "https://SomeLink/"
+						'href' = 'https://SomeLink/'
 
 					}
 
-					"InputFields" = @(
+					'InputFields' = @(
 
 						[pscustomobject]@{
 
-							"Name"  = "SAMLResponse"
-							"Value" = "IamSAMLiAM"
+							'Name'  = 'SAMLResponse'
+							'Value' = 'IamSAMLiAM'
 
 						}
 
@@ -57,33 +57,33 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			$response = Get-PASSAMLResponse -URL "https://pvwa.somecompany.com/PasswordVault"
+			$response = Get-PASSAMLResponse -URL 'https://pvwa.somecompany.com/PasswordVault'
 
 		}
 
-		Context "Standard Operation" {
+		Context 'Standard Operation' {
 
-			It "sends expected requests" {
+			It 'sends expected requests' {
 
 				Assert-MockCalled Invoke-WebRequest -Times 2 -Exactly -Scope It
 
 			}
 
-			It "returns expected response" {
+			It 'returns expected response' {
 
-				$response | Should -Be "IamSAMLiAM"
+				$response | Should -Be 'IamSAMLiAM'
 
 			}
 
-			It "throws expected error"{
+			It 'throws expected error' {
 
 				Mock Invoke-WebRequest -MockWith {
 
-					Throw "Some Error"
+					Throw 'Some Error'
 
 				}
 
-				{Get-PASSAMLResponse -URL "https://pvwa.somecompany.com/PasswordVault"} | Should -Throw "Failed to get SAMLResponse"
+				{ Get-PASSAMLResponse -URL 'https://pvwa.somecompany.com/PasswordVault' } | Should -Throw 'Failed to get SAMLResponse'
 
 			}
 

--- a/Tests/Get-PASSafeMember.Tests.ps1
+++ b/Tests/Get-PASSafeMember.Tests.ps1
@@ -72,7 +72,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Safes/SomeSafe/Members/SomeMember"
+					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Safes/SomeSafe/Members/SomeMember/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -145,7 +145,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Safes/SomeSafe/Members/SomeMember"
+					$URI -eq "$($Script:BaseURI)/api/Safes/SomeSafe/Members/SomeMember/"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Get-PASSafeShareLogo.Tests.ps1
+++ b/Tests/Get-PASSafeShareLogo.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -34,17 +34,17 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 	}
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
-			Write-output "Squint and This is an Image"
-		}
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
+				Write-Output 'Squint and This is an Image'
+			}
 			$response = Get-PASSafeShareLogo -ImageType Square
-}
-		Context "Mandatory Parameters" {
+		}
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'ImageType' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -56,15 +56,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -74,13 +74,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
@@ -88,9 +88,9 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 

--- a/Tests/Get-PASServer.Tests.ps1
+++ b/Tests/Get-PASServer.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,22 +35,22 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
-			[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
+				[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
+			}
+
+			$response = Get-PASServer
 		}
+		Context 'Input' {
 
-		$response = Get-PASServer
-}
-		Context "Input" {
-
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -60,13 +60,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
@@ -74,15 +74,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 

--- a/Tests/Get-PASServerWebService.Tests.ps1
+++ b/Tests/Get-PASServerWebService.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -34,27 +34,27 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 	}
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
-BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
-			[PSCustomObject]@{
-				"ServerName"            = "Val1";
-				"ServerID"              = "Val2";
-				"ApplicationName"       = "AppName";
-				"AuthenticationMethods" = "SomeThing"
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
+				[PSCustomObject]@{
+					'ServerName'            = 'Val1';
+					'ServerID'              = 'Val2';
+					'ApplicationName'       = 'AppName';
+					'AuthenticationMethods' = 'SomeThing'
+				}
 			}
+
+			$response = Get-PASServerWebService -BaseURI 'https://SomeURL' -PVWAAppName SomeApp
 		}
+		Context 'Input' {
 
-		$response = Get-PASServerWebService -BaseURI "https://SomeURL" -PVWAAppName SomeApp
-}
-		Context "Input" {
-
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -64,13 +64,13 @@ BeforeEach{
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
@@ -78,15 +78,15 @@ BeforeEach{
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 4
 

--- a/Tests/Get-PASUser.Tests.ps1
+++ b/Tests/Get-PASUser.Tests.ps1
@@ -70,7 +70,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/SomeUser"
+					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/SomeUser/"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Get-PASUserLoginInfo.Tests.ps1
+++ b/Tests/Get-PASUserLoginInfo.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,22 +35,22 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
-			[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
+				[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
+			}
+
+			$response = Get-PASUserLoginInfo
 		}
+		Context 'Input' {
 
-		$response = Get-PASUserLoginInfo
-}
-		Context "Input" {
-
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -60,35 +60,35 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-$Script:ExternalVersion = "1.0"
-				{ Get-PASUserLoginInfo  } | Should -Throw
-$Script:ExternalVersion = "0.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
+				{ Get-PASUserLoginInfo } | Should -Throw
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 

--- a/Tests/Get-ParentFunction.Tests.ps1
+++ b/Tests/Get-ParentFunction.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -36,8 +36,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		It 'returns parent function name' {
-			Function Test-Parent {Test-Child}
-			Function Test-Child {Get-ParentFunction}
+			Function Test-Parent { Test-Child }
+			Function Test-Child { Get-ParentFunction }
 			$ThisTest = Test-Parent
 
 			$ThisTest.FunctionName | Should -Be Test-Parent
@@ -46,28 +46,28 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		It 'returns expected parent function name from expected scope' {
 			Function Test-Example {
 				[CmdletBinding()]
-				param([parameter(ParameterSetName = "ExampleParamSet")][string]$Name)
+				param([parameter(ParameterSetName = 'ExampleParamSet')][string]$Name)
 				Test-Parent
 			}
-			Function Test-Parent {Test-Child}
-			Function Test-Child {Get-ParentFunction -Scope 3}
-			$ThisTest = Test-Example -Name "test"
+			Function Test-Parent { Test-Child }
+			Function Test-Child { Get-ParentFunction -Scope 3 }
+			$ThisTest = Test-Example -Name 'test'
 
-			$ThisTest.FunctionName | Should -Be "Test-Example"
+			$ThisTest.FunctionName | Should -Be 'Test-Example'
 
 		}
 
 		It 'returns expected ParameterSetName from expected scope' {
 			Function Test-Example {
 				[CmdletBinding()]
-				param([parameter(ParameterSetName = "ExampleParamSet")][string]$Name)
+				param([parameter(ParameterSetName = 'ExampleParamSet')][string]$Name)
 				Test-Parent
 			}
-			Function Test-Parent {Test-Child}
-			Function Test-Child {Get-ParentFunction -Scope 3}
-			$ThisTest = Test-Example -Name "test"
+			Function Test-Parent { Test-Child }
+			Function Test-Child { Get-ParentFunction -Scope 3 }
+			$ThisTest = Test-Example -Name 'test'
 
-			$ThisTest.ParameterSetName | Should -Be "ExampleParamSet"
+			$ThisTest.ParameterSetName | Should -Be 'ExampleParamSet'
 		}
 
 

--- a/Tests/Hide-SecretValue.Tests.ps1
+++ b/Tests/Hide-SecretValue.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,27 +35,27 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context	"General Tests"{
-			BeforeEach{
+		Context	'General Tests' {
+			BeforeEach {
 
 				[array]$Secrets = @(
-					"Secret",
-					"Password",
-					"NewCredentials",
-					"NewPassword",
-					"BindPassword",
-					"InitialPassword"
+					'Secret',
+					'Password',
+					'NewCredentials',
+					'NewPassword',
+					'BindPassword',
+					'InitialPassword'
 				)
 
 				$String = [pscustomobject]@{
-					"Property"         = "Value"
-					"Password"         = "SecretValue"
-					"Secret"           = "DontShareThis"
-					"NewCredentials"   = "S3cr3t"
-					"NewPassword"      = "Password123!"
-					"BindPassword"     = "ABCDE123!"
-					"InitialPassword"  = "123456"
-					"InnocentProperty" = "SomeValue"
+					'Property'         = 'Value'
+					'Password'         = 'SecretValue'
+					'Secret'           = 'DontShareThis'
+					'NewCredentials'   = 'S3cr3t'
+					'NewPassword'      = 'Password123!'
+					'BindPassword'     = 'ABCDE123!'
+					'InitialPassword'  = '123456'
+					'InnocentProperty' = 'SomeValue'
 				} | ConvertTo-Json
 			}
 
@@ -66,25 +66,25 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 			}
 
 
-				It "does not include <Parameter> value in return data" -TestCases @{Parameter = 'Secret' },
-				@{Parameter = 'Password' },
-				@{Parameter = 'NewCredentials' },
-				@{Parameter = 'NewPassword' },
-				@{Parameter = 'BindPassword' },
-				@{Parameter = 'InitialPassword' } {
-					$ReturnData = Hide-SecretValue -InputValue $String -SecretsToRemove Property
-					$ReturnData | ConvertFrom-Json | Select-Object -ExpandProperty $Parameter | Should -Be "******"
+			It 'does not include <Parameter> value in return data' -TestCases @{Parameter = 'Secret' },
+			@{Parameter = 'Password' },
+			@{Parameter = 'NewCredentials' },
+			@{Parameter = 'NewPassword' },
+			@{Parameter = 'BindPassword' },
+			@{Parameter = 'InitialPassword' } {
+				$ReturnData = Hide-SecretValue -InputValue $String -SecretsToRemove Property
+				$ReturnData | ConvertFrom-Json | Select-Object -ExpandProperty $Parameter | Should -Be '******'
 
-				}
+			}
 
 			It 'does not return additional specified parameters' {
 				$ReturnData = Hide-SecretValue -InputValue $String -SecretsToRemove Property
-				$ReturnData | ConvertFrom-Json | Select-Object -ExpandProperty Property | Should -Be "******"
+				$ReturnData | ConvertFrom-Json | Select-Object -ExpandProperty Property | Should -Be '******'
 			}
 
 			It 'returns expected value' {
 				$ReturnData = Hide-SecretValue -InputValue $String -SecretsToRemove Property
-				$ReturnData | ConvertFrom-Json | Select-Object -ExpandProperty InnocentProperty | Should -Be "SomeValue"
+				$ReturnData | ConvertFrom-Json | Select-Object -ExpandProperty InnocentProperty | Should -Be 'SomeValue'
 			}
 
 		}

--- a/Tests/Import-PASConnectionComponent.Tests.ps1
+++ b/Tests/Import-PASConnectionComponent.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,26 +35,26 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
-			[PSCustomObject]@{"ConnectionComponentID" = "SomeConnectionComponent" }
-		}
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
+				[PSCustomObject]@{'ConnectionComponentID' = 'SomeConnectionComponent' }
+			}
 
 			#Create a 512b file to test with
 			$file = [System.IO.File]::Create("$env:Temp\test.zip")
 			$file.SetLength(0.5kb)
 			$file.Close()
 
-		$response = Import-PASConnectionComponent -ImportFile $($file.name)
+			$response = Import-PASConnectionComponent -ImportFile $($file.name)
 
-}
+		}
 
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'ImportFile' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -64,27 +64,27 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "throws if InputFile does not exist" {
+			It 'throws if InputFile does not exist' {
 				{ Import-PASConnectionComponent -ImportFile SomeFile.txt } | Should -Throw
 			}
 
-			It "throws if InputFile resolves to a folder" {
+			It 'throws if InputFile resolves to a folder' {
 				{ Import-PASConnectionComponent -ImportFile $pwd } | Should -Throw
 			}
 
-			It "throws if InputFile does not have a zip extention" {
+			It 'throws if InputFile does not have a zip extention' {
 				{ Import-PASConnectionComponent -ImportFile README.MD } | Should -Throw
 			}
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -94,13 +94,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -112,43 +112,43 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected number of properties" {
+			It 'has a request body with expected number of properties' {
 
 				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
 			}
 
-			It "has body content of expected length" {
+			It 'has body content of expected length' {
 
 				($Script:RequestBody.ImportFile).length | Should -Be 512
 
 			}
 
-			It "throws error if version requirement not met" {
-$Script:ExternalVersion = "1.0"
-				{ Import-PASConnectionComponent -ImportFile $($file.name)  } | Should -Throw
-$Script:ExternalVersion = "0.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
+				{ Import-PASConnectionComponent -ImportFile $($file.name) } | Should -Throw
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be System.Management.Automation.PSCustomObject
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be System.Management.Automation.PSCustomObject
 
 			}
 

--- a/Tests/Import-PASPlatform.Tests.ps1
+++ b/Tests/Import-PASPlatform.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,25 +35,25 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
+		BeforeEach {
 			Mock Invoke-PASRestMethod -MockWith {
-			[PSCustomObject]@{"PlatformID" = "SomePlatform" }
-		}
+				[PSCustomObject]@{'PlatformID' = 'SomePlatform' }
+			}
 
-		#Create a 512b file to test with
-		$file = [System.IO.File]::Create("$env:Temp\testPlatform.zip")
-		$file.SetLength(0.5kb)
-		$file.Close()
+			#Create a 512b file to test with
+			$file = [System.IO.File]::Create("$env:Temp\testPlatform.zip")
+			$file.SetLength(0.5kb)
+			$file.Close()
 
 			$response = Import-PASPlatform -ImportFile $($file.name)
 
 		}
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'ImportFile' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -65,27 +65,27 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "throws if InputFile does not exist" {
+			It 'throws if InputFile does not exist' {
 				{ Import-PASPlatform -ImportFile SomeFile.txt } | Should -Throw
 			}
 
-			It "throws if InputFile resolves to a folder" {
+			It 'throws if InputFile resolves to a folder' {
 				{ Import-PASPlatform -ImportFile $pwd } | Should -Throw
 			}
 
-			It "throws if InputFile does not have a zip extention" {
+			It 'throws if InputFile does not have a zip extention' {
 				{ Import-PASPlatform -ImportFile README.MD } | Should -Throw
 			}
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -95,13 +95,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -113,44 +113,44 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected number of properties" {
+			It 'has a request body with expected number of properties' {
 
 				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
 			}
 
-			It "has body content of expected length" {
+			It 'has body content of expected length' {
 
 				($Script:RequestBody.ImportFile).length | Should -Be 512
 
 			}
 
-			It "throws error if version requirement not met" {
-$Script:ExternalVersion = "1.0"
-				{ Import-PASPlatform -ImportFile $($file.name)  } | Should -Throw
-$Script:ExternalVersion = "0.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
+				{ Import-PASPlatform -ImportFile $($file.name) } | Should -Throw
+				$Script:ExternalVersion = '0.0'
 			}
 
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be System.Management.Automation.PSCustomObject
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be System.Management.Automation.PSCustomObject
 
 			}
 

--- a/Tests/Invoke-PASCPMOperation.Tests.ps1
+++ b/Tests/Invoke-PASCPMOperation.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -36,157 +36,157 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 
-		Context "Standard Operation" {
+		Context 'Standard Operation' {
 
 			BeforeEach {
 				Mock Invoke-PASRestMethod -MockWith { }
 
-				$AccountID = "SomeID"
-				$Password = "SomePassword" | ConvertTo-SecureString -AsPlainText -Force
+				$AccountID = 'SomeID'
+				$Password = 'SomePassword' | ConvertTo-SecureString -AsPlainText -Force
 
 				$Script:RequestBody = $null
-				$Script:BaseURI = "https://SomeURL/SomeApp"
-				$Script:ExternalVersion = "0.0"
+				$Script:BaseURI = 'https://SomeURL/SomeApp'
+				$Script:ExternalVersion = '0.0'
 				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 			}
 
-			It "sends verify request to expected api endpoint" {
+			It 'sends verify request to expected api endpoint' {
 
 				Invoke-PASCPMOperation -AccountID $AccountID -VerifyTask
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Scope It -ParameterFilter {
 
-					$URI -eq "https://SomeURL/SomeApp/API/Accounts/SomeID/Verify"
+					$URI -eq 'https://SomeURL/SomeApp/API/Accounts/SomeID/Verify'
 				}
 
 			}
 
-			It "sends verify request using expected method" {
+			It 'sends verify request using expected method' {
 
 				Invoke-PASCPMOperation -AccountID $AccountID -VerifyTask
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Scope It -ParameterFilter {
 
-					$Method -eq "POST"
+					$Method -eq 'POST'
 				}
 
 			}
 
-			It "sends verify request to expected classic api endpoint" {
+			It 'sends verify request to expected classic api endpoint' {
 
 				Invoke-PASCPMOperation -AccountID $AccountID -VerifyTask -UseClassicAPI
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Scope It -ParameterFilter {
 
-					$URI -eq "https://SomeURL/SomeApp/WebServices/PIMServices.svc/Accounts/SomeID/VerifyCredentials"
+					$URI -eq 'https://SomeURL/SomeApp/WebServices/PIMServices.svc/Accounts/SomeID/VerifyCredentials'
 				}
 
 			}
 
-			It "sends change request to expected api endpoint" {
+			It 'sends change request to expected api endpoint' {
 
 				Invoke-PASCPMOperation -AccountID $AccountID -ChangeTask
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Scope It -ParameterFilter {
 
-					$URI -eq "https://SomeURL/SomeApp/API/Accounts/SomeID/Change"
+					$URI -eq 'https://SomeURL/SomeApp/API/Accounts/SomeID/Change'
 				}
 
 			}
 
-			It "sends change request using expected method" {
+			It 'sends change request using expected method' {
 
 				Invoke-PASCPMOperation -AccountID $AccountID -ChangeTask
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Scope It -ParameterFilter {
 
-					$Method -eq "POST"
+					$Method -eq 'POST'
 				}
 
 			}
 
-			It "sends change request to expected classic api endpoint" {
-				Invoke-PASCPMOperation -AccountID $AccountID -ChangeTask -ImmediateChangeByCPM "Yes" -ChangeCredsForGroup "No"
+			It 'sends change request to expected classic api endpoint' {
+				Invoke-PASCPMOperation -AccountID $AccountID -ChangeTask -ImmediateChangeByCPM 'Yes' -ChangeCredsForGroup 'No'
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Scope It -ParameterFilter {
 
-					$URI -eq "https://SomeURL/SomeApp/WebServices/PIMServices.svc/Accounts/SomeID/ChangeCredentials"
+					$URI -eq 'https://SomeURL/SomeApp/WebServices/PIMServices.svc/Accounts/SomeID/ChangeCredentials'
 				}
 
 			}
 
-			It "sends change request to classic api using expected method" {
+			It 'sends change request to classic api using expected method' {
 
-				Invoke-PASCPMOperation -AccountID $AccountID -ChangeTask -ImmediateChangeByCPM "Yes" -ChangeCredsForGroup "No"
+				Invoke-PASCPMOperation -AccountID $AccountID -ChangeTask -ImmediateChangeByCPM 'Yes' -ChangeCredsForGroup 'No'
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Scope It -ParameterFilter {
 
-					$Method -eq "PUT"
+					$Method -eq 'PUT'
 				}
 
 			}
 
-			It "sends change request, when specifying value, to expected api endpoint" {
+			It 'sends change request, when specifying value, to expected api endpoint' {
 
 				Invoke-PASCPMOperation -AccountID $AccountID -ChangeTask -ChangeImmediately $true -NewCredentials $Password
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Scope It -ParameterFilter {
 
-					$URI -eq "https://SomeURL/SomeApp/API/Accounts/SomeID/SetNextPassword"
+					$URI -eq 'https://SomeURL/SomeApp/API/Accounts/SomeID/SetNextPassword'
 				}
 
 			}
 
-			It "sends change request, when specifying value, with expected method" {
+			It 'sends change request, when specifying value, with expected method' {
 
 				Invoke-PASCPMOperation -AccountID $AccountID -ChangeTask -ChangeImmediately $true -NewCredentials $Password
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Scope It -ParameterFilter {
 
-					$Method -eq "POST"
+					$Method -eq 'POST'
 				}
 
 			}
 
-			It "sends change request, when updating only the vault, to expected api endpoint" {
+			It 'sends change request, when updating only the vault, to expected api endpoint' {
 
 				Invoke-PASCPMOperation -AccountID $AccountID -ChangeTask -NewCredentials $Password
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Scope It -ParameterFilter {
 
-					$URI -eq "https://SomeURL/SomeApp/API/Accounts/SomeID/Password/Update"
+					$URI -eq 'https://SomeURL/SomeApp/API/Accounts/SomeID/Password/Update'
 				}
 
 			}
 
-			It "sends change request, when updating only the vault, with expected method" {
+			It 'sends change request, when updating only the vault, with expected method' {
 
 				Invoke-PASCPMOperation -AccountID $AccountID -ChangeTask -NewCredentials $Password
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Scope It -ParameterFilter {
 
-					$Method -eq "POST"
+					$Method -eq 'POST'
 				}
 
 			}
 
-			It "sends reconcile request to expected api endpoint" {
+			It 'sends reconcile request to expected api endpoint' {
 				Invoke-PASCPMOperation -AccountID $AccountID -ReconcileTask
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Scope It -ParameterFilter {
 
-					$URI -eq "https://SomeURL/SomeApp/API/Accounts/SomeID/Reconcile"
+					$URI -eq 'https://SomeURL/SomeApp/API/Accounts/SomeID/Reconcile'
 				}
 
 			}
 
-			It "sends reconcile request using expected method" {
+			It 'sends reconcile request using expected method' {
 
 				Invoke-PASCPMOperation -AccountID $AccountID -ReconcileTask
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Scope It -ParameterFilter {
 
-					$Method -eq "POST"
+					$Method -eq 'POST'
 				}
 
 			}

--- a/Tests/Invoke-PASRestMethod.Tests.ps1
+++ b/Tests/Invoke-PASRestMethod.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,18 +35,18 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Standard Operation" {
+		Context 'Standard Operation' {
 
 			BeforeEach {
 
 				$Response = New-MockObject -Type Microsoft.PowerShell.Commands.WebResponseObject
 				$Response | Add-Member -MemberType NoteProperty -Name StatusCode -Value 200 -Force
-				$Response | Add-Member -MemberType NoteProperty -Name Headers -Value @{ "Content-Type" = 'application/json; charset=utf-8' } -Force
+				$Response | Add-Member -MemberType NoteProperty -Name Headers -Value @{ 'Content-Type' = 'application/json; charset=utf-8' } -Force
 				$Response | Add-Member -MemberType NoteProperty -Name Content -Value (@{
-						"prop1"   = "value1";
-						"prop2"   = "value2";
-						"prop123" = 123
-						"test"    = 321
+						'prop1'   = 'value1';
+						'prop2'   = 'value2';
+						'prop123' = 123
+						'test'    = 321
 					} | ConvertTo-Json) -Force
 
 				$Failure = New-MockObject -Type Microsoft.PowerShell.Commands.WebResponseObject
@@ -61,40 +61,40 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 				Mock Skip-CertificateCheck -MockWith { }
 
 				$SessionVariable = @{
-					"URI"             = "https://CyberArk_URL"
-					"Method"          = "GET"
-					"SessionVariable" = "varSession"
+					'URI'             = 'https://CyberArk_URL'
+					'Method'          = 'GET'
+					'SessionVariable' = 'varSession'
 				}
 
 				$WebSession = @{
-					"URI"        = "https://CyberArk_URL"
-					"Method"     = "GET"
-					"WebSession" = New-Object Microsoft.PowerShell.Commands.WebRequestSession
-					"Body"       = "something"
+					'URI'        = 'https://CyberArk_URL'
+					'Method'     = 'GET'
+					'WebSession' = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+					'Body'       = 'something'
 				}
 
 				Set-Variable varSession -Value $(New-Object Microsoft.PowerShell.Commands.WebRequestSession)
-				$VarSession.Headers["Test"] = "OK"
+				$VarSession.Headers['Test'] = 'OK'
 
 			}
 
-			It "does not throw" {
+			It 'does not throw' {
 
-				{ 	$DebugPreference = "Continue"
+				{ $DebugPreference = 'Continue'
 					Invoke-PASRestMethod @WebSession 5>&1
-					$DebugPreference = "SilentlyContinue" } | Should -Not -Throw
+					$DebugPreference = 'SilentlyContinue' } | Should -Not -Throw
 
 			}
-			It "sends request" {
+			It 'sends request' {
 
 				Invoke-PASRestMethod @WebSession
-				Assert-MockCalled "Invoke-WebRequest" -Times 1 -Scope It -Exactly
+				Assert-MockCalled 'Invoke-WebRequest' -Times 1 -Scope It -Exactly
 
 			}
 
-			if ([Net.SecurityProtocolType].GetEnumNames() -contains "Tls12") {
+			if ([Net.SecurityProtocolType].GetEnumNames() -contains 'Tls12') {
 
-				It "enforces use of TLS 1.2" {
+				It 'enforces use of TLS 1.2' {
 					[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls11
 					Invoke-PASRestMethod @WebSession
 					[System.Net.ServicePointManager]::SecurityProtocol | Should -Be Tls12
@@ -102,83 +102,83 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-				it "specifies -SslProtocol TLS12" {
+			It 'specifies -SslProtocol TLS12' {
 
-					If ($IsCoreCLR) {
+				If ($IsCoreCLR) {
 
-						Mock Test-IsCoreCLR -MockWith { return $true }
-						Mock Invoke-WebRequest -MockWith { }
-						Invoke-PASRestMethod @WebSession
-						Assert-MockCalled "Invoke-WebRequest" -Times 1 -Scope It -Exactly -ParameterFilter {
-							$SslProtocol -eq "TLS12"
-						}
-					}else{Set-ItResult -Inconclusive}
-				}
+					Mock Test-IsCoreCLR -MockWith { return $true }
+					Mock Invoke-WebRequest -MockWith { }
+					Invoke-PASRestMethod @WebSession
+					Assert-MockCalled 'Invoke-WebRequest' -Times 1 -Scope It -Exactly -ParameterFilter {
+						$SslProtocol -eq 'TLS12'
+					}
+				} else { Set-ItResult -Inconclusive }
+			}
 
-				it "specifies SkipHeaderValidation" {
+			It 'specifies SkipHeaderValidation' {
 
-					If ($IsCoreCLR) {
-						Mock Test-IsCoreCLR -MockWith { return $true }
-						Mock Invoke-WebRequest -MockWith { }
+				If ($IsCoreCLR) {
+					Mock Test-IsCoreCLR -MockWith { return $true }
+					Mock Invoke-WebRequest -MockWith { }
 
-						Invoke-PASRestMethod @WebSession
-						Assert-MockCalled "Invoke-WebRequest" -Times 1 -Scope It -Exactly -ParameterFilter {
-							$SkipHeaderValidation -eq $true
-						}
-					}else{Set-ItResult -Inconclusive}
-				}
+					Invoke-PASRestMethod @WebSession
+					Assert-MockCalled 'Invoke-WebRequest' -Times 1 -Scope It -Exactly -ParameterFilter {
+						$SkipHeaderValidation -eq $true
+					}
+				} else { Set-ItResult -Inconclusive }
+			}
 
-				It "invokes Skip-CertificateCheck when run from PowerShell" {
-					Mock Test-IsCoreCLR -MockWith { return $false }
+			It 'invokes Skip-CertificateCheck when run from PowerShell' {
+				Mock Test-IsCoreCLR -MockWith { return $false }
+				Invoke-PASRestMethod @WebSession -SkipCertificateCheck
+				Assert-MockCalled 'Skip-CertificateCheck' -Times 1 -Scope It -Exactly
+			}
+
+			It 'uses parameter SkipCertificateCheck when run from PWSH' {
+
+				If ($IsCoreCLR) {
+					Mock Test-IsCoreCLR -MockWith { return $true }
+
+					Mock Invoke-WebRequest -MockWith { }
 					Invoke-PASRestMethod @WebSession -SkipCertificateCheck
-					Assert-MockCalled "Skip-CertificateCheck" -Times 1 -Scope It -Exactly
-				}
+					Assert-MockCalled 'Invoke-WebRequest' -Times 1 -Scope It -Exactly -ParameterFilter {
+						$SkipCertificateCheck -eq $true
+					}
+				} else { Set-ItResult -Inconclusive }
+			}
 
-				It "uses parameter SkipCertificateCheck when run from PWSH" {
+			It 'Skips Certificate Validation when run from PWSH' {
+				If ($IsCoreCLR) {
 
-					If ($IsCoreCLR) {
-						Mock Test-IsCoreCLR -MockWith { return $true }
+					Mock Test-IsCoreCLR -MockWith { return $true }
+					Mock Invoke-WebRequest -MockWith { }
+					$Script:SkipCertificateCheck = $true
+					Invoke-PASRestMethod @WebSession
+					Assert-MockCalled 'Invoke-WebRequest' -Times 1 -Scope It -Exactly -ParameterFilter {
+						$SkipCertificateCheck -eq $true
+					}
 
-						Mock Invoke-WebRequest -MockWith { }
-						Invoke-PASRestMethod @WebSession -SkipCertificateCheck
-						Assert-MockCalled "Invoke-WebRequest" -Times 1 -Scope It -Exactly -ParameterFilter {
-							$SkipCertificateCheck -eq $true
-						}
-					}else{Set-ItResult -Inconclusive}
-				}
-
-				It "Skips Certificate Validation when run from PWSH" {
-					If ($IsCoreCLR) {
-
-						Mock Test-IsCoreCLR -MockWith { return $true }
-						Mock Invoke-WebRequest -MockWith { }
-						$Script:SkipCertificateCheck = $true
-						Invoke-PASRestMethod @WebSession
-						Assert-MockCalled "Invoke-WebRequest" -Times 1 -Scope It -Exactly -ParameterFilter {
-							$SkipCertificateCheck -eq $true
-						}
-
-					}else{Set-ItResult -Inconclusive}
-				}
+				} else { Set-ItResult -Inconclusive }
+			}
 
 
-			It "sets WebSession variable in the module scope" {
+			It 'sets WebSession variable in the module scope' {
 				Invoke-PASRestMethod @SessionVariable
 				$Script:WebSession | Should -Not -BeNullOrEmpty
 			}
 
-			It "returns WebSession sessionvariable value" {
+			It 'returns WebSession sessionvariable value' {
 				Invoke-PASRestMethod @SessionVariable
-				$Script:WebSession.Headers["Test"] | Should -Be "OK"
+				$Script:WebSession.Headers['Test'] | Should -Be 'OK'
 			}
 
-			It "sends output to Get-PASResponse" {
+			It 'sends output to Get-PASResponse' {
 				Mock Get-PASResponse { }
 				Invoke-PASRestMethod @WebSession
-				Assert-MockCalled "Get-PASResponse" -Times 1 -Scope It -Exactly
+				Assert-MockCalled 'Get-PASResponse' -Times 1 -Scope It -Exactly
 			}
 
-			It "does not invoke Get-PASResponse if there an error code indicating failure" {
+			It 'does not invoke Get-PASResponse if there an error code indicating failure' {
 				Mock Invoke-WebRequest -MockWith {
 
 					return $Failure
@@ -186,79 +186,79 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 				}
 				Mock Get-PASResponse { }
 				Invoke-PASRestMethod @WebSession
-				Assert-MockCalled "Get-PASResponse" -Times 0 -Scope It -Exactly
+				Assert-MockCalled 'Get-PASResponse' -Times 0 -Scope It -Exactly
 			}
 
 		}
 
-		Context "Error Handling" {
+		Context 'Error Handling' {
 
 			BeforeEach {
 
 				If ($IsCoreCLR) {
-				$errorDetails = $([pscustomobject]@{"ErrorCode" = "URA999"; "ErrorMessage" = "Some Error Message" } | ConvertTo-Json)
-				$statusCode = 400
-				$response = New-Object System.Net.Http.HttpResponseMessage $statusCode
-				$exception = New-Object Microsoft.PowerShell.Commands.HttpResponseException "$statusCode ($($response.ReasonPhrase))", $response
-				$errorCategory = [System.Management.Automation.ErrorCategory]::InvalidOperation
-				$errorID = 'WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand'
-				$targetObject = $null
-				$errorRecord = New-Object Management.Automation.ErrorRecord $exception, $errorID, $errorCategory, $targetObject
-				$errorRecord.ErrorDetails = $errorDetails
+					$errorDetails = $([pscustomobject]@{'ErrorCode' = 'URA999'; 'ErrorMessage' = 'Some Error Message' } | ConvertTo-Json)
+					$statusCode = 400
+					$response = New-Object System.Net.Http.HttpResponseMessage $statusCode
+					$exception = New-Object Microsoft.PowerShell.Commands.HttpResponseException "$statusCode ($($response.ReasonPhrase))", $response
+					$errorCategory = [System.Management.Automation.ErrorCategory]::InvalidOperation
+					$errorID = 'WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand'
+					$targetObject = $null
+					$errorRecord = New-Object Management.Automation.ErrorRecord $exception, $errorID, $errorCategory, $targetObject
+					$errorRecord.ErrorDetails = $errorDetails
 				}
 
 				$WebSession = @{
-					"URI"        = "https://CyberArk_URL"
-					"Method"     = "GET"
-					"WebSession" = New-Object Microsoft.PowerShell.Commands.WebRequestSession
-					"Body"       = "something"
+					'URI'        = 'https://CyberArk_URL'
+					'Method'     = 'GET'
+					'WebSession' = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+					'Body'       = 'something'
 				}
 
 			}
 
-			it "catches Uri Format Exceptions" {
+			It 'catches Uri Format Exceptions' {
 
-				{ Invoke-PASRestMethod -Method GET -URI "/s/r/f/c" } | Should -Throw -ExpectedMessage "Invalid URI: The hostname could not be parsed. Run New-PASSession"
+				{ Invoke-PASRestMethod -Method GET -URI '/s/r/f/c' } | Should -Throw -ExpectedMessage 'Invalid URI: The hostname could not be parsed. Run New-PASSession'
 			}
 
-			it "reports generic Http Request Exceptions" {
+			It 'reports generic Http Request Exceptions' {
 
-				$Credentials = New-Object System.Management.Automation.PSCredential ("SomeUser", $(ConvertTo-SecureString "SomePassword" -AsPlainText -Force))
-				{ New-PASSession -Credential $Credentials -BaseURI "https://dead.server.no-site.io" } | Should -Throw
+				$Credentials = New-Object System.Management.Automation.PSCredential ('SomeUser', $(ConvertTo-SecureString 'SomePassword' -AsPlainText -Force))
+				{ New-PASSession -Credential $Credentials -BaseURI 'https://dead.server.no-site.io' } | Should -Throw
 
 			}
 
-			it "reports expected error message" {
+			It 'reports expected error message' {
 				If ($IsCoreCLR) {
 					Mock Invoke-WebRequest { Throw $errorRecord }
 
 					{ Invoke-PASRestMethod @WebSession } | Should -Throw
-				}Else{Set-ItResult -Inconclusive}
+				} Else { Set-ItResult -Inconclusive }
 
 			}
 
-			it "reports http errors not returned as json" {
+			It 'reports http errors not returned as json' {
 				If ($IsCoreCLR) {
 					$errorDetails = '"ErrorCode" [=] "URA999"[;] "ErrorMessage" [=] "Some Error Message"'
 					$errorRecord = New-Object Management.Automation.ErrorRecord $exception, $errorID, $errorCategory, $targetObject
 					$errorRecord.ErrorDetails = $errorDetails
 					Mock Invoke-WebRequest { Throw $errorRecord }
 					{ Invoke-PASRestMethod @WebSession } | Should -Throw
-				}Else { Set-ItResult -Inconclusive}
+				} Else { Set-ItResult -Inconclusive }
 			}
 
-			it "reports inner error messages" {
+			It 'reports inner error messages' {
 				If ($IsCoreCLR) {
-					$Details = [pscustomobject]@{"ErrorCode" = "URA666"; "ErrorMessage" = "Some Inner Error" }
-					$errorDetails = $([pscustomobject]@{"ErrorCode" = "URA999"; "ErrorMessage" = "Some Error Message" ; "Details" = $Details } | ConvertTo-Json)
+					$Details = [pscustomobject]@{'ErrorCode' = 'URA666'; 'ErrorMessage' = 'Some Inner Error' }
+					$errorDetails = $([pscustomobject]@{'ErrorCode' = 'URA999'; 'ErrorMessage' = 'Some Error Message' ; 'Details' = $Details } | ConvertTo-Json)
 					$errorRecord = New-Object Management.Automation.ErrorRecord $exception, $errorID, $errorCategory, $targetObject
 					$errorRecord.ErrorDetails = $errorDetails
 					Mock Invoke-WebRequest { Throw $errorRecord }
 					{ Invoke-PASRestMethod @WebSession } | Should -Throw
-				}Else { Set-ItResult -Inconclusive }
+				} Else { Set-ItResult -Inconclusive }
 			}
 
-			it "catches other errors" {
+			It 'catches other errors' {
 				If ($IsCoreCLR) {
 					$errorDetails = $null
 					$errorRecord = New-Object Management.Automation.ErrorRecord $exception, $errorID, $errorCategory, $targetObject
@@ -266,7 +266,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 					Mock Invoke-WebRequest { Throw $errorRecord }
 
 					{ Invoke-PASRestMethod @WebSession } | Should -Throw
-				}Else { Set-ItResult -Inconclusive }
+				} Else { Set-ItResult -Inconclusive }
 
 			}
 

--- a/Tests/New-PASAccountGroup.Tests.ps1
+++ b/Tests/New-PASAccountGroup.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,27 +35,27 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
 
-		}
+			}
 
-		$InputObj = [pscustomobject]@{
-			"GroupName"       = "SomeName"
-			"GroupPlatformID" = "SomePlatform"
-			"Safe"            = "SomeSafe"
-		}
+			$InputObj = [pscustomobject]@{
+				'GroupName'       = 'SomeName'
+				'GroupPlatformID' = 'SomePlatform'
+				'Safe'            = 'SomeSafe'
+			}
 
 			$response = $InputObj | New-PASAccountGroup
 
-}
-		Context "Mandatory Parameters" {
+		}
+		Context 'Mandatory Parameters' {
 
-			$Parameters = @{Parameter = 'GroupName'},
-			@{Parameter = 'GroupPlatformID'},
-			@{Parameter = 'Safe'}
+			$Parameters = @{Parameter = 'GroupName' },
+			@{Parameter = 'GroupPlatformID' },
+			@{Parameter = 'Safe' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -67,15 +67,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -85,13 +85,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -103,23 +103,23 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected number of properties" {
+			It 'has a request body with expected number of properties' {
 
 				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 3
 
 			}
 
-			It "throws error if version requirement not met" {
-$Script:ExternalVersion = "1.0"
-				{$InputObj | New-PASAccountGroup } | Should -Throw
-$Script:ExternalVersion = "0.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
+				{ $InputObj | New-PASAccountGroup } | Should -Throw
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides no output" {
+			It 'provides no output' {
 
 				$response | Should -BeNullOrEmpty
 

--- a/Tests/New-PASAccountObject.Tests.ps1
+++ b/Tests/New-PASAccountObject.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,61 +35,61 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "General" {
+		Context 'General' {
 
 			BeforeEach {
 
-				$props = @{"SomeProp" = "SomeValue" }
+				$props = @{'SomeProp' = 'SomeValue' }
 				$InputObj = [PSCustomObject]@{
-					"address"                          = "someaddress"
-					"SafeName"                         = "SomeSafe"
-					"PlatformID"                       = "SomePlatform"
-					"userName"                         = "SomeUser"
-					"secret"                           = $("P_Password" | ConvertTo-SecureString -AsPlainText -Force)
-					"automaticManagementEnabled"       = $true
-					"remoteMachines"                   = "someMachine"
-					"accessRestrictedToRemoteMachines" = $false
-					"platformAccountProperties"        = $props
+					'address'                          = 'someaddress'
+					'SafeName'                         = 'SomeSafe'
+					'PlatformID'                       = 'SomePlatform'
+					'userName'                         = 'SomeUser'
+					'secret'                           = $('P_Password' | ConvertTo-SecureString -AsPlainText -Force)
+					'automaticManagementEnabled'       = $true
+					'remoteMachines'                   = 'someMachine'
+					'accessRestrictedToRemoteMachines' = $false
+					'platformAccountProperties'        = $props
 				}
 				Mock Invoke-PASRestMethod -MockWith {  }
 
 
 			}
 
-			It "does not throw" {
+			It 'does not throw' {
 
 				{ $InputObj | New-PASAccountObject } | Should -Not -Throw
 
 			}
 
-			It "outputs expected object type" {
+			It 'outputs expected object type' {
 				$InputObj | New-PASAccountObject | Should -BeOfType Hashtable
 			}
 
-			It "has output with expected number of keys" {
+			It 'has output with expected number of keys' {
 				$result = $InputObj | New-PASAccountObject
 				$result.keys.count | Should -Be 8
 			}
 
-			It "has expected value for remoteMachinesAccess" {
+			It 'has expected value for remoteMachinesAccess' {
 				$result = $InputObj | New-PASAccountObject
-				$result["remoteMachinesAccess"].keys | Should -Contain remoteMachines
-				$result["remoteMachinesAccess"].keys | Should -Contain accessRestrictedToRemoteMachines
+				$result['remoteMachinesAccess'].keys | Should -Contain remoteMachines
+				$result['remoteMachinesAccess'].keys | Should -Contain accessRestrictedToRemoteMachines
 			}
 
-			It "has expected value for secretManagement" {
+			It 'has expected value for secretManagement' {
 				$result = $InputObj | New-PASAccountObject
-				$result["secretManagement"].keys | Should -Contain automaticManagementEnabled
+				$result['secretManagement'].keys | Should -Contain automaticManagementEnabled
 			}
 
-			It "has expected value for platformAccountProperties" {
+			It 'has expected value for platformAccountProperties' {
 				$result = $InputObj | New-PASAccountObject
-				$result["platformAccountProperties"].keys | Should -Contain SomeProp
+				$result['platformAccountProperties'].keys | Should -Contain SomeProp
 			}
 
-			It "has expected value for secret" {
+			It 'has expected value for secret' {
 				$result = $InputObj | New-PASAccountObject
-				$result["secret"] | Should -Be "P_Password"
+				$result['secret'] | Should -Be 'P_Password'
 			}
 
 		}

--- a/Tests/New-PASDirectoryMapping.Tests.ps1
+++ b/Tests/New-PASDirectoryMapping.Tests.ps1
@@ -82,7 +82,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | New-PASDirectoryMapping -MappingAuthorizations RestoreAllSafes
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/LDAP/Directories/SomeDirectory/Mappings"
+					$URI -eq "$($Script:BaseURI)/api/Configuration/LDAP/Directories/SomeDirectory/Mappings/"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/New-PASGroup.Tests.ps1
+++ b/Tests/New-PASGroup.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,27 +35,27 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Input" {
+		Context 'Input' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith { }
 
 				$InputObject = [PSCustomObject]@{
-					GroupName = "SomeGroup"
-					Description = "Some Description"
-					Location = "\Some\Location"
+					GroupName   = 'SomeGroup'
+					Description = 'Some Description'
+					Location    = '\Some\Location'
 				}
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 				$InputObject | New-PASGroup
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 				$InputObject | New-PASGroup
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -65,14 +65,14 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 				$InputObject | New-PASGroup
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
-				New-PASGroup -groupName SomeGroup -description "Some Description" -location "/Some/Location"
+			It 'sends request with expected body' {
+				New-PASGroup -groupName SomeGroup -description 'Some Description' -location '/Some/Location'
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$Body -ne $null
@@ -81,46 +81,46 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.2"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.2'
 
 				{ $InputObject | New-PASGroup } | Should -Throw
 
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
 			BeforeEach {
 
 				$InputObject = [PSCustomObject]@{
-					GroupName   = "SomeGroup"
-					Description = "Some Description"
-					Location    = "\Some\Location"
+					GroupName   = 'SomeGroup'
+					Description = 'Some Description'
+					Location    = '\Some\Location'
 				}
 
 				Mock Invoke-PASRestMethod -MockWith {
 					[pscustomobject]@{
-						"Prop1" = "Value1"
-						"Prop2" = "Value2"
-						"Prop3" = "Value3"
-						"Prop4" = "Value4"
+						'Prop1' = 'Value1'
+						'Prop2' = 'Value2'
+						'Prop3' = 'Value3'
+						'Prop4' = 'Value4'
 					}
 				}
 
 			}
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response = $InputObject | New-PASGroup
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				$response = $InputObject | New-PASGroup
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 4

--- a/Tests/New-PASOnboardingRule.Tests.ps1
+++ b/Tests/New-PASOnboardingRule.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -34,22 +34,22 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 	}
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
-BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
-			[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
+				[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
+			}
+
+			$InputObj = [pscustomobject]@{
+				'DecisionPlatformId' = 'SomePlatform'
+				'DecisionSafeName'   = 'SomeSafe'
+				'SystemTypeFilter'   = 'Windows'
+
+			}
+
+			$response = $InputObj | New-PASOnboardingRule
+
 		}
-
-		$InputObj = [pscustomobject]@{
-			"DecisionPlatformId" = "SomePlatform"
-			"DecisionSafeName"   = "SomeSafe"
-			"SystemTypeFilter"   = "Windows"
-
-		}
-
-		$response = $InputObj | New-PASOnboardingRule
-
-}
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'DecisionPlatformId' },
 			@{Parameter = 'DecisionSafeName' },
@@ -57,7 +57,7 @@ BeforeEach{
 			@{Parameter = 'TargetPlatformId' },
 			@{Parameter = 'TargetSafeName' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -69,15 +69,15 @@ BeforeEach{
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -87,13 +87,13 @@ BeforeEach{
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -105,24 +105,24 @@ BeforeEach{
 
 			}
 
-			It "has a request body with expected number of properties" {
+			It 'has a request body with expected number of properties' {
 
 				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 3
 
 			}
 
-			It "throws error if minimum version requirement not met" {
-				$Script:ExternalVersion = "1.0"
+			It 'throws error if minimum version requirement not met' {
+				$Script:ExternalVersion = '1.0'
 				{ $InputObj | New-PASOnboardingRule } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
-			It "accepts alternative parameterset input" {
+			It 'accepts alternative parameterset input' {
 
 				$InputObj = [pscustomobject]@{
-					"TargetPlatformId" = "SomePlatform"
-					"TargetSafeName"   = "SomeSafe"
-					"SystemTypeFilter" = "Windows"
+					'TargetPlatformId' = 'SomePlatform'
+					'TargetSafeName'   = 'SomeSafe'
+					'SystemTypeFilter' = 'Windows'
 
 				}
 
@@ -130,40 +130,40 @@ BeforeEach{
 
 			}
 
-			It "throws error if parameterset version requirement not met" {
+			It 'throws error if parameterset version requirement not met' {
 
 				$InputObj = [pscustomobject]@{
-					"TargetPlatformId" = "SomePlatform"
-					"TargetSafeName"   = "SomeSafe"
-					"SystemTypeFilter" = "Windows"
+					'TargetPlatformId' = 'SomePlatform'
+					'TargetSafeName'   = 'SomeSafe'
+					'SystemTypeFilter' = 'Windows'
 
 				}
-				$Script:ExternalVersion = "10.1.0"
+				$Script:ExternalVersion = '10.1.0'
 				{ $InputObj | New-PASOnboardingRule } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.OnboardingRule
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.OnboardingRule
 
 			}
 

--- a/Tests/New-PASPSMSession.Tests.ps1
+++ b/Tests/New-PASPSMSession.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,12 +35,12 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'AccountID' },
 			@{Parameter = 'ConnectionComponent' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -50,41 +50,41 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input" {
+		Context 'Input' {
 
 			BeforeEach {
 				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{"Prop1" = "VAL1"; "Prop2" = "Val2"; "Prop3" = "Val3" }
+					[PSCustomObject]@{'Prop1' = 'VAL1'; 'Prop2' = 'Val2'; 'Prop3' = 'Val3' }
 				}
 
 				$InputObj = [pscustomobject]@{
 
-					"AccountID"           = "99_9"
-					"ConnectionComponent" = "SomeConnectionComponent"
+					'AccountID'           = '99_9'
+					'ConnectionComponent' = 'SomeConnectionComponent'
 
 				}
 
 				$AdHocObj = [pscustomobject]@{
-					"ConnectionComponent" = "SomeConnectionComponent"
-					"UserName"            = "SomeUser"
-					"secret"              = "SomeSecret" | ConvertTo-SecureString -AsPlainText -Force
-					"address"             = "Some.Address"
-					"platformID"          = "SomePlatform"
+					'ConnectionComponent' = 'SomeConnectionComponent'
+					'UserName'            = 'SomeUser'
+					'secret'              = 'SomeSecret' | ConvertTo-SecureString -AsPlainText -Force
+					'address'             = 'Some.Address'
+					'platformID'          = 'SomePlatform'
 
 				}
 
-				$Script:BaseURI = "https://SomeURL/SomeApp"
-				$Script:ExternalVersion = "0.0"
+				$Script:BaseURI = 'https://SomeURL/SomeApp'
+				$Script:ExternalVersion = '0.0'
 				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 				Mock Out-PASFile -MockWith { }
 			}
 
-			It "throws if path is invalid" {
-				{ $InputObj | New-PASPSMSession -ConnectionMethod RDP -path A:\test.txt } | Should -Throw
+			It 'throws if path is invalid' {
+				{ $InputObj | New-PASPSMSession -ConnectionMethod RDP -Path A:\test.txt } | Should -Throw
 			}
 
-			It "sends request" {
+			It 'sends request' {
 
 				$InputObj | New-PASPSMSession -ConnectionMethod RDP
 
@@ -92,7 +92,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected endpoint for PSMConnect" {
+			It 'sends request to expected endpoint for PSMConnect' {
 
 				$InputObj | New-PASPSMSession -ConnectionMethod RDP
 
@@ -104,7 +104,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				$InputObj | New-PASPSMSession -ConnectionMethod RDP
 
@@ -112,9 +112,9 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
-				$InputObj | New-PASPSMSession -ConnectionMethod RDP -PSMRemoteMachine "SomeMachine"
+				$InputObj | New-PASPSMSession -ConnectionMethod RDP -PSMRemoteMachine 'SomeMachine'
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -126,54 +126,54 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected number of properties" {
+			It 'has a request body with expected number of properties' {
 
 				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
-			It "has a request body with expected ConnectionParams" {
+			It 'has a request body with expected ConnectionParams' {
 
-				$Script:RequestBody.ConnectionParams.PSMRemoteMachine.Value | Should -Be "SomeMachine"
+				$Script:RequestBody.ConnectionParams.PSMRemoteMachine.Value | Should -Be 'SomeMachine'
 
 			}
 
-			It "has expected Accept key in header" {
+			It 'has expected Accept key in header' {
 
 				$InputObj | New-PASPSMSession -ConnectionMethod RDP
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$WebSession.Headers["Accept"] -eq 'application/octet-stream' } -Times 1 -Exactly -Scope It
+					$WebSession.Headers['Accept'] -eq 'application/octet-stream' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "specifies expected Accept key in header for PSMGW requests" {
+			It 'specifies expected Accept key in header for PSMGW requests' {
 
 				$InputObj | New-PASPSMSession -ConnectionMethod PSMGW
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$WebSession.Headers["Accept"] -eq '* / *' } -Times 1 -Exactly -Scope It
+					$WebSession.Headers['Accept'] -eq '* / *' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met for RDP connection method" {
-				$Script:ExternalVersion = "9.8"
+			It 'throws error if version requirement not met for RDP connection method' {
+				$Script:ExternalVersion = '9.8'
 				{ $InputObj | New-PASPSMSession -ConnectionMethod RDP } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
-			It "throws error if version requirement not met for PSMGW connection method" {
+			It 'throws error if version requirement not met for PSMGW connection method' {
 
-				$Script:ExternalVersion = "9.10"
+				$Script:ExternalVersion = '9.10'
 				{ $InputObj | New-PASPSMSession -ConnectionMethod PSMGW } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
-			It "sends request to expected endpoint for AdHocConnect" {
+			It 'sends request to expected endpoint for AdHocConnect' {
 
-				$AdHocObj | New-PASPSMSession -ConnectionMethod RDP -PSMRemoteMachine "SomeServer"
+				$AdHocObj | New-PASPSMSession -ConnectionMethod RDP -PSMRemoteMachine 'SomeServer'
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$URI -eq "$($Script:BaseURI)/API/Accounts/AdHocConnect"
@@ -182,57 +182,57 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request with expected PSMConnectPrerequisites ConnectionComponent for AdHocConnect" {
+			It 'sends request with expected PSMConnectPrerequisites ConnectionComponent for AdHocConnect' {
 
-				$AdHocObj | New-PASPSMSession -ConnectionMethod RDP -PSMRemoteMachine "SomeServer"
+				$AdHocObj | New-PASPSMSession -ConnectionMethod RDP -PSMRemoteMachine 'SomeServer'
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 					$RequestBody = $Body | ConvertFrom-Json
-					$RequestBody.PSMConnectPrerequisites.ConnectionComponent -eq "SomeConnectionComponent"
+					$RequestBody.PSMConnectPrerequisites.ConnectionComponent -eq 'SomeConnectionComponent'
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected PSMConnectPrerequisites ConnectionParams for AdHocConnect" {
+			It 'sends request with expected PSMConnectPrerequisites ConnectionParams for AdHocConnect' {
 
-				$AdHocObj | New-PASPSMSession -ConnectionMethod RDP -PSMRemoteMachine "SomeServer"
+				$AdHocObj | New-PASPSMSession -ConnectionMethod RDP -PSMRemoteMachine 'SomeServer'
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 					$RequestBody = $Body | ConvertFrom-Json
-					$RequestBody.PSMConnectPrerequisites.ConnectionParams.PSMRemoteMachine.value -eq "SomeServer"
+					$RequestBody.PSMConnectPrerequisites.ConnectionParams.PSMRemoteMachine.value -eq 'SomeServer'
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met for AdHocConnect" {
-				$Script:ExternalVersion = "10.4"
+			It 'throws error if version requirement not met for AdHocConnect' {
+				$Script:ExternalVersion = '10.4'
 				{ $AdHocObj | New-PASPSMSession -ConnectionMethod PSMGW } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
 
 			BeforeEach {
 				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{"PSMGWRequest" = "VAL1"; "PSMGWURL" = "Val2"; "Prop3" = "Val3" }
+					[PSCustomObject]@{'PSMGWRequest' = 'VAL1'; 'PSMGWURL' = 'Val2'; 'Prop3' = 'Val3' }
 				}
 
 				$InputObj = [pscustomobject]@{
 
-					"AccountID"           = "99_9"
-					"ConnectionComponent" = "SomeConnectionComponent"
+					'AccountID'           = '99_9'
+					'ConnectionComponent' = 'SomeConnectionComponent'
 
 				}
 
-				$Script:BaseURI = "https://SomeURL/SomeApp"
-				$Script:ExternalVersion = "0.0"
+				$Script:BaseURI = 'https://SomeURL/SomeApp'
+				$Script:ExternalVersion = '0.0'
 				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 				Mock Out-PASFile -MockWith { }
 			}
 
-			It "outputs PSMGW connection information" {
+			It 'outputs PSMGW connection information' {
 				$InputObj | New-PASPSMSession -ConnectionMethod PSMGW | Should -Not -Be Null
 			}
 

--- a/Tests/New-PASRequest.Tests.ps1
+++ b/Tests/New-PASRequest.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -36,28 +36,28 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 		BeforeEach {
 			Mock Invoke-PASRestMethod -MockWith {
-				[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "val2"; "PropA" = "ValA"; "PropB" = "ValB"; "PropC" = "ValC" }
+				[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'val2'; 'PropA' = 'ValA'; 'PropB' = 'ValB'; 'PropC' = 'ValC' }
 			}
 
 			$InputObj = [pscustomobject]@{
-				"AccountID"              = "SomeID"
-				"Reason"                 =	"Some Important Reason"
-				"TicketingSystemName"    = "SomeName"
-				"TicketID"               = "TicketID123"
-				"MultipleAccessRequired" = $true
-				"FromDate"               = (Get-Date 1-1-2018)
-				"ToDate"                 = (Get-Date 12-12-2018)
-				"PSMRemoteMachine"       = "SomeMachine"
+				'AccountID'              = 'SomeID'
+				'Reason'                 =	'Some Important Reason'
+				'TicketingSystemName'    = 'SomeName'
+				'TicketID'               = 'TicketID123'
+				'MultipleAccessRequired' = $true
+				'FromDate'               = (Get-Date 1-1-2018)
+				'ToDate'                 = (Get-Date 12-12-2018)
+				'PSMRemoteMachine'       = 'SomeMachine'
 			}
 
 			$response = $InputObj | New-PASRequest
 
 		}
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'AccountID' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -69,15 +69,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -87,13 +87,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -105,7 +105,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected number of properties" {
+			It 'has a request body with expected number of properties' {
 
 				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 8
 
@@ -123,37 +123,37 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected ConnectionParams" {
+			It 'has a request body with expected ConnectionParams' {
 
-				$Script:RequestBody.ConnectionParams.PSMRemoteMachine.Value | Should -Be "SomeMachine"
+				$Script:RequestBody.ConnectionParams.PSMRemoteMachine.Value | Should -Be 'SomeMachine'
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
 				{ $InputObj | New-PASRequest } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 5
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Request
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Request
 
 			}
 

--- a/Tests/New-PASUser.Tests.ps1
+++ b/Tests/New-PASUser.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,42 +35,42 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
-			It "specifies parameter UserName as mandatory for ParameterSet Gen1" {
+			It 'specifies parameter UserName as mandatory for ParameterSet Gen1' {
 
-				(Get-Command New-PASUser).Parameters["UserName"].ParameterSets["Gen1"].IsMandatory | Should -Be $true
-
-			}
-
-			It "specifies parameter UserName as mandatory for ParameterSet Gen2" {
-
-				(Get-Command New-PASUser).Parameters["UserName"].ParameterSets["Gen2"].IsMandatory | Should -Be $true
+				(Get-Command New-PASUser).Parameters['UserName'].ParameterSets['Gen1'].IsMandatory | Should -Be $true
 
 			}
 
-			It "specifies parameter InitialPassword as mandatory for ParameterSet Gen1" {
+			It 'specifies parameter UserName as mandatory for ParameterSet Gen2' {
 
-				(Get-Command New-PASUser).Parameters["InitialPassword"].ParameterSets["Gen1"].IsMandatory | Should -Be $true
+				(Get-Command New-PASUser).Parameters['UserName'].ParameterSets['Gen2'].IsMandatory | Should -Be $true
+
+			}
+
+			It 'specifies parameter InitialPassword as mandatory for ParameterSet Gen1' {
+
+				(Get-Command New-PASUser).Parameters['InitialPassword'].ParameterSets['Gen1'].IsMandatory | Should -Be $true
 
 			}
 
 		}
 
-		Context "Input - Gen1" {
+		Context 'Input - Gen1' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{"Detail1" = "Detail"; "Detail2" = "Detail" }
+					[PSCustomObject]@{'Detail1' = 'Detail'; 'Detail2' = 'Detail' }
 				}
 
 				$InputObj = [pscustomobject]@{
-					"UserName"        = "SomeUser"
-					"InitialPassword" = $("P_Password" | ConvertTo-SecureString -AsPlainText -Force)
-					"FirstName"       = "Some"
-					"LastName"        = "User"
-					"ExpiryDate"      = "10/31/2018"
+					'UserName'        = 'SomeUser'
+					'InitialPassword' = $('P_Password' | ConvertTo-SecureString -AsPlainText -Force)
+					'FirstName'       = 'Some'
+					'LastName'        = 'User'
+					'ExpiryDate'      = '10/31/2018'
 
 				}
 
@@ -78,13 +78,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -94,13 +94,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -112,7 +112,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected number of properties" {
+			It 'has a request body with expected number of properties' {
 
 				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 5
 
@@ -120,23 +120,23 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input - Gen2" {
+		Context 'Input - Gen2' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{"Detail1" = "Detail"; "Detail2" = "Detail" }
+					[PSCustomObject]@{'Detail1' = 'Detail'; 'Detail2' = 'Detail' }
 				}
 
 				$InputObj = [pscustomobject]@{
-					"UserName"        = "SomeUser"
-					"InitialPassword" = $("P_Password" | ConvertTo-SecureString -AsPlainText -Force)
-					"FirstName"       = "Some"
-					"LastName"        = "User"
-					"ExpiryDate"      = "10/31/2018"
-					"workStreet"      = "SomeStreet"
-					"homePage"        = "www.geocities.com"
-					"faxNumber"       = "1979"
+					'UserName'        = 'SomeUser'
+					'InitialPassword' = $('P_Password' | ConvertTo-SecureString -AsPlainText -Force)
+					'FirstName'       = 'Some'
+					'LastName'        = 'User'
+					'ExpiryDate'      = '10/31/2018'
+					'workStreet'      = 'SomeStreet'
+					'homePage'        = 'www.geocities.com'
+					'faxNumber'       = '1979'
 
 				}
 
@@ -144,13 +144,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -160,13 +160,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -178,37 +178,37 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected number of properties" {
+			It 'has a request body with expected number of properties' {
 
 				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 7
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
 
 				{ $InputObj | New-PASUser } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 
 			}
 
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{"Detail1" = "Detail"; "Detail2" = "Detail" }
+					[PSCustomObject]@{'Detail1' = 'Detail'; 'Detail2' = 'Detail' }
 				}
 
 				$InputObj = [pscustomobject]@{
-					"UserName"        = "SomeUser"
-					"InitialPassword" = $("P_Password" | ConvertTo-SecureString -AsPlainText -Force)
-					"FirstName"       = "Some"
-					"LastName"        = "User"
-					"ExpiryDate"      = "10/31/2018"
+					'UserName'        = 'SomeUser'
+					'InitialPassword' = $('P_Password' | ConvertTo-SecureString -AsPlainText -Force)
+					'FirstName'       = 'Some'
+					'LastName'        = 'User'
+					'ExpiryDate'      = '10/31/2018'
 
 				}
 
@@ -216,25 +216,25 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
-			It "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
 				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.User
 
 			}
 
-			It "outputs object with expected typename - Gen2" {
+			It 'outputs object with expected typename - Gen2' {
 				$response = $InputObj | New-PASUser
 				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.User.Extended
 

--- a/Tests/Out-PASFile.Tests.ps1
+++ b/Tests/Out-PASFile.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -37,12 +37,12 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Standard Operation" {
+		Context 'Standard Operation' {
 			BeforeEach {
 
 				$Object = [PSCustomObject]@{
 					Content = New-Object Byte[] 512
-					Headers = @{"Content-Disposition" = "attachment; filename=FILENAME.zip" }
+					Headers = @{'Content-Disposition' = 'attachment; filename=FILENAME.zip' }
 				}
 
 				Mock Get-Item -MockWith { }
@@ -51,14 +51,14 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			it "does not throw" {
+			It 'does not throw' {
 
-				{ Out-PASFile -InputObject $Object -Path "C:\Temp" } | Should -Not -Throw
+				{ Out-PASFile -InputObject $Object -Path 'C:\Temp' } | Should -Not -Throw
 
 			}
 
-			It "throws on Set-Content error" {
-				Mock Set-Content -MockWith { throw "error" }
+			It 'throws on Set-Content error' {
+				Mock Set-Content -MockWith { throw 'error' }
 				{ Out-PASFile -InputObject $Object } | Should -Throw
 			}
 

--- a/Tests/Remove-PASAccount.Tests.ps1
+++ b/Tests/Remove-PASAccount.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -36,11 +36,11 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'AccountID' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -52,7 +52,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input V9 API" {
+		Context 'Input V9 API' {
 
 			BeforeEach {
 				Mock Invoke-PASRestMethod -MockWith {
@@ -61,7 +61,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 				$InputObj = [pscustomobject]@{
 
-					"AccountID" = "11_1"
+					'AccountID' = '11_1'
 
 				}
 
@@ -69,13 +69,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -85,13 +85,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
@@ -99,7 +99,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input V10 API" {
+		Context 'Input V10 API' {
 
 			BeforeEach {
 				Mock Invoke-PASRestMethod -MockWith {
@@ -108,7 +108,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 				$InputObj = [pscustomobject]@{
 
-					"AccountID" = "11_1"
+					'AccountID' = '11_1'
 
 				}
 
@@ -116,13 +116,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 				#$response = $InputObj | Remove-PASAccount
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 				#$response = $InputObj | Remove-PASAccount
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -132,27 +132,27 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 				#$response = $InputObj | Remove-PASAccount
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 				#$response = $InputObj | Remove-PASAccount
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
 				{ $InputObj | Remove-PASAccount } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
 			BeforeEach {
 				Mock Invoke-PASRestMethod -MockWith {
@@ -161,7 +161,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 				$InputObj = [pscustomobject]@{
 
-					"AccountID" = "11_1"
+					'AccountID' = '11_1'
 
 				}
 
@@ -169,7 +169,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			it "provides no output" {
+			It 'provides no output' {
 				#$response = $InputObj | Remove-PASAccount
 				$response | Should -BeNullOrEmpty
 

--- a/Tests/Remove-PASAccountACL.Tests.ps1
+++ b/Tests/Remove-PASAccountACL.Tests.ps1
@@ -83,7 +83,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Account/ServerA.domain.com|root|UNIXSSH/PrivilegedCommands/22"
+					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Account/ServerA.domain.com|root|UNIXSSH/PrivilegedCommands/22/"
 				} -Times 1 -Exactly -Scope It
 
 			}

--- a/Tests/Remove-PASAccountGroupMember.Tests.ps1
+++ b/Tests/Remove-PASAccountGroupMember.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,24 +35,24 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
 
-		}
+			}
 
-		$InputObj = [pscustomobject]@{
-"AccountID"    = "99_9"
-			"GroupID"      = "88_8"
+			$InputObj = [pscustomobject]@{
+				'AccountID' = '99_9'
+				'GroupID'   = '88_8'
 
-		}
+			}
 			$response = $InputObj | Remove-PASAccountGroupMember
-}
-		Context "Mandatory Parameters" {
+		}
+		Context 'Mandatory Parameters' {
 
-			$Parameters = @{Parameter = 'AccountID'},
-			@{Parameter = 'GroupID'}
+			$Parameters = @{Parameter = 'AccountID' },
+			@{Parameter = 'GroupID' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -64,15 +64,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -82,29 +82,29 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope It
-
-			}
-
-			It "sends request with no body" {
-
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-$Script:ExternalVersion = "1.0"
-				{$InputObj | Remove-PASAccountGroupMember } | Should -Throw
-$Script:ExternalVersion = "0.0"
+			It 'sends request with no body' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
+				{ $InputObj | Remove-PASAccountGroupMember } | Should -Throw
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides no output" {
+			It 'provides no output' {
 
 				$response | Should -BeNullOrEmpty
 

--- a/Tests/Remove-PASApplication.Tests.ps1
+++ b/Tests/Remove-PASApplication.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,22 +35,22 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
 
-		}
+			}
 
-		$InputObj = [pscustomobject]@{
-"AppID"        = "SomeApplication"
+			$InputObj = [pscustomobject]@{
+				'AppID' = 'SomeApplication'
 
-		}
+			}
 			$response = $InputObj | Remove-PASApplication
-}
-		Context "Mandatory Parameters" {
+		}
+		Context 'Mandatory Parameters' {
 
-			$Parameters = @{Parameter = 'AppID'}
+			$Parameters = @{Parameter = 'AppID' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -62,15 +62,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -80,23 +80,23 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides no output" {
+			It 'provides no output' {
 
 				$response | Should -BeNullOrEmpty
 

--- a/Tests/Remove-PASApplicationAuthenticationMethod.Tests.ps1
+++ b/Tests/Remove-PASApplicationAuthenticationMethod.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,24 +35,24 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
 
-		}
+			}
 
-		$InputObj = [pscustomobject]@{
-			"AppID"        = "SomeApplication"
-			"AuthID"       = "SomeAuth"
+			$InputObj = [pscustomobject]@{
+				'AppID'  = 'SomeApplication'
+				'AuthID' = 'SomeAuth'
 
-		}
+			}
 			$response = $InputObj | Remove-PASApplicationAuthenticationMethod
-}
-		Context "Mandatory Parameters" {
+		}
+		Context 'Mandatory Parameters' {
 
-			$Parameters = @{Parameter = 'AppID'},
-			@{Parameter = 'AuthID'}
+			$Parameters = @{Parameter = 'AppID' },
+			@{Parameter = 'AuthID' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -64,15 +64,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -82,23 +82,23 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides no output" {
+			It 'provides no output' {
 
 				$response | Should -BeNullOrEmpty
 

--- a/Tests/Remove-PASAuthenticationMethod.Tests.ps1
+++ b/Tests/Remove-PASAuthenticationMethod.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -36,15 +36,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		BeforeEach {
-			$Script:ExternalVersion = "0.0"
+			$Script:ExternalVersion = '0.0'
 
 			Mock Invoke-PASRestMethod -MockWith {
-				[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+				[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
 			}
 
 			$InputObject = [PSCustomObject]@{
 
-				id = "idValue"
+				id = 'idValue'
 
 			}
 
@@ -52,15 +52,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -70,29 +70,29 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
 				{ $InputObject | Remove-PASAuthenticationMethod } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			It "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 

--- a/Tests/Remove-PASDirectory.Tests.ps1
+++ b/Tests/Remove-PASDirectory.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,11 +35,11 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'id' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -49,63 +49,63 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input" {
+		Context 'Input' {
 
 			BeforeEach {
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 				Mock Invoke-PASRestMethod -MockWith { }
 
 				$response = Remove-PASDirectory -id SomeDir
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/LDAP/Directories/SomeDir"
+					$URI -eq "$($Script:BaseURI)/api/Configuration/LDAP/Directories/SomeDir/"
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
 				{ Get-PASDirectory } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
 			BeforeEach {
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 				Mock Invoke-PASRestMethod -MockWith { }
 
 				$response = Remove-PASDirectory -id SomeDir
 
 			}
 
-			it "provides no output" {
+			It 'provides no output' {
 
 				$response | Should -BeNullOrEmpty
 

--- a/Tests/Remove-PASDirectoryMapping.Tests.ps1
+++ b/Tests/Remove-PASDirectoryMapping.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,12 +35,12 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'DirectoryName' },
-				@{Parameter = 'MappingID' }
+			@{Parameter = 'MappingID' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -50,63 +50,63 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input" {
+		Context 'Input' {
 
 			BeforeEach {
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 				Mock Invoke-PASRestMethod -MockWith { }
 
 				$response = Remove-PASDirectoryMapping -DirectoryName SomeDir -MappingID 99
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/LDAP/Directories/SomeDir/Mappings/99"
+					$URI -eq "$($Script:BaseURI)/api/Configuration/LDAP/Directories/SomeDir/Mappings/99/"
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
 				{ Get-PASDirectory } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
 			BeforeEach {
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 				Mock Invoke-PASRestMethod -MockWith { }
 
 				$response = Remove-PASDirectoryMapping -DirectoryName SomeDir -MappingID 99
 
 			}
 
-			it "provides no output" {
+			It 'provides no output' {
 
 				$response | Should -BeNullOrEmpty
 

--- a/Tests/Remove-PASGroup.Tests.ps1
+++ b/Tests/Remove-PASGroup.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "11.5"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '11.5'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -41,16 +41,16 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 			}
 
 			$InputObj = [pscustomobject]@{
-				"GroupID" = 1234
+				'GroupID' = 1234
 
 			}
 		}
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'GroupID' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -62,28 +62,28 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 				$InputObj | Remove-PASGroup
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint"{
+			It 'sends request to expected endpoint' {
 				Remove-PASGroup -GroupID 1234
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 					$URI -eq "$($Script:BaseURI)/API/UserGroups/1234"
 				}-Times 1 -Exactly -Scope It
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 				$InputObj | Remove-PASGroup
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 				$InputObj | Remove-PASGroup
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
@@ -91,9 +91,9 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides no output" {
+			It 'provides no output' {
 				$response = $InputObj | Remove-PASGroup
 				$response | Should -BeNullOrEmpty
 

--- a/Tests/Remove-PASOnboardingRule.Tests.ps1
+++ b/Tests/Remove-PASOnboardingRule.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,23 +35,23 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
 
-		}
+			}
 
-		$InputObj = [pscustomobject]@{
-"RuleID"       = "SomeRule"
+			$InputObj = [pscustomobject]@{
+				'RuleID' = 'SomeRule'
 
-		}
+			}
 			$response = $InputObj | Remove-PASOnboardingRule
 
-}
-		Context "Mandatory Parameters" {
+		}
+		Context 'Mandatory Parameters' {
 
-			$Parameters = @{Parameter = 'RuleID'}
+			$Parameters = @{Parameter = 'RuleID' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -63,41 +63,41 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/AutomaticOnboardingRules/SomeRule"
+					$URI -eq "$($Script:BaseURI)/api/AutomaticOnboardingRules/SomeRule/"
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides no output" {
+			It 'provides no output' {
 
 				$response | Should -BeNullOrEmpty
 

--- a/Tests/Remove-PASOpenIDConnectProvider.Tests.ps1
+++ b/Tests/Remove-PASOpenIDConnectProvider.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -36,15 +36,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		BeforeEach {
-			$Script:ExternalVersion = "0.0"
+			$Script:ExternalVersion = '0.0'
 
 			Mock Invoke-PASRestMethod -MockWith {
-				[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+				[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
 			}
 
 			$InputObject = [PSCustomObject]@{
 
-				id = "idValue"
+				id = 'idValue'
 
 			}
 
@@ -52,15 +52,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -70,29 +70,29 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
 				{ $InputObject | Remove-PASOpenIDConnectProvider } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			It "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 

--- a/Tests/Remove-PASPlatform.Tests.ps1
+++ b/Tests/Remove-PASPlatform.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -41,12 +41,12 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 			}
 
 			$InputObj = [pscustomobject]@{
-				"ID" = 1234
+				'ID' = 1234
 
 			}
 		}
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'ID' },
 			@{Parameter = 'TargetPlatform' },
@@ -54,7 +54,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 			@{Parameter = 'GroupPlatform' },
 			@{Parameter = 'RotationalGroup' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -66,15 +66,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 				$InputObj | Remove-PASPlatform -TargetPlatform
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint - TargetPlatform" {
+			It 'sends request to expected endpoint - TargetPlatform' {
 				$InputObj | Remove-PASPlatform -TargetPlatform
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -84,7 +84,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected endpoint - DependentPlatform" {
+			It 'sends request to expected endpoint - DependentPlatform' {
 				$InputObj | Remove-PASPlatform -DependentPlatform
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -94,7 +94,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected endpoint - GroupPlatform" {
+			It 'sends request to expected endpoint - GroupPlatform' {
 				$InputObj | Remove-PASPlatform -GroupPlatform
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -104,7 +104,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected endpoint - RotationalGroup" {
+			It 'sends request to expected endpoint - RotationalGroup' {
 				$InputObj | Remove-PASPlatform -RotationalGroup
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -114,13 +114,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 				$InputObj | Remove-PASPlatform -GroupPlatform
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 				$InputObj | Remove-PASPlatform -RotationalGroup
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
@@ -128,9 +128,9 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides no output" {
+			It 'provides no output' {
 				$response = $InputObj | Remove-PASPlatform -TargetPlatform
 				$response | Should -BeNullOrEmpty
 

--- a/Tests/Remove-PASPolicyACL.Tests.ps1
+++ b/Tests/Remove-PASPolicyACL.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,24 +35,24 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
-			#[pscustomobject]@{"AddAccountPrivilegedCommandResult" = [pscustomobject]@{"some" = "thing"}}
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
+				#[pscustomobject]@{"AddAccountPrivilegedCommandResult" = [pscustomobject]@{"some" = "thing"}}
 
-		}
+			}
 
-		$InputObj = [pscustomobject]@{
-"PolicyID"     = "UNIXSSH"
-			"Id"           = 22
-		}
+			$InputObj = [pscustomobject]@{
+				'PolicyID' = 'UNIXSSH'
+				'Id'       = 22
+			}
 			$response = $InputObj | Remove-PASPolicyACL
-}
-		Context "Mandatory Parameters" {
+		}
+		Context 'Mandatory Parameters' {
 
-			$Parameters = @{Parameter = 'PolicyId'},
-			@{Parameter = 'Id'}
+			$Parameters = @{Parameter = 'PolicyId' },
+			@{Parameter = 'Id' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -64,30 +64,30 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Policy/UNIXSSH/PrivilegedCommands/22"
+					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Policy/UNIXSSH/PrivilegedCommands/22/"
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -99,9 +99,9 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides no output" {
+			It 'provides no output' {
 
 				$response | Should -BeNullOrEmpty
 

--- a/Tests/Remove-PASPublicSSHKey.Tests.ps1
+++ b/Tests/Remove-PASPublicSSHKey.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,24 +35,24 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
 
-		}
+			}
 
-		$InputObj = [pscustomobject]@{
-"UserName"     = "SomeUser"
-			"KeyID"        = "SomeKeyID"
+			$InputObj = [pscustomobject]@{
+				'UserName' = 'SomeUser'
+				'KeyID'    = 'SomeKeyID'
 
-		}
+			}
 			$response = $InputObj | Remove-PASPublicSSHKey
-}
-		Context "Mandatory Parameters" {
+		}
+		Context 'Mandatory Parameters' {
 
-			$Parameters = @{Parameter = 'UserName'},
-			@{Parameter = 'KeyID'}
+			$Parameters = @{Parameter = 'UserName' },
+			@{Parameter = 'KeyID' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -64,41 +64,41 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/SomeUser/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys/SomeKeyID"
+					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/SomeUser/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys/SomeKeyID/"
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides no output" {
+			It 'provides no output' {
 
 				$response | Should -BeNullOrEmpty
 

--- a/Tests/Remove-PASRequest.Tests.ps1
+++ b/Tests/Remove-PASRequest.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,22 +35,22 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
 
-		}
+			}
 
-		$InputObj = [pscustomobject]@{
-"RequestID"    = "99_9"
+			$InputObj = [pscustomobject]@{
+				'RequestID' = '99_9'
 
-		}
+			}
 			$response = $InputObj | Remove-PASRequest
-}
-		Context "Mandatory Parameters" {
+		}
+		Context 'Mandatory Parameters' {
 
-			$Parameters = @{Parameter = 'RequestID'}
+			$Parameters = @{Parameter = 'RequestID' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -62,15 +62,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -80,29 +80,29 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'DELETE' } -Times 1 -Exactly -Scope It
-
-			}
-
-			It "sends request with no body" {
-
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-$Script:ExternalVersion = "1.0"
-				{$InputObj | Remove-PASRequest } | Should -Throw
-$Script:ExternalVersion = "0.0"
+			It 'sends request with no body' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
+				{ $InputObj | Remove-PASRequest } | Should -Throw
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides no output" {
+			It 'provides no output' {
 
 				$response | Should -BeNullOrEmpty
 

--- a/Tests/Remove-PASSafeMember.Tests.ps1
+++ b/Tests/Remove-PASSafeMember.Tests.ps1
@@ -81,7 +81,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Safes/SomeSafe/members/SomeUser"
+					$URI -eq "$($Script:BaseURI)/api/Safes/SomeSafe/members/SomeUser/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -119,7 +119,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Safes/SomeSafe/Members/SomeUser"
+					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Safes/SomeSafe/Members/SomeUser/"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Remove-PASUser.Tests.ps1
+++ b/Tests/Remove-PASUser.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,22 +35,22 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-BeforeEach{
+		BeforeEach {
 			Mock Invoke-PASRestMethod -MockWith {
 
+			}
+
+			$InputObj = [pscustomobject]@{
+				'UserName' = 'ThatUser'
+
+			}
 		}
 
-		$InputObj = [pscustomobject]@{
-			"UserName"     = "ThatUser"
+		Context 'Mandatory Parameters' {
 
-		}
-}
+			$Parameters = @{Parameter = 'UserName' }
 
-		Context "Mandatory Parameters" {
-
-			$Parameters = @{Parameter = 'UserName'}
-
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -62,25 +62,25 @@ BeforeEach{
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 				$InputObj | Remove-PASUser
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint - Classic API" {
+			It 'sends request to expected endpoint - Classic API' {
 				$InputObj | Remove-PASUser
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/ThatUser"
+					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/ThatUser/"
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint - V2 API" {
+			It 'sends request to expected endpoint - V2 API' {
 				Remove-PASUser -id 1234
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -90,13 +90,13 @@ BeforeEach{
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 				$InputObj | Remove-PASUser
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'DELETE' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 				$InputObj | Remove-PASUser
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
@@ -104,9 +104,9 @@ BeforeEach{
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides no output" {
+			It 'provides no output' {
 				$response = $InputObj | Remove-PASUser
 				$response | Should -BeNullOrEmpty
 

--- a/Tests/Resume-PASPSMSession.Tests.ps1
+++ b/Tests/Resume-PASPSMSession.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,25 +35,25 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
 
-		}
+			}
 
-				$InputObj = [pscustomobject]@{
-			"LiveSessionId" = "SomeSessionID"
+			$InputObj = [pscustomobject]@{
+				'LiveSessionId' = 'SomeSessionID'
 
-		}
+			}
 
 			$response = $InputObj | Resume-PASPSMSession
 
-	}
+		}
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
-			$Parameters = @{Parameter = 'LiveSessionId'}
+			$Parameters = @{Parameter = 'LiveSessionId' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -65,15 +65,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -83,29 +83,29 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope It
-
-			}
-
-			It "sends request with no body" {
-
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-$Script:ExternalVersion = "1.0"
-				{$InputObj | Resume-PASPSMSession } | Should -Throw
-$Script:ExternalVersion = "0.0"
+			It 'sends request with no body' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
+				{ $InputObj | Resume-PASPSMSession } | Should -Throw
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides no output" {
+			It 'provides no output' {
 
 				$response | Should -Be $null
 

--- a/Tests/Set-PASAccount.Tests.ps1
+++ b/Tests/Set-PASAccount.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,7 +35,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'AccountID' },
 			@{Parameter = 'Folder' },
@@ -44,7 +44,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 			@{Parameter = 'path' },
 			@{Parameter = 'operations' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -54,57 +54,57 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "v10 API" {
+		Context 'v10 API' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
 					[pscustomobject]@{
-						"UpdateAccountResult" = [pscustomobject]@{
-							"Prop1" = "Value1"
-							"Prop2" = "Value2"
-							"Prop3" = "Value3"
-							"Prop4" = "Value4"
+						'UpdateAccountResult' = [pscustomobject]@{
+							'Prop1' = 'Value1'
+							'Prop2' = 'Value2'
+							'Prop3' = 'Value3'
+							'Prop4' = 'Value4'
 						}
 					}
 				}
 
 				$InputObjV10 = [pscustomobject]@{
-					"PVWAAppName" = "P_App"
-					"AccountID"   = "12_3"
+					'PVWAAppName' = 'P_App'
+					'AccountID'   = '12_3'
 				}
 
 				[array]$MultiOps = (
-					@{"op" = "add"; "path" = "/addthis"; "value" = "AddValue" },
-					@{"op" = "replace"; "path" = "/replace/this/path"; "value" = "ReplaceValue" },
-					@{"op" = "remove"; "path" = "/removethispath" }
+					@{'op' = 'add'; 'path' = '/addthis'; 'value' = 'AddValue' },
+					@{'op' = 'replace'; 'path' = '/replace/this/path'; 'value' = 'ReplaceValue' },
+					@{'op' = 'remove'; 'path' = '/removethispath' }
 				)
 
 			}
 
-			It "sends request - V10SingleOp ParameterSet" {
+			It 'sends request - V10SingleOp ParameterSet' {
 
-				$InputObjV10 | Set-PASAccount -op Add -path "/somepath" -value SomeValue
+				$InputObjV10 | Set-PASAccount -op Add -path '/somepath' -value SomeValue
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request - V10SingleOp ParameterSet" {
+			It 'sends request - V10SingleOp ParameterSet' {
 
-				$InputObjV10 | Set-PASAccount -op Add -path "/somepath" -value SomeValue
+				$InputObjV10 | Set-PASAccount -op Add -path '/somepath' -value SomeValue
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request - V10MultiOp ParameterSet" {
+			It 'sends request - V10MultiOp ParameterSet' {
 
 				$InputObjV10 | Set-PASAccount -operations $MultiOps
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint - V10SingleOp ParameterSet" {
-				$InputObjV10 | Set-PASAccount -op Remove -path "/somepath" -value SomeValue
+			It 'sends request to expected endpoint - V10SingleOp ParameterSet' {
+				$InputObjV10 | Set-PASAccount -op Remove -path '/somepath' -value SomeValue
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$URI -eq "$($Script:BaseURI)/api/Accounts/12_3"
@@ -113,7 +113,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request to expected endpoint - V10MultiOp ParameterSet" {
+			It 'sends request to expected endpoint - V10MultiOp ParameterSet' {
 				$InputObjV10 | Set-PASAccount -operations $MultiOps
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -123,64 +123,64 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			it "provides output - V10 ParameterSet" {
-				$response = $InputObjV10 | Set-PASAccount -op Replace -path "/somepath" -value SomeValue
+			It 'provides output - V10 ParameterSet' {
+				$response = $InputObjV10 | Set-PASAccount -op Replace -path '/somepath' -value SomeValue
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties - V10 ParameterSet" {
-				$response = $InputObjV10 | Set-PASAccount -op Replace -path "/somepath" -value SomeValue
+			It 'has output with expected number of properties - V10 ParameterSet' {
+				$response = $InputObjV10 | Set-PASAccount -op Replace -path '/somepath' -value SomeValue
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
-			it "outputs object with expected typename - V10 ParameterSet" {
-				$response = $InputObjV10 | Set-PASAccount -op Replace -path "/somepath" -value SomeValue
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Account.V10
+			It 'outputs object with expected typename - V10 ParameterSet' {
+				$response = $InputObjV10 | Set-PASAccount -op Replace -path '/somepath' -value SomeValue
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Account.V10
 
 			}
 
 		}
 
-		Context "Classic API" {
+		Context 'Classic API' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
 					[pscustomobject]@{
-						"UpdateAccountResult" = [pscustomobject]@{
-							"Prop1" = "Value1"
-							"Prop2" = "Value2"
-							"Prop3" = "Value3"
-							"Prop4" = "Value4"
+						'UpdateAccountResult' = [pscustomobject]@{
+							'Prop1' = 'Value1'
+							'Prop2' = 'Value2'
+							'Prop3' = 'Value3'
+							'Prop4' = 'Value4'
 						}
 					}
 				}
 
 				$InputObj = [pscustomobject]@{
-					"AccountID"   = "12_3"
-					"Folder"      = "Root"
-					"AccountName" = "Name"
-					"Name"        = "SomeName"
-					"PolicyID"    = "SomePolicy"
-					"Safe"        = "SafeName"
-					"Random"      = "Rand"
-					"Random1"     = "RandomValue"
+					'AccountID'   = '12_3'
+					'Folder'      = 'Root'
+					'AccountName' = 'Name'
+					'Name'        = 'SomeName'
+					'PolicyID'    = 'SomePolicy'
+					'Safe'        = 'SafeName'
+					'Random'      = 'Rand'
+					'Random1'     = 'RandomValue'
 
 				}
-				[void]$InputObj.PSObject.TypeNames.Insert(0, "psPAS.CyberArk.Vault.Account")
+				[void]$InputObj.PSObject.TypeNames.Insert(0, 'psPAS.CyberArk.Vault.Account')
 
 			}
 
-			It "sends request - V9 ParameterSet" {
-				$InputObj | Set-PASAccount -Properties @{"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = "Val3" }
+			It 'sends request - V9 ParameterSet' {
+				$InputObj | Set-PASAccount -Properties @{'Prop1' = 'Val1'; 'Prop2' = 'Val2'; 'Prop3' = 'Val3' }
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint - V9 ParameterSet" {
-				$InputObj | Set-PASAccount -Properties @{"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = "Val3" }
+			It 'sends request to expected endpoint - V9 ParameterSet' {
+				$InputObj | Set-PASAccount -Properties @{'Prop1' = 'Val1'; 'Prop2' = 'Val2'; 'Prop3' = 'Val3' }
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Accounts/12_3"
@@ -189,37 +189,37 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method - V9 ParameterSet" {
-				$InputObj | Set-PASAccount -Properties @{"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = "Val3" }
+			It 'uses expected method - V9 ParameterSet' {
+				$InputObj | Set-PASAccount -Properties @{'Prop1' = 'Val1'; 'Prop2' = 'Val2'; 'Prop3' = 'Val3' }
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PUT' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body - V9 ParameterSet" {
-				$InputObj | Set-PASAccount -Properties @{"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = "Val3" }
+			It 'sends request with expected body - V9 ParameterSet' {
+				$InputObj | Set-PASAccount -Properties @{'Prop1' = 'Val1'; 'Prop2' = 'Val2'; 'Prop3' = 'Val3' }
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					($Body | ConvertFrom-Json | select-Object -ExpandProperty Accounts) -ne $null
+					($Body | ConvertFrom-Json | Select-Object -ExpandProperty Accounts) -ne $null
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			it "provides output - V9 ParameterSet" {
-				$response = $InputObj | Set-PASAccount -Properties @{"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = "Val3" }
+			It 'provides output - V9 ParameterSet' {
+				$response = $InputObj | Set-PASAccount -Properties @{'Prop1' = 'Val1'; 'Prop2' = 'Val2'; 'Prop3' = 'Val3' }
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties - V9 ParameterSet" {
-				$response = $InputObj | Set-PASAccount -Properties @{"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = "Val3" }
+			It 'has output with expected number of properties - V9 ParameterSet' {
+				$response = $InputObj | Set-PASAccount -Properties @{'Prop1' = 'Val1'; 'Prop2' = 'Val2'; 'Prop3' = 'Val3' }
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 5
 
 			}
 
-			it "outputs object with expected typename - V9 ParameterSet" {
-				$response = $InputObj | Set-PASAccount -Properties @{"Prop1" = "Val1"; "Prop2" = "Val2"; "Prop3" = "Val3" }
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Account
+			It 'outputs object with expected typename - V9 ParameterSet' {
+				$response = $InputObj | Set-PASAccount -Properties @{'Prop1' = 'Val1'; 'Prop2' = 'Val2'; 'Prop3' = 'Val3' }
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Account
 
 			}
 

--- a/Tests/Set-PASAuthenticationMethod.Tests.ps1
+++ b/Tests/Set-PASAuthenticationMethod.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -37,20 +37,20 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		BeforeEach {
 			Mock Invoke-PASRestMethod -MockWith {
-				[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+				[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
 			}
 
-			$response = Set-PASAuthenticationMethod -id SomeID -enabled $true
+			$response = Set-PASAuthenticationMethod -ID SomeID -enabled $true
 		}
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -60,37 +60,37 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PUT' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-					$($Body | ConvertFrom-Json | Select-Object -ExpandProperty enabled) -eq "True"
+					$($Body | ConvertFrom-Json | Select-Object -ExpandProperty enabled) -eq 'True'
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
-				{ Set-PASAuthenticationMethod -id SomeID } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
+				{ Set-PASAuthenticationMethod -ID SomeID } | Should -Throw
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 

--- a/Tests/Set-PASDirectoryMapping.Tests.ps1
+++ b/Tests/Set-PASDirectoryMapping.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,56 +35,56 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Standard Operation" {
+		Context 'Standard Operation' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+					[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
 				}
 
 				$InputObj = [pscustomobject]@{
-					"DirectoryName" = "SomeDirectory"
-					"MappingID"     = "SomeMappingID"
-					"MappingName"   = "SomeName"
-					"LDAPBranch"    = "SomeBranch"
+					'DirectoryName' = 'SomeDirectory'
+					'MappingID'     = 'SomeMappingID'
+					'MappingName'   = 'SomeName'
+					'LDAPBranch'    = 'SomeBranch'
 
 				}
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 				$InputObj | Set-PASDirectoryMapping -MappingAuthorizations AddUpdateUsers ActivateUsers
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 				$InputObj | Set-PASDirectoryMapping -MappingAuthorizations AddUpdateUsers, ActivateUsers
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/LDAP/Directories/SomeDirectory/Mappings/SomeMappingID"
+					$URI -eq "$($Script:BaseURI)/api/Configuration/LDAP/Directories/SomeDirectory/Mappings/SomeMappingID/"
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 				$InputObj | Set-PASDirectoryMapping -MappingAuthorizations AddUpdateUsers, ActivateUsers
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PUT' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
 				{ $InputObj | Set-PASDirectoryMapping } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "10.9"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '10.9'
 				{ $InputObj | Set-PASDirectoryMapping -UserActivityLogPeriod 10 } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Set-PASDirectoryMappingOrder.Tests.ps1
+++ b/Tests/Set-PASDirectoryMappingOrder.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,15 +35,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Standard Operation" {
+		Context 'Standard Operation' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith { }
 
 				$InputObj = [pscustomobject]@{
-					"DirectoryName" = "DOMAIN"
-					"MappingsOrder" = (1, 2, 3, 4, 5)
+					'DirectoryName' = 'DOMAIN'
+					'MappingsOrder' = (1, 2, 3, 4, 5)
 				}
 
 			}

--- a/Tests/Set-PASOnboardingRule.Tests.ps1
+++ b/Tests/Set-PASOnboardingRule.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,14 +35,14 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'Id' },
 			@{Parameter = 'TargetPlatformId' },
 			@{Parameter = 'TargetSafeName' },
 			@{Parameter = 'SystemTypeFilter' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -52,45 +52,45 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input" {
+		Context 'Input' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith { }
 
 				$InputObj = [pscustomobject]@{
-					"SystemTypeFilter" = "Windows"
-					"TargetSafeName"   = "SomeSafe"
-					"TargetPlatformId" = "SomePlatform"
-					"Id"               = "123"
+					'SystemTypeFilter' = 'Windows'
+					'TargetSafeName'   = 'SomeSafe'
+					'TargetPlatformId' = 'SomePlatform'
+					'Id'               = '123'
 
 				}
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 				$InputObj | Set-PASOnboardingRule
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 				$InputObj | Set-PASOnboardingRule
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/AutomaticOnboardingRules/123"
+					$URI -eq "$($Script:BaseURI)/api/AutomaticOnboardingRules/123/"
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 				$InputObj | Set-PASOnboardingRule
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PUT' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 				$InputObj | Set-PASOnboardingRule
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 					($Body) -ne $null
@@ -98,7 +98,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected number of properties" {
+			It 'has a request body with expected number of properties' {
 				$InputObj | Set-PASOnboardingRule
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -107,27 +107,27 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 				} -Times 1 -Exactly -Scope It
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.2"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.2'
 
 				{ $InputObj | Set-PASOnboardingRule } | Should -Throw
 
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
 
 					[pscustomobject]@{
-						"Prop1" = "Value1"
-						"Prop2" = "Value2"
-						"Prop3" = "Value3"
-						"Prop4" = "Value4"
+						'Prop1' = 'Value1'
+						'Prop2' = 'Value2'
+						'Prop3' = 'Value3'
+						'Prop4' = 'Value4'
 					}
 
 
@@ -136,24 +136,24 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 				$InputObj = [pscustomobject]@{
-					"SystemTypeFilter" = "Windows"
-					"TargetSafeName"   = "SomeSafe"
-					"TargetPlatformId" = "SomePlatform"
-					"Id"               = "123"
+					'SystemTypeFilter' = 'Windows'
+					'TargetSafeName'   = 'SomeSafe'
+					'TargetPlatformId' = 'SomePlatform'
+					'Id'               = '123'
 
 				}
 
 			}
 
-			it "provides output" {
+			It 'provides output' {
 				$response = $InputObj | Set-PASOnboardingRule
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 				$response = $InputObj | Set-PASOnboardingRule
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.OnboardingRule
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.OnboardingRule
 
 			}
 

--- a/Tests/Set-PASOpenIDConnectProvider.Tests.ps1
+++ b/Tests/Set-PASOpenIDConnectProvider.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -36,21 +36,21 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		BeforeEach {
-			$Script:ExternalVersion = "0.0"
+			$Script:ExternalVersion = '0.0'
 
 			Mock Invoke-PASRestMethod -MockWith {
-				[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+				[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
 			}
 
-			$clientSecret = $("SomeClientSecret" | ConvertTo-SecureString -AsPlainText -Force)
+			$clientSecret = $('SomeClientSecret' | ConvertTo-SecureString -AsPlainText -Force)
 
 			$InputObject = [PSCustomObject]@{
 
-				id                   = "idValue"
-				authenticationFlow   = "Code"
-				discoveryEndpointUrl = "https://SomeValue"
-				clientId             = "00000159875dgjut02f5"
-				clientSecretMethod   = "Post"
+				id                   = 'idValue'
+				authenticationFlow   = 'Code'
+				discoveryEndpointUrl = 'https://SomeValue'
+				clientId             = '00000159875dgjut02f5'
+				clientSecretMethod   = 'Post'
 				clientSecret         = $clientSecret
 			}
 
@@ -58,15 +58,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -76,13 +76,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PUT' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 					$($Body | ConvertFrom-Json) -ne $null
@@ -90,27 +90,27 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "throws error if userNameClaim contains invalid characters" {
-				{ $InputObject | Add-PASOpenIDConnectProvider -userNameClaim "abc_123-456" } | Should -Throw
+			It 'throws error if userNameClaim contains invalid characters' {
+				{ $InputObject | Add-PASOpenIDConnectProvider -userNameClaim 'abc_123-456' } | Should -Throw
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
 				{ $InputObject | Set-PASOpenIDConnectProvider } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			It "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 

--- a/Tests/Set-PASPTAEvent.Tests.ps1
+++ b/Tests/Set-PASPTAEvent.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,27 +35,27 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Input" {
+		Context 'Input' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{"addsaferesult" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" } }
+					[PSCustomObject]@{'addsaferesult' = [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' } }
 				}
 
-				$Script:BaseURI = "https://SomeURL/SomeApp"
-				$Script:ExternalVersion = "0.0"
+				$Script:BaseURI = 'https://SomeURL/SomeApp'
+				$Script:ExternalVersion = '0.0'
 				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 				Set-PASPTAEvent -EventID 1234 -mStatus CLOSED
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 				Set-PASPTAEvent -EventID 1234 -mStatus CLOSED
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -65,58 +65,58 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 				Set-PASPTAEvent -EventID 1234 -mStatus CLOSED
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PATCH' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
-				Set-PASPTAEvent  -EventID 1234 -mStatus CLOSED
+			It 'sends request with expected body' {
+				Set-PASPTAEvent -EventID 1234 -mStatus CLOSED
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					($Body | ConvertFrom-Json | Select-Object -ExpandProperty mStatus) -eq "ClOSED"
+					($Body | ConvertFrom-Json | Select-Object -ExpandProperty mStatus) -eq 'ClOSED'
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
-				{ Set-PASPTAEvent  -EventID 1234 -mStatus CLOSED } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
+				{ Set-PASPTAEvent -EventID 1234 -mStatus CLOSED } | Should -Throw
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{"addsaferesult" = [PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" } }
+					[PSCustomObject]@{'addsaferesult' = [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' } }
 				}
 
-				$Script:BaseURI = "https://SomeURL/SomeApp"
-				$Script:ExternalVersion = "0.0"
+				$Script:BaseURI = 'https://SomeURL/SomeApp'
+				$Script:ExternalVersion = '0.0'
 				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 			}
 
-			it "provides output" {
+			It 'provides output' {
 
 				Set-PASPTAEvent -EventID 1234 -mStatus CLOSED | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				(Set-PASPTAEvent -EventID 1234 -mStatus CLOSED | Get-Member -MemberType NoteProperty).length | Should -Be 1
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				Set-PASPTAEvent -EventID 1234 -mStatus CLOSED | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PTA.Event
+				Set-PASPTAEvent -EventID 1234 -mStatus CLOSED | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PTA.Event
 
 			}
 

--- a/Tests/Set-PASPTARemediation.Tests.ps1
+++ b/Tests/Set-PASPTARemediation.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,28 +35,28 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
-			[PSCustomObject]@{"automaticRemediation" = [PSCustomObject]@{
-					"prop1" = "Value1"
-					"prop2" = "Value2"
-					"prop3" = "Value3"
-					"prop4" = "Value4"
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
+				[PSCustomObject]@{'automaticRemediation' = [PSCustomObject]@{
+						'prop1' = 'Value1'
+						'prop2' = 'Value2'
+						'prop3' = 'Value3'
+						'prop4' = 'Value4'
+					}
 				}
 			}
+
+			$response = Set-PASPTARemediation -changePassword_OverPassTheHash $true -reconcilePassword_SuspectedPasswordChange $true
 		}
+		Context 'Input' {
 
-		$response = Set-PASPTARemediation -changePassword_OverPassTheHash $true -reconcilePassword_SuspectedPasswordChange $true
-}
-		Context "Input" {
-
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -66,13 +66,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PATCH' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -84,37 +84,37 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected number of properties" {
+			It 'has a request body with expected number of properties' {
 
 				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
-			It "throws error if version requirement not met" {
-$Script:ExternalVersion = "1.0"
-				{ Set-PASPTARemediation  } | Should -Throw
-$Script:ExternalVersion = "0.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
+				{ Set-PASPTARemediation } | Should -Throw
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 4
 
 			}
 
-			it "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
-				$response | get-member | select-object -expandproperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PTA.Remediation
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.PTA.Remediation
 
 			}
 

--- a/Tests/Set-PASPTARule.Tests.ps1
+++ b/Tests/Set-PASPTARule.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,36 +35,36 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
 
-		}
+			}
 
-		$InputObj = [pscustomobject]@{
-"id"           = 99
-			"category"     = "KEYSTROKES"
-			"regex"        = "(.*)Some Pattern(.*)"
-			"score"        = 80
-			"description"  = "Some String"
-			"response"     = "NONE"
-			"active"       = $true
+			$InputObj = [pscustomobject]@{
+				'id'          = 99
+				'category'    = 'KEYSTROKES'
+				'regex'       = '(.*)Some Pattern(.*)'
+				'score'       = 80
+				'description' = 'Some String'
+				'response'    = 'NONE'
+				'active'      = $true
 
-		}
+			}
 
 			$response = $InputObj | Set-PASPTARule
 
-}
-		Context "Mandatory Parameters" {
+		}
+		Context 'Mandatory Parameters' {
 
-			$Parameters = @{Parameter = 'id'},
-			@{Parameter = 'category'},
-			@{Parameter = 'regex'},
-			@{Parameter = 'score'},
-			@{Parameter = 'description'},
-			@{Parameter = 'response'},
-			@{Parameter = 'active'}
+			$Parameters = @{Parameter = 'id' },
+			@{Parameter = 'category' },
+			@{Parameter = 'regex' },
+			@{Parameter = 'score' },
+			@{Parameter = 'description' },
+			@{Parameter = 'response' },
+			@{Parameter = 'active' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -76,15 +76,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -94,13 +94,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'PUT' } -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PUT' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -112,23 +112,23 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "has a request body with expected number of properties" {
+			It 'has a request body with expected number of properties' {
 
 				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 7
 
 			}
 
-			It "throws error if version requirement not met" {
-$Script:ExternalVersion = "1.0"
-				{$InputObj | Set-PASPTARule } | Should -Throw
-$Script:ExternalVersion = "0.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
+				{ $InputObj | Set-PASPTARule } | Should -Throw
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides no output" {
+			It 'provides no output' {
 
 				$response | Should -BeNullOrEmpty
 

--- a/Tests/Set-PASPlatformPSMConfig.Tests.ps1
+++ b/Tests/Set-PASPlatformPSMConfig.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -37,20 +37,20 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		BeforeEach {
 			Mock Invoke-PASRestMethod -MockWith {
-				[PSCustomObject]@{"Prop1" = "Val1"; "Prop2" = "Val2" }
+				[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
 			}
 
 			$response = Set-PASPlatformPSMConfig -ID 42 -PSMServerID SomePSMServer
 		}
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -60,37 +60,37 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PUT' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-					$($Body | ConvertFrom-Json | Select-Object -ExpandProperty PSMServerID) -eq "SomePSMServer"
+					$($Body | ConvertFrom-Json | Select-Object -ExpandProperty PSMServerID) -eq 'SomePSMServer'
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
-				{ Set-PASPlatformPSMConfig  -ID 42 -PSMServerID SomePSMServer } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
+				{ Set-PASPlatformPSMConfig -ID 42 -PSMServerID SomePSMServer } | Should -Throw
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 

--- a/Tests/Set-PASSafeMember.Tests.ps1
+++ b/Tests/Set-PASSafeMember.Tests.ps1
@@ -98,7 +98,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Safes/SomeSafe/Members/SomeUser"
+					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Safes/SomeSafe/Members/SomeUser/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -186,7 +186,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Safes/SomeSafe/Members/SomeUser"
+					$URI -eq "$($Script:BaseURI)/api/Safes/SomeSafe/Members/SomeUser/"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Set-PASUser.Tests.ps1
+++ b/Tests/Set-PASUser.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,60 +35,60 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Mandatory Parameters" {
+		Context 'Mandatory Parameters' {
 
-			It "specifies parameter UserName as mandatory for ParameterSet Gen1" {
+			It 'specifies parameter UserName as mandatory for ParameterSet Gen1' {
 
-				(Get-Command Set-PASUser).Parameters["UserName"].ParameterSets["Gen1"].IsMandatory | Should -Be $true
+				(Get-Command Set-PASUser).Parameters['UserName'].ParameterSets['Gen1'].IsMandatory | Should -Be $true
 
 			}
 
-			It "specifies parameter UserName as mandatory for ParameterSet Gen2" {
+			It 'specifies parameter UserName as mandatory for ParameterSet Gen2' {
 
-				(Get-Command Set-PASUser).Parameters["UserName"].ParameterSets["Gen2"].IsMandatory | Should -Be $true
+				(Get-Command Set-PASUser).Parameters['UserName'].ParameterSets['Gen2'].IsMandatory | Should -Be $true
 
 			}
 
 		}
 
-		Context "Input - Gen1" {
+		Context 'Input - Gen1' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{"Detail1" = "Detail"; "Detail2" = "Detail" }
+					[PSCustomObject]@{'Detail1' = 'Detail'; 'Detail2' = 'Detail' }
 				}
 
 				$InputObj = [pscustomobject]@{
-					"UserName"    = "SomeUser"
-					"NewPassword" = $("P_Password" | ConvertTo-SecureString -AsPlainText -Force)
-					"FirstName"   = "Some"
-					"LastName"    = "User"
-					"ExpiryDate"  = "10/31/2018"
+					'UserName'    = 'SomeUser'
+					'NewPassword' = $('P_Password' | ConvertTo-SecureString -AsPlainText -Force)
+					'FirstName'   = 'Some'
+					'LastName'    = 'User'
+					'ExpiryDate'  = '10/31/2018'
 
 				}
 
-				$response = $InputObj | Set-PASUser -NewPassword $("P_Password" | ConvertTo-SecureString -AsPlainText -Force) -ExpiryDate "10/31/2018" -UseClassicAPI
+				$response = $InputObj | Set-PASUser -NewPassword $('P_Password' | ConvertTo-SecureString -AsPlainText -Force) -ExpiryDate '10/31/2018' -UseClassicAPI
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/SomeUser"
+					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/SomeUser/"
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PUT' } -Times 1 -Exactly -Scope It
 
@@ -96,24 +96,24 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 		}
 
-		Context "Input - Gen2" {
+		Context 'Input - Gen2' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{"Detail1" = "Detail"; "Detail2" = "Detail" }
+					[PSCustomObject]@{'Detail1' = 'Detail'; 'Detail2' = 'Detail' }
 				}
 
 				$InputObj = [pscustomobject]@{
-					"id"          = 1234
-					"UserName"    = "SomeUser"
-					"NewPassword" = $("P_Password" | ConvertTo-SecureString -AsPlainText -Force)
-					"FirstName"   = "Some"
-					"LastName"    = "User"
-					"ExpiryDate"  = "10/31/2018"
-					"workStreet"  = "SomeStreet"
-					"homePage"    = "www.geocities.com"
-					"faxNumber"   = "1979"
+					'id'          = 1234
+					'UserName'    = 'SomeUser'
+					'NewPassword' = $('P_Password' | ConvertTo-SecureString -AsPlainText -Force)
+					'FirstName'   = 'Some'
+					'LastName'    = 'User'
+					'ExpiryDate'  = '10/31/2018'
+					'workStreet'  = 'SomeStreet'
+					'homePage'    = 'www.geocities.com'
+					'faxNumber'   = '1979'
 
 				}
 
@@ -121,13 +121,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -137,13 +137,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PUT' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -155,51 +155,51 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "1.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
 
 				{ $InputObj | Set-PASUser } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 
 			}
 
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{"Detail1" = "Detail"; "Detail2" = "Detail" }
+					[PSCustomObject]@{'Detail1' = 'Detail'; 'Detail2' = 'Detail' }
 				}
 
 				$InputObj = [pscustomobject]@{
-					"UserName"    = "SomeUser"
-					"NewPassword" = $("P_Password" | ConvertTo-SecureString -AsPlainText -Force)
-					"FirstName"   = "Some"
-					"LastName"    = "User"
-					"ExpiryDate"  = "10/31/2018"
+					'UserName'    = 'SomeUser'
+					'NewPassword' = $('P_Password' | ConvertTo-SecureString -AsPlainText -Force)
+					'FirstName'   = 'Some'
+					'LastName'    = 'User'
+					'ExpiryDate'  = '10/31/2018'
 
 				}
 
-				$response = $InputObj | Set-PASUser -NewPassword $("P_Password" | ConvertTo-SecureString -AsPlainText -Force) -ExpiryDate "10/31/2018" -UseClassicAPI
+				$response = $InputObj | Set-PASUser -NewPassword $('P_Password' | ConvertTo-SecureString -AsPlainText -Force) -ExpiryDate '10/31/2018' -UseClassicAPI
 
 			}
 
-			It "provides output" {
+			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
 
 			}
 
-			It "has output with expected number of properties" {
+			It 'has output with expected number of properties' {
 
 				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
 
 			}
 
-			It "outputs object with expected typename" {
+			It 'outputs object with expected typename' {
 
 				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.User
 

--- a/Tests/Set-PASUserPassword.Tests.ps1
+++ b/Tests/Set-PASUserPassword.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,20 +35,20 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Standard Operation" {
+		Context 'Standard Operation' {
 
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith { }
 
 				$InputObj = [pscustomobject]@{
-					"id"          = "12345"
-					"NewPassword" = $("P_Password" | ConvertTo-SecureString -AsPlainText -Force)
+					'id'          = '12345'
+					'NewPassword' = $('P_Password' | ConvertTo-SecureString -AsPlainText -Force)
 				}
 
 				$InputObj1 = [pscustomobject]@{
-					"id"          = "12345"
-					"NewPassword" = $("P_PasswordP_PasswordP_PasswordP_PasswordP_PasswordP_PasswordP_Password" | ConvertTo-SecureString -AsPlainText -Force)
+					'id'          = '12345'
+					'NewPassword' = $('P_PasswordP_PasswordP_PasswordP_PasswordP_PasswordP_PasswordP_Password' | ConvertTo-SecureString -AsPlainText -Force)
 				}
 			}
 
@@ -57,7 +57,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 			}
 
 			It 'throws if NewPassword exceeds 39 characters' {
-				{ $InputObj1 | Set-PASUserPassword } | Should -Throw -ExpectedMessage "Password must not exceed 39 characters"
+				{ $InputObj1 | Set-PASUserPassword } | Should -Throw -ExpectedMessage 'Password must not exceed 39 characters'
 			}
 
 			It 'sends request' {

--- a/Tests/Skip-CertificateCheck.Tests.ps1
+++ b/Tests/Skip-CertificateCheck.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,13 +35,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "General" {
+		Context 'General' {
 
 			BeforeEach {
 
 			}
 
-			It "does not throw" {
+			It 'does not throw' {
 
 				{ Skip-CertificateCheck } | Should -Not -Throw
 

--- a/Tests/Start-PASAccountImportJob.Tests.ps1
+++ b/Tests/Start-PASAccountImportJob.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,11 +35,11 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "General" {
+		Context 'General' {
 
 			BeforeEach {
 
-				Mock Invoke-PASRestMethod -MockWith { "11" }
+				Mock Invoke-PASRestMethod -MockWith { '11' }
 				Mock Get-PASAccountImportJob -MockWith {}
 				$Accounts = @(
 					New-PASAccountObject -uploadIndex 1 -userName SomeAccount1 -address domain.com -platformID WinDomain -SafeName SomeSafe
@@ -50,19 +50,19 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "does not throw" {
+			It 'does not throw' {
 
 				{ Start-PASAccountImportJob -Accounts $Accounts } | Should -Not -Throw
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 				Start-PASAccountImportJob -Accounts $Accounts
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 				Start-PASAccountImportJob -Accounts $Accounts
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -72,13 +72,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 				Start-PASAccountImportJob -Accounts $Accounts
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with expected body" {
+			It 'sends request with expected body' {
 				Start-PASAccountImportJob -Accounts $Accounts
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -90,28 +90,28 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "invokes Get-PASAccountImportJob" {
+			It 'invokes Get-PASAccountImportJob' {
 
 				Start-PASAccountImportJob -Accounts $Accounts
 				Assert-MockCalled Get-PASAccountImportJob -ParameterFilter {
 
-					$id -eq "11"
+					$id -eq '11'
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
-			It "returns ID value if Get-PASAccountImportJob throws" {
+			It 'returns ID value if Get-PASAccountImportJob throws' {
 				Mock Get-PASAccountImportJob -MockWith { throw }
 				$result = Start-PASAccountImportJob -Accounts $Accounts
 				$result.id | Should -Be 11
 			}
 
-			It "throws error if version requirement not met" {
-				$Script:ExternalVersion = "11.5"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '11.5'
 
 				{ $InputObj | Start-PASAccountImportJob } | Should -Throw
-				$Script:ExternalVersion = "0.0"
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Stop-PASPSMSession.Tests.ps1
+++ b/Tests/Stop-PASPSMSession.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,22 +35,22 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
 
-		}
+			}
 
-		$InputObj = [pscustomobject]@{
-			"LiveSessionId" = "SomeSessionID"
+			$InputObj = [pscustomobject]@{
+				'LiveSessionId' = 'SomeSessionID'
 
-		}
+			}
 			$response = $InputObj | Stop-PASPSMSession
-}
-		Context "Mandatory Parameters" {
+		}
+		Context 'Mandatory Parameters' {
 
 			$Parameters = @{Parameter = 'LiveSessionId' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -62,15 +62,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -80,29 +80,29 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-$Script:ExternalVersion = "1.0"
-				{ $InputObj | Stop-PASPSMSession  } | Should -Throw
-$Script:ExternalVersion = "0.0"
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
+				{ $InputObj | Stop-PASPSMSession } | Should -Throw
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides no output" {
+			It 'provides no output' {
 
 				$response | Should -Be $null
 

--- a/Tests/Suspend-PASPSMSession.Tests.ps1
+++ b/Tests/Suspend-PASPSMSession.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,23 +35,23 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
 
-		}
+			}
 
-				$InputObj = [pscustomobject]@{
-			"LiveSessionId" = "SomeSessionID"
+			$InputObj = [pscustomobject]@{
+				'LiveSessionId' = 'SomeSessionID'
 
-		}
+			}
 
 			$response = $InputObj | Suspend-PASPSMSession
-}
-		Context "Mandatory Parameters" {
+		}
+		Context 'Mandatory Parameters' {
 
-			$Parameters = @{Parameter = 'LiveSessionId'}
+			$Parameters = @{Parameter = 'LiveSessionId' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -63,15 +63,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -81,29 +81,29 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope It
-
-			}
-
-			It "sends request with no body" {
-
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "throws error if version requirement not met" {
-$Script:ExternalVersion = "1.0"
-				{$InputObj | Suspend-PASPSMSession } | Should -Throw
-$Script:ExternalVersion = "0.0"
+			It 'sends request with no body' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'throws error if version requirement not met' {
+				$Script:ExternalVersion = '1.0'
+				{ $InputObj | Suspend-PASPSMSession } | Should -Throw
+				$Script:ExternalVersion = '0.0'
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides no output" {
+			It 'provides no output' {
 
 				$response | Should -Be $null
 

--- a/Tests/Test-PASPSMRecording.Tests.ps1
+++ b/Tests/Test-PASPSMRecording.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,7 +35,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Standard Operation" {
+		Context 'Standard Operation' {
 
 			BeforeEach {
 
@@ -44,7 +44,7 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 				}
 
 				$InputObj = [pscustomobject]@{
-					"SessionID" = "777_7"
+					'SessionID' = '777_7'
 
 				}
 
@@ -52,13 +52,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -68,13 +68,13 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 

--- a/Tests/Unblock-PASUser.Tests.ps1
+++ b/Tests/Unblock-PASUser.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,31 +35,31 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Standard Operation" {
+		Context 'Standard Operation' {
 
 			BeforeEach {
 
-				$Script:BaseURI = "https://SomeURL/SomeApp"
-				$Script:ExternalVersion = "0.0"
+				$Script:BaseURI = 'https://SomeURL/SomeApp'
+				$Script:ExternalVersion = '0.0'
 				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{"Detail1" = "Detail"; "Detail2" = "Detail" }
+					[PSCustomObject]@{'Detail1' = 'Detail'; 'Detail2' = 'Detail' }
 				}
 			}
 
-			It "sends request to V10" {
+			It 'sends request to V10' {
 				Unblock-PASUser -id 123
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It -ParameterFilter {
-					$URI -eq "https://SomeURL/SomeApp/api/Users/123/Activate"
+					$URI -eq 'https://SomeURL/SomeApp/api/Users/123/Activate'
 				}
 
 			}
 
-			It "sends request to Classic API" {
+			It 'sends request to Classic API' {
 				Unblock-PASUser -UserName MrFatFingers -Suspended $false
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It -ParameterFilter {
-					$URI -eq "https://SomeURL/SomeApp/WebServices/PIMServices.svc/Users/MrFatFingers"
+					$URI -eq 'https://SomeURL/SomeApp/WebServices/PIMServices.svc/Users/MrFatFingers/'
 				}
 
 			}

--- a/Tests/Unlock-PASAccount.Tests.ps1
+++ b/Tests/Unlock-PASAccount.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,24 +35,24 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach{
-		Mock Invoke-PASRestMethod -MockWith {
+		BeforeEach {
+			Mock Invoke-PASRestMethod -MockWith {
 
-		}
+			}
 
-		$InputObj = [pscustomobject]@{
-			"AccountID"    = "22_2"
+			$InputObj = [pscustomobject]@{
+				'AccountID' = '22_2'
 
-		}
+			}
 
 			$response = $InputObj | Unlock-PASAccount
 
-	}
-		Context "Mandatory Parameters" {
+		}
+		Context 'Mandatory Parameters' {
 
-			$Parameters = @{Parameter = 'AccountID'}
+			$Parameters = @{Parameter = 'AccountID' }
 
-			It "specifies parameter <Parameter> as mandatory" -TestCases $Parameters {
+			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
@@ -64,15 +64,15 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 
 
-		Context "Input" {
+		Context 'Input' {
 
-			It "sends request" {
+			It 'sends request' {
 
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request to expected endpoint" {
+			It 'sends request to expected endpoint' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
@@ -82,23 +82,23 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 			}
 
-			It "uses expected method" {
+			It 'uses expected method' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Method -match 'POST' } -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
-			It "sends request with no body" {
+			It 'sends request with no body' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {$Body -eq $null} -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
 
 			}
 
 		}
 
-		Context "Output" {
+		Context 'Output' {
 
-			it "provides no output" {
+			It 'provides no output' {
 
 				$response | Should -BeNullOrEmpty
 

--- a/Tests/Use-PASSession.Tests.ps1
+++ b/Tests/Use-PASSession.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace ".Tests.ps1") {
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -20,8 +20,8 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = "https://SomeURL/SomeApp"
-		$Script:ExternalVersion = "0.0"
+		$Script:BaseURI = 'https://SomeURL/SomeApp'
+		$Script:ExternalVersion = '0.0'
 		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 	}
@@ -35,23 +35,23 @@ Describe $($PSCommandPath -Replace ".Tests.ps1") {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		Context "Standard Operation" {
+		Context 'Standard Operation' {
 
 			BeforeEach {
 				$session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
-				$session.Headers["Test"] = "SomeValue"
+				$session.Headers['Test'] = 'SomeValue'
 
 				$InputObject = [PSCustomObject]@{
 					PSTypeName      = 'psPAS.CyberArk.Vault.Session'
-					User            = "SomeUser"
-					BaseURI         = "SomeURL"
-					ExternalVersion = "6.6"
+					User            = 'SomeUser'
+					BaseURI         = 'SomeURL'
+					ExternalVersion = '6.6'
 					WebSession      = $session
 				}
 
 			}
 
-			it "invokes set-variable the expected number of times" {
+			It 'invokes set-variable the expected number of times' {
 				Mock Set-Variable -MockWith { }
 				Use-PASSession -Session $InputObject
 				Assert-MockCalled Set-Variable -Times 3 -Exactly -Scope It

--- a/Tests/psPAS.Tests.ps1
+++ b/Tests/psPAS.Tests.ps1
@@ -8,7 +8,7 @@
     A generic set of tests to apply to a module
 #>
 
-Describe "Module" -Tag "Consistency" {
+Describe 'Module' -Tag 'Consistency' {
 
 	#Get Current Directory
 	$Here = Split-Path -Parent $PSCommandPath
@@ -40,49 +40,49 @@ Describe "Module" -Tag "Consistency" {
 
 	Context $ManifestPath -Tag Manifest {
 
-		It "has a valid manifest" -TestCases @{ManifestPath = $ManifestPath } {
+		It 'has a valid manifest' -TestCases @{ManifestPath = $ManifestPath } {
 			param($ManifestPath)
 			{ $null = Test-ModuleManifest -Path $ManifestPath -ErrorAction Stop -WarningAction SilentlyContinue } |
-			Should -Not -Throw
+				Should -Not -Throw
 
 		}
 
-		It "specifies valid root module" -TestCases @{RootModule = $Module.RootModule ; ModuleName = $ModuleName } {
+		It 'specifies valid root module' -TestCases @{RootModule = $Module.RootModule ; ModuleName = $ModuleName } {
 			param($RootModule, $ModuleName)
 			$RootModule | Should -Be "$ModuleName.psm1"
 
 		}
 
-		It "has a valid description" -TestCases @{Description = $Module.Description } {
+		It 'has a valid description' -TestCases @{Description = $Module.Description } {
 			param($Description)
 			$Description | Should -Not -BeNullOrEmpty
 
 		}
 
-		It "has a valid guid" -TestCases @{Guid = $Module.Guid } {
+		It 'has a valid guid' -TestCases @{Guid = $Module.Guid } {
 			param($Guid)
 			$Guid | Should -Be '11c880d2-1430-4bd2-b6e8-f324741b460b'
 
 		}
 
-		It "has a valid copyright" -TestCases @{Copyright = $Module.Copyright } {
+		It 'has a valid copyright' -TestCases @{Copyright = $Module.Copyright } {
 			param($Copyright)
 			$Copyright | Should -Not -BeNullOrEmpty
 
 		}
 
-		Context "Files To Process" -Tag "FilesToProcess" {
+		Context 'Files To Process' -Tag 'FilesToProcess' {
 
 			foreach ($file in ($Module.ExportedFormatFiles)) {
-				Context $file -Tag "FormatData" {
-					It "exists" -TestCases @{
+				Context $file -Tag 'FormatData' {
+					It 'exists' -TestCases @{
 						'File' = $file
 					} {
 						param($File)
 						$File | Should -Exist
 					}
 
-					It "is valid" -TestCases @{
+					It 'is valid' -TestCases @{
 						'File' = $file
 					} {
 						param($File)
@@ -92,15 +92,15 @@ Describe "Module" -Tag "Consistency" {
 				}
 
 				foreach ($file in ($Module.ExportedTypeFiles)) {
-					Context $file -Tag "TypeData" {
-						It "exists" -TestCases @{
+					Context $file -Tag 'TypeData' {
+						It 'exists' -TestCases @{
 							'File' = $file
 						} {
 							param($File)
 							$File | Should -Exist
 						}
 
-						It "is valid" -TestCases @{
+						It 'is valid' -TestCases @{
 							'File' = $file
 						} {
 							param($File)
@@ -112,112 +112,114 @@ Describe "Module" -Tag "Consistency" {
 			}
 		}
 
-		Context "Exported Function Analysis" -Tag "Functions" {
+		Context 'Exported Function Analysis' -Tag 'Functions' {
 
 			It 'exports the expected number of functions' {
 
 				($PublicFunctions | Measure-Object | Select-Object -ExpandProperty Count) |
 
-				Should -Be ($ExportedFunctions | Measure-Object | Select-Object -ExpandProperty Count)
+					Should -Be ($ExportedFunctions | Measure-Object | Select-Object -ExpandProperty Count)
 
-			}
+				}
 
-			foreach ($ExportedFunction in $ExportedFunctions) {
+				foreach ($ExportedFunction in $ExportedFunctions) {
 
-				Context "$ExportedFunction" -Tag "$ExportedFunction" {
-					It "is public" -TestCases @{
-						'ExportedFunction' = $ExportedFunction
-						'PublicFunctions'  = $PublicFunctions
-					} {
-						param($ExportedFunction, $PublicFunctions)
-						$PublicFunctions | Should -Contain $ExportedFunction
-					}
-
-					It "has a related pester tests file" -TestCases @{
-						'ExportedFunction' = $ExportedFunction
-						'Here'             = $here
-					} {
-						param($ExportedFunction, $here)
-						Test-Path (Join-Path $here "$ExportedFunction.Tests.ps1") | Should -Be $true
-					}
-
-					Context Help -Tag "Help" {
-
-						$help = Get-Help $ExportedFunction -Full
-
-						It 'has synopsis' -TestCases @{ "Help" = $help } {
-							param($help)
-							$help.synopsis | Should -Not -BeNullOrEmpty
-
+					Context "$ExportedFunction" -Tag "$ExportedFunction" {
+						It 'is public' -TestCases @{
+							'ExportedFunction' = $ExportedFunction
+							'PublicFunctions'  = $PublicFunctions
+						} {
+							param($ExportedFunction, $PublicFunctions)
+							$PublicFunctions | Should -Contain $ExportedFunction
 						}
 
-						It 'has description' -TestCases @{ "Help" = $help } {
-							param($help)
-							$help.description | Should -Not -BeNullOrEmpty
-
+						It 'has a related pester tests file' -TestCases @{
+							'ExportedFunction' = $ExportedFunction
+							'Here'             = $here
+						} {
+							param($ExportedFunction, $here)
+							Test-Path (Join-Path $here "$ExportedFunction.Tests.ps1") | Should -Be $true
 						}
 
-						It 'has example code' -TestCases @{ "Help" = $help } {
-							param($help)
-							$help.examples.example.code | Should -Not -BeNullOrEmpty
+						Context Help -Tag 'Help' {
 
-						}
+							$help = Get-Help $ExportedFunction -Full
 
-						[array]$HelpParameters = $help.parameters.parameter | Where-Object name -NotIn @("WhatIf", "Confirm")
+							It 'has synopsis' -TestCases @{ 'Help' = $help } {
+								param($help)
+								$help.synopsis | Should -Not -BeNullOrEmpty
 
-						foreach ($HelpParameter in $HelpParameters) {
+							}
 
-							It "has description of parameter <name>" -Tag "$($HelpParameter.name)" -TestCases @{
-								'description' = $HelpParameter.description
-								'name'        = $HelpParameter.name
-							} {
-								param($description, $name)
-								$description | Should -Not -BeNullOrEmpty
+							It 'has description' -TestCases @{ 'Help' = $help } {
+								param($help)
+								$help.description | Should -Not -BeNullOrEmpty
+
+							}
+
+							It 'has example code' -TestCases @{ 'Help' = $help } {
+								param($help)
+								$help.examples.example.code | Should -Not -BeNullOrEmpty
+
+							}
+
+							[array]$HelpParameters = $help.parameters.parameter | Where-Object name -NotIn @('WhatIf', 'Confirm')
+
+							foreach ($HelpParameter in $HelpParameters) {
+
+								It 'has description of parameter <name>' -Tag "$($HelpParameter.name)" -TestCases @{
+									'description' = $HelpParameter.description
+									'name'        = $HelpParameter.name
+								} {
+									param($description, $name)
+									$description | Should -Not -BeNullOrEmpty
+								}
+
 							}
 
 						}
-
 					}
+
 				}
 
 			}
 
-		}
+			Context 'Exported Alias Analysis' -Tag Alias {
 
-		Context "Exported Alias Analysis" -Tag Alias {
+				foreach ($Alias in $ExportedAliases) {
 
-			foreach ($Alias in $ExportedAliases) {
-
-				It "<Alias> resolves to public function" -Tag $Alias -TestCases @{
-					'Alias'           = $Alias
-					'PublicFunctions' = $PublicFunctions
-				} {
-					param($Alias, $PublicFunctions)
-					$PublicFunctions | Should -Contain $((Get-Alias $Alias).ResolvedCommand.Name)
-				}
-
-			}
-
-		}
-
-	}
-
-	Context "PSScriptAnalyzer Analysis" -Tag "PSScriptAnalyzer" {
-
-		Foreach ($Script in $scripts) {
-
-			Context $Script.Name -Tag "$($Script.BaseName)", "$($Script.Name)" {
-
-				Foreach ($rule in $rules) {
-
-					It "passes rule: <RuleName>" -Tag $rule -TestCases @{
-						'RuleName' = $rule.RuleName
-						'FileName' = $script.Name
-						'FilePath' = $script.FullName
+					It '<Alias> resolves to public function' -Tag $Alias -TestCases @{
+						'Alias'           = $Alias
+						'PublicFunctions' = $PublicFunctions
 					} {
-						param($RuleName, $FileName, $FilePath)
+						param($Alias, $PublicFunctions)
+						$PublicFunctions | Should -Contain $((Get-Alias $Alias).ResolvedCommand.Name)
+					}
 
-						Invoke-ScriptAnalyzer -Path $FilePath -IncludeRule $RuleName | Should -BeNullOrEmpty
+				}
+
+			}
+
+		}
+
+		Context 'PSScriptAnalyzer Analysis' -Tag 'PSScriptAnalyzer' {
+
+			Foreach ($Script in $scripts) {
+
+				Context $Script.Name -Tag "$($Script.BaseName)", "$($Script.Name)" {
+
+					Foreach ($rule in $rules) {
+
+						It 'passes rule: <RuleName>' -Tag $rule -TestCases @{
+							'RuleName' = $rule.RuleName
+							'FileName' = $script.Name
+							'FilePath' = $script.FullName
+						} {
+							param($RuleName, $FileName, $FilePath)
+
+							Invoke-ScriptAnalyzer -Path $FilePath -IncludeRule $RuleName | Should -BeNullOrEmpty
+
+						}
 
 					}
 
@@ -228,5 +230,3 @@ Describe "Module" -Tag "Consistency" {
 		}
 
 	}
-
-}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # version format
-version: 5.2.{build}
+version: 5.3.{build}
 
 environment:
   #GIT_TRACE: 1

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -350,6 +350,10 @@ commands:
         url: /commands/Remove-PASGroup
       - title: "Set-PASGroup"
         url: /commands/Set-PASGroup
+      - title: "Enable-PASUser"
+        url: /commands/Enable-PASUser
+      - title: "Disable-PASUser"
+        url: /commands/Disable-PASUser
 
 # documentation links
 docs:
@@ -407,3 +411,5 @@ docs:
         url: https://www.powershellgallery.com/packages/PoShPACLI/
       - title: "VaultControl"
         url: https://www.powershellgallery.com/packages/VaultControl/
+      - title: "PSMPSession"
+        url: https://www.powershellgallery.com/packages/PSMPSession/

--- a/docs/collections/_commands/Add-PASSafeMember.md
+++ b/docs/collections/_commands/Add-PASSafeMember.md
@@ -71,6 +71,17 @@ Minimum required version 12.1
 
 ### EXAMPLE 2
 ```
+Add-PASSafeMember -SafeName Windows_Domain_Safe -MemberName anLDAPGroup -SearchIn cybr.lab -UseAccounts $true `
+-RetrieveAccounts $true -ListAccounts $true
+```
+
+Adds the LDAP Group *anLDAPGroup* to *Windows_Domain_Safe* with Use, Retrieve & List permissions.
+There should be Directory named *cybr.lab* in the LDAP Integration settings.
+
+Minimum required version 12.1
+
+### EXAMPLE 3
+```
 $Role = [PSCustomObject]@{
 
   UseAccounts                  = $true
@@ -87,7 +98,7 @@ Grant User23 UseAccounts, RetrieveAccounts & ListAccounts only.
 
 Minimum required version 12.1
 
-### EXAMPLE 3
+### EXAMPLE 4
 ```
 $Role = [PSCustomObject]@{
 

--- a/docs/collections/_commands/Disable-PASUser.md
+++ b/docs/collections/_commands/Disable-PASUser.md
@@ -1,0 +1,93 @@
+---
+external help file: psPAS-help.xml
+Module Name: psPAS
+online version: https://pspas.pspete.dev/commands/Disable-PASPlatform
+schema: 2.0.0
+---
+
+# Disable-PASUser
+
+## SYNOPSIS
+
+Disables a specific vault user.
+
+## SYNTAX
+
+```
+Disable-PASUser [-id] <Int32> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Sets the status of an enabled vault user to disabled
+
+## EXAMPLES
+
+### Example 1
+```powershell
+Disable-PASUser -id 1234
+```
+
+Disables the vault user with id 1234
+
+## PARAMETERS
+
+### -id
+The unique numerical id of the user
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: 0
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[https://pspas.pspete.dev/commands/Disable-PASUser](https://pspas.pspete.dev/commands/Disable-PASUser)
+
+[https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/Disable-user.htm](https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/Disable-user.htm)

--- a/docs/collections/_commands/Enable-PASUser.md
+++ b/docs/collections/_commands/Enable-PASUser.md
@@ -1,0 +1,93 @@
+---
+external help file: psPAS-help.xml
+Module Name: psPAS
+online version: https://pspas.pspete.dev/commands/Enable-PASPlatform
+schema: 2.0.0
+---
+
+# Enable-PASUser
+
+## SYNOPSIS
+
+Enables a specific vault user.
+
+## SYNTAX
+
+```
+Enable-PASUser [-id] <Int32> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Reenables a disabled vault user
+
+## EXAMPLES
+
+### Example 1
+```powershell
+Enable-PASUser -id 1234
+```
+
+Enables the vault user with id 1234
+
+## PARAMETERS
+
+### -id
+The unique numerical id of the user
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: 0
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[https://pspas.pspete.dev/commands/Enable-PASUser](https://pspas.pspete.dev/commands/Enable-PASUser)
+
+[https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/Enable-user.htm](https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/Enable-user.htm)

--- a/docs/collections/_commands/Get-PASAccount.md
+++ b/docs/collections/_commands/Get-PASAccount.md
@@ -17,8 +17,8 @@ Returns information about a single account. (Version 9.3 - 10.3)
 
 ### Gen2Query (Default)
 ```
-Get-PASAccount [-search <String>] [-searchType <String>] [-safeName <String>] [-modificationTime <DateTime>]
- [-sort <String[]>] [-TimeoutSec <Int32>] [<CommonParameters>]
+Get-PASAccount [-search <String>] [-searchType <String>] [-safeName <String>] -savedFilter <String>
+ [-modificationTime <DateTime>] [-sort <String[]>] [-TimeoutSec <Int32>] [<CommonParameters>]
 ```
 
 ### Gen2ID
@@ -138,6 +138,15 @@ Get-PASAccount -search root -sort name
 Returns all accounts matching "root", sorted by AccountName.
 
 Requires minimum version of 10.4
+
+### EXAMPLE 10
+```
+Get-PASAccount -savedFilter New
+```
+
+Returns all accounts from the "New" Saved Filter
+
+Requires minimum version of 12.6
 
 ## PARAMETERS
 
@@ -319,6 +328,28 @@ Required: False
 Position: Named
 Default value: 0
 Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -savedFilter
+Specify a value matching one of the configured Saved Filters:
+'Regular', 'Recently', 'New', 'Link', 'Deleted', 'PolicyFailures',
+'AccessedByUsers', 'ModifiedByUsers', 'ModifiedByCPM', 'DisabledPasswordByUser',
+'DisabledPasswordByCPM', 'ScheduledForChange', 'ScheduledForVerify', 'ScheduledForReconcile',
+'SuccessfullyReconciled', 'FailedChange', 'FailedVerify', 'FailedReconcile', 'LockedOrNew',
+'Locked', 'Favorites'
+
+Requires minimum version of 12.6
+
+```yaml
+Type: String
+Parameter Sets: Gen2Query
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 

--- a/docs/collections/_commands/Get-PASAccount.md
+++ b/docs/collections/_commands/Get-PASAccount.md
@@ -17,7 +17,7 @@ Returns information about a single account. (Version 9.3 - 10.3)
 
 ### Gen2Query (Default)
 ```
-Get-PASAccount [-search <String>] [-searchType <String>] [-safeName <String>] -savedFilter <String>
+Get-PASAccount [-search <String>] [-searchType <String>] [-safeName <String>] [-savedFilter <String>]
  [-modificationTime <DateTime>] [-sort <String[]>] [-TimeoutSec <Int32>] [<CommonParameters>]
 ```
 
@@ -346,7 +346,7 @@ Type: String
 Parameter Sets: Gen2Query
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)

--- a/docs/collections/_commands/Get-PASAccountGroup.md
+++ b/docs/collections/_commands/Get-PASAccountGroup.md
@@ -62,7 +62,7 @@ Accept wildcard characters: False
 ### -UseGen1API
 Specify to force usage the Gen1 API endpoint.
 
-Should be specified for versions earlier than 10.5
+This is based on the Get Account Groups By Safe API, introduced in PAS 10.5, depreciated in 12.6
 
 ```yaml
 Type: SwitchParameter

--- a/docs/collections/_commands/Get-PASGroup.md
+++ b/docs/collections/_commands/Get-PASGroup.md
@@ -16,8 +16,8 @@ List groups from the vault
 
 ### groupType (Default)
 ```
-Get-PASGroup [-groupType <String>] [-sort <String[]>] [-search <String>] [-includeMembers <Boolean>]
- [<CommonParameters>]
+Get-PASGroup [-groupType <String>] [-groupName <String>] [-sort <String[]>] [-search <String>]
+ [-includeMembers <Boolean>] [<CommonParameters>]
 ```
 
 ### filter
@@ -83,6 +83,12 @@ Get-PASGroup -search Admins -includeMembers $true
 ```
 
 Returns all existing groups matching search, includes vault group member details in result.
+
+### EXAMPLE 8
+```
+Get-PASGroup -groupName "Vault Admins" -includeMembers $true
+```
+Returns group matching name, includes vault group member details in result.
 
 ## PARAMETERS
 
@@ -165,6 +171,23 @@ Requires minimum version of 12.2
 ```yaml
 Type: String[]
 Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -groupName
+Search for groups by name.
+
+Requires minimum version of 12.2
+
+```yaml
+Type: String
+Parameter Sets: groupType
 Aliases:
 
 Required: False

--- a/docs/collections/_commands/Get-PASGroup.md
+++ b/docs/collections/_commands/Get-PASGroup.md
@@ -20,6 +20,11 @@ Get-PASGroup [-groupType <String>] [-groupName <String>] [-sort <String[]>] [-se
  [-includeMembers <Boolean>] [<CommonParameters>]
 ```
 
+### byID
+```
+Get-PASGroup -id <Int32> [-includeMembers <Boolean>] [<CommonParameters>]
+```
+
 ### filter
 ```
 Get-PASGroup [-filter <String>] [-sort <String[]>] [-search <String>] [-includeMembers <Boolean>]
@@ -88,7 +93,14 @@ Returns all existing groups matching search, includes vault group member details
 ```
 Get-PASGroup -groupName "Vault Admins" -includeMembers $true
 ```
-Returns group matching name, includes vault group member details in result.
+
+### EXAMPLE 9
+```
+Get-PASGroup -id 11
+```
+
+Returns group with id 11.
+Requires minimum version of 12.6
 
 ## PARAMETERS
 
@@ -110,7 +122,7 @@ Accept wildcard characters: False
 ### -filter
 Filter according to REST standard.
 
-*depreciated parameter in psPAS - filter value will automatically be set with if groupType specified.
+*depreciated parameter in psPAS - filter value will automatically be set if groupType specified.
 
 ```yaml
 Type: String
@@ -129,7 +141,7 @@ Search will match when ALL search terms appear in the group name.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: groupType, filter
 Aliases:
 
 Required: False
@@ -170,7 +182,7 @@ Requires minimum version of 12.2
 
 ```yaml
 Type: String[]
-Parameter Sets: (All)
+Parameter Sets: groupType, filter
 Aliases:
 
 Required: False
@@ -191,6 +203,22 @@ Parameter Sets: groupType
 Aliases:
 
 Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -id
+The integer id value of the group to get details of.
+Requires minimum version of 12.6
+
+```yaml
+Type: Int32
+Parameter Sets: byID
+Aliases:
+
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)

--- a/docs/collections/_commands/Get-PASUser.md
+++ b/docs/collections/_commands/Get-PASUser.md
@@ -162,6 +162,7 @@ The user's name
 Default operation targets the Gen2 API & requires minimum version of 12.2.
 
 For operation against versions earlier than 12.2, the `UseGen1API` parameter should also be specified.
+
 ```yaml
 Type: String
 Parameter Sets: Gen2, Gen2-ExtendedDetails

--- a/docs/collections/_commands/Set-PASSafe.md
+++ b/docs/collections/_commands/Set-PASSafe.md
@@ -45,6 +45,8 @@ Set-PASSafe -SafeName <String> [-NewSafeName <String>] [-Description <String>] [
 ## DESCRIPTION
 Updates a single safe in the Vault.
 Manage Safe permission is required.
+All required properties should be sent in the request.
+Any properties set on the safe not included in the request will be cleared.
 
 ## EXAMPLES
 
@@ -58,6 +60,15 @@ Updates description and version retention on SAFE using Gen2 API
 Minimum required version 12.2
 
 ### EXAMPLE 2
+```
+Get-PASSafe -SafeName SAFE | Set-PASSafe -SafeName SAFE -NumberOfVersionsRetention 10
+```
+
+Updates version retention on SAFE using Gen2 API, maintaining all other properties.
+
+Minimum required version 12.2
+
+### EXAMPLE 3
 ```
 Set-PASSafe -SafeName SAFE -Description "New-Description" -NumberOfDaysRetention 10 -UseGen1API
 ```

--- a/docs/collections/_commands/Set-PASSafe.md
+++ b/docs/collections/_commands/Set-PASSafe.md
@@ -126,7 +126,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: False
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
@@ -158,7 +158,7 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: False
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 

--- a/docs/collections/_docs/10-compatibility.md
+++ b/docs/collections/_docs/10-compatibility.md
@@ -165,7 +165,11 @@ If you are using version 9.7+, and the function being invoked requires version 9
 [`Remove-PASPrivateSSHKey`][Remove-PASPrivateSSHKey]                                     |**12.1**                                            |Delete MFA caching SSH Keys
 [`Set-PASGroup`][Set-PASGroup]                                                           |**12.0**                                            |Update CyberArk groups
 [`Get-PASPlatformSummary`][Get-PASPlatformSummary]                                       |**12.2**                                            |Get basic information on current platform system types
+[`Enable-PASUser`][Enable-PASUser]                                                       |**12.6**                                            |Enable CyberArk Users
+[`Disable-PASUser`][Enable-PASUser]                                                      |**12.6**                                            |Disable CyberArk Users
 
+[Enable-PASUser]:/commands/Enable-PASUser
+[Disable-PASUser]:/commands/Disable-PASUser
 [Get-PASPlatformSummary]:/commands/Get-PASPlatformSummary
 [Clear-PASDiscoveredAccountList]:/commands/Clear-PASDiscoveredAccountList
 [Get-PASAccountPasswordVersion]:/commands/Get-PASAccountPasswordVersion
@@ -332,8 +336,9 @@ If you are using version 9.7+, and the function being invoked requires version 9
 
 ### Get-PASAccountGroup
 
-- Version 10.5 introduced a new API endpoint.
-- The Gen1 API endpoint can be used by specifying the `-UseGen1API` parameter.
+- Version 10.5 introduced a new API endpoint, "Get Safe account groups".
+  - This API is depreciated from version 12.6.
+  - The "Get Safe account groups" API endpoint can be used by specifying the `-UseGen1API` parameter.
 
 ### Add-PASAccount
 
@@ -342,6 +347,7 @@ If you are using version 9.7+, and the function being invoked requires version 9
 
 ### Get-PASAccount
 
+- 12.6 introduced ability to use the `savedFilter` parameter
 - 11.4 introduced ability to filter by modificationTime
 - Version 10.4 introduced a new API endpoint.
   - Supports:
@@ -574,7 +580,8 @@ If you are using version 9.7+, and the function being invoked requires version 9
 ### Get-PASGroup
 
 - Version 12.0 introduced `includeMembers` parameter.
-- Version 12.2 introduced new `sort` parameter.
+- Version 12.2 introduced new `sort` & `groupName` parameters.
+- Version 12.6 introduced the `id` parameter.
 
 ### Set-PASSafe
 

--- a/docs/collections/_pages/commands.md
+++ b/docs/collections/_pages/commands.md
@@ -199,6 +199,8 @@ A psPAS command may not appear in the below list due to it not being explicitly 
 [Delete an MFA caching SSH key for another user][Delete an MFA caching SSH key for another user]     | [Remove-PASPrivateSSHKey][Remove-PASPrivateSSHKey]
 [Update Group][Update Group]                                                                         | [Set-PASGroup][Set-PASGroup]
 [Extended Account Overview][Extended Account Overview]                                               | [Get-PASAccountDetail][Get-PASAccountDetail]
+[Enable User][Enable User]                                                                           | [Enable-PASUser][Enable-PASUser]
+[Disable User][Disable User]                                                                         | [Disable-PASUser][Disable-PASUser]
 
 [Get-PASDiscoveredAccount]:/commands/Get-PASDiscoveredAccount
 [Start-PASAccountImportJob]:/commands/Start-PASAccountImportJob
@@ -341,7 +343,11 @@ A psPAS command may not appear in the below list due to it not being explicitly 
 [Remove-PASPrivateSSHKey]:/commands/Remove-PASPrivateSSHKey
 [Set-PASGroup]:/commands/Set-PASGroup
 [Get-PASAccountDetail]:/commands/Get-PASAccountDetail
+[Enable-PASUser]:/commands/Enable-PASUser
+[Disable-PASUser]:/commands/Disable-PASUser
 
+[Enable User]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/Enable-user.htm?tocpath=Developer%7CREST%20APIs%7CUser%20management%7CUsers%7C_____8
+[Disable User]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/Disable-user.htm?tocpath=Developer%7CREST%20APIs%7CUser%20management%7CUsers%7C_____9
 [Extended Account Overview]:https://documenter.getpostman.com/view/998920/RzZ9Gz1U#d20c01c2-f7fc-4717-bf10-d8c51cb11411
 [Delete discovered accounts]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Delete-Discovered-accounts.htm
 [Get Secret Versions]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/Secrets-Get-versions.htm

--- a/docs/collections/_pages/commands.md
+++ b/docs/collections/_pages/commands.md
@@ -2,7 +2,7 @@
 title: "psPAS + API Command Reference"
 permalink: /commands/
 excerpt: "Command Reference"
-last_modified_at: 2021-04-23zT01:33:52-00:00
+last_modified_at: 2022-06-08zT01:33:52-00:00
 toc: false
 layout: single-mod
 classes: wide
@@ -50,7 +50,7 @@ A psPAS command may not appear in the below list due to it not being explicitly 
 [Get password value][Get password value]                                                    | [Get-PASAccountPassword][Get-PASAccountPassword]
 [Retrieve private SSH key account][Retrieve private SSH key account]                        | [Get-PASAccountSSHKey][Get-PASAccountSSHKey]
 [Get Just in Time access][Get Just in Time access]                                          | [Request-PASJustInTimeAccess][Request-PASJustInTimeAccess]
-[Revoke Just in Time access][Revoke Just in Time access]                                    | [Revoke-PASJustInTimeAccess][Revke-PASJustInTimeAccess]
+[Revoke Just in Time access][Revoke Just in Time access]                                    | [Revoke-PASJustInTimeAccess][Revoke-PASJustInTimeAccess]
 [Add allowed referrer][Add allowed referrer]                                                | [Add-PASAllowedReferrer][Add-PASAllowedReferrer]
 [Get allowed referrer][Get allowed referrer]                                                | [Get-PASAllowedReferrer][Get-PASAllowedReferrer]
 [Get applications][Get applications]                                                        | [Get-PASApplication][Get-PASApplication]

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -47,24 +47,6 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
-    "array-filter": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
-      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
-      "dev": true
-    },
-    "array-map": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
-      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
-      "dev": true
-    },
-    "array-reduce": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
-      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
-      "dev": true
-    },
     "array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
@@ -1446,12 +1428,6 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
-    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -1928,16 +1904,10 @@
       "dev": true
     },
     "shell-quote": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
-      "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
-      "dev": true,
-      "requires": {
-        "array-filter": "~0.0.0",
-        "array-map": "~0.0.0",
-        "array-reduce": "~0.0.0",
-        "jsonify": "~0.0.0"
-      }
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
+      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
+      "dev": true
     },
     "snapdragon": {
       "version": "0.8.2",

--- a/psPAS/Functions/AccountACL/Add-PASAccountACL.ps1
+++ b/psPAS/Functions/AccountACL/Add-PASAccountACL.ps1
@@ -6,8 +6,8 @@ function Add-PASAccountACL {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[Alias("PolicyID")]
-		[Alias("PlatformID")]
+		[Alias('PolicyID')]
+		[Alias('PlatformID')]
 		[ValidateNotNullOrEmpty()]
 		[string]$AccountPolicyId,
 
@@ -15,7 +15,7 @@ function Add-PASAccountACL {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[Alias("Address")]
+		[Alias('Address')]
 		[ValidateNotNullOrEmpty()]
 		[string]$AccountAddress,
 
@@ -43,7 +43,7 @@ function Add-PASAccountACL {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $false
 		)]
-		[ValidateSet("Allow", "Deny")]
+		[ValidateSet('Allow', 'Deny')]
 		[string]$PermissionType,
 
 		[parameter(
@@ -78,9 +78,9 @@ function Add-PASAccountACL {
 		#Request body
 		$Body = $PSBoundParameters |
 
-		Get-PASParameter -ParametersToRemove AccountAddress, AccountUserName, AccountPolicyID |
+			Get-PASParameter -ParametersToRemove AccountAddress, AccountUserName, AccountPolicyID |
 
-		ConvertTo-Json
+			ConvertTo-Json
 
 		#Send Request
 		$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body -WebSession $Script:WebSession
@@ -89,7 +89,7 @@ function Add-PASAccountACL {
 
 			$result.AddAccountPrivilegedCommandResult |
 
-			Add-ObjectDetail -typename psPAS.CyberArk.Vault.ACL.Account
+				Add-ObjectDetail -typename psPAS.CyberArk.Vault.ACL.Account
 
 		}
 

--- a/psPAS/Functions/AccountACL/Add-PASAccountACL.ps1
+++ b/psPAS/Functions/AccountACL/Add-PASAccountACL.ps1
@@ -73,7 +73,7 @@ function Add-PASAccountACL {
 
                 Get-EscapedString)|$($AccountPolicyId |
 
-                    Get-EscapedString)/PrivilegedCommands"
+                    Get-EscapedString)/PrivilegedCommands/"
 
 		#Request body
 		$Body = $PSBoundParameters |

--- a/psPAS/Functions/AccountACL/Get-PASAccountACL.ps1
+++ b/psPAS/Functions/AccountACL/Get-PASAccountACL.ps1
@@ -37,7 +37,7 @@ function Get-PASAccountACL {
 
                 Get-EscapedString)|$($AccountPolicyId |
 
-                    Get-EscapedString)/PrivilegedCommands"
+                    Get-EscapedString)/PrivilegedCommands/"
 
 		#Send request to Web Service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession #DevSkim: ignore DS104456

--- a/psPAS/Functions/AccountACL/Get-PASAccountACL.ps1
+++ b/psPAS/Functions/AccountACL/Get-PASAccountACL.ps1
@@ -6,14 +6,14 @@ function Get-PASAccountACL {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[Alias("PolicyID")]
+		[Alias('PolicyID')]
 		[string]$AccountPolicyId,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[Alias("Address")]
+		[Alias('Address')]
 		[ValidateNotNullOrEmpty()]
 		[string]$AccountAddress,
 
@@ -21,7 +21,7 @@ function Get-PASAccountACL {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[Alias("UserName")]
+		[Alias('UserName')]
 		[ValidateNotNullOrEmpty()]
 		[string]$AccountUserName
 	)
@@ -46,7 +46,7 @@ function Get-PASAccountACL {
 
 			$result.ListAccountPrivilegedCommandsResult |
 
-			Add-ObjectDetail -typename psPAS.CyberArk.Vault.ACL.Account
+				Add-ObjectDetail -typename psPAS.CyberArk.Vault.ACL.Account
 
 		}
 

--- a/psPAS/Functions/AccountACL/Remove-PASAccountACL.ps1
+++ b/psPAS/Functions/AccountACL/Remove-PASAccountACL.ps1
@@ -42,7 +42,7 @@ function Remove-PASAccountACL {
 
                 Get-EscapedString)|$($AccountPolicyId |
 
-                    Get-EscapedString)/PrivilegedCommands/$Id"
+                    Get-EscapedString)/PrivilegedCommands/$Id/"
 
 		#Request Body
 		$Body = @{ }

--- a/psPAS/Functions/AccountACL/Remove-PASAccountACL.ps1
+++ b/psPAS/Functions/AccountACL/Remove-PASAccountACL.ps1
@@ -6,7 +6,7 @@ function Remove-PASAccountACL {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[Alias("PolicyID")]
+		[Alias('PolicyID')]
 		[ValidateNotNullOrEmpty()]
 		[string]$AccountPolicyId,
 

--- a/psPAS/Functions/AccountGroups/Add-PASAccountGroupMember.ps1
+++ b/psPAS/Functions/AccountGroups/Add-PASAccountGroupMember.ps1
@@ -30,7 +30,7 @@ function Add-PASAccountGroupMember {
 		#Create body of request
 		$body = $PSBoundParameters |
 
-		Get-PASParameter -ParametersToRemove GroupID | ConvertTo-Json
+			Get-PASParameter -ParametersToRemove GroupID | ConvertTo-Json
 
 		#send request to PAS web service
 		Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession

--- a/psPAS/Functions/AccountGroups/Get-PASAccountGroup.ps1
+++ b/psPAS/Functions/AccountGroups/Get-PASAccountGroup.ps1
@@ -1,25 +1,25 @@
 # .ExternalHelp psPAS-help.xml
 function Get-PASAccountGroup {
-	[CmdletBinding(DefaultParameterSetName = "Gen2")]
+	[CmdletBinding(DefaultParameterSetName = 'Gen2')]
 	param(
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[string]$Safe,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $false,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
-		[Alias("UseClassicAPI")]
+		[Alias('UseClassicAPI')]
 		[switch]$UseGen1API
 	)
 
@@ -29,7 +29,7 @@ function Get-PASAccountGroup {
 
 		switch ($PSCmdlet.ParameterSetName) {
 
-			"Gen1" {
+			'Gen1' {
 
 				Assert-VersionRequirement -RequiredVersion 9.10
 				#Create URL for Request

--- a/psPAS/Functions/AccountGroups/Get-PASAccountGroup.ps1
+++ b/psPAS/Functions/AccountGroups/Get-PASAccountGroup.ps1
@@ -31,9 +31,9 @@ function Get-PASAccountGroup {
 
 			'Gen1' {
 
-				Assert-VersionRequirement -RequiredVersion 9.10
+				Assert-VersionRequirement -RequiredVersion 10.5 -MaximumVersion 12.3
 				#Create URL for Request
-				$URI = "$Script:BaseURI/API/AccountGroups?$($PSBoundParameters | Get-PASParameter | ConvertTo-QueryString)"
+				$URI = "$Script:BaseURI/API/Safes/$($Safe | Get-EscapedString)/AccountGroups"
 
 				break
 
@@ -41,9 +41,9 @@ function Get-PASAccountGroup {
 
 			default {
 
-				Assert-VersionRequirement -RequiredVersion 10.5
+				Assert-VersionRequirement -RequiredVersion 9.10
 				#Create URL for Request
-				$URI = "$Script:BaseURI/API/Safes/$($Safe | Get-EscapedString)/AccountGroups"
+				$URI = "$Script:BaseURI/API/AccountGroups?$($PSBoundParameters | Get-PASParameter | ConvertTo-QueryString)"
 
 			}
 

--- a/psPAS/Functions/AccountGroups/New-PASAccountGroup.ps1
+++ b/psPAS/Functions/AccountGroups/New-PASAccountGroup.ps1
@@ -34,7 +34,7 @@ function New-PASAccountGroup {
 		#Create body of request
 		$body = $PSBoundParameters | Get-PASParameter | ConvertTo-Json
 
-		if ($PSCmdlet.ShouldProcess($GroupName, "Define New Account Group")) {
+		if ($PSCmdlet.ShouldProcess($GroupName, 'Define New Account Group')) {
 
 			#send request to PAS web service
 			Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession

--- a/psPAS/Functions/Accounts/Add-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Add-PASAccount.ps1
@@ -6,168 +6,168 @@ function Add-PASAccount {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[string]$name,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[string]$address,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[string]$userName,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
-		[Alias("PolicyID")]
+		[Alias('PolicyID')]
 		[string]$platformID,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateNotNullOrEmpty()]
-		[Alias("safe")]
+		[Alias('safe')]
 		[string]$SafeName,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
-		[ValidateSet("Password", "Key")]
+		[ValidateSet('Password', 'Key')]
 		[string]$secretType,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[securestring]$secret,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[hashtable]$platformAccountProperties,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[boolean]$automaticManagementEnabled,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[string]$manualManagementReason,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[string]$remoteMachines,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[boolean]$accessRestrictedToRemoteMachines,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[string]$accountName,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[securestring]$password,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[boolean]$disableAutoMgmt,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[string]$disableAutoMgmtReason,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[string]$groupName,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[string]$groupPlatformID,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[int]$Port,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[ValidateNotNullOrEmpty()]
 		[string]$ExtraPass1Name,
@@ -175,14 +175,14 @@ function Add-PASAccount {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[string]$ExtraPass1Folder,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[ValidateNotNullOrEmpty()]
 		[string]$ExtraPass1Safe,
@@ -190,7 +190,7 @@ function Add-PASAccount {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[ValidateNotNullOrEmpty()]
 		[string]$ExtraPass3Name,
@@ -198,14 +198,14 @@ function Add-PASAccount {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[string]$ExtraPass3Folder,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[ValidateNotNullOrEmpty()]
 		[string]$ExtraPass3Safe,
@@ -213,7 +213,7 @@ function Add-PASAccount {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[hashtable]$DynamicProperties
 	)
@@ -221,8 +221,8 @@ function Add-PASAccount {
 	BEGIN {
 
 		#V9 baseparameters are contained in JSON object at the same depth
-		$baseParameters = [Collections.Generic.List[String]]@("Safe", "PlatformID", "Address", "AccountName", "Password", "Username",
-			"DisableAutoMgmt", "DisableAutoMgmtReason", "GroupName", "GroupPlatformID")
+		$baseParameters = [Collections.Generic.List[String]]@('Safe', 'PlatformID', 'Address', 'AccountName', 'Password', 'Username',
+			'DisableAutoMgmt', 'DisableAutoMgmtReason', 'GroupName', 'GroupPlatformID')
 
 	}#begin
 
@@ -233,7 +233,7 @@ function Add-PASAccount {
 
 		switch ($PSCmdlet.ParameterSetName) {
 
-			"Gen2" {
+			'Gen2' {
 
 				Assert-VersionRequirement -RequiredVersion 10.4
 
@@ -248,24 +248,24 @@ function Add-PASAccount {
 
 			}
 
-			"Gen1" {
+			'Gen1' {
 
 				#Create URL for Request
 				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Account"
 
 				#deal with Password SecureString
-				If ($PSBoundParameters.ContainsKey("password")) {
+				If ($PSBoundParameters.ContainsKey('password')) {
 
 					#Include decoded password in request
-					$boundParameters["password"] = $(ConvertTo-InsecureString -SecureString $password)
+					$boundParameters['password'] = $(ConvertTo-InsecureString -SecureString $password)
 
 				}
 
 				#Process for required formatting - fix V10 specific parameter names
-				$boundParameters.remove("SafeName")
-				$boundParameters.remove("userName")
-				$boundParameters["safe"] = $SafeName
-				$boundParameters["username"] = $userName
+				$boundParameters.remove('SafeName')
+				$boundParameters.remove('userName')
+				$boundParameters['safe'] = $SafeName
+				$boundParameters['username'] = $userName
 
 				#declare empty hashtable to hold "non-base" parameters
 				$properties = @{ }
@@ -277,7 +277,7 @@ function Add-PASAccount {
 				$boundParameters.keys | Where-Object { $baseParameters -notcontains $_ } | ForEach-Object {
 
 					#For all "non-base" parameters except "DynamicProperties"
-					if ($_ -ne "DynamicProperties") {
+					if ($_ -ne 'DynamicProperties') {
 
 						#Add key/Value to "properties" hashtable
 						$properties[$_] = $boundParameters[$_]
@@ -302,13 +302,13 @@ function Add-PASAccount {
 				}
 
 				#Add "non-base" parameter hashtable as value of "properties" on boundparameters object
-				$boundParameters["properties"] = [Collections.Generic.List[String]]@($properties.getenumerator() | ForEach-Object { $_ })
+				$boundParameters['properties'] = [Collections.Generic.List[String]]@($properties.getenumerator() | ForEach-Object { $_ })
 
 				#Create body of request
 				$body = @{
 
 					#account node does not contain non-base parameters
-					"account" = $boundParameters | Get-PASParameter -ParametersToRemove $keysToRemove
+					'account' = $boundParameters | Get-PASParameter -ParametersToRemove $keysToRemove
 
 					#ensure nodes at all required depths are included in the JSON object
 				} | ConvertTo-Json -Depth 4
@@ -322,12 +322,12 @@ function Add-PASAccount {
 		#send request to PAS web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
 
-		if ($PSCmdlet.ParameterSetName -eq "Gen2") {
+		if ($PSCmdlet.ParameterSetName -eq 'Gen2') {
 
 			If ($null -ne $result) {
 
 				#Return Results
-				$result | Add-ObjectDetail -typename "psPAS.CyberArk.Vault.Account.V10"
+				$result | Add-ObjectDetail -typename 'psPAS.CyberArk.Vault.Account.V10'
 
 			}
 
@@ -336,4 +336,5 @@ function Add-PASAccount {
 	}#process
 
 	END { }#end
+
 }

--- a/psPAS/Functions/Accounts/Add-PASDiscoveredAccount.ps1
+++ b/psPAS/Functions/Accounts/Add-PASDiscoveredAccount.ps1
@@ -1,8 +1,8 @@
 ﻿# .ExternalHelp psPAS-help.xml
 function Add-PASDiscoveredAccount {
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '', Justification = "Username not used for authentication")]
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'platformTypeAccountProperties', Justification = "False Positive")]
-	[CmdletBinding(DefaultParameterSetName = "Windows")]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '', Justification = 'Username not used for authentication')]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'platformTypeAccountProperties', Justification = 'False Positive')]
+	[CmdletBinding(DefaultParameterSetName = 'Windows')]
 	param(
 		[parameter(
 			Mandatory = $true,
@@ -39,7 +39,7 @@ function Add-PASDiscoveredAccount {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("Windows Server Local", "Windows Desktop Local", "Windows Domain", "Unix", "Unix SSH Key", "AWS", "AWS Access Keys", "Azure Password Management")]
+		[ValidateSet('Windows Server Local', 'Windows Desktop Local', 'Windows Domain', 'Unix', 'Unix SSH Key', 'AWS', 'AWS Access Keys', 'Azure Password Management')]
 		[string]$platformType,
 
 		[parameter(
@@ -106,7 +106,7 @@ function Add-PASDiscoveredAccount {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("Workstation", "Server")]
+		[ValidateSet('Workstation', 'Server')]
 		[string]$osFamily,
 
 		[parameter(
@@ -124,47 +124,47 @@ function Add-PASDiscoveredAccount {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Windows"
+			ParameterSetName = 'Windows'
 		)]
 		[string]$SID,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Unix"
+			ParameterSetName = 'Unix'
 		)]
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "UnixSSHKey"
+			ParameterSetName = 'UnixSSHKey'
 		)]
 		[string]$uid,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Unix"
+			ParameterSetName = 'Unix'
 		)]
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "UnixSSHKey"
+			ParameterSetName = 'UnixSSHKey'
 		)]
 		[string]$gid,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "UnixSSHKey"
+			ParameterSetName = 'UnixSSHKey'
 		)]
 		[string]$fingerprint,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "UnixSSHKey"
+			ParameterSetName = 'UnixSSHKey'
 		)]
 		[ValidateSet(1024, 2048, 4096, 8192)]
 		[int]$size,
@@ -172,36 +172,36 @@ function Add-PASDiscoveredAccount {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "UnixSSHKey"
+			ParameterSetName = 'UnixSSHKey'
 		)]
 		[string]$path,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "UnixSSHKey"
+			ParameterSetName = 'UnixSSHKey'
 		)]
 		[string]$format,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "UnixSSHKey"
+			ParameterSetName = 'UnixSSHKey'
 		)]
 		[string]$comment,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "UnixSSHKey"
+			ParameterSetName = 'UnixSSHKey'
 		)]
-		[ValidateSet("RSA", "DSA")]
+		[ValidateSet('RSA', 'DSA')]
 		[string]$encryption,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AWS"
+			ParameterSetName = 'AWS'
 		)]
 		[ValidateLength(12, 12)]
 		[string]$awsAccountID,
@@ -209,21 +209,21 @@ function Add-PASDiscoveredAccount {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AWS"
+			ParameterSetName = 'AWS'
 		)]
 		[string]$awsAccessKeyID,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Dependency"
+			ParameterSetName = 'Dependency'
 		)]
 		[hashtable[]]$Dependencies,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Azure"
+			ParameterSetName = 'Azure'
 		)]
 		[string]$activeDirectoryID
 	)
@@ -232,14 +232,14 @@ function Add-PASDiscoveredAccount {
 
 		switch ($PSCmdlet.ParameterSetName) {
 
-			{ $PSItem -match "Azure" } {
+			{ $PSItem -match 'Azure' } {
 
 				#v11.7 required for Azure
 				Assert-VersionRequirement -RequiredVersion 11.7
 
 			}
 
-			{ $PSItem -match "AWS|Dependency" } {
+			{ $PSItem -match 'AWS|Dependency' } {
 
 				#v10.8 required for AWS & Dependencies
 				Assert-VersionRequirement -RequiredVersion 10.8
@@ -255,9 +255,9 @@ function Add-PASDiscoveredAccount {
 
 		}
 
-		$AccountProperties = [Collections.Generic.List[String]]@("SID", "uid", "gid", "fingerprint", "size", "path", "format", "comment", "encryption", "awsAccountID", "awsAccessKeyID", "activeDirectoryID")
+		$AccountProperties = [Collections.Generic.List[String]]@('SID', 'uid', 'gid', 'fingerprint', 'size', 'path', 'format', 'comment', 'encryption', 'awsAccountID', 'awsAccessKeyID', 'activeDirectoryID')
 
-		$DateTimes = [Collections.Generic.List[String]]@("discoveryDate", "lastLogonDateTime", "lastPasswordSetDateTime", "passwordExpirationDateTime")
+		$DateTimes = [Collections.Generic.List[String]]@('discoveryDate', 'lastLogonDateTime', 'lastPasswordSetDateTime', 'passwordExpirationDateTime')
 
 	}#begin
 
@@ -293,7 +293,7 @@ function Add-PASDiscoveredAccount {
 
 			If ($platformTypeAccountProperties.Count -gt 0) {
 
-				$boundParameters["platformTypeAccountProperties"] = $platformTypeAccountProperties
+				$boundParameters['platformTypeAccountProperties'] = $platformTypeAccountProperties
 
 			}
 
@@ -314,4 +314,5 @@ function Add-PASDiscoveredAccount {
 	}#process
 
 	END { }#end
+
 }

--- a/psPAS/Functions/Accounts/Add-PASPendingAccount.ps1
+++ b/psPAS/Functions/Accounts/Add-PASPendingAccount.ps1
@@ -1,7 +1,7 @@
 # .ExternalHelp psPAS-help.xml
 function Add-PASPendingAccount {
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '', Justification = "Username not used for authentication")]
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', 'LastPasswordSet', Justification = "Parameter does not hold password")]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '', Justification = 'Username not used for authentication')]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', 'LastPasswordSet', Justification = 'Parameter does not hold password')]
 	[CmdletBinding()]
 	param(
 		[parameter(
@@ -27,14 +27,14 @@ function Add-PASPendingAccount {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("Windows", "Unix")]
+		[ValidateSet('Windows', 'Unix')]
 		[string]$OSType,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("enabled", "disabled")]
+		[ValidateSet('enabled', 'disabled')]
 		[string]$AccountEnabled,
 
 		[parameter(
@@ -47,7 +47,7 @@ function Add-PASPendingAccount {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("domain", "local")]
+		[ValidateSet('domain', 'local')]
 		[string]$AccountType,
 
 		[parameter(
@@ -96,7 +96,7 @@ function Add-PASPendingAccount {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("Privileged", "Non-privileged")]
+		[ValidateSet('Privileged', 'Non-privileged')]
 		[string]$AccountCategory,
 
 		[parameter(
@@ -134,7 +134,7 @@ function Add-PASPendingAccount {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("Workstation", "Server")]
+		[ValidateSet('Workstation', 'Server')]
 		[string]$MachineOSFamily
 	)
 
@@ -148,13 +148,13 @@ function Add-PASPendingAccount {
 		#Get all parameters that will be sent in the request
 		$boundParameters = $PSBoundParameters | Get-PASParameter
 
-		If ($PSBoundParameters.ContainsKey("AccountDiscoveryDate")) {
+		If ($PSBoundParameters.ContainsKey('AccountDiscoveryDate')) {
 
 			#Convert ExpiryDate to string in Required format
-			$Date = (Get-Date $AccountDiscoveryDate.ToUniversalTime() -Format "yyyy-MM-ddTHH:mm:ssZ").ToString()
+			$Date = (Get-Date $AccountDiscoveryDate.ToUniversalTime() -Format 'yyyy-MM-ddTHH:mm:ssZ').ToString()
 
 			#Include date string in request
-			$boundParameters["AccountDiscoveryDate"] = $Date
+			$boundParameters['AccountDiscoveryDate'] = $Date
 
 		}
 
@@ -162,7 +162,7 @@ function Add-PASPendingAccount {
 		$body = @{
 
 			#pendingaccount node
-			"pendingAccount" = $boundParameters | Get-PASParameter
+			'pendingAccount' = $boundParameters | Get-PASParameter
 
 			#JSON object
 		} | ConvertTo-Json
@@ -173,4 +173,5 @@ function Add-PASPendingAccount {
 	}#process
 
 	END { }#end
+
 }

--- a/psPAS/Functions/Accounts/Disable-PASCPMAutoManagement.ps1
+++ b/psPAS/Functions/Accounts/Disable-PASCPMAutoManagement.ps1
@@ -6,13 +6,13 @@ function Disable-PASCPMAutoManagement {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[Alias("id")]
+		[Alias('id')]
 		[string]$AccountID,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "manualManagementReason"
+			ParameterSetName = 'manualManagementReason'
 		)]
 		[string]$Reason
 
@@ -24,9 +24,9 @@ function Disable-PASCPMAutoManagement {
 
 		$ops = [Collections.Generic.List[Object]]@(
 			@{
-				"path"  = "/secretManagement/automaticManagementEnabled"
-				"op"    = "replace"
-				"value" = $false
+				'path'  = '/secretManagement/automaticManagementEnabled'
+				'op'    = 'replace'
+				'value' = $false
 			}
 		)
 
@@ -34,12 +34,12 @@ function Disable-PASCPMAutoManagement {
 
 	PROCESS {
 
-		if ($PSCmdlet.ParameterSetName -eq "manualManagementReason") {
+		if ($PSCmdlet.ParameterSetName -eq 'manualManagementReason') {
 
 			$null = $ops.Add(@{
-					"path"  = "/secretManagement/manualManagementReason"
-					"op"    = "replace"
-					"value" = $Reason
+					'path'  = '/secretManagement/manualManagementReason'
+					'op'    = 'replace'
+					'value' = $Reason
 				})
 		}
 

--- a/psPAS/Functions/Accounts/Enable-PASCPMAutoManagement.ps1
+++ b/psPAS/Functions/Accounts/Enable-PASCPMAutoManagement.ps1
@@ -6,7 +6,7 @@ function Enable-PASCPMAutoManagement {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[Alias("id")]
+		[Alias('id')]
 		[string]$AccountID
 
 	)
@@ -17,14 +17,14 @@ function Enable-PASCPMAutoManagement {
 
 		$ops = [Collections.Generic.List[Object]]@(
 			@{
-				"path"  = "/secretManagement/automaticManagementEnabled"
-				"op"    = "replace"
-				"value" = $true
+				'path'  = '/secretManagement/automaticManagementEnabled'
+				'op'    = 'replace'
+				'value' = $true
 			},
 			@{
-				"path"  = "/secretManagement/manualManagementReason"
-				"op"    = "replace"
-				"value" = ""
+				'path'  = '/secretManagement/manualManagementReason'
+				'op'    = 'replace'
+				'value' = ''
 			}
 		)
 

--- a/psPAS/Functions/Accounts/Get-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccount.ps1
@@ -43,6 +43,18 @@ function Get-PASAccount {
 		[string]$safeName,
 
 		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'Gen2Query'
+		)]
+		[ValidateSet('Regular', 'Recently', 'New', 'Link', 'Deleted', 'PolicyFailures',
+			'AccessedByUsers', 'ModifiedByUsers', 'ModifiedByCPM', 'DisabledPasswordByUser',
+			'DisabledPasswordByCPM', 'ScheduledForChange', 'ScheduledForVerify', 'ScheduledForReconcile',
+			'SuccessfullyReconciled', 'FailedChange', 'FailedVerify', 'FailedReconcile', 'LockedOrNew',
+			'Locked', 'Favorites')]
+		[string]$savedFilter,
+
+		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Gen2Query'
@@ -108,6 +120,12 @@ function Get-PASAccount {
 			( { $PSItem -match 'Gen2' } ) {
 
 				switch ($PSBoundParameters) {
+
+					( { $PSItem.ContainsKey('savedFilter') }) {
+						#check required version
+						Assert-VersionRequirement -RequiredVersion 12.6
+
+					}
 
 					( { $PSItem.ContainsKey('modificationTime') }) {
 						#check required version

--- a/psPAS/Functions/Accounts/Get-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccount.ps1
@@ -43,7 +43,7 @@ function Get-PASAccount {
 		[string]$safeName,
 
 		[parameter(
-			Mandatory = $true,
+			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Gen2Query'
 		)]

--- a/psPAS/Functions/Accounts/Get-PASAccountActivity.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccountActivity.ps1
@@ -6,7 +6,7 @@ function Get-PASAccountActivity {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[Alias("id")]
+		[Alias('id')]
 		[string]$AccountID
 
 
@@ -29,7 +29,7 @@ function Get-PASAccountActivity {
 			#Return Results
 			$result.GetAccountActivitiesResult |
 
-			Add-ObjectDetail -typename psPAS.CyberArk.Vault.Account.Activity
+				Add-ObjectDetail -typename psPAS.CyberArk.Vault.Account.Activity
 
 		}
 

--- a/psPAS/Functions/Accounts/Get-PASAccountImportJob.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccountImportJob.ps1
@@ -5,7 +5,7 @@ Function Get-PASAccountImportJob {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byID"
+			ParameterSetName = 'byID'
 		)]
 		[string]$id
 	)
@@ -21,7 +21,7 @@ Function Get-PASAccountImportJob {
 		#Create URL for Request
 		$URI = "$Script:BaseURI/api/bulkactions/accounts"
 
-		If ($PSCmdlet.ParameterSetName -eq "byID") {
+		If ($PSCmdlet.ParameterSetName -eq 'byID') {
 
 			$URI = "$URI/$id"
 
@@ -32,13 +32,13 @@ Function Get-PASAccountImportJob {
 
 		If ($null -ne $Result) {
 
-			If ($PSCmdlet.ParameterSetName -ne "byID") {
+			If ($PSCmdlet.ParameterSetName -ne 'byID') {
 
 				$Result = $Result.BulkActions
 
 			}
 
-			$Result | Add-ObjectDetail -typename "psPAS.CyberArk.Vault.Account.Job"
+			$Result | Add-ObjectDetail -typename 'psPAS.CyberArk.Vault.Account.Job'
 
 		}
 

--- a/psPAS/Functions/Accounts/Get-PASAccountSSHKey.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccountSSHKey.ps1
@@ -6,7 +6,7 @@ Function Get-PASAccountSSHKey {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[Alias("id")]
+		[Alias('id')]
 		[string]$AccountID,
 
 		[parameter(
@@ -37,7 +37,7 @@ Function Get-PASAccountSSHKey {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("retrieve")]
+		[ValidateSet('retrieve')]
 		[string]$ActionType,
 
 		[parameter(

--- a/psPAS/Functions/Accounts/Get-PASDiscoveredAccount.ps1
+++ b/psPAS/Functions/Accounts/Get-PASDiscoveredAccount.ps1
@@ -1,62 +1,62 @@
 # .ExternalHelp psPAS-help.xml
 Function Get-PASDiscoveredAccount {
-	[CmdletBinding(DefaultParameterSetName = "byQuery")]
+	[CmdletBinding(DefaultParameterSetName = 'byQuery')]
 	param(
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byID"
+			ParameterSetName = 'byID'
 		)]
 		[string]$id,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byQuery"
+			ParameterSetName = 'byQuery'
 		)]
-		[ValidateSet("Windows Server Local", "Windows Desktop Local", "Windows Domain", "Unix", "Unix SSH Key", "AWS", "AWS Access Keys", "Azure Password Management")]
+		[ValidateSet('Windows Server Local', 'Windows Desktop Local', 'Windows Domain', 'Unix', 'Unix SSH Key', 'AWS', 'AWS Access Keys', 'Azure Password Management')]
 		[string]$platformType,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byQuery"
+			ParameterSetName = 'byQuery'
 		)]
 		[boolean]$privileged,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byQuery"
+			ParameterSetName = 'byQuery'
 		)]
 		[boolean]$AccountEnabled,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byQuery"
+			ParameterSetName = 'byQuery'
 		)]
 		[string]$search,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byQuery"
+			ParameterSetName = 'byQuery'
 		)]
-		[ValidateSet("startswith", "contains")]
+		[ValidateSet('startswith', 'contains')]
 		[string]$searchType,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byQuery"
+			ParameterSetName = 'byQuery'
 		)]
 		[int]$offset,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byQuery"
+			ParameterSetName = 'byQuery'
 		)]
 		[ValidateRange(1, 1000)]
 		[int]$limit
@@ -68,7 +68,7 @@ Function Get-PASDiscoveredAccount {
 		Assert-VersionRequirement -RequiredVersion 11.6
 
 		#Parameter to include as filter value in url
-		$Parameters = [Collections.Generic.List[String]]@("platformType", "privileged", "accountEnabled")
+		$Parameters = [Collections.Generic.List[String]]@('platformType', 'privileged', 'accountEnabled')
 
 	}
 
@@ -79,7 +79,7 @@ Function Get-PASDiscoveredAccount {
 
 		switch ($PSCmdlet.ParameterSetName) {
 
-			"byID" {
+			'byID' {
 
 				$URI = "$URI/$id"
 
@@ -87,9 +87,9 @@ Function Get-PASDiscoveredAccount {
 
 			}
 
-			"byQuery" {
+			'byQuery' {
 
-				If ($platformType -eq "Azure Password Management") {
+				If ($platformType -eq 'Azure Password Management') {
 
 					Assert-VersionRequirement -RequiredVersion 11.7
 
@@ -127,7 +127,7 @@ Function Get-PASDiscoveredAccount {
 
 		If ($null -ne $Result) {
 
-			If ($PSCmdlet.ParameterSetName -eq "byQuery") {
+			If ($PSCmdlet.ParameterSetName -eq 'byQuery') {
 
 				#Process nextlink if querying
 				$Result = $Result | Get-NextLink

--- a/psPAS/Functions/Accounts/Invoke-PASCPMOperation.ps1
+++ b/psPAS/Functions/Accounts/Invoke-PASCPMOperation.ps1
@@ -1,6 +1,6 @@
 # .ExternalHelp psPAS-help.xml
 function Invoke-PASCPMOperation {
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', 'ChangeCredsForGroup', Justification = "Parameter does not hold password")]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', 'ChangeCredsForGroup', Justification = 'Parameter does not hold password')]
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
 		[parameter(
@@ -8,85 +8,85 @@ function Invoke-PASCPMOperation {
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateNotNullOrEmpty()]
-		[Alias("id")]
+		[Alias('id')]
 		[string]$AccountID,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "VerifyCredentials"
+			ParameterSetName = 'VerifyCredentials'
 		)]
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Verify"
+			ParameterSetName = 'Verify'
 		)]
 		[switch]$VerifyTask,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Password/Update"
+			ParameterSetName = 'Password/Update'
 		)]
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "SetNextPassword"
+			ParameterSetName = 'SetNextPassword'
 		)]
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Change"
+			ParameterSetName = 'Change'
 		)]
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "ChangeCredentials"
+			ParameterSetName = 'ChangeCredentials'
 		)]
 		[switch]$ChangeTask,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Reconcile"
+			ParameterSetName = 'Reconcile'
 		)]
 		[switch]$ReconcileTask,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "SetNextPassword"
+			ParameterSetName = 'SetNextPassword'
 		)]
 		[boolean]$ChangeImmediately,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "SetNextPassword"
+			ParameterSetName = 'SetNextPassword'
 		)]
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Password/Update"
+			ParameterSetName = 'Password/Update'
 		)]
 		[securestring]$NewCredentials,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $false,
-			ParameterSetName = "Change"
+			ParameterSetName = 'Change'
 		)]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Password/Update"
+			ParameterSetName = 'Password/Update'
 		)]
 		[boolean]$ChangeEntireGroup,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $false,
-			ParameterSetName = "ChangeCredentials"
+			ParameterSetName = 'ChangeCredentials'
 		)]
 		[ValidateSet('Yes', 'No')]
 		[string]$ImmediateChangeByCPM,
@@ -94,7 +94,7 @@ function Invoke-PASCPMOperation {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $false,
-			ParameterSetName = "ChangeCredentials"
+			ParameterSetName = 'ChangeCredentials'
 		)]
 		[ValidateSet('Yes', 'No')]
 		[string]$ChangeCredsForGroup,
@@ -102,9 +102,9 @@ function Invoke-PASCPMOperation {
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "VerifyCredentials"
+			ParameterSetName = 'VerifyCredentials'
 		)]
-		[Alias("UseClassicAPI")]
+		[Alias('UseClassicAPI')]
 		[switch]$UseGen1API
 	)
 
@@ -112,8 +112,8 @@ function Invoke-PASCPMOperation {
 
 		#Create hashtable for splatting
 		$ThisRequest = @{ }
-		$ThisRequest["WebSession"] = $Script:WebSession
-		$ThisRequest["Method"] = "PUT"
+		$ThisRequest['WebSession'] = $Script:WebSession
+		$ThisRequest['Method'] = 'PUT'
 
 	}#Begin
 
@@ -125,24 +125,24 @@ function Invoke-PASCPMOperation {
 
 		switch ($PSCmdlet.ParameterSetName) {
 
-			"ChangeCredentials" {
+			'ChangeCredentials' {
 
 				#add ImmediateChangeByCPM to header as key=value pair
-				$ThisRequest["WebSession"].Headers["ImmediateChangeByCPM"] = $ImmediateChangeByCPM
+				$ThisRequest['WebSession'].Headers['ImmediateChangeByCPM'] = $ImmediateChangeByCPM
 
 				#create request body
-				$ThisRequest["Body"] = $boundParameters | ConvertTo-Json
+				$ThisRequest['Body'] = $boundParameters | ConvertTo-Json
 
 			}
 
-			"VerifyCredentials" {
+			'VerifyCredentials' {
 
 				#Empty Body
-				$ThisRequest["Body"] = @{ } | ConvertTo-Json
+				$ThisRequest['Body'] = @{ } | ConvertTo-Json
 
 			}
 
-			{ $PSItem -match "Credentials$" } {
+			{ $PSItem -match 'Credentials$' } {
 
 				$URI = "$Script:BaseURI/WebServices/PIMServices.svc"
 				break
@@ -158,28 +158,28 @@ function Invoke-PASCPMOperation {
 				$URI = "$Script:BaseURI/API"
 
 				#verify/change/reconcile method
-				$ThisRequest["Method"] = "POST"
+				$ThisRequest['Method'] = 'POST'
 
 				#deal with NewCredentials SecureString
-				If ($PSBoundParameters.ContainsKey("NewCredentials")) {
+				If ($PSBoundParameters.ContainsKey('NewCredentials')) {
 
 					#Specifying next password value, or changing in the vault requires 10.1 or above
 					Assert-VersionRequirement -RequiredVersion 10.1
 
 					#Include decoded password in request
-					$boundParameters["NewCredentials"] = $(ConvertTo-InsecureString -SecureString $NewCredentials)
+					$boundParameters['NewCredentials'] = $(ConvertTo-InsecureString -SecureString $NewCredentials)
 
 				}
 
 				#create request body
-				$ThisRequest["Body"] = $boundParameters | ConvertTo-Json
+				$ThisRequest['Body'] = $boundParameters | ConvertTo-Json
 
 			}
 
 		}
 
 		#Use AccountID + ParameterSet name for required URI
-		$ThisRequest["URI"] = "$URI/Accounts/$AccountID/$($PSCmdlet.ParameterSetName)"
+		$ThisRequest['URI'] = "$URI/Accounts/$AccountID/$($PSCmdlet.ParameterSetName)"
 
 		if ($PSCmdlet.ShouldProcess($AccountID, "Initiate CPM $($PSBoundParameters.Keys | Where-Object{$_ -like '*Task'})")) {
 
@@ -188,10 +188,10 @@ function Invoke-PASCPMOperation {
 
 		}
 
-		If ($ThisRequest["WebSession"].Headers.ContainsKey("ImmediateChangeByCPM")) {
+		If ($ThisRequest['WebSession'].Headers.ContainsKey('ImmediateChangeByCPM')) {
 
 			#Ensure ImmediateChangeByCPM is removed from WebSession Header
-			$ThisRequest["WebSession"].Headers.Remove("ImmediateChangeByCPM") | Out-Null
+			$ThisRequest['WebSession'].Headers.Remove('ImmediateChangeByCPM') | Out-Null
 
 		}
 

--- a/psPAS/Functions/Accounts/New-PASAccountObject.ps1
+++ b/psPAS/Functions/Accounts/New-PASAccountObject.ps1
@@ -1,109 +1,109 @@
 # .ExternalHelp psPAS-help.xml
 Function New-PASAccountObject {
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'remoteMachinesAccess', Justification = "False Positive")]
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'secretManagement', Justification = "False Positive")]
-	[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = "AccountObject")]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'remoteMachinesAccess', Justification = 'False Positive')]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'secretManagement', Justification = 'False Positive')]
+	[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'AccountObject')]
 	param(
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AccountObject"
+			ParameterSetName = 'AccountObject'
 		)]
 		[int]$uploadIndex,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AccountObject"
+			ParameterSetName = 'AccountObject'
 		)]
 		[string]$userName,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AccountObject"
+			ParameterSetName = 'AccountObject'
 		)]
 		[string]$name,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AccountObject"
+			ParameterSetName = 'AccountObject'
 		)]
 		[string]$address,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AccountObject"
+			ParameterSetName = 'AccountObject'
 		)]
-		[Alias("PolicyID")]
+		[Alias('PolicyID')]
 		[string]$platformID,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AccountObject"
+			ParameterSetName = 'AccountObject'
 		)]
 		[ValidateNotNullOrEmpty()]
-		[Alias("safe")]
+		[Alias('safe')]
 		[string]$SafeName,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AccountObject"
+			ParameterSetName = 'AccountObject'
 		)]
-		[ValidateSet("Password", "Key")]
+		[ValidateSet('Password', 'Key')]
 		[string]$secretType,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AccountObject"
+			ParameterSetName = 'AccountObject'
 		)]
 		[securestring]$secret,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AccountObject"
+			ParameterSetName = 'AccountObject'
 		)]
 		[hashtable]$platformAccountProperties,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AccountObject"
+			ParameterSetName = 'AccountObject'
 		)]
 		[boolean]$automaticManagementEnabled,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AccountObject"
+			ParameterSetName = 'AccountObject'
 		)]
 		[string]$manualManagementReason,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AccountObject"
+			ParameterSetName = 'AccountObject'
 		)]
 		[string]$remoteMachines,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AccountObject"
+			ParameterSetName = 'AccountObject'
 		)]
 		[boolean]$accessRestrictedToRemoteMachines,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "AccountObject"
+			ParameterSetName = 'AccountObject'
 		)]
 		[string]$groupName
 
@@ -112,8 +112,8 @@ Function New-PASAccountObject {
 	Begin {
 
 		#V10 parameters are nested under JSON object properties
-		$remoteMachine = [Collections.Generic.List[String]]@("remoteMachines", "accessRestrictedToRemoteMachines")
-		$SecretMgmt = [Collections.Generic.List[String]]@("automaticManagementEnabled", "manualManagementReason")
+		$remoteMachine = [Collections.Generic.List[String]]@('remoteMachines', 'accessRestrictedToRemoteMachines')
+		$SecretMgmt = [Collections.Generic.List[String]]@('automaticManagementEnabled', 'manualManagementReason')
 
 	}
 
@@ -124,13 +124,13 @@ Function New-PASAccountObject {
 
 		switch ($PSCmdlet.ParameterSetName) {
 
-			"AccountObject" {
+			'AccountObject' {
 
 				#deal with "secret" SecureString
-				If ($PSBoundParameters.ContainsKey("secret")) {
+				If ($PSBoundParameters.ContainsKey('secret')) {
 
 					#Include decoded password in request
-					$boundParameters["secret"] = $(ConvertTo-InsecureString -SecureString $secret)
+					$boundParameters['secret'] = $(ConvertTo-InsecureString -SecureString $secret)
 
 				}
 
@@ -146,7 +146,7 @@ Function New-PASAccountObject {
 
 				} {
 
-					$boundParameters["remoteMachinesAccess"] = $remoteMachinesAccess
+					$boundParameters['remoteMachinesAccess'] = $remoteMachinesAccess
 
 				}
 
@@ -161,11 +161,11 @@ Function New-PASAccountObject {
 
 				} {
 
-					$boundParameters["secretManagement"] = $secretManagement
+					$boundParameters['secretManagement'] = $secretManagement
 
 				}
 
-				if ($PSCmdlet.ShouldProcess($userName, "Create Account Object Definition")) {
+				if ($PSCmdlet.ShouldProcess($userName, 'Create Account Object Definition')) {
 
 					$boundParameters | Get-PASParameter -ParametersToRemove @($remoteMachine + $SecretMgmt)
 

--- a/psPAS/Functions/Accounts/Remove-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Remove-PASAccount.ps1
@@ -1,6 +1,6 @@
 # .ExternalHelp psPAS-help.xml
 function Remove-PASAccount {
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'UseGen1API', Justification = "False Positive")]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'UseGen1API', Justification = 'False Positive')]
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
 		[parameter(
@@ -8,15 +8,15 @@ function Remove-PASAccount {
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateNotNullOrEmpty()]
-		[Alias("id")]
+		[Alias('id')]
 		[string]$AccountID,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $false,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
-		[Alias("UseClassicAPI")]
+		[Alias('UseClassicAPI')]
 		[switch]$UseGen1API
 	)
 
@@ -29,7 +29,7 @@ function Remove-PASAccount {
 
 		switch ($PSCmdlet.ParameterSetName) {
 
-			"Gen1" {
+			'Gen1' {
 
 				#Create URL for request (earlier than 10.4)
 				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Accounts/$AccountID"
@@ -46,7 +46,7 @@ function Remove-PASAccount {
 
 		}
 
-		if ($PSCmdlet.ShouldProcess($AccountID, "Delete Account")) {
+		if ($PSCmdlet.ShouldProcess($AccountID, 'Delete Account')) {
 
 			#Send request to webservice
 			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
@@ -56,4 +56,5 @@ function Remove-PASAccount {
 	}#process
 
 	END { }#end
+
 }

--- a/psPAS/Functions/Accounts/Set-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Set-PASAccount.ps1
@@ -1,6 +1,6 @@
 # .ExternalHelp psPAS-help.xml
 function Set-PASAccount {
-	[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = "Gen2SingleOp")]
+	[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'Gen2SingleOp')]
 	param(
 
 		[parameter(
@@ -8,118 +8,118 @@ function Set-PASAccount {
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateNotNullOrEmpty()]
-		[Alias("id")]
+		[Alias('id')]
 		[string]$AccountID,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2SingleOp"
+			ParameterSetName = 'Gen2SingleOp'
 		)]
-		[ValidateSet("add", "replace", "remove")]
-		[Alias("Operation")]
+		[ValidateSet('add', 'replace', 'remove')]
+		[Alias('Operation')]
 		[string]$op,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2SingleOp"
+			ParameterSetName = 'Gen2SingleOp'
 		)]
 		[string]$path,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2SingleOp"
+			ParameterSetName = 'Gen2SingleOp'
 		)]
 		[string]$value,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2MultiOp"
+			ParameterSetName = 'Gen2MultiOp'
 		)]
 		[hashtable[]]$operations,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[string]$Folder,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
-		[Alias("Name")]
+		[Alias('Name')]
 		[string]$AccountName,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[string]$DeviceType,
 
-		[Alias("PolicyID")]
+		[Alias('PolicyID')]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[string]$PlatformID,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[string]$Address,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[string]$UserName,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[string]$GroupName,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[string]$GroupPlatformID,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelineByPropertyName = $false,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[hashtable]$Properties = @{ },
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipeline = $false,
-			ParameterSetName = "Gen2SingleOp"
+			ParameterSetName = 'Gen2SingleOp'
 		)]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipeline = $false,
-			ParameterSetName = "Gen2MultiOp"
+			ParameterSetName = 'Gen2MultiOp'
 		)]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipeline = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[PSObject]$InputObject
 	)
@@ -135,7 +135,7 @@ function Set-PASAccount {
 
 		switch ($PSCmdlet.ParameterSetName) {
 
-			{ $PSItem -match "Gen2" } {
+			{ $PSItem -match 'Gen2' } {
 
 				Assert-VersionRequirement -RequiredVersion 10.4
 
@@ -143,14 +143,14 @@ function Set-PASAccount {
 				$URI = "$Script:BaseURI/api/Accounts/$AccountID"
 
 				#Define method for request
-				$Method = "PATCH"
+				$Method = 'PATCH'
 
 				#Define type of output object
-				$Type = "psPAS.CyberArk.Vault.Account.V10"
+				$Type = 'psPAS.CyberArk.Vault.Account.V10'
 
-				if ($PSCmdlet.ParameterSetName -match "Gen2MultiOp") {
+				if ($PSCmdlet.ParameterSetName -match 'Gen2MultiOp') {
 
-					$boundParameters = $boundParameters["operations"]
+					$boundParameters = $boundParameters['operations']
 
 				}
 
@@ -160,28 +160,28 @@ function Set-PASAccount {
 
 			}
 
-			"Gen1" {
+			'Gen1' {
 
 				#Create URL for Request
 				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Accounts/$AccountID"
 
 				#Define method for request
-				$Method = "PUT"
+				$Method = 'PUT'
 
 				#Define type of output object
-				$Type = "psPAS.CyberArk.Vault.Account"
+				$Type = 'psPAS.CyberArk.Vault.Account'
 
-				if ($PSBoundParameters.ContainsKey("Properties")) {
+				if ($PSBoundParameters.ContainsKey('Properties')) {
 
 					#Format "Properties" parameter value.
 					#Array of key=value pairs required for JSON convertion
-					$boundParameters["Properties"] = [Collections.Generic.List[String]]@($boundParameters["Properties"].getenumerator() |
+					$boundParameters['Properties'] = [Collections.Generic.List[String]]@($boundParameters['Properties'].getenumerator() |
 
 							ForEach-Object { $_ })
 
 				}
 
-				If (($InputObject) -and (($InputObject | Get-Member).TypeName -eq "psPAS.CyberArk.Vault.Account")) {
+				If (($InputObject) -and (($InputObject | Get-Member).TypeName -eq 'psPAS.CyberArk.Vault.Account')) {
 
 					#If InputObject is psPAS.CyberArk.Vault.Account
 					#*i.e. receiving pipeline from Get-PASAccount
@@ -193,39 +193,39 @@ function Set-PASAccount {
 						#exclude properties output by get-pasaccount not applicable to set-pasaccount request
 						Select-Object -Property * -ExcludeProperty Name, PolicyID, Safe |
 
-							#get all remaining noteproperties
-							Get-Member -MemberType "NoteProperty" |
+						#get all remaining noteproperties
+						Get-Member -MemberType 'NoteProperty' |
 
-								#For each property
-								ForEach-Object {
+						#For each property
+						ForEach-Object {
 
-									#Initialise hashtable
-									$ExistingProperty = @{ }
+							#Initialise hashtable
+							$ExistingProperty = @{ }
 
-									#if property is not bound to function parameter by name,
-									if (!(($PSBoundParameters.ContainsKey($($_.Name))) -or (
+							#if property is not bound to function parameter by name,
+							if (!(($PSBoundParameters.ContainsKey($($_.Name))) -or (
 
-												#if not being explicitly updated.
-												$($Properties).ContainsKey($($_.Name))))) {
+										#if not being explicitly updated.
+										$($Properties).ContainsKey($($_.Name))))) {
 
-										[hashtable]$ExistingProperty.Add($($_.Name), $($InputObject.$($_.Name)))
+								[hashtable]$ExistingProperty.Add($($_.Name), $($InputObject.$($_.Name)))
 
-										#Add to Properties node of request data
-										[array]$boundParameters["Properties"] += $ExistingProperty.GetEnumerator() | ForEach-Object { $_ }
-										#*any existing properties of an account not sent in a "set" request will be cleared on the account.
-										#*This ensures correctly formatted request with all existing account properties included
-										#*when function is sent data via the pipeline.
+								#Add to Properties node of request data
+								[array]$boundParameters['Properties'] += $ExistingProperty.GetEnumerator() | ForEach-Object { $_ }
+								#*any existing properties of an account not sent in a "set" request will be cleared on the account.
+								#*This ensures correctly formatted request with all existing account properties included
+								#*when function is sent data via the pipeline.
 
-									}
+							}
 
-								}
+						}
 
 				}
 
 				#Create body of request
 				$body = @{
 
-					"Accounts" = $boundParameters
+					'Accounts' = $boundParameters
 
 					#ensure nodes at all required depths are included in the JSON object
 				} | ConvertTo-Json -Depth 3
@@ -235,7 +235,7 @@ function Set-PASAccount {
 			}
 		}
 
-		if ($PSCmdlet.ShouldProcess($AccountID, "Update Account Properties")) {
+		if ($PSCmdlet.ShouldProcess($AccountID, 'Update Account Properties')) {
 
 			#send request to PAS web service
 			$Result = Invoke-PASRestMethod -Uri $URI -Method $Method -Body $Body -WebSession $Script:WebSession
@@ -244,7 +244,7 @@ function Set-PASAccount {
 
 				switch ($PSCmdlet.ParameterSetName) {
 
-					"Gen1" { $Return = $Result.UpdateAccountResult ; break }
+					'Gen1' { $Return = $Result.UpdateAccountResult ; break }
 
 					default { $Return = $Result }
 
@@ -252,7 +252,7 @@ function Set-PASAccount {
 
 				$Return | Add-ObjectDetail -typename $Type -PropertyToAdd @{
 
-					"AccountID" = $AccountID
+					'AccountID' = $AccountID
 
 				}
 

--- a/psPAS/Functions/Accounts/Start-PASAccountImportJob.ps1
+++ b/psPAS/Functions/Accounts/Start-PASAccountImportJob.ps1
@@ -32,7 +32,7 @@ Function Start-PASAccountImportJob {
 		#Create body of request
 		$body = $boundParameters | Get-PASParameter | ConvertTo-Json -Depth 3
 
-		if ($PSCmdlet.ShouldProcess("List of $($accountsList.count) account(s)", "Start Bulk Account Import Job")) {
+		if ($PSCmdlet.ShouldProcess("List of $($accountsList.count) account(s)", 'Start Bulk Account Import Job')) {
 
 			#send request
 			$Result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
@@ -50,7 +50,7 @@ Function Start-PASAccountImportJob {
 				catch {
 
 					#Return Import Job ID
-					[PSCustomObject]@{"id" = $Result }
+					[PSCustomObject]@{'id' = $Result }
 
 				}
 

--- a/psPAS/Functions/Accounts/Unlock-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Unlock-PASAccount.ps1
@@ -7,7 +7,7 @@ function Unlock-PASAccount {
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateNotNullOrEmpty()]
-		[Alias("id")]
+		[Alias('id')]
 		[string]$AccountID
 	)
 
@@ -18,7 +18,7 @@ function Unlock-PASAccount {
 		#Create URL for request
 		$URI = "$Script:BaseURI/API/Accounts/$AccountID/CheckIn"
 
-		if ($PSCmdlet.ShouldProcess($AccountID, "Check-In Exclusive Access Account")) {
+		if ($PSCmdlet.ShouldProcess($AccountID, 'Check-In Exclusive Access Account')) {
 
 			#send request to web service
 			Invoke-PASRestMethod -Uri $URI -Method POST -WebSession $Script:WebSession

--- a/psPAS/Functions/Applications/Add-PASApplication.ps1
+++ b/psPAS/Functions/Applications/Add-PASApplication.ps1
@@ -8,7 +8,7 @@ function Add-PASApplication {
 		)]
 		[ValidateNotNullOrEmpty()]
 		[ValidateLength(1, 127)]
-		[ValidateScript( { $_ -notmatch ".*(\&).*" })]
+		[ValidateScript( { $_ -notmatch '.*(\&).*' })]
 		[string]$AppID,
 
 		[parameter(
@@ -88,20 +88,20 @@ function Add-PASApplication {
 		#Get request parameters
 		$boundParameters = $PSBoundParameters | Get-PASParameter
 
-		If ($PSBoundParameters.ContainsKey("ExpirationDate")) {
+		If ($PSBoundParameters.ContainsKey('ExpirationDate')) {
 
 			#Convert ExpiryDate to string in Required format
 			$Date = (Get-Date $ExpirationDate -Format MM-dd-yyyy).ToString()
 
 			#Include date string in request
-			$boundParameters["ExpirationDate"] = $Date
+			$boundParameters['ExpirationDate'] = $Date
 
 		}
 
 		#Create Request Body
 		$body = @{
 
-			"application" = $boundParameters
+			'application' = $boundParameters
 
 		} | ConvertTo-Json
 
@@ -111,4 +111,5 @@ function Add-PASApplication {
 	}#process
 
 	END { }#end
+
 }

--- a/psPAS/Functions/Applications/Add-PASApplicationAuthenticationMethod.ps1
+++ b/psPAS/Functions/Applications/Add-PASApplicationAuthenticationMethod.ps1
@@ -127,7 +127,7 @@ function Add-PASApplicationAuthenticationMethod {
 
     PROCESS {
 
-        $URI = "$Script:BaseURI/WebServices/PIMServices.svc/Applications/$($AppID | Get-EscapedString)/Authentications"
+        $URI = "$Script:BaseURI/WebServices/PIMServices.svc/Applications/$($AppID | Get-EscapedString)/Authentications/"
 
         $boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove AppID
 

--- a/psPAS/Functions/Applications/Add-PASApplicationAuthenticationMethod.ps1
+++ b/psPAS/Functions/Applications/Add-PASApplicationAuthenticationMethod.ps1
@@ -5,32 +5,32 @@ function Add-PASApplicationAuthenticationMethod {
         [parameter(
             Mandatory = $true,
             ValueFromPipelinebyPropertyName = $true,
-            ParameterSetName = "path"
+            ParameterSetName = 'path'
         )]
         [parameter(
             Mandatory = $true,
             ValueFromPipelinebyPropertyName = $true,
-            ParameterSetName = "certificateattr"
+            ParameterSetName = 'certificateattr'
         )]
         [parameter(
             Mandatory = $true,
             ValueFromPipelinebyPropertyName = $true,
-            ParameterSetName = "certificateserialnumber"
+            ParameterSetName = 'certificateserialnumber'
         )]
         [parameter(
             Mandatory = $true,
             ValueFromPipelinebyPropertyName = $true,
-            ParameterSetName = "hash"
+            ParameterSetName = 'hash'
         )]
         [parameter(
             Mandatory = $true,
             ValueFromPipelinebyPropertyName = $true,
-            ParameterSetName = "osUser"
+            ParameterSetName = 'osUser'
         )]
         [parameter(
             Mandatory = $true,
             ValueFromPipelinebyPropertyName = $true,
-            ParameterSetName = "machineAddress"
+            ParameterSetName = 'machineAddress'
         )]
         [ValidateNotNullOrEmpty()]
         [string]$AppID,
@@ -38,87 +38,87 @@ function Add-PASApplicationAuthenticationMethod {
         [parameter(
             Mandatory = $true,
             ValueFromPipelinebyPropertyName = $true,
-            ParameterSetName = "path"
+            ParameterSetName = 'path'
         )]
         [string]$path,
 
         [parameter(
             Mandatory = $true,
             ValueFromPipelinebyPropertyName = $true,
-            ParameterSetName = "hash"
+            ParameterSetName = 'hash'
         )]
         [string]$hash,
 
         [parameter(
             Mandatory = $true,
             ValueFromPipelinebyPropertyName = $true,
-            ParameterSetName = "osUser"
+            ParameterSetName = 'osUser'
         )]
         [string]$osUser,
 
         [parameter(
             Mandatory = $true,
             ValueFromPipelinebyPropertyName = $true,
-            ParameterSetName = "machineAddress"
+            ParameterSetName = 'machineAddress'
         )]
         [string]$machineAddress,
 
         [parameter(
             Mandatory = $true,
             ValueFromPipelinebyPropertyName = $true,
-            ParameterSetName = "certificateserialnumber"
+            ParameterSetName = 'certificateserialnumber'
         )]
         [string]$certificateserialnumber,
 
         [parameter(
             Mandatory = $false,
             ValueFromPipelinebyPropertyName = $true,
-            ParameterSetName = "certificateattr"
+            ParameterSetName = 'certificateattr'
         )]
         [string[]]$Subject,
 
         [parameter(
             Mandatory = $false,
             ValueFromPipelinebyPropertyName = $true,
-            ParameterSetName = "certificateattr"
+            ParameterSetName = 'certificateattr'
         )]
         [string[]]$Issuer,
 
         [parameter(
             Mandatory = $false,
             ValueFromPipelinebyPropertyName = $true,
-            ParameterSetName = "certificateattr"
+            ParameterSetName = 'certificateattr'
         )]
         [string[]]$SubjectAlternativeName,
 
         [parameter(
             Mandatory = $false,
             ValueFromPipelinebyPropertyName = $true,
-            ParameterSetName = "path"
+            ParameterSetName = 'path'
         )]
         [boolean]$IsFolder,
 
         [parameter(
             Mandatory = $false,
             ValueFromPipelinebyPropertyName = $true,
-            ParameterSetName = "path"
+            ParameterSetName = 'path'
         )]
         [boolean]$AllowInternalScripts,
 
         [parameter(
             Mandatory = $false,
             ValueFromPipelinebyPropertyName = $true,
-            ParameterSetName = "certificateattr"
+            ParameterSetName = 'certificateattr'
         )]
         [parameter(
             Mandatory = $false,
             ValueFromPipelinebyPropertyName = $true,
-            ParameterSetName = "certificateserialnumber"
+            ParameterSetName = 'certificateserialnumber'
         )]
         [parameter(
             Mandatory = $false,
             ValueFromPipelinebyPropertyName = $true,
-            ParameterSetName = "hash"
+            ParameterSetName = 'hash'
         )]
         [string]$Comment
     )
@@ -132,20 +132,20 @@ function Add-PASApplicationAuthenticationMethod {
         $boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove AppID
 
         #Accepted authtype names match parameterset names
-        $boundParameters.Add("AuthType", $($PSCmdlet.ParameterSetName))
+        $boundParameters.Add('AuthType', $($PSCmdlet.ParameterSetName))
 
         #When parameterset name matches parametername
         If ($boundParameters.ContainsKey($PSCmdlet.ParameterSetName)) {
 
             #Rename hashtable key to "AuthValue"
-            $boundParameters.Add("AuthValue", $boundParameters.$($PSCmdlet.ParameterSetName))
+            $boundParameters.Add('AuthValue', $boundParameters.$($PSCmdlet.ParameterSetName))
             $boundParameters.Remove($($PSCmdlet.ParameterSetName))
 
         }
 
         $Body = @{
 
-            "authentication" = $boundParameters
+            'authentication' = $boundParameters
 
         } | ConvertTo-Json
 

--- a/psPAS/Functions/Applications/Get-PASApplication.ps1
+++ b/psPAS/Functions/Applications/Get-PASApplication.ps1
@@ -49,7 +49,7 @@ function Get-PASApplication {
 		If ($($PSCmdlet.ParameterSetName) -eq 'byAppID') {
 
 			#Build URL from base URL
-			$URI = "$URI/$($AppID | Get-EscapedString)"
+			$URI = "$URI/$($AppID | Get-EscapedString)/"
 
 		}
 

--- a/psPAS/Functions/Applications/Get-PASApplication.ps1
+++ b/psPAS/Functions/Applications/Get-PASApplication.ps1
@@ -5,12 +5,12 @@ function Get-PASApplication {
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byAppID"
+			ParameterSetName = 'byAppID'
 		)]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byQuery"
+			ParameterSetName = 'byQuery'
 		)]
 		[ValidateNotNullOrEmpty()]
 		[string]$AppID,
@@ -18,14 +18,14 @@ function Get-PASApplication {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $false,
-			ParameterSetName = "byAppID"
+			ParameterSetName = 'byAppID'
 		)]
 		[switch]$ExactMatch,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byQuery"
+			ParameterSetName = 'byQuery'
 		)]
 		[ValidateNotNullOrEmpty()]
 		[string]$Location,
@@ -33,7 +33,7 @@ function Get-PASApplication {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byQuery"
+			ParameterSetName = 'byQuery'
 		)]
 		[boolean]$IncludeSublocations
 	)
@@ -46,7 +46,7 @@ function Get-PASApplication {
 		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Applications"
 
 		#If AppID specified
-		If ($($PSCmdlet.ParameterSetName) -eq "byAppID") {
+		If ($($PSCmdlet.ParameterSetName) -eq 'byAppID') {
 
 			#Build URL from base URL
 			$URI = "$URI/$($AppID | Get-EscapedString)"
@@ -54,7 +54,7 @@ function Get-PASApplication {
 		}
 
 		#If search query specified
-		ElseIf ($($PSCmdlet.ParameterSetName) -eq "byQuery") {
+		ElseIf ($($PSCmdlet.ParameterSetName) -eq 'byQuery') {
 
 			#Get Parameters to include in request
 			$boundParameters = $PSBoundParameters | Get-PASParameter

--- a/psPAS/Functions/Applications/Get-PASApplicationAuthenticationMethod.ps1
+++ b/psPAS/Functions/Applications/Get-PASApplicationAuthenticationMethod.ps1
@@ -15,7 +15,7 @@ function Get-PASApplicationAuthenticationMethod {
 
 		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Applications/$($AppID |
 
-            Get-EscapedString)/Authentications"
+            Get-EscapedString)/Authentications/"
 
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
 

--- a/psPAS/Functions/Applications/Remove-PASApplication.ps1
+++ b/psPAS/Functions/Applications/Remove-PASApplication.ps1
@@ -17,7 +17,7 @@ function Remove-PASApplication {
 		#Request URL
 		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Applications/$($AppID | Get-EscapedString)/"
 
-		if ($PSCmdlet.ShouldProcess($AppID, "Delete Application")) {
+		if ($PSCmdlet.ShouldProcess($AppID, 'Delete Application')) {
 
 			#Send Request
 			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession

--- a/psPAS/Functions/Authentication/Add-PASAuthenticationMethod.ps1
+++ b/psPAS/Functions/Authentication/Add-PASAuthenticationMethod.ps1
@@ -1,7 +1,7 @@
 # .ExternalHelp psPAS-help.xml
 Function Add-PASAuthenticationMethod {
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', '', Justification = "passwordFieldLabel not related to password value")]
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUsernameAndPasswordParams', '', Justification = "usernameFieldLabel & passwordFieldLabel not related to password value")]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', '', Justification = 'passwordFieldLabel not related to password value')]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUsernameAndPasswordParams', '', Justification = 'usernameFieldLabel & passwordFieldLabel not related to password value')]
 	[CmdletBinding()]
 	param(
 		[parameter(
@@ -40,7 +40,7 @@ Function Add-PASAuthenticationMethod {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("cyberark", "radius", "ldap")]
+		[ValidateSet('cyberark', 'radius', 'ldap')]
 		[string]$secondFactorAuth,
 
 		[parameter(

--- a/psPAS/Functions/Authentication/Add-PASOpenIDConnectProvider.ps1
+++ b/psPAS/Functions/Authentication/Add-PASOpenIDConnectProvider.ps1
@@ -15,7 +15,7 @@ Function Add-PASOpenIDConnectProvider {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("Code", "Implicit")]
+		[ValidateSet('Code', 'Implicit')]
 		[ValidateNotNullOrEmpty()]
 		[string]$authenticationFlow,
 
@@ -74,7 +74,7 @@ Function Add-PASOpenIDConnectProvider {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("Basic", "Post")]
+		[ValidateSet('Basic', 'Post')]
 		[ValidateLength(1, 50)]
 		[ValidateNotNullOrEmpty()]
 		[string]$clientSecretMethod,
@@ -105,10 +105,10 @@ Function Add-PASOpenIDConnectProvider {
 		$boundParameters = $PSBoundParameters | Get-PASParameter
 
 		#deal with clientSecret SecureString
-		If ($PSBoundParameters.ContainsKey("clientSecret")) {
+		If ($PSBoundParameters.ContainsKey('clientSecret')) {
 
 			#Include decoded clientSecret in request
-			$boundParameters["clientSecret"] = $(ConvertTo-InsecureString -SecureString $clientSecret)
+			$boundParameters['clientSecret'] = $(ConvertTo-InsecureString -SecureString $clientSecret)
 
 		}
 

--- a/psPAS/Functions/Authentication/Add-PASPublicSSHKey.ps1
+++ b/psPAS/Functions/Authentication/Add-PASPublicSSHKey.ps1
@@ -25,7 +25,7 @@ function Add-PASPublicSSHKey {
 		#Create URL to endpoint for request
 		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName |
 
-            Get-EscapedString)/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys"
+            Get-EscapedString)/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys/"
 
 		#create request body
 		$Body = @{

--- a/psPAS/Functions/Authentication/Add-PASPublicSSHKey.ps1
+++ b/psPAS/Functions/Authentication/Add-PASPublicSSHKey.ps1
@@ -6,7 +6,7 @@ function Add-PASPublicSSHKey {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateScript( { $_ -notmatch ".*(%|\&|\+|\.).*" })]
+		[ValidateScript( { $_ -notmatch '.*(%|\&|\+|\.).*' })]
 		[string]$UserName,
 
 		[parameter(
@@ -30,7 +30,7 @@ function Add-PASPublicSSHKey {
 		#create request body
 		$Body = @{
 
-			"PublicSSHKey" = $PublicSSHKey
+			'PublicSSHKey' = $PublicSSHKey
 
 		} | ConvertTo-Json
 
@@ -41,15 +41,16 @@ function Add-PASPublicSSHKey {
 
 			$result.AddUserAuthorizedKeyResult |
 
-			Add-ObjectDetail -typename psPAS.CyberArk.Vault.PublicSSHKey -PropertyToAdd @{
+				Add-ObjectDetail -typename psPAS.CyberArk.Vault.PublicSSHKey -PropertyToAdd @{
 
-				"UserName" = $UserName
+					'UserName' = $UserName
 
-			}
+				}
 
 		}
 
 	}#process
 
 	END { }#end
+
 }

--- a/psPAS/Functions/Authentication/Close-PASSession.ps1
+++ b/psPAS/Functions/Authentication/Close-PASSession.ps1
@@ -1,24 +1,24 @@
 # .ExternalHelp psPAS-help.xml
 function Close-PASSession {
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'UseGen1API', Justification = "False Positive")]
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'SharedAuthentication', Justification = "False Positive")]
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'SAMLAuthentication', Justification = "False Positive")]
-	[CmdletBinding(DefaultParameterSetName = "Gen2")]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'UseGen1API', Justification = 'False Positive')]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'SharedAuthentication', Justification = 'False Positive')]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'SAMLAuthentication', Justification = 'False Positive')]
+	[CmdletBinding(DefaultParameterSetName = 'Gen2')]
 	param(
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $false,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
-		[Alias("UseClassicAPI")]
+		[Alias('UseClassicAPI')]
 		[switch]$UseGen1API,
 
 		[Parameter(
 			Mandatory = $false,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "shared"
+			ParameterSetName = 'shared'
 		)]
 		[switch]$SharedAuthentication,
 
@@ -26,7 +26,7 @@ function Close-PASSession {
 			Mandatory = $false,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "saml"
+			ParameterSetName = 'saml'
 		)]
 		[switch]$SAMLAuthentication
 
@@ -36,28 +36,28 @@ function Close-PASSession {
 
 		Switch ($PSCmdlet.ParameterSetName) {
 
-			"Gen1" {
+			'Gen1' {
 
 				$URI = "$Script:BaseURI/WebServices/auth/Cyberark/CyberArkAuthenticationService.svc/Logoff"
 				break
 
 			}
 
-			"saml" {
+			'saml' {
 
 				$URI = "$Script:BaseURI/WebServices/auth/SAML/SAMLAuthenticationService.svc/Logoff"
 				break
 
 			}
 
-			"shared" {
+			'shared' {
 
 				$URI = "$Script:BaseURI/WebServices/auth/Shared/RestfulAuthenticationService.svc/Logoff"
 				break
 
 			}
 
-			"Gen2" {
+			'Gen2' {
 
 				$URI = "$Script:BaseURI/API/Auth/Logoff"
 				break
@@ -78,7 +78,7 @@ function Close-PASSession {
 	END {
 
 		#Set ExternalVersion to 0.0
-		[System.Version]$Version = "0.0"
+		[System.Version]$Version = '0.0'
 		Set-Variable -Name ExternalVersion -Value $Version -Scope Script -ErrorAction SilentlyContinue
 
 		#Clear Module scope variables on logoff

--- a/psPAS/Functions/Authentication/Get-PASPublicSSHKey.ps1
+++ b/psPAS/Functions/Authentication/Get-PASPublicSSHKey.ps1
@@ -18,7 +18,7 @@ function Get-PASPublicSSHKey {
 		#Create URL for request
 		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName |
 
-            Get-EscapedString)/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys"
+            Get-EscapedString)/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys/"
 
 		#Send request to web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession

--- a/psPAS/Functions/Authentication/Get-PASPublicSSHKey.ps1
+++ b/psPAS/Functions/Authentication/Get-PASPublicSSHKey.ps1
@@ -6,7 +6,7 @@ function Get-PASPublicSSHKey {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateScript( { $_ -notmatch ".*(%|\&|\+|\.).*" })]
+		[ValidateScript( { $_ -notmatch '.*(%|\&|\+|\.).*' })]
 		[string]$UserName
 
 	)
@@ -27,11 +27,11 @@ function Get-PASPublicSSHKey {
 
 			$result.GetUserAuthorizedKeysResult |
 
-			Add-ObjectDetail -typename psPAS.CyberArk.Vault.PublicSSHKey -PropertyToAdd @{
+				Add-ObjectDetail -typename psPAS.CyberArk.Vault.PublicSSHKey -PropertyToAdd @{
 
-				"UserName" = $UserName
+					'UserName' = $UserName
 
-			}
+				}
 
 		}
 

--- a/psPAS/Functions/Authentication/Remove-PASAuthenticationMethod.ps1
+++ b/psPAS/Functions/Authentication/Remove-PASAuthenticationMethod.ps1
@@ -22,7 +22,7 @@ Function Remove-PASAuthenticationMethod {
 		#Create URL for request
 		$URI = "$Script:BaseURI/api/Configuration/AuthenticationMethods/$($id | Get-EscapedString)"
 
-		if ($PSCmdlet.ShouldProcess($id, "Delete Authentication Method")) {
+		if ($PSCmdlet.ShouldProcess($id, 'Delete Authentication Method')) {
 
 			#send request to web service
 			$result = Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession

--- a/psPAS/Functions/Authentication/Remove-PASOpenIDConnectProvider.ps1
+++ b/psPAS/Functions/Authentication/Remove-PASOpenIDConnectProvider.ps1
@@ -23,7 +23,7 @@ Function Remove-PASOpenIDConnectProvider {
 		#Create URL for request
 		$URI = "$Script:BaseURI/api/Configuration/OIDC/Providers/$($id | Get-EscapedString)"
 
-		if ($PSCmdlet.ShouldProcess($id, "Delete OIDC Provider")) {
+		if ($PSCmdlet.ShouldProcess($id, 'Delete OIDC Provider')) {
 
 			#Send request to web service
 			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession

--- a/psPAS/Functions/Authentication/Remove-PASPublicSSHKey.ps1
+++ b/psPAS/Functions/Authentication/Remove-PASPublicSSHKey.ps1
@@ -6,7 +6,7 @@ function Remove-PASPublicSSHKey {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateScript( { $_ -notmatch ".*(%|\&|\+|\.).*" })]
+		[ValidateScript( { $_ -notmatch '.*(%|\&|\+|\.).*' })]
 		[string]$UserName,
 
 		[parameter(
@@ -26,7 +26,7 @@ function Remove-PASPublicSSHKey {
 
             Get-EscapedString)/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys/$KeyID"
 
-		if ($PSCmdlet.ShouldProcess($KeyID, "Delete Public SSH Key")) {
+		if ($PSCmdlet.ShouldProcess($KeyID, 'Delete Public SSH Key')) {
 
 			#Send Request to web service
 			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
@@ -36,4 +36,5 @@ function Remove-PASPublicSSHKey {
 	}#process
 
 	END { }#end
+
 }

--- a/psPAS/Functions/Authentication/Remove-PASPublicSSHKey.ps1
+++ b/psPAS/Functions/Authentication/Remove-PASPublicSSHKey.ps1
@@ -24,7 +24,7 @@ function Remove-PASPublicSSHKey {
 		#Create URL string for request
 		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName |
 
-            Get-EscapedString)/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys/$KeyID"
+            Get-EscapedString)/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys/$KeyID/"
 
 		if ($PSCmdlet.ShouldProcess($KeyID, 'Delete Public SSH Key')) {
 

--- a/psPAS/Functions/Authentication/Set-PASAuthenticationMethod.ps1
+++ b/psPAS/Functions/Authentication/Set-PASAuthenticationMethod.ps1
@@ -1,7 +1,7 @@
 # .ExternalHelp psPAS-help.xml
 Function Set-PASAuthenticationMethod {
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', '', Justification = "passwordFieldLabel not related to password value")]
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUsernameAndPasswordParams', '', Justification = "usernameFieldLabel & passwordFieldLabel not related to password value")]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', '', Justification = 'passwordFieldLabel not related to password value')]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUsernameAndPasswordParams', '', Justification = 'usernameFieldLabel & passwordFieldLabel not related to password value')]
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
 		[parameter(
@@ -40,7 +40,7 @@ Function Set-PASAuthenticationMethod {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("cyberark", "radius", "ldap")]
+		[ValidateSet('cyberark', 'radius', 'ldap')]
 		[string]$secondFactorAuth,
 
 		[parameter(
@@ -79,13 +79,12 @@ Function Set-PASAuthenticationMethod {
 		#Request body
 		$Body = $PSBoundParameters | Get-PASParameter -ParametersToRemove ID | ConvertTo-Json
 
-		if ($PSCmdlet.ShouldProcess($ID, "Update Authentication Method")) {
+		if ($PSCmdlet.ShouldProcess($ID, 'Update Authentication Method')) {
 
 			#send request to web service
 			$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body -WebSession $Script:WebSession
 
 		}
-
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/Authentication/Set-PASOpenIDConnectProvider.ps1
+++ b/psPAS/Functions/Authentication/Set-PASOpenIDConnectProvider.ps1
@@ -15,7 +15,7 @@ Function Set-PASOpenIDConnectProvider {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("Code", "Implicit")]
+		[ValidateSet('Code', 'Implicit')]
 		[ValidateNotNullOrEmpty()]
 		[string]$authenticationFlow,
 
@@ -74,7 +74,7 @@ Function Set-PASOpenIDConnectProvider {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("Basic", "Post")]
+		[ValidateSet('Basic', 'Post')]
 		[ValidateLength(1, 50)]
 		[ValidateNotNullOrEmpty()]
 		[string]$clientSecretMethod,
@@ -105,17 +105,17 @@ Function Set-PASOpenIDConnectProvider {
 		$boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove id
 
 		#deal with clientSecret SecureString
-		If ($PSBoundParameters.ContainsKey("clientSecret")) {
+		If ($PSBoundParameters.ContainsKey('clientSecret')) {
 
 			#Include decoded clientSecret in request
-			$boundParameters["clientSecret"] = $(ConvertTo-InsecureString -SecureString $clientSecret)
+			$boundParameters['clientSecret'] = $(ConvertTo-InsecureString -SecureString $clientSecret)
 
 		}
 
 		#Create body of request
 		$body = $boundParameters | ConvertTo-Json
 
-		if ($PSCmdlet.ShouldProcess($id, "Update OIDC Provider")) {
+		if ($PSCmdlet.ShouldProcess($id, 'Update OIDC Provider')) {
 
 			#send request to web service
 			$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $body -WebSession $Script:WebSession

--- a/psPAS/Functions/Connections/Import-PASConnectionComponent.ps1
+++ b/psPAS/Functions/Connections/Import-PASConnectionComponent.ps1
@@ -25,9 +25,9 @@ function Import-PASConnectionComponent {
 		$FileBytes = $ImportFile | Get-ByteArray
 
 		#Create Request Body
-		$Body = @{"ImportFile" = $FileBytes } | ConvertTo-Json
+		$Body = @{'ImportFile' = $FileBytes } | ConvertTo-Json
 
-		if ($PSCmdlet.ShouldProcess($ImportFile, "Imports Connection Component")) {
+		if ($PSCmdlet.ShouldProcess($ImportFile, 'Imports Connection Component')) {
 
 			#send request to web service
 			Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession -Debug:$false

--- a/psPAS/Functions/EventSecurity/Add-PASPTARule.ps1
+++ b/psPAS/Functions/EventSecurity/Add-PASPTARule.ps1
@@ -6,7 +6,7 @@ Function Add-PASPTARule {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("SSH", "WINDOWS", "SCP", "KEYSTROKES", "SQL")]
+		[ValidateSet('SSH', 'WINDOWS', 'SCP', 'KEYSTROKES', 'SQL')]
 		[string]$category,
 
 		[parameter(
@@ -32,7 +32,7 @@ Function Add-PASPTARule {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("NONE", "TERMINATE", "SUSPEND")]
+		[ValidateSet('NONE', 'TERMINATE', 'SUSPEND')]
 		[string]$response,
 
 		[parameter(
@@ -67,11 +67,12 @@ Function Add-PASPTARule {
 		If ($null -ne $result) {
 
 			#Return Results
-			$result | Add-ObjectDetail -typename "psPAS.CyberArk.Vault.PTA.Rule"
+			$result | Add-ObjectDetail -typename 'psPAS.CyberArk.Vault.PTA.Rule'
 
 		}
 
 	}#process
 
 	END { }#end
+
 }

--- a/psPAS/Functions/EventSecurity/Get-PASPTAEvent.ps1
+++ b/psPAS/Functions/EventSecurity/Get-PASPTAEvent.ps1
@@ -1,43 +1,43 @@
 # .ExternalHelp psPAS-help.xml
 Function Get-PASPTAEvent {
-	[CmdletBinding(DefaultParameterSetName = "11.3")]
+	[CmdletBinding(DefaultParameterSetName = '11.3')]
 	param(
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "11.4"
+			ParameterSetName = '11.4'
 		)]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "11.3"
+			ParameterSetName = '11.3'
 		)]
 		[datetime]$fromUpdateDate,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "11.3"
+			ParameterSetName = '11.3'
 		)]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "11.4"
+			ParameterSetName = '11.4'
 		)]
-		[ValidateSet("OPEN", "CLOSED")]
+		[ValidateSet('OPEN', 'CLOSED')]
 		[string]$status,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "11.4"
+			ParameterSetName = '11.4'
 		)]
 		[string]$accountID,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "10.3"
+			ParameterSetName = '10.3'
 		)]
 		[datetime]$lastUpdatedEventDate
 
@@ -59,14 +59,14 @@ Function Get-PASPTAEvent {
 
 		switch ($PSCmdlet.ParameterSetName) {
 
-			"10.3" {
+			'10.3' {
 
-				if ($PSBoundParameters.ContainsKey("lastUpdatedEventDate")) {
+				if ($PSBoundParameters.ContainsKey('lastUpdatedEventDate')) {
 
 					#add Unix Time Stamp of lastUpdatedEventDate to header as key=value pair
-					$boundParameters["lastUpdatedEventDate"] = $lastUpdatedEventDate | ConvertTo-UnixTime
+					$boundParameters['lastUpdatedEventDate'] = $lastUpdatedEventDate | ConvertTo-UnixTime
 
-					$ThisSession.Headers["lastUpdatedEventDate"] = $boundParameters["lastUpdatedEventDate"]
+					$ThisSession.Headers['lastUpdatedEventDate'] = $boundParameters['lastUpdatedEventDate']
 
 				}
 
@@ -76,10 +76,10 @@ Function Get-PASPTAEvent {
 
 			default {
 
-				if ($PSBoundParameters.ContainsKey("fromUpdateDate")) {
+				if ($PSBoundParameters.ContainsKey('fromUpdateDate')) {
 
 					#Include time as unixtimestamp in milliseconds
-					$boundParameters["fromUpdateDate"] = $fromUpdateDate | ConvertTo-UnixTime -Milliseconds
+					$boundParameters['fromUpdateDate'] = $fromUpdateDate | ConvertTo-UnixTime -Milliseconds
 
 				}
 

--- a/psPAS/Functions/EventSecurity/Get-PASPTARemediation.ps1
+++ b/psPAS/Functions/EventSecurity/Get-PASPTARemediation.ps1
@@ -25,4 +25,5 @@ Function Get-PASPTARemediation {
 	}#process
 
 	END { }#end
+
 }

--- a/psPAS/Functions/EventSecurity/Get-PASPTARule.ps1
+++ b/psPAS/Functions/EventSecurity/Get-PASPTARule.ps1
@@ -25,4 +25,5 @@ Function Get-PASPTARule {
 	}#process
 
 	END { }#end
+
 }

--- a/psPAS/Functions/EventSecurity/Set-PASPTAEvent.ps1
+++ b/psPAS/Functions/EventSecurity/Set-PASPTAEvent.ps1
@@ -12,7 +12,7 @@ Function Set-PASPTAEvent {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("OPEN", "CLOSED")]
+		[ValidateSet('OPEN', 'CLOSED')]
 		[string]$mStatus
 
 	)
@@ -29,7 +29,7 @@ Function Set-PASPTAEvent {
 		#Get Parameters to include in request
 		$body = $PSBoundParameters | Get-PASParameter -ParametersToRemove EventID | ConvertTo-Json
 
-		if ($PSCmdlet.ShouldProcess($EventID, "Update Event Status")) {
+		if ($PSCmdlet.ShouldProcess($EventID, 'Update Event Status')) {
 
 			#Send request to web service
 			$result = Invoke-PASRestMethod -Uri $URI -Method PATCH -Body $body

--- a/psPAS/Functions/EventSecurity/Set-PASPTARemediation.ps1
+++ b/psPAS/Functions/EventSecurity/Set-PASPTARemediation.ps1
@@ -46,7 +46,7 @@ Function Set-PASPTARemediation {
 		#Create body of request
 		$body = $boundParameters | ConvertTo-Json
 
-		if ($PSCmdlet.ShouldProcess("PTA", "Update Automatic Remediation Config")) {
+		if ($PSCmdlet.ShouldProcess('PTA', 'Update Automatic Remediation Config')) {
 
 			#send request to PAS web service
 			$result = Invoke-PASRestMethod -Uri $URI -Method PATCH -Body $Body -WebSession $Script:WebSession
@@ -54,7 +54,7 @@ Function Set-PASPTARemediation {
 			If ($null -ne $result) {
 
 				#Return Results
-				$result.automaticRemediation | Add-ObjectDetail -typename "psPAS.CyberArk.Vault.PTA.Remediation"
+				$result.automaticRemediation | Add-ObjectDetail -typename 'psPAS.CyberArk.Vault.PTA.Remediation'
 
 			}
 

--- a/psPAS/Functions/EventSecurity/Set-PASPTARule.ps1
+++ b/psPAS/Functions/EventSecurity/Set-PASPTARule.ps1
@@ -12,7 +12,7 @@ Function Set-PASPTARule {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("SSH", "WINDOWS", "SCP", "KEYSTROKES", "SQL")]
+		[ValidateSet('SSH', 'WINDOWS', 'SCP', 'KEYSTROKES', 'SQL')]
 		[string]$category,
 
 		[parameter(
@@ -38,7 +38,7 @@ Function Set-PASPTARule {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("NONE", "TERMINATE", "SUSPEND")]
+		[ValidateSet('NONE', 'TERMINATE', 'SUSPEND')]
 		[string]$response,
 
 		[parameter(
@@ -66,7 +66,7 @@ Function Set-PASPTARule {
 		#Create body of request
 		$body = $boundParameters | ConvertTo-Json
 
-		if ($PSCmdlet.ShouldProcess($id, "Update Risky Activity Rule")) {
+		if ($PSCmdlet.ShouldProcess($id, 'Update Risky Activity Rule')) {
 
 			#send request to PAS web service
 			Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body -WebSession $Script:WebSession
@@ -76,4 +76,5 @@ Function Set-PASPTARule {
 	}#process
 
 	END { }#end
+
 }

--- a/psPAS/Functions/LDAPDirectories/Add-PASDirectory.ps1
+++ b/psPAS/Functions/LDAPDirectories/Add-PASDirectory.ps1
@@ -1,60 +1,60 @@
 # .ExternalHelp psPAS-help.xml
 function Add-PASDirectory {
 	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlaintextForPassword', '', Justification = "It's a path to password object")]
-	[CmdletBinding(DefaultParameterSetName = "10.4")]
+	[CmdletBinding(DefaultParameterSetName = '10.4')]
 	param(
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "10.4"
+			ParameterSetName = '10.4'
 		)]
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "10.7"
+			ParameterSetName = '10.7'
 		)]
 		[string]$DirectoryType,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "10.4"
+			ParameterSetName = '10.4'
 		)]
 		[string[]]$HostAddresses,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "10.4"
+			ParameterSetName = '10.4'
 		)]
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "10.7"
+			ParameterSetName = '10.7'
 		)]
 		[string]$BindUsername,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "10.4"
+			ParameterSetName = '10.4'
 		)]
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "10.7"
+			ParameterSetName = '10.7'
 		)]
 		[securestring]$BindPassword,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "10.4"
+			ParameterSetName = '10.4'
 		)]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "10.7"
+			ParameterSetName = '10.7'
 		)]
 		[ValidateRange(1, 65535)]
 		[int]$Port,
@@ -62,43 +62,43 @@ function Add-PASDirectory {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "10.7"
+			ParameterSetName = '10.7'
 		)]
 		[hashtable[]]$DCList,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "10.4"
+			ParameterSetName = '10.4'
 		)]
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "10.7"
+			ParameterSetName = '10.7'
 		)]
 		[string]$DomainName,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "10.4"
+			ParameterSetName = '10.4'
 		)]
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "10.7"
+			ParameterSetName = '10.7'
 		)]
 		[string]$DomainBaseContext,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "10.4"
+			ParameterSetName = '10.4'
 		)]
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "10.7"
+			ParameterSetName = '10.7'
 		)]
 		[boolean]$SSLConnect
 
@@ -119,10 +119,10 @@ function Add-PASDirectory {
 		$boundParameters = $PSBoundParameters | Get-PASParameter
 
 		#deal with BindPassword SecureString
-		If ($PSBoundParameters.ContainsKey("BindPassword")) {
+		If ($PSBoundParameters.ContainsKey('BindPassword')) {
 
 			#Include decoded bind password in request
-			$boundParameters["BindPassword"] = $(ConvertTo-InsecureString -SecureString $BindPassword)
+			$boundParameters['BindPassword'] = $(ConvertTo-InsecureString -SecureString $BindPassword)
 
 		}
 
@@ -141,4 +141,5 @@ function Add-PASDirectory {
 	}#process
 
 	END { }#end
+
 }

--- a/psPAS/Functions/LDAPDirectories/Get-PASDirectory.ps1
+++ b/psPAS/Functions/LDAPDirectories/Get-PASDirectory.ps1
@@ -5,9 +5,9 @@ function Get-PASDirectory {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "id"
+			ParameterSetName = 'id'
 		)]
-		[Alias("DomainName")]
+		[Alias('DomainName')]
 		[string]$id
 
 	)
@@ -25,14 +25,14 @@ function Get-PASDirectory {
 
 		switch ($PSCmdlet.ParameterSetName) {
 
-			"id" {
+			'id' {
 
 				Assert-VersionRequirement -RequiredVersion 10.5
 
 				#Update URL for request
 				$URI = "$URI/$id/"
 
-				$type = "psPAS.CyberArk.Vault.Directory.Extended"
+				$type = 'psPAS.CyberArk.Vault.Directory.Extended'
 
 				break
 
@@ -40,7 +40,7 @@ function Get-PASDirectory {
 
 			default {
 
-				$type = "psPAS.CyberArk.Vault.Directory"
+				$type = 'psPAS.CyberArk.Vault.Directory'
 
 				break
 
@@ -61,4 +61,5 @@ function Get-PASDirectory {
 	}#process
 
 	END { }#end
+
 }

--- a/psPAS/Functions/LDAPDirectories/Get-PASDirectoryMapping.ps1
+++ b/psPAS/Functions/LDAPDirectories/Get-PASDirectoryMapping.ps1
@@ -31,12 +31,12 @@ function Get-PASDirectoryMapping {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/Configuration/LDAP/Directories/$DirectoryName/Mappings"
+		$URI = "$Script:BaseURI/api/Configuration/LDAP/Directories/$DirectoryName/Mappings/"
 
 		if ($PSCmdlet.ParameterSetName -eq 'Mapping') {
 
 			#Update URL for request
-			$URI = "$URI/$MappingID"
+			$URI = "$URI$MappingID/"
 
 		}
 

--- a/psPAS/Functions/LDAPDirectories/Get-PASDirectoryMapping.ps1
+++ b/psPAS/Functions/LDAPDirectories/Get-PASDirectoryMapping.ps1
@@ -1,24 +1,24 @@
 # .ExternalHelp psPAS-help.xml
 function Get-PASDirectoryMapping {
-	[CmdletBinding(DefaultParameterSetName = "All")]
+	[CmdletBinding(DefaultParameterSetName = 'All')]
 	param(
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "All"
+			ParameterSetName = 'All'
 		)]
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Mapping"
+			ParameterSetName = 'Mapping'
 		)]
-		[Alias("DomainName")]
+		[Alias('DomainName')]
 		[string]$DirectoryName,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Mapping"
+			ParameterSetName = 'Mapping'
 		)]
 		[string]$MappingID
 
@@ -33,7 +33,7 @@ function Get-PASDirectoryMapping {
 		#Create URL for request
 		$URI = "$Script:BaseURI/api/Configuration/LDAP/Directories/$DirectoryName/Mappings"
 
-		if ($PSCmdlet.ParameterSetName -eq "Mapping") {
+		if ($PSCmdlet.ParameterSetName -eq 'Mapping') {
 
 			#Update URL for request
 			$URI = "$URI/$MappingID"
@@ -53,4 +53,5 @@ function Get-PASDirectoryMapping {
 	}#process
 
 	END { }#end
+
 }

--- a/psPAS/Functions/LDAPDirectories/New-PASDirectoryMapping.ps1
+++ b/psPAS/Functions/LDAPDirectories/New-PASDirectoryMapping.ps1
@@ -75,7 +75,7 @@ function New-PASDirectoryMapping {
 			'MappingAuthorizations' {
 
 				#Transform MappingAuthorizations
-				$boundParameters.Add("MappingAuthorizations", [array][int]$MappingAuthorizations)
+				$boundParameters.Add('MappingAuthorizations', [array][int]$MappingAuthorizations)
 				Continue
 
 			}
@@ -88,7 +88,7 @@ function New-PASDirectoryMapping {
 
 			}
 
-			{ $_ -match "VaultGroups|Location|LDAPQuery" } {
+			{ $_ -match 'VaultGroups|Location|LDAPQuery' } {
 
 				#v10.7
 				Assert-VersionRequirement -RequiredVersion 10.7
@@ -110,7 +110,7 @@ function New-PASDirectoryMapping {
 
 		$body = $boundParameters | ConvertTo-Json
 
-		if ($PSCmdlet.ShouldProcess($MappingName, "Create Directory Mapping")) {
+		if ($PSCmdlet.ShouldProcess($MappingName, 'Create Directory Mapping')) {
 
 			#send request to web service
 			$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession

--- a/psPAS/Functions/LDAPDirectories/New-PASDirectoryMapping.ps1
+++ b/psPAS/Functions/LDAPDirectories/New-PASDirectoryMapping.ps1
@@ -106,7 +106,7 @@ function New-PASDirectoryMapping {
 		}
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/Configuration/LDAP/Directories/$DirectoryName/Mappings"
+		$URI = "$Script:BaseURI/api/Configuration/LDAP/Directories/$DirectoryName/Mappings/"
 
 		$body = $boundParameters | ConvertTo-Json
 

--- a/psPAS/Functions/LDAPDirectories/Remove-PASDirectory.ps1
+++ b/psPAS/Functions/LDAPDirectories/Remove-PASDirectory.ps1
@@ -18,7 +18,7 @@ function Remove-PASDirectory {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/Configuration/LDAP/Directories/$id"
+		$URI = "$Script:BaseURI/api/Configuration/LDAP/Directories/$id/"
 
 		if ($PSCmdlet.ShouldProcess($id, 'Delete Directory')) {
 

--- a/psPAS/Functions/LDAPDirectories/Remove-PASDirectory.ps1
+++ b/psPAS/Functions/LDAPDirectories/Remove-PASDirectory.ps1
@@ -6,7 +6,7 @@ function Remove-PASDirectory {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[Alias("DomainName")]
+		[Alias('DomainName')]
 		[string]$id
 
 	)
@@ -20,7 +20,7 @@ function Remove-PASDirectory {
 		#Create URL for request
 		$URI = "$Script:BaseURI/api/Configuration/LDAP/Directories/$id"
 
-		if ($PSCmdlet.ShouldProcess($id, "Delete Directory")) {
+		if ($PSCmdlet.ShouldProcess($id, 'Delete Directory')) {
 
 			#send request to web service
 			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
@@ -30,4 +30,5 @@ function Remove-PASDirectory {
 	}#process
 
 	END { }#end
+
 }

--- a/psPAS/Functions/LDAPDirectories/Remove-PASDirectoryMapping.ps1
+++ b/psPAS/Functions/LDAPDirectories/Remove-PASDirectoryMapping.ps1
@@ -24,7 +24,7 @@ function Remove-PASDirectoryMapping {
 		#Create URL for request
 		$URI = "$Script:BaseURI/api/Configuration/LDAP/Directories/$DirectoryName/Mappings/$MappingID"
 
-		if ($PSCmdlet.ShouldProcess($MappingID, "Delete Directory Mapping")) {
+		if ($PSCmdlet.ShouldProcess($MappingID, 'Delete Directory Mapping')) {
 
 			#send request to web service
 			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
@@ -34,4 +34,5 @@ function Remove-PASDirectoryMapping {
 	}#process
 
 	END { }#end
+
 }

--- a/psPAS/Functions/LDAPDirectories/Remove-PASDirectoryMapping.ps1
+++ b/psPAS/Functions/LDAPDirectories/Remove-PASDirectoryMapping.ps1
@@ -22,7 +22,7 @@ function Remove-PASDirectoryMapping {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/Configuration/LDAP/Directories/$DirectoryName/Mappings/$MappingID"
+		$URI = "$Script:BaseURI/api/Configuration/LDAP/Directories/$DirectoryName/Mappings/$MappingID/"
 
 		if ($PSCmdlet.ShouldProcess($MappingID, 'Delete Directory Mapping')) {
 

--- a/psPAS/Functions/LDAPDirectories/Set-PASDirectoryMapping.ps1
+++ b/psPAS/Functions/LDAPDirectories/Set-PASDirectoryMapping.ps1
@@ -100,7 +100,7 @@ function Set-PASDirectoryMapping {
 		}
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/Configuration/LDAP/Directories/$DirectoryName/Mappings/$MappingID"
+		$URI = "$Script:BaseURI/api/Configuration/LDAP/Directories/$DirectoryName/Mappings/$MappingID/"
 
 		$body = $boundParameters | ConvertTo-Json
 

--- a/psPAS/Functions/LDAPDirectories/Set-PASDirectoryMapping.ps1
+++ b/psPAS/Functions/LDAPDirectories/Set-PASDirectoryMapping.ps1
@@ -84,7 +84,7 @@ function Set-PASDirectoryMapping {
 			'MappingAuthorizations' {
 
 				#Transform MappingAuthorizations
-				$boundParameters.Add("MappingAuthorizations", [array][int]$MappingAuthorizations)
+				$boundParameters.Add('MappingAuthorizations', [array][int]$MappingAuthorizations)
 				Continue
 
 			}
@@ -104,7 +104,7 @@ function Set-PASDirectoryMapping {
 
 		$body = $boundParameters | ConvertTo-Json
 
-		if ($PSCmdlet.ShouldProcess($MappingID, "Update Directory Mapping")) {
+		if ($PSCmdlet.ShouldProcess($MappingID, 'Update Directory Mapping')) {
 
 			#send request to web service
 			$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body -WebSession $Script:WebSession
@@ -121,4 +121,5 @@ function Set-PASDirectoryMapping {
 	}#process
 
 	END { }#end
+
 }

--- a/psPAS/Functions/LDAPDirectories/Set-PASDirectoryMappingOrder.ps1
+++ b/psPAS/Functions/LDAPDirectories/Set-PASDirectoryMappingOrder.ps1
@@ -29,7 +29,7 @@ function Set-PASDirectoryMappingOrder {
 		#Get request parameters
 		$body = $($PSBoundParameters | Get-PASParameter -ParametersToRemove DirectoryName) | ConvertTo-Json
 
-		if ($PSCmdlet.ShouldProcess($DirectoryName, "Update Directory Mapping Order")) {
+		if ($PSCmdlet.ShouldProcess($DirectoryName, 'Update Directory Mapping Order')) {
 
 			#send request to web service
 			Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession

--- a/psPAS/Functions/LDAPDirectories/Set-PASDirectoryMappingOrder.ps1
+++ b/psPAS/Functions/LDAPDirectories/Set-PASDirectoryMappingOrder.ps1
@@ -24,7 +24,7 @@ function Set-PASDirectoryMappingOrder {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/Configuration/LDAP/Directories/$DirectoryName/Mappings/Reorder"
+		$URI = "$Script:BaseURI/api/Configuration/LDAP/Directories/$DirectoryName/Mappings/Reorder/"
 
 		#Get request parameters
 		$body = $($PSBoundParameters | Get-PASParameter -ParametersToRemove DirectoryName) | ConvertTo-Json

--- a/psPAS/Functions/Monitoring/Connect-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Connect-PASPSMSession.ps1
@@ -13,7 +13,7 @@ function Connect-PASPSMSession {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("RDP", "PSMGW")]
+		[ValidateSet('RDP', 'PSMGW')]
 		[string]$ConnectionMethod
 	)
 
@@ -29,24 +29,23 @@ function Connect-PASPSMSession {
 		$ThisSession = $Script:WebSession
 
 		#if a connection method is specified
-		If ($PSBoundParameters.ContainsKey("ConnectionMethod")) {
+		If ($PSBoundParameters.ContainsKey('ConnectionMethod')) {
 
 			#The information needs to passed in the header
-			if ($PSBoundParameters["ConnectionMethod"] -eq "RDP") {
+			if ($PSBoundParameters['ConnectionMethod'] -eq 'RDP') {
 
 				#RDP accept "application/json" response
-				$Accept = "application/json"
+				$Accept = 'application/json'
 
-			}
-			elseif ($PSBoundParameters["ConnectionMethod"] -eq "PSMGW") {
+			} elseif ($PSBoundParameters['ConnectionMethod'] -eq 'PSMGW') {
 
 				#PSMGW accept * / * response
-				$Accept = "* / *"
+				$Accept = '* / *'
 
 			}
 
 			#add detail to header
-			$ThisSession.Headers["Accept"] = $Accept
+			$ThisSession.Headers['Accept'] = $Accept
 
 		}
 

--- a/psPAS/Functions/Monitoring/Get-PASPSMRecording.ps1
+++ b/psPAS/Functions/Monitoring/Get-PASPSMRecording.ps1
@@ -1,18 +1,18 @@
 # .ExternalHelp psPAS-help.xml
 function Get-PASPSMRecording {
-	[CmdletBinding(DefaultParameterSetName = "byQuery")]
+	[CmdletBinding(DefaultParameterSetName = 'byQuery')]
 	param(
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byRecordingID"
+			ParameterSetName = 'byRecordingID'
 		)]
 		[string]$RecordingID,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byQuery"
+			ParameterSetName = 'byQuery'
 		)]
 		[ValidateNotNullOrEmpty()]
 		[int]$Limit,
@@ -20,55 +20,55 @@ function Get-PASPSMRecording {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byQuery"
+			ParameterSetName = 'byQuery'
 		)]
-		[ValidateSet("RiskScore", "FileName", "SafeName", "FolderName", "PSMVaultUserName", "FromIP", "RemoteMachine",
-			"Client", "Protocol", "AccountUserName", "AccountAddress", "AccountPlatformID", "PSMStartTime", "TicketID",
-			"-RiskScore", "-FileName", "-SafeName", "-FolderName", "-PSMVaultUserName", "-FromIP", "-RemoteMachine",
-			"-Client", "-Protocol", "-AccountUserName", "-AccountAddress", "-AccountPlatformID", "-PSMStartTime",
-			"-TicketID"
+		[ValidateSet('RiskScore', 'FileName', 'SafeName', 'FolderName', 'PSMVaultUserName', 'FromIP', 'RemoteMachine',
+			'Client', 'Protocol', 'AccountUserName', 'AccountAddress', 'AccountPlatformID', 'PSMStartTime', 'TicketID',
+			'-RiskScore', '-FileName', '-SafeName', '-FolderName', '-PSMVaultUserName', '-FromIP', '-RemoteMachine',
+			'-Client', '-Protocol', '-AccountUserName', '-AccountAddress', '-AccountPlatformID', '-PSMStartTime',
+			'-TicketID'
 		)]
 		[string]$Sort,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byQuery"
+			ParameterSetName = 'byQuery'
 		)]
 		[int]$Offset,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byQuery"
+			ParameterSetName = 'byQuery'
 		)]
 		[string]$Search,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byQuery"
+			ParameterSetName = 'byQuery'
 		)]
 		[string]$Safe,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byQuery"
+			ParameterSetName = 'byQuery'
 		)]
 		[int]$FromTime,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byQuery"
+			ParameterSetName = 'byQuery'
 		)]
 		[int]$ToTime,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byQuery"
+			ParameterSetName = 'byQuery'
 		)]
 		[string]$Activities
 	)
@@ -84,7 +84,7 @@ function Get-PASPSMRecording {
 
 		switch ($PSCmdlet.ParameterSetName) {
 
-			"byRecordingID" {
+			'byRecordingID' {
 				Assert-VersionRequirement -RequiredVersion 10.6
 
 				$URI = "$URI/$RecordingID"
@@ -93,7 +93,7 @@ function Get-PASPSMRecording {
 
 			}
 
-			"byQuery" {
+			'byQuery' {
 				#Get Parameters to include in request
 				$boundParameters = $PSBoundParameters | Get-PASParameter
 

--- a/psPAS/Functions/Monitoring/Get-PASPSMRecordingActivity.ps1
+++ b/psPAS/Functions/Monitoring/Get-PASPSMRecordingActivity.ps1
@@ -6,7 +6,7 @@ function Get-PASPSMRecordingActivity {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[Alias("SessionID")]
+		[Alias('SessionID')]
 		[string]$RecordingID
 	)
 

--- a/psPAS/Functions/Monitoring/Get-PASPSMRecordingProperty.ps1
+++ b/psPAS/Functions/Monitoring/Get-PASPSMRecordingProperty.ps1
@@ -6,7 +6,7 @@ function Get-PASPSMRecordingProperty {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[Alias("SessionID")]
+		[Alias('SessionID')]
 		[string]$RecordingID
 	)
 

--- a/psPAS/Functions/Monitoring/Get-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Get-PASPSMSession.ps1
@@ -1,18 +1,18 @@
 # .ExternalHelp psPAS-help.xml
 function Get-PASPSMSession {
-	[CmdletBinding(DefaultParameterSetName = "byQuery")]
+	[CmdletBinding(DefaultParameterSetName = 'byQuery')]
 	param(
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "bySessionID"
+			ParameterSetName = 'bySessionID'
 		)]
 		[string]$liveSessionId,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byQuery"
+			ParameterSetName = 'byQuery'
 		)]
 		[ValidateNotNullOrEmpty()]
 		[int]$Limit,
@@ -20,55 +20,55 @@ function Get-PASPSMSession {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byQuery"
+			ParameterSetName = 'byQuery'
 		)]
-		[ValidateSet("RiskScore", "FileName", "SafeName", "FolderName", "PSMVaultUserName", "FromIP", "RemoteMachine",
-			"Client", "Protocol", "AccountUserName", "AccountAddress", "AccountPlatformID", "PSMStartTime", "TicketID",
-			"-RiskScore", "-FileName", "-SafeName", "-FolderName", "-PSMVaultUserName", "-FromIP", "-RemoteMachine",
-			"-Client", "-Protocol", "-AccountUserName", "-AccountAddress", "-AccountPlatformID", "-PSMStartTime",
-			"-TicketID"
+		[ValidateSet('RiskScore', 'FileName', 'SafeName', 'FolderName', 'PSMVaultUserName', 'FromIP', 'RemoteMachine',
+			'Client', 'Protocol', 'AccountUserName', 'AccountAddress', 'AccountPlatformID', 'PSMStartTime', 'TicketID',
+			'-RiskScore', '-FileName', '-SafeName', '-FolderName', '-PSMVaultUserName', '-FromIP', '-RemoteMachine',
+			'-Client', '-Protocol', '-AccountUserName', '-AccountAddress', '-AccountPlatformID', '-PSMStartTime',
+			'-TicketID'
 		)]
 		[string]$Sort,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byQuery"
+			ParameterSetName = 'byQuery'
 		)]
 		[int]$Offset,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byQuery"
+			ParameterSetName = 'byQuery'
 		)]
 		[string]$Search,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byQuery"
+			ParameterSetName = 'byQuery'
 		)]
 		[string]$Safe,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byQuery"
+			ParameterSetName = 'byQuery'
 		)]
 		[int]$FromTime,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byQuery"
+			ParameterSetName = 'byQuery'
 		)]
 		[int]$ToTime,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "byQuery"
+			ParameterSetName = 'byQuery'
 		)]
 		[string]$Activities
 	)
@@ -84,7 +84,7 @@ function Get-PASPSMSession {
 
 		switch ($PSCmdlet.ParameterSetName) {
 
-			"bySessionID" {
+			'bySessionID' {
 				Assert-VersionRequirement -RequiredVersion 10.6
 
 				$URI = "$URI/$liveSessionId"
@@ -93,7 +93,7 @@ function Get-PASPSMSession {
 
 			}
 
-			"byQuery" {
+			'byQuery' {
 				#Get Parameters to include in request
 				$boundParameters = $PSBoundParameters | Get-PASParameter
 

--- a/psPAS/Functions/Monitoring/Get-PASPSMSessionActivity.ps1
+++ b/psPAS/Functions/Monitoring/Get-PASPSMSessionActivity.ps1
@@ -6,7 +6,7 @@ function Get-PASPSMSessionActivity {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[Alias("SessionID")]
+		[Alias('SessionID')]
 		[string]$liveSessionId
 	)
 

--- a/psPAS/Functions/Monitoring/Get-PASPSMSessionProperty.ps1
+++ b/psPAS/Functions/Monitoring/Get-PASPSMSessionProperty.ps1
@@ -6,7 +6,7 @@ function Get-PASPSMSessionProperty {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[Alias("SessionID")]
+		[Alias('SessionID')]
 		[string]$liveSessionId
 	)
 

--- a/psPAS/Functions/Monitoring/Resume-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Resume-PASPSMSession.ps1
@@ -7,7 +7,7 @@ function Resume-PASPSMSession {
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateNotNullOrEmpty()]
-		[Alias("SessionGuid")]
+		[Alias('SessionGuid')]
 		[string]$LiveSessionId
 	)
 
@@ -20,7 +20,7 @@ function Resume-PASPSMSession {
 		#Create URL for Request
 		$URI = "$Script:BaseURI/api/LiveSessions/$($LiveSessionId | Get-EscapedString)/Resume"
 
-		if ($PSCmdlet.ShouldProcess($LiveSessionId, "Resume PSM Session")) {
+		if ($PSCmdlet.ShouldProcess($LiveSessionId, 'Resume PSM Session')) {
 
 			#send request to PAS web service
 			Invoke-PASRestMethod -Uri $URI -Method POST -WebSession $Script:WebSession

--- a/psPAS/Functions/Monitoring/Stop-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Stop-PASPSMSession.ps1
@@ -7,7 +7,7 @@ function Stop-PASPSMSession {
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateNotNullOrEmpty()]
-		[Alias("SessionGuid")]
+		[Alias('SessionGuid')]
 		[string]$LiveSessionId
 	)
 
@@ -20,7 +20,7 @@ function Stop-PASPSMSession {
 		#Create URL for Request
 		$URI = "$Script:BaseURI/api/LiveSessions/$($LiveSessionId | Get-EscapedString)/Terminate"
 
-		if ($PSCmdlet.ShouldProcess($LiveSessionId, "Terminate PSM Session")) {
+		if ($PSCmdlet.ShouldProcess($LiveSessionId, 'Terminate PSM Session')) {
 
 			#send request to PAS web service
 			Invoke-PASRestMethod -Uri $URI -Method POST -WebSession $Script:WebSession

--- a/psPAS/Functions/Monitoring/Suspend-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Suspend-PASPSMSession.ps1
@@ -7,7 +7,7 @@ function Suspend-PASPSMSession {
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateNotNullOrEmpty()]
-		[Alias("SessionGuid")]
+		[Alias('SessionGuid')]
 		[string]$LiveSessionId
 	)
 
@@ -20,7 +20,7 @@ function Suspend-PASPSMSession {
 		#Create URL for Request
 		$URI = "$Script:BaseURI/api/LiveSessions/$($LiveSessionId | Get-EscapedString)/Suspend"
 
-		if ($PSCmdlet.ShouldProcess($LiveSessionId, "Suspend PSM Session")) {
+		if ($PSCmdlet.ShouldProcess($LiveSessionId, 'Suspend PSM Session')) {
 
 			#send request to PAS web service
 			Invoke-PASRestMethod -Uri $URI -Method POST -WebSession $Script:WebSession

--- a/psPAS/Functions/OnboardingRules/Get-PASOnboardingRule.ps1
+++ b/psPAS/Functions/OnboardingRules/Get-PASOnboardingRule.ps1
@@ -5,7 +5,7 @@ function Get-PASOnboardingRule {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Names"
+			ParameterSetName = 'Names'
 		)]
 		[ValidateNotNullOrEmpty()]
 		[string]$Names
@@ -20,7 +20,7 @@ function Get-PASOnboardingRule {
 		#Create URL for request
 		$URI = "$Script:BaseURI/api/AutomaticOnboardingRules"
 
-		If ($PSBoundParameters.ContainsKey("Names")) {
+		If ($PSBoundParameters.ContainsKey('Names')) {
 
 			Assert-VersionRequirement -RequiredVersion 10.2
 

--- a/psPAS/Functions/OnboardingRules/New-PASOnboardingRule.ps1
+++ b/psPAS/Functions/OnboardingRules/New-PASOnboardingRule.ps1
@@ -1,11 +1,11 @@
 ﻿# .ExternalHelp psPAS-help.xml
 function New-PASOnboardingRule {
-	[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = "Gen2")]
+	[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'Gen2')]
 	param(
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[ValidateLength(1, 99)]
 		[string]$DecisionPlatformId,
@@ -13,7 +13,7 @@ function New-PASOnboardingRule {
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(1, 99)]
 		[string]$TargetPlatformId,
@@ -21,7 +21,7 @@ function New-PASOnboardingRule {
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
 		[ValidateLength(1, 28)]
 		[string]$DecisionSafeName,
@@ -29,7 +29,7 @@ function New-PASOnboardingRule {
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(1, 28)]
 		[string]$TargetSafeName,
@@ -37,15 +37,15 @@ function New-PASOnboardingRule {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen1"
+			ParameterSetName = 'Gen1'
 		)]
-		[ValidateSet("Yes", "No")]
+		[ValidateSet('Yes', 'No')]
 		[String]$IsAdminUIDFilter,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
 		[boolean]$IsAdminIDFilter,
 
@@ -53,14 +53,14 @@ function New-PASOnboardingRule {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("Workstation", "Server")]
+		[ValidateSet('Workstation', 'Server')]
 		[string]$MachineTypeFilter,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("Windows", "Unix")]
+		[ValidateSet('Windows', 'Unix')]
 		[string]$SystemTypeFilter,
 
 		[parameter(
@@ -73,9 +73,9 @@ function New-PASOnboardingRule {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
-		[ValidateSet("Equals", "Begins", "Ends")]
+		[ValidateSet('Equals', 'Begins', 'Ends')]
 		[string]$UserNameMethod,
 
 		[parameter(
@@ -88,17 +88,17 @@ function New-PASOnboardingRule {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
-		[ValidateSet("Equals", "Begins", "Ends")]
+		[ValidateSet('Equals', 'Begins', 'Ends')]
 		[string]$AddressMethod,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "Gen2"
+			ParameterSetName = 'Gen2'
 		)]
-		[ValidateSet("Any", "Privileged", "NonPrivileged")]
+		[ValidateSet('Any', 'Privileged', 'NonPrivileged')]
 		[string]$AccountCategoryFilter,
 
 		[parameter(
@@ -129,14 +129,14 @@ function New-PASOnboardingRule {
 		#Get Values for ShouldProcess Message
 		switch ($PSCmdlet.ParameterSetName) {
 
-			"Gen2" {
+			'Gen2' {
 				Assert-VersionRequirement -RequiredVersion 10.2
 				#version 10.2 parameters
 				$SafeName = $TargetSafeName
 				$PlatformID = $TargetPlatformId
 			}
 
-			"Gen1" {
+			'Gen1' {
 				Assert-VersionRequirement -RequiredVersion 9.8
 				#pre 10.2 parameters
 				$SafeName = $DecisionSafeName

--- a/psPAS/Functions/OnboardingRules/Remove-PASOnboardingRule.ps1
+++ b/psPAS/Functions/OnboardingRules/Remove-PASOnboardingRule.ps1
@@ -16,7 +16,7 @@ function Remove-PASOnboardingRule {
 		#Create URL for request
 		$URI = "$Script:BaseURI/api/AutomaticOnboardingRules/$($RuleID | Get-EscapedString)"
 
-		if ($PSCmdlet.ShouldProcess($RuleID, "Delete On-boarding Rule")) {
+		if ($PSCmdlet.ShouldProcess($RuleID, 'Delete On-boarding Rule')) {
 
 			#Send request to web service
 			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
@@ -26,4 +26,5 @@ function Remove-PASOnboardingRule {
 	}#process
 
 	END { }#end
+
 }

--- a/psPAS/Functions/OnboardingRules/Remove-PASOnboardingRule.ps1
+++ b/psPAS/Functions/OnboardingRules/Remove-PASOnboardingRule.ps1
@@ -14,7 +14,7 @@ function Remove-PASOnboardingRule {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/AutomaticOnboardingRules/$($RuleID | Get-EscapedString)"
+		$URI = "$Script:BaseURI/api/AutomaticOnboardingRules/$($RuleID | Get-EscapedString)/"
 
 		if ($PSCmdlet.ShouldProcess($RuleID, 'Delete On-boarding Rule')) {
 

--- a/psPAS/Functions/OnboardingRules/Set-PASOnboardingRule.ps1
+++ b/psPAS/Functions/OnboardingRules/Set-PASOnboardingRule.ps1
@@ -99,7 +99,7 @@ function Set-PASOnboardingRule {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/AutomaticOnboardingRules/$Id"
+		$URI = "$Script:BaseURI/api/AutomaticOnboardingRules/$Id/"
 
 		#create request body
 		$body = $PSBoundParameters | Get-PASParameter -ParametersToRemove Id | ConvertTo-Json

--- a/psPAS/Functions/OnboardingRules/Set-PASOnboardingRule.ps1
+++ b/psPAS/Functions/OnboardingRules/Set-PASOnboardingRule.ps1
@@ -32,14 +32,14 @@ function Set-PASOnboardingRule {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("Workstation", "Server")]
+		[ValidateSet('Workstation', 'Server')]
 		[string]$MachineTypeFilter,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("Windows", "Unix")]
+		[ValidateSet('Windows', 'Unix')]
 		[string]$SystemTypeFilter,
 
 		[parameter(
@@ -53,7 +53,7 @@ function Set-PASOnboardingRule {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("Equals", "Begins", "Ends")]
+		[ValidateSet('Equals', 'Begins', 'Ends')]
 		[string]$UserNameMethod,
 
 		[parameter(
@@ -67,14 +67,14 @@ function Set-PASOnboardingRule {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("Equals", "Begins", "Ends")]
+		[ValidateSet('Equals', 'Begins', 'Ends')]
 		[string]$AddressMethod,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("Any", "Privileged", "NonPrivileged")]
+		[ValidateSet('Any', 'Privileged', 'NonPrivileged')]
 		[string]$AccountCategoryFilter,
 
 		[parameter(

--- a/psPAS/Functions/Platforms/Copy-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Copy-PASPlatform.ps1
@@ -5,28 +5,28 @@ Function Copy-PASPlatform {
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "targets"
+			ParameterSetName = 'targets'
 		)]
 		[switch]$TargetPlatform,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "dependents"
+			ParameterSetName = 'dependents'
 		)]
 		[switch]$DependentPlatform,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "groups"
+			ParameterSetName = 'groups'
 		)]
 		[switch]$GroupPlatform,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "rotationalGroups"
+			ParameterSetName = 'rotationalGroups'
 		)]
 		[switch]$RotationalGroup,
 

--- a/psPAS/Functions/Platforms/Disable-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Disable-PASPlatform.ps1
@@ -1,28 +1,28 @@
 # .ExternalHelp psPAS-help.xml
 Function Disable-PASPlatform {
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'TargetPlatform', Justification = "False Positive")]
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'GroupPlatform', Justification = "False Positive")]
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'RotationalGroup', Justification = "False Positive")]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'TargetPlatform', Justification = 'False Positive')]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'GroupPlatform', Justification = 'False Positive')]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'RotationalGroup', Justification = 'False Positive')]
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "targets"
+			ParameterSetName = 'targets'
 		)]
 		[switch]$TargetPlatform,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "groups"
+			ParameterSetName = 'groups'
 		)]
 		[switch]$GroupPlatform,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "rotationalGroups"
+			ParameterSetName = 'rotationalGroups'
 		)]
 		[switch]$RotationalGroup,
 

--- a/psPAS/Functions/Platforms/Enable-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Enable-PASPlatform.ps1
@@ -1,28 +1,28 @@
 # .ExternalHelp psPAS-help.xml
 Function Enable-PASPlatform {
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'TargetPlatform', Justification = "False Positive")]
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'GroupPlatform', Justification = "False Positive")]
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'RotationalGroup', Justification = "False Positive")]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'TargetPlatform', Justification = 'False Positive')]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'GroupPlatform', Justification = 'False Positive')]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'RotationalGroup', Justification = 'False Positive')]
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "targets"
+			ParameterSetName = 'targets'
 		)]
 		[switch]$TargetPlatform,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "groups"
+			ParameterSetName = 'groups'
 		)]
 		[switch]$GroupPlatform,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "rotationalGroups"
+			ParameterSetName = 'rotationalGroups'
 		)]
 		[switch]$RotationalGroup,
 

--- a/psPAS/Functions/Platforms/Export-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Export-PASPlatform.ps1
@@ -25,7 +25,7 @@ function Export-PASPlatform {
 		#Create URL for request
 		$URI = "$Script:BaseURI/API/Platforms/$PlatformID/Export?platformID=$PlatformID"
 
-		if ($PSCmdlet.ShouldProcess($PlatformID, "Exports Platform Package")) {
+		if ($PSCmdlet.ShouldProcess($PlatformID, 'Exports Platform Package')) {
 
 			#send request to web service
 			$result = Invoke-PASRestMethod -Uri $URI -Method POST -WebSession $Script:WebSession -Debug:$false

--- a/psPAS/Functions/Platforms/Get-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Get-PASPlatform.ps1
@@ -144,7 +144,7 @@ function Get-PASPlatform {
 				Assert-VersionRequirement -RequiredVersion 9.10
 
 				#Create request URL
-				$URI = "$Script:BaseURI/API/Platforms/$($PlatformID | Get-EscapedString)"
+				$URI = "$Script:BaseURI/API/Platforms/$($PlatformID | Get-EscapedString)/"
 
 				break
 

--- a/psPAS/Functions/Platforms/Get-PASPlatformSafe.ps1
+++ b/psPAS/Functions/Platforms/Get-PASPlatformSafe.ps1
@@ -16,7 +16,7 @@ function Get-PASPlatformSafe {
 	PROCESS {
 
 		#Create request URL
-		$URI = "$Script:BaseURI/API/Platforms/$($PlatformID | Get-EscapedString)/Safes"
+		$URI = "$Script:BaseURI/API/Platforms/$($PlatformID | Get-EscapedString)/Safes/"
 
 		#Send request to web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession

--- a/psPAS/Functions/Platforms/Get-PASPlatformSafe.ps1
+++ b/psPAS/Functions/Platforms/Get-PASPlatformSafe.ps1
@@ -24,7 +24,7 @@ function Get-PASPlatformSafe {
 		If ($result.count -gt 0) {
 
 			#Return Results
-			$result.value | ForEach-Object { [pscustomobject]@{"SafeName" = $PSItem } }
+			$result.value | ForEach-Object { [pscustomobject]@{'SafeName' = $PSItem } }
 
 		}
 

--- a/psPAS/Functions/Platforms/Import-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Import-PASPlatform.ps1
@@ -24,9 +24,9 @@ function Import-PASPlatform {
 		#Convert File to byte array
 		$FileBytes = $ImportFile | Get-ByteArray
 
-		$Body = @{"ImportFile" = $FileBytes } | ConvertTo-Json
+		$Body = @{'ImportFile' = $FileBytes } | ConvertTo-Json
 
-		if ($PSCmdlet.ShouldProcess($ImportFile, "Imports Platform Package")) {
+		if ($PSCmdlet.ShouldProcess($ImportFile, 'Imports Platform Package')) {
 
 			#send request to web service
 			Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession -Debug:$false

--- a/psPAS/Functions/Platforms/Remove-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Remove-PASPlatform.ps1
@@ -1,36 +1,36 @@
 # .ExternalHelp psPAS-help.xml
 Function Remove-PASPlatform {
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'TargetPlatform', Justification = "False Positive")]
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'DependentPlatform', Justification = "False Positive")]
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'GroupPlatform', Justification = "False Positive")]
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'RotationalGroup', Justification = "False Positive")]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'TargetPlatform', Justification = 'False Positive')]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'DependentPlatform', Justification = 'False Positive')]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'GroupPlatform', Justification = 'False Positive')]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'RotationalGroup', Justification = 'False Positive')]
 	[CmdletBinding(SupportsShouldProcess)]
 	param(
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "targets"
+			ParameterSetName = 'targets'
 		)]
 		[switch]$TargetPlatform,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "dependents"
+			ParameterSetName = 'dependents'
 		)]
 		[switch]$DependentPlatform,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "groups"
+			ParameterSetName = 'groups'
 		)]
 		[switch]$GroupPlatform,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "rotationalGroups"
+			ParameterSetName = 'rotationalGroups'
 		)]
 		[switch]$RotationalGroup,
 

--- a/psPAS/Functions/Platforms/Set-PASPlatformPSMConfig.ps1
+++ b/psPAS/Functions/Platforms/Set-PASPlatformPSMConfig.ps1
@@ -35,7 +35,7 @@ Function Set-PASPlatformPSMConfig {
 		#Request body
 		$Body = $PSBoundParameters | Get-PASParameter -ParametersToRemove ID | ConvertTo-Json
 
-		if ($PSCmdlet.ShouldProcess($ID, "Update Platform PSM Config")) {
+		if ($PSCmdlet.ShouldProcess($ID, 'Update Platform PSM Config')) {
 
 			#send request to web service
 			$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body -WebSession $Script:WebSession

--- a/psPAS/Functions/PolicyACL/Add-PASPolicyACL.ps1
+++ b/psPAS/Functions/PolicyACL/Add-PASPolicyACL.ps1
@@ -51,7 +51,7 @@ function Add-PASPolicyACL {
 		#Create URL for request
 		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Policy/$($PolicyID |
 
-            Get-EscapedString)/PrivilegedCommands"
+            Get-EscapedString)/PrivilegedCommands/"
 
 		#Create request body
 		$body = $PSBoundParameters |

--- a/psPAS/Functions/PolicyACL/Add-PASPolicyACL.ps1
+++ b/psPAS/Functions/PolicyACL/Add-PASPolicyACL.ps1
@@ -19,7 +19,7 @@ function Add-PASPolicyACL {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateSet("Allow", "Deny")]
+		[ValidateSet('Allow', 'Deny')]
 		[string]$PermissionType,
 
 		[parameter(
@@ -56,9 +56,9 @@ function Add-PASPolicyACL {
 		#Create request body
 		$body = $PSBoundParameters |
 
-		Get-PASParameter -ParametersToRemove PolicyId |
+			Get-PASParameter -ParametersToRemove PolicyId |
 
-		ConvertTo-Json
+			ConvertTo-Json
 
 		#Send request to web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body -WebSession $Script:WebSession
@@ -67,7 +67,7 @@ function Add-PASPolicyACL {
 
 			$result.AddPolicyPrivilegedCommandResult |
 
-			Add-ObjectDetail -typename psPAS.CyberArk.Vault.ACL.Policy
+				Add-ObjectDetail -typename psPAS.CyberArk.Vault.ACL.Policy
 
 		}
 

--- a/psPAS/Functions/PolicyACL/Get-PASPolicyACL.ps1
+++ b/psPAS/Functions/PolicyACL/Get-PASPolicyACL.ps1
@@ -27,7 +27,7 @@ function Get-PASPolicyACL {
 
 			$result.ListPolicyPrivilegedCommandsResult |
 
-			Add-ObjectDetail -typename psPAS.CyberArk.Vault.ACL.Policy
+				Add-ObjectDetail -typename psPAS.CyberArk.Vault.ACL.Policy
 
 		}
 

--- a/psPAS/Functions/PolicyACL/Get-PASPolicyACL.ps1
+++ b/psPAS/Functions/PolicyACL/Get-PASPolicyACL.ps1
@@ -18,7 +18,7 @@ function Get-PASPolicyACL {
 		#Create URL for request
 		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Policy/$($PolicyID |
 
-            Get-EscapedString)/PrivilegedCommands"
+            Get-EscapedString)/PrivilegedCommands/"
 
 		#Send Request to web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession

--- a/psPAS/Functions/PolicyACL/Remove-PASPolicyACL.ps1
+++ b/psPAS/Functions/PolicyACL/Remove-PASPolicyACL.ps1
@@ -24,7 +24,7 @@ function Remove-PASPolicyACL {
 		#Create base URL for request
 		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Policy/$($PolicyID |
 
-            Get-EscapedString)/PrivilegedCommands/$($Id | Get-EscapedString)"
+            Get-EscapedString)/PrivilegedCommands/$($Id | Get-EscapedString)/"
 
 		if ($PSCmdlet.ShouldProcess($PolicyID, "Delete Rule $Id")) {
 

--- a/psPAS/Functions/Requests/Approve-PASRequest.ps1
+++ b/psPAS/Functions/Requests/Approve-PASRequest.ps1
@@ -28,7 +28,7 @@ function Approve-PASRequest {
 		#Create body of request
 		$body = $PSBoundParameters | Get-PASParameter -ParametersToRemove RequestId | ConvertTo-Json
 
-		if ($PSCmdlet.ShouldProcess($RequestId, "Confirm Request for Account Access")) {
+		if ($PSCmdlet.ShouldProcess($RequestId, 'Confirm Request for Account Access')) {
 
 			#send request to PAS web service
 			Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession

--- a/psPAS/Functions/Requests/Deny-PASRequest.ps1
+++ b/psPAS/Functions/Requests/Deny-PASRequest.ps1
@@ -28,7 +28,7 @@ function Deny-PASRequest {
 		#Create body of request
 		$body = $PSBoundParameters | Get-PASParameter -ParametersToRemove RequestId | ConvertTo-Json
 
-		if ($PSCmdlet.ShouldProcess($RequestId, "Reject Request for Account Access")) {
+		if ($PSCmdlet.ShouldProcess($RequestId, 'Reject Request for Account Access')) {
 
 			#send request to PAS web service
 			Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession

--- a/psPAS/Functions/Requests/Get-PASRequest.ps1
+++ b/psPAS/Functions/Requests/Get-PASRequest.ps1
@@ -7,7 +7,7 @@ function Get-PASRequest {
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateNotNullOrEmpty()]
-		[ValidateSet("MyRequests", "IncomingRequests")]
+		[ValidateSet('MyRequests', 'IncomingRequests')]
 		[string]$RequestType,
 
 		[parameter(

--- a/psPAS/Functions/Requests/Get-PASRequestDetail.ps1
+++ b/psPAS/Functions/Requests/Get-PASRequestDetail.ps1
@@ -7,7 +7,7 @@ function Get-PASRequestDetail {
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateNotNullOrEmpty()]
-		[ValidateSet("MyRequests", "IncomingRequests")]
+		[ValidateSet('MyRequests', 'IncomingRequests')]
 		[string]$RequestType,
 
 		[parameter(

--- a/psPAS/Functions/Requests/New-PASRequest.ps1
+++ b/psPAS/Functions/Requests/New-PASRequest.ps1
@@ -1,6 +1,6 @@
 # .ExternalHelp psPAS-help.xml
 function New-PASRequest {
-	[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = "ConnectionParams")]
+	[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'ConnectionParams')]
 	param(
 		[parameter(
 			Mandatory = $true,
@@ -66,53 +66,53 @@ function New-PASRequest {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "ConnectionParams"
+			ParameterSetName = 'ConnectionParams'
 		)]
-		[ValidateSet("Yes", "No")]
+		[ValidateSet('Yes', 'No')]
 		[string]$AllowMappingLocalDrives,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "ConnectionParams"
+			ParameterSetName = 'ConnectionParams'
 		)]
-		[ValidateSet("Yes", "No")]
+		[ValidateSet('Yes', 'No')]
 		[string]$AllowConnectToConsole,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "ConnectionParams"
+			ParameterSetName = 'ConnectionParams'
 		)]
-		[ValidateSet("Yes", "No")]
+		[ValidateSet('Yes', 'No')]
 		[string]$RedirectSmartCards,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "ConnectionParams"
+			ParameterSetName = 'ConnectionParams'
 		)]
 		[string]$PSMRemoteMachine,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "ConnectionParams"
+			ParameterSetName = 'ConnectionParams'
 		)]
 		[string]$LogonDomain,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "ConnectionParams"
+			ParameterSetName = 'ConnectionParams'
 		)]
-		[ValidateSet("Yes", "No")]
+		[ValidateSet('Yes', 'No')]
 		[string]$AllowSelectHTML5,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = "ManualParams"
+			ParameterSetName = 'ManualParams'
 		)]
 		[hashtable]$ConnectionParams
 	)
@@ -128,17 +128,17 @@ function New-PASRequest {
 
 		$boundParameters = $PSBoundParameters | Get-PASParameter
 
-		if ($boundParameters.ContainsKey("FromDate")) {
+		if ($boundParameters.ContainsKey('FromDate')) {
 
 			#convert to unix time
-			$boundParameters["FromDate"] = $FromDate | ConvertTo-UnixTime
+			$boundParameters['FromDate'] = $FromDate | ConvertTo-UnixTime
 
 		}
 
-		if ($boundParameters.ContainsKey("ToDate")) {
+		if ($boundParameters.ContainsKey('ToDate')) {
 
 			#convert to unix time
-			$boundParameters["ToDate"] = $ToDate | ConvertTo-UnixTime
+			$boundParameters['ToDate'] = $ToDate | ConvertTo-UnixTime
 
 		}
 
@@ -149,7 +149,7 @@ function New-PASRequest {
 		#Create body of request
 		$body = $boundParameters | ConvertTo-Json
 
-		if ($PSCmdlet.ShouldProcess($AccountId, "Create Request for Account Access")) {
+		if ($PSCmdlet.ShouldProcess($AccountId, 'Create Request for Account Access')) {
 
 			#send request to PAS web service
 			$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession

--- a/psPAS/Functions/Requests/Remove-PASRequest.ps1
+++ b/psPAS/Functions/Requests/Remove-PASRequest.ps1
@@ -19,7 +19,7 @@ function Remove-PASRequest {
 		#Create URL for request
 		$URI = "$Script:BaseURI/API/MyRequests/$($RequestID)"
 
-		if ($PSCmdlet.ShouldProcess($RequestID, "Delete Request")) {
+		if ($PSCmdlet.ShouldProcess($RequestID, 'Delete Request')) {
 
 			#Send request to web service
 			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
@@ -29,4 +29,5 @@ function Remove-PASRequest {
 	}#process
 
 	END { }#end
+
 }

--- a/psPAS/Functions/SafeMembers/Get-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Get-PASSafeMember.ps1
@@ -149,7 +149,7 @@ function Get-PASSafeMember {
 				Assert-VersionRequirement -RequiredVersion 12.2
 
 				#Create URL for member specific request
-				$URI = "$URI/$($MemberName | Get-EscapedString)"
+				$URI = "$URI/$($MemberName | Get-EscapedString)/"
 
 				$boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToKeep useCache
 
@@ -173,7 +173,7 @@ function Get-PASSafeMember {
 				Assert-VersionRequirement -MaximumVersion 12.3
 
 				#Create URL for member specific request
-				$URI = "$URI/$($MemberName | Get-EscapedString)"
+				$URI = "$URI/$($MemberName | Get-EscapedString)/"
 				#Send a PUT Request instead of GET
 				$Method = 'PUT'
 				#Send an empty body

--- a/psPAS/Functions/SafeMembers/Remove-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Remove-PASSafeMember.ps1
@@ -36,7 +36,7 @@ function Remove-PASSafeMember {
 
 				#Create URL for request
 				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Safes/$($SafeName |
-					Get-EscapedString)/Members/$($MemberName | Get-EscapedString)"
+					Get-EscapedString)/Members/$($MemberName | Get-EscapedString)/"
 
 			}
 
@@ -46,7 +46,7 @@ function Remove-PASSafeMember {
 
 				#Create URL for request
 				$URI = "$Script:BaseURI/api/Safes/$($SafeName |
-					Get-EscapedString)/Members/$($MemberName | Get-EscapedString)"
+					Get-EscapedString)/Members/$($MemberName | Get-EscapedString)/"
 
 			}
 

--- a/psPAS/Functions/SafeMembers/Remove-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Remove-PASSafeMember.ps1
@@ -46,7 +46,7 @@ function Remove-PASSafeMember {
 
 				#Create URL for request
 				$URI = "$Script:BaseURI/api/Safes/$($SafeName |
-					Get-EscapedString)/members/$($MemberName | Get-EscapedString)"
+					Get-EscapedString)/Members/$($MemberName | Get-EscapedString)"
 
 			}
 

--- a/psPAS/Functions/SafeMembers/Set-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Set-PASSafeMember.ps1
@@ -212,7 +212,7 @@ function Set-PASSafeMember {
 
 				#Create URL for request
 				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Safes/$($SafeName |
-					Get-EscapedString)/Members/$($MemberName | Get-EscapedString)"
+					Get-EscapedString)/Members/$($MemberName | Get-EscapedString)/"
 
 				If ($PSBoundParameters.ContainsKey('MembershipExpirationDate')) {
 
@@ -244,7 +244,7 @@ function Set-PASSafeMember {
 				Assert-VersionRequirement -RequiredVersion 12.2
 
 				#Create URL for request
-				$URI = "$Script:BaseURI/api/Safes/$($SafeName | Get-EscapedString)/Members/$($MemberName | Get-EscapedString)"
+				$URI = "$Script:BaseURI/api/Safes/$($SafeName | Get-EscapedString)/Members/$($MemberName | Get-EscapedString)/"
 
 				If ($PSBoundParameters.ContainsKey('MembershipExpirationDate')) {
 

--- a/psPAS/Functions/Safes/Remove-PASSafe.ps1
+++ b/psPAS/Functions/Safes/Remove-PASSafe.ps1
@@ -66,4 +66,5 @@ function Remove-PASSafe {
 	}#process
 
 	END { }#end
+
 }

--- a/psPAS/Functions/ServerWebServices/Get-PASSafeShareLogo.ps1
+++ b/psPAS/Functions/ServerWebServices/Get-PASSafeShareLogo.ps1
@@ -5,7 +5,7 @@ function Get-PASSafeShareLogo {
 		[parameter(
 			Mandatory = $true
 		)]
-		[ValidateSet("Square", "Watermark")]
+		[ValidateSet('Square', 'Watermark')]
 		[String]$ImageType
 	)
 
@@ -29,4 +29,5 @@ function Get-PASSafeShareLogo {
 	}#process
 
 	END { }#end
+
 }

--- a/psPAS/Functions/ServerWebServices/Get-PASServerWebService.ps1
+++ b/psPAS/Functions/ServerWebServices/Get-PASServerWebService.ps1
@@ -18,7 +18,7 @@ function Get-PASServerWebService {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = "PasswordVault"
+		[string]$PVWAAppName = 'PasswordVault'
 	)
 
 	BEGIN { }#begin
@@ -41,4 +41,5 @@ function Get-PASServerWebService {
 	}#process
 
 	END { }#end
+
 }

--- a/psPAS/Functions/SystemHealth/Get-PASComponentDetail.ps1
+++ b/psPAS/Functions/SystemHealth/Get-PASComponentDetail.ps1
@@ -7,7 +7,7 @@ Function Get-PASComponentDetail {
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateNotNullOrEmpty()]
-		[ValidateSet("PVWA", "SessionManagement", "CPM", "AIM")]
+		[ValidateSet('PVWA', 'SessionManagement', 'CPM', 'AIM')]
 		[string]$ComponentID
 
 	)
@@ -34,4 +34,5 @@ Function Get-PASComponentDetail {
 	}#process
 
 	END { }#end
+
 }

--- a/psPAS/Functions/SystemHealth/Get-PASComponentSummary.ps1
+++ b/psPAS/Functions/SystemHealth/Get-PASComponentSummary.ps1
@@ -22,8 +22,8 @@ Function Get-PASComponentSummary {
 			$result | Select-Object -ExpandProperty Components
 
 			$result | Select-Object -ExpandProperty Vaults | Add-ObjectDetail -PropertyToAdd @{
-				"ComponentID"   = "EPV"
-				"ComponentName" = "EPV"
+				'ComponentID'   = 'EPV'
+				'ComponentName' = 'EPV'
 			} | Select-Object ComponentID, ComponentName, Role, IP, IsLoggedOn
 
 		}
@@ -31,4 +31,5 @@ Function Get-PASComponentSummary {
 	}#process
 
 	END { }#end
+
 }

--- a/psPAS/Functions/User/Add-PASGroupMember.ps1
+++ b/psPAS/Functions/User/Add-PASGroupMember.ps1
@@ -59,7 +59,7 @@ function Add-PASGroupMember {
 				Assert-VersionRequirement -MaximumVersion 12.3
 
 				#Create URL for request
-				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Groups/$($GroupName | Get-EscapedString)/Users"
+				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Groups/$($GroupName | Get-EscapedString)/Users/"
 
 				break
 

--- a/psPAS/Functions/User/Disable-PASUser.ps1
+++ b/psPAS/Functions/User/Disable-PASUser.ps1
@@ -1,0 +1,34 @@
+# .ExternalHelp psPAS-help.xml
+function Disable-PASUser {
+
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [parameter(
+            Mandatory = $true,
+            ValueFromPipelinebyPropertyName = $true
+        )]
+        [int]$id
+    )
+
+    BEGIN {
+
+        Assert-VersionRequirement -RequiredVersion 12.6
+
+    }#begin
+
+    PROCESS {
+
+        $URI = "$Script:BaseURI/API/Users/$id/disable/"
+
+        if ($PSCmdlet.ShouldProcess($id, 'Disable User')) {
+
+            #send request to web service
+            Invoke-PASRestMethod -Uri $URI -Method POST -WebSession $Script:WebSession
+
+        }
+
+    }#process
+
+    END { }#end
+
+}

--- a/psPAS/Functions/User/Enable-PASUser.ps1
+++ b/psPAS/Functions/User/Enable-PASUser.ps1
@@ -1,0 +1,34 @@
+# .ExternalHelp psPAS-help.xml
+function Enable-PASUser {
+
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [parameter(
+            Mandatory = $true,
+            ValueFromPipelinebyPropertyName = $true
+        )]
+        [int]$id
+    )
+
+    BEGIN {
+
+        Assert-VersionRequirement -RequiredVersion 12.6
+
+    }#begin
+
+    PROCESS {
+
+        $URI = "$Script:BaseURI/API/Users/$id/enable/"
+
+        if ($PSCmdlet.ShouldProcess($id, 'Enable User')) {
+
+            #send request to web service
+            Invoke-PASRestMethod -Uri $URI -Method POST -WebSession $Script:WebSession
+
+        }
+
+    }#process
+
+    END { }#end
+
+}

--- a/psPAS/Functions/User/Get-PASGroup.ps1
+++ b/psPAS/Functions/User/Get-PASGroup.ps1
@@ -13,6 +13,13 @@ function Get-PASGroup {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'groupType'
+		)]
+		[string]$groupName,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'filter'
 		)]
 		[ValidateSet('groupType eq Directory', 'groupType eq Vault')]
@@ -60,7 +67,7 @@ function Get-PASGroup {
 
 			}
 
-			{ $_ -match 'sort' } {
+			{ $_ -match 'sort|groupName' } {
 
 				#Sort parameter require 12.2
 				Assert-VersionRequirement -RequiredVersion 12.2
@@ -73,8 +80,8 @@ function Get-PASGroup {
 		$URI = "$Script:BaseURI/API/UserGroups"
 
 		#Get Parameters to include in request
-		$boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove groupType
-		$filterProperties = $PSBoundParameters | Get-PASParameter -ParametersToKeep groupType
+		$boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove groupType, groupName
+		$filterProperties = $PSBoundParameters | Get-PASParameter -ParametersToKeep groupType, groupName
 		$FilterString = $filterProperties | ConvertTo-FilterString
 
 		If ($null -ne $FilterString) {

--- a/psPAS/Functions/User/Get-PASUser.ps1
+++ b/psPAS/Functions/User/Get-PASUser.ps1
@@ -153,7 +153,7 @@ function Get-PASUser {
 				Assert-VersionRequirement -MaximumVersion 12.3
 
 				#Create URL for request
-				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)"
+				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)/"
 
 				$TypeName = 'psPAS.CyberArk.Vault.User'
 

--- a/psPAS/Functions/User/New-PASGroup.ps1
+++ b/psPAS/Functions/User/New-PASGroup.ps1
@@ -33,7 +33,7 @@ function New-PASGroup {
 		#Construct Request Body
 		$Body = $PSBoundParameters | Get-PASParameter | ConvertTo-Json
 
-		if ($PSCmdlet.ShouldProcess($groupName, "Create Group")) {
+		if ($PSCmdlet.ShouldProcess($groupName, 'Create Group')) {
 
 			#send request to web service
 			$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession

--- a/psPAS/Functions/User/Remove-PASGroup.ps1
+++ b/psPAS/Functions/User/Remove-PASGroup.ps1
@@ -20,7 +20,7 @@ Function Remove-PASGroup {
 		#Create URL for request
 		$URI = "$Script:BaseURI/API/UserGroups/$GroupID"
 
-		if ($PSCmdlet.ShouldProcess($GroupID, "Delete Group")) {
+		if ($PSCmdlet.ShouldProcess($GroupID, 'Delete Group')) {
 
 			#send request to web service
 			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession

--- a/psPAS/Functions/User/Remove-PASUser.ps1
+++ b/psPAS/Functions/User/Remove-PASUser.ps1
@@ -45,7 +45,7 @@ function Remove-PASUser {
 				Assert-VersionRequirement -MaximumVersion 12.3
 
 				#Create URL for request
-				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)"
+				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)/"
 
 				break
 

--- a/psPAS/Functions/User/Remove-PASUser.ps1
+++ b/psPAS/Functions/User/Remove-PASUser.ps1
@@ -63,4 +63,5 @@ function Remove-PASUser {
 	}#process
 
 	END { }#end
+
 }

--- a/psPAS/Functions/User/Set-PASUser.ps1
+++ b/psPAS/Functions/User/Set-PASUser.ps1
@@ -438,7 +438,7 @@ function Set-PASUser {
 				}
 
 				#Create URL for request
-				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)"
+				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)/"
 
 				$TypeName = 'psPAS.CyberArk.Vault.User'
 

--- a/psPAS/Functions/User/Set-PASUserPassword.ps1
+++ b/psPAS/Functions/User/Set-PASUserPassword.ps1
@@ -27,11 +27,11 @@ function Set-PASUserPassword {
 		$Password = ConvertTo-InsecureString -SecureString $NewPassword
 
 		If ($Password.length -gt 39) {
-			throw "Password must not exceed 39 characters"
+			throw 'Password must not exceed 39 characters'
 		}
 
 		#Include decoded password in request
-		$boundParameters["NewPassword"] = $Password
+		$boundParameters['NewPassword'] = $Password
 
 		#Create URL for request
 		$URI = "$Script:BaseURI/api/Users/$id/ResetPassword"
@@ -39,7 +39,7 @@ function Set-PASUserPassword {
 		#create request body
 		$body = $boundParameters | ConvertTo-Json
 
-		if ($PSCmdlet.ShouldProcess($id, "Reset Password")) {
+		if ($PSCmdlet.ShouldProcess($id, 'Reset Password')) {
 
 			#send request to web service
 			Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession

--- a/psPAS/Functions/User/Unblock-PASUser.ps1
+++ b/psPAS/Functions/User/Unblock-PASUser.ps1
@@ -53,7 +53,7 @@ function Unblock-PASUser {
 				Assert-VersionRequirement -MaximumVersion 12.3
 
 				#Create request
-				$Request['URI'] = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)"
+				$Request['URI'] = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)/"
 				$Request['Method'] = 'PUT'
 				$Request['Body'] = $PSBoundParameters | Get-PASParameter -ParametersToRemove UserName | ConvertTo-Json
 

--- a/psPAS/Private/Assert-VersionRequirement.ps1
+++ b/psPAS/Private/Assert-VersionRequirement.ps1
@@ -77,7 +77,7 @@ General notes
 				Continue
 
 			}
-		
+
 			'MaximumVersion' {
 
 				If (-not (Compare-MaximumVersion -Version $ExternalVersion -MaximumVersion $MaximumVersion)) {

--- a/psPAS/Private/Compare-MinimumVersion.ps1
+++ b/psPAS/Private/Compare-MinimumVersion.ps1
@@ -34,7 +34,7 @@ Function Compare-MinimumVersion {
 			Mandatory = $true,
 			ValueFromPipelineByPropertyName = $true
 		)]
-		[Alias("ExternalVersion")]
+		[Alias('ExternalVersion')]
 		[System.Version]
 		$Version,
 
@@ -52,7 +52,7 @@ Function Compare-MinimumVersion {
 	Process {
 
 		# Only compare if version greater than "0.0"
-		If ($Version -gt "0.0") {
+		If ($Version -gt '0.0') {
 
 			#Determine if Version is greater than or equal to MinimumVersion
 			If ($Version -ge $MinimumVersion) {

--- a/psPAS/Private/ConvertTo-ConnectionParam.ps1
+++ b/psPAS/Private/ConvertTo-ConnectionParam.ps1
@@ -26,7 +26,7 @@ $output["ConnectionParams"]["LogonDomain"]["Value"] = LogonDomainValue
 $output["SomeProperty"] = SomeValue
 
 #>
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'ConnectionParams', Justification = "False Positive")]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'ConnectionParams', Justification = 'False Positive')]
 	[CmdletBinding()]
 	[OutputType('System.Hashtable')]
 	param(
@@ -38,8 +38,8 @@ $output["SomeProperty"] = SomeValue
 	)
 
 	Begin {
-		$ConnectionParameters = [Collections.Generic.List[String]]@("AllowMappingLocalDrives", "AllowConnectToConsole",
-			"RedirectSmartCards", "PSMRemoteMachine", "LogonDomain", "AllowSelectHTML5")
+		$ConnectionParameters = [Collections.Generic.List[String]]@('AllowMappingLocalDrives', 'AllowConnectToConsole',
+			'RedirectSmartCards', 'PSMRemoteMachine', 'LogonDomain', 'AllowSelectHTML5')
 	}
 
 	Process {
@@ -55,14 +55,14 @@ $output["SomeProperty"] = SomeValue
 
 				#For Each ConnectionParams Parameter
 				#add key=value to hashtable
-				$ConnectionParams.Add($PSItem, @{"value" = $Parameters[$PSItem] })
+				$ConnectionParams.Add($PSItem, @{'value' = $Parameters[$PSItem] })
 
 			} {
 				if ($ConnectionParams.keys.count -gt 0) {
 
 					#if ConnectionParameters have been specified
 					#Add ConnectionParams to boundParameters
-					$Parameters["ConnectionParams"] = $ConnectionParams
+					$Parameters['ConnectionParams'] = $ConnectionParams
 
 				}
 

--- a/psPAS/Private/ConvertTo-FilterString.ps1
+++ b/psPAS/Private/ConvertTo-FilterString.ps1
@@ -28,7 +28,7 @@ Output: @{"filter" = "Key eq Value AND Key eq Value"}
 Returns datetime as unixtime, with `gte` operator.
 
 #>
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'FilterList', Justification = "False Positive")]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'FilterList', Justification = 'False Positive')]
 	[CmdletBinding()]
 	[OutputType('System.Hashtable')]
 	param(
@@ -71,7 +71,7 @@ Returns datetime as unixtime, with `gte` operator.
 
 				If ($FilterList.count -gt 0) {
 
-					@{"filter" = $FilterList -join " AND " }
+					@{'filter' = $FilterList -join ' AND ' }
 
 				}
 			}

--- a/psPAS/Private/ConvertTo-QueryString.ps1
+++ b/psPAS/Private/ConvertTo-QueryString.ps1
@@ -20,8 +20,8 @@ Joins Multiple Key Value pairs with '&'
 Formats input as: "Key=Value&Key=Value"
 
 #>
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'FilterList', Justification = "False Positive")]
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'NoEscape', Justification = "False Positive")]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'FilterList', Justification = 'False Positive')]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'NoEscape', Justification = 'False Positive')]
 	[CmdletBinding()]
 	[OutputType('System.String')]
 	param(
@@ -55,8 +55,7 @@ Formats input as: "Key=Value&Key=Value"
 					#Return Key=Value string, unescaped.
 					$Value = "$PSItem=$($Parameters[$PSItem])"
 
-				}
-				Else {
+				} Else {
 
 					#Return Key=Value string, escaped.
 					$Value = "$PSItem=$($Parameters[$PSItem] | Get-EscapedString)"
@@ -69,7 +68,7 @@ Formats input as: "Key=Value&Key=Value"
 
 				If ($FilterList.count -gt 0) {
 
-					$FilterList -join "&"
+					$FilterList -join '&'
 
 				}
 			}

--- a/psPAS/Private/ConvertTo-UnixTime.ps1
+++ b/psPAS/Private/ConvertTo-UnixTime.ps1
@@ -32,7 +32,7 @@ Get-Date | ConvertTo-UnixTime
 		$currentCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
 	}
 	process {
-		[System.Threading.Thread]::CurrentThread.CurrentCulture = "en-US"
+		[System.Threading.Thread]::CurrentThread.CurrentCulture = 'en-US'
 
 		$UnixTime = [math]::Round($(Get-Date $Date.ToUniversalTime() -UFormat %s))
 

--- a/psPAS/Private/Format-PASUserObject.ps1
+++ b/psPAS/Private/Format-PASUserObject.ps1
@@ -24,11 +24,11 @@ Function Format-PASUserObject {
 	)
 
 	Begin {
-		$businessAddressParams = [Collections.Generic.List[String]]@("workStreet", "workCity", "workState", "workZip", "workCountry")
-		$internetParams = [Collections.Generic.List[String]]@("homePage", "homeEmail", "businessEmail", "otherEmail")
-		$phonesParams = [Collections.Generic.List[String]]@("homeNumber", "businessNumber", "cellularNumber", "faxNumber", "pagerNumber")
-		$personalDetailsParams = [Collections.Generic.List[String]]@("street", "city", "state", "zip", "country", "title", "organization",
-			"department", "profession", "FirstName", "middleName", "LastName")
+		$businessAddressParams = [Collections.Generic.List[String]]@('workStreet', 'workCity', 'workState', 'workZip', 'workCountry')
+		$internetParams = [Collections.Generic.List[String]]@('homePage', 'homeEmail', 'businessEmail', 'otherEmail')
+		$phonesParams = [Collections.Generic.List[String]]@('homeNumber', 'businessNumber', 'cellularNumber', 'faxNumber', 'pagerNumber')
+		$personalDetailsParams = [Collections.Generic.List[String]]@('street', 'city', 'state', 'zip', 'country', 'title', 'organization',
+			'department', 'profession', 'FirstName', 'middleName', 'LastName')
 	}
 
 	Process {
@@ -39,53 +39,53 @@ Function Format-PASUserObject {
 		#Process each key of the input hashtable
 		switch ($UserProperties.keys) {
 
-			"ExpiryDate" {
+			'ExpiryDate' {
 				#Include date string in required format
-				$UserObject["ExpiryDate"] = $UserProperties["ExpiryDate"] | ConvertTo-UnixTime
+				$UserObject['ExpiryDate'] = $UserProperties['ExpiryDate'] | ConvertTo-UnixTime
 
 			}
 
 			{ $businessAddressParams -contains $PSItem } {
 
 				#Create businessAddress key if it does not exist
-				if (-not($UserObject.ContainsKey("businessAddress"))) {
-					$UserObject.Add("businessAddress", @{})
+				if (-not($UserObject.ContainsKey('businessAddress'))) {
+					$UserObject.Add('businessAddress', @{})
 				}
 				#Add as Key/Value under businessAddress
-				$UserObject["businessAddress"].Add($PSItem, $UserObject[$PSItem])
+				$UserObject['businessAddress'].Add($PSItem, $UserObject[$PSItem])
 
 			}
 
 			{ $internetParams -contains $PSItem } {
 
 				#Create internet key if it does not exist
-				if (-not($UserObject.ContainsKey("internet"))) {
-					$UserObject.Add("internet", @{})
+				if (-not($UserObject.ContainsKey('internet'))) {
+					$UserObject.Add('internet', @{})
 				}
 				#Add as Key/Value under internet
-				$UserObject["internet"].Add($PSItem, $UserObject[$PSItem])
+				$UserObject['internet'].Add($PSItem, $UserObject[$PSItem])
 
 			}
 
 			{ $phonesParams -contains $PSItem } {
 
 				#Create phones key if it does not exist
-				if (-not($UserObject.ContainsKey("phones"))) {
-					$UserObject.Add("phones", @{})
+				if (-not($UserObject.ContainsKey('phones'))) {
+					$UserObject.Add('phones', @{})
 				}
 				#Add as Key/Value under phones
-				$UserObject["phones"].Add($PSItem, $UserObject[$PSItem])
+				$UserObject['phones'].Add($PSItem, $UserObject[$PSItem])
 
 			}
 
 			{ $personalDetailsParams -contains $PSItem } {
 
 				#Create personalDetails key if it does not exist
-				if (-not($UserObject.ContainsKey("personalDetails"))) {
-					$UserObject.Add("personalDetails", @{})
+				if (-not($UserObject.ContainsKey('personalDetails'))) {
+					$UserObject.Add('personalDetails', @{})
 				}
 				#Add as Key/Value under personalDetails
-				$UserObject["personalDetails"].Add($PSItem, $UserObject[$PSItem])
+				$UserObject['personalDetails'].Add($PSItem, $UserObject[$PSItem])
 
 			}
 

--- a/psPAS/Private/Get-ByteArray.ps1
+++ b/psPAS/Private/Get-ByteArray.ps1
@@ -22,7 +22,7 @@ Get-ByteArray -Path "C:\SomeFile.zip"
 			ValueFromPipeline = $true
 		)]
 		[ValidateNotNullOrEmpty()]
-		[ValidateScript( { Test-Path -Path $_ -PathType Leaf})]
+		[ValidateScript( { Test-Path -Path $_ -PathType Leaf })]
 		[String]
 		$Path
 	)

--- a/psPAS/Private/Get-PASParameter.ps1
+++ b/psPAS/Private/Get-PASParameter.ps1
@@ -31,10 +31,10 @@ $PSBoundParameters object
 .OUTPUTS
 Hashtable/$PSBoundParameters object, with defined parameters removed.
 #>
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'FilteredParameters', Justification = "False Positive")]
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'ParametersToKeep', Justification = "False Positive")]
-	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'ParametersToRemove', Justification = "False Positive")]
-	[CmdletBinding(DefaultParameterSetName = "Remove")]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'FilteredParameters', Justification = 'False Positive')]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'ParametersToKeep', Justification = 'False Positive')]
+	[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'ParametersToRemove', Justification = 'False Positive')]
+	[CmdletBinding(DefaultParameterSetName = 'Remove')]
 	[OutputType('System.Collections.Hashtable')]
 	param(
 		[parameter(
@@ -45,13 +45,13 @@ Hashtable/$PSBoundParameters object, with defined parameters removed.
 
 		[parameter(
 			Mandatory = $false,
-			ParameterSetName = "Remove"
+			ParameterSetName = 'Remove'
 		)]
 		[array]$ParametersToRemove = @(),
 
 		[parameter(
 			Mandatory = $false,
-			ParameterSetName = "Keep"
+			ParameterSetName = 'Keep'
 		)]
 		[array]$ParametersToKeep = @()
 
@@ -62,10 +62,10 @@ Hashtable/$PSBoundParameters object, with defined parameters removed.
 		$BaseParameters = [Collections.Generic.List[String]]@(
 			[System.Management.Automation.PSCmdlet]::CommonParameters +
 			[System.Management.Automation.PSCmdlet]::OptionalCommonParameters +
-			"SessionVariable" +
-			"UseClassicAPI" +
-			"UseGen1API" +
-			"TimeoutSec"
+			'SessionVariable' +
+			'UseClassicAPI' +
+			'UseGen1API' +
+			'TimeoutSec'
 		)
 
 	}#begin
@@ -78,7 +78,7 @@ Hashtable/$PSBoundParameters object, with defined parameters removed.
 
 		} {
 
-			if ($PSCmdlet.ParameterSetName -eq "Keep") {
+			if ($PSCmdlet.ParameterSetName -eq 'Keep') {
 
 				if ($ParametersToKeep -contains $PSItem) {
 

--- a/psPAS/Private/Get-PASResponse.ps1
+++ b/psPAS/Private/Get-PASResponse.ps1
@@ -40,7 +40,7 @@ function Get-PASResponse {
 			$PASResponse = $APIResponse.Content
 
 			#get response content type
-			$ContentType = $APIResponse.Headers["Content-Type"]
+			$ContentType = $APIResponse.Headers['Content-Type']
 
 			#handle content type
 			switch ($ContentType) {
@@ -55,7 +55,7 @@ function Get-PASResponse {
 
 							[System.Management.Automation.ErrorRecord]::new(
 
-								"Guru Meditation - HTML Response Received",
+								'Guru Meditation - HTML Response Received',
 								$StatusCode,
 								[System.Management.Automation.ErrorCategory]::NotSpecified,
 								$APIResponse
@@ -80,7 +80,7 @@ function Get-PASResponse {
 				default {
 
 					# Byte Array expected for files to be saved
-					if ($($PASResponse | Get-Member | Select-Object -ExpandProperty typename) -eq "System.Byte" ) {
+					if ($($PASResponse | Get-Member | Select-Object -ExpandProperty typename) -eq 'System.Byte' ) {
 
 						#return content and headers
 						$PASResponse = $APIResponse | Select-Object Content, Headers

--- a/psPAS/Private/Out-PASFile.ps1
+++ b/psPAS/Private/Out-PASFile.ps1
@@ -40,17 +40,17 @@ function Out-PASFile {
 		If (-not ($Path)) {
 
 			#Default to TEMP if path not provided
-			$Path = [Environment]::GetEnvironmentVariable("Temp")
+			$Path = [Environment]::GetEnvironmentVariable('Temp')
 
 		}
 
 		#Get filename from Content-Disposition Header element.
-		$FileName = ($InputObject.Headers["Content-Disposition"] -split "filename=")[1] -replace '"'
+		$FileName = ($InputObject.Headers['Content-Disposition'] -split 'filename=')[1] -replace '"'
 
 		#Define output path
 		$OutputPath = Join-Path $Path $FileName
 
-		if ($PSCmdlet.ShouldProcess($OutputPath, "Save File")) {
+		if ($PSCmdlet.ShouldProcess($OutputPath, 'Save File')) {
 
 			try {
 
@@ -58,14 +58,14 @@ function Out-PASFile {
 				$output = @{
 					Path     = $OutputPath
 					Value    = $InputObject.Content
-					Encoding = "Byte"
+					Encoding = 'Byte'
 				}
 
 				If (Test-IsCoreCLR) {
 
 					#amend parameters for splatting if we are in Core
-					$output.Add("AsByteStream", $true)
-					$output.Remove("Encoding")
+					$output.Add('AsByteStream', $true)
+					$output.Remove('Encoding')
 
 				}
 

--- a/psPAS/Private/Skip-CertificateCheck.ps1
+++ b/psPAS/Private/Skip-CertificateCheck.ps1
@@ -15,7 +15,7 @@ Function Skip-CertificateCheck {
 	$CompilerParameters.GenerateExecutable = $false
 	$CompilerParameters.GenerateInMemory = $true
 	$CompilerParameters.IncludeDebugInformation = $false
-	$CompilerParameters.ReferencedAssemblies.Add("System.DLL") | Out-Null
+	$CompilerParameters.ReferencedAssemblies.Add('System.DLL') | Out-Null
 	$CertificatePolicy = @'
         namespace Local.ToolkitExtensions.Net.CertificatePolicy
         {
@@ -35,7 +35,7 @@ Function Skip-CertificateCheck {
 		$PolicyResult = $CSharpCodeProvider.CompileAssemblyFromSource($CompilerParameters, $CertificatePolicy)
 		$CompiledAssembly = $PolicyResult.CompiledAssembly
 		## Create an instance of TrustAll and attach it to the ServicePointManager
-		$TrustAll = $CompiledAssembly.CreateInstance("Local.ToolkitExtensions.Net.CertificatePolicy.TrustAll")
+		$TrustAll = $CompiledAssembly.CreateInstance('Local.ToolkitExtensions.Net.CertificatePolicy.TrustAll')
 		[System.Net.ServicePointManager]::CertificatePolicy = $TrustAll
 
 	}

--- a/psPAS/about_psPAS.help.txt
+++ b/psPAS/about_psPAS.help.txt
@@ -5,7 +5,7 @@ SHORT DESCRIPTION
     psPAS is a PowerShell interface for the CyberArk REST Web Services.
 
 LONG DESCRIPTION
-    psPAS sends requests to , and receives data from, a CyberArk Privileged Access Security Web Service.
+    psPAS sends requests to, and receives data from, a CyberArk Privileged Access Security Web Service.
     It issues commands to the Web Service allowing a user to issue create, list, modify and delete operations to be
     performed against entities in a Privileged Access Security solution from either a PowerShell console or script.
 

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -7999,6 +7999,15 @@ Add-PASDiscoveredAccount -UserName ServiceUser -Address 1.2.3.4 -discoveryDate (
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
+        <dev:code>Add-PASSafeMember -SafeName Windows_Domain_Safe -MemberName anLDAPGroup -SearchIn cybr.lab -UseAccounts $true `
+-RetrieveAccounts $true -ListAccounts $true</dev:code>
+        <dev:remarks>
+          <maml:para>Adds the LDAP Group anLDAPGroup to Windows_Domain_Safe with Use, Retrieve &amp; List permissions. There should be Directory named cybr.lab in the LDAP Integration settings.</maml:para>
+          <maml:para>Minimum required version 12.1</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 3 --------------------------</maml:title>
         <dev:code>$Role = [PSCustomObject]@{
 
   UseAccounts                  = $true
@@ -8015,7 +8024,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         </dev:remarks>
       </command:example>
       <command:example>
-        <maml:title>-------------------------- EXAMPLE 3 --------------------------</maml:title>
+        <maml:title>-------------------------- EXAMPLE 4 --------------------------</maml:title>
         <dev:code>$Role = [PSCustomObject]@{
 
   UseAccounts                  = $true
@@ -13195,6 +13204,19 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>groupName</maml:name>
+          <maml:description>
+            <maml:para>Search for groups by name.</maml:para>
+            <maml:para>Requires minimum version of 12.2</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Get-PASGroup</maml:name>
@@ -13321,6 +13343,19 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>groupName</maml:name>
+        <maml:description>
+          <maml:para>Search for groups by name.</maml:para>
+          <maml:para>Requires minimum version of 12.2</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
     </command:parameters>
     <command:inputTypes />
     <command:returnValues />
@@ -13377,6 +13412,13 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <dev:code>Get-PASGroup -search Admins -includeMembers $true</dev:code>
         <dev:remarks>
           <maml:para>Returns all existing groups matching search, includes vault group member details in result.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 8 --------------------------</maml:title>
+        <dev:code>Get-PASGroup -groupName "Vault Admins" -includeMembers $true</dev:code>
+        <dev:remarks>
+          <maml:para>Returns group matching name, includes vault group member details in result.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -31713,7 +31755,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>Updates a single safe in the Vault. Manage Safe permission is required.</maml:para>
+      <maml:para>Updates a single safe in the Vault. Manage Safe permission is required. All required properties should be sent in the request. Any properties set on the safe not included in the request will be cleared.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -32348,6 +32390,14 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
+        <dev:code>Get-PASSafe -SafeName SAFE | Set-PASSafe -SafeName SAFE -NumberOfVersionsRetention 10</dev:code>
+        <dev:remarks>
+          <maml:para>Updates version retention on SAFE using Gen2 API, maintaining all other properties.</maml:para>
+          <maml:para>Minimum required version 12.2</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 3 --------------------------</maml:title>
         <dev:code>Set-PASSafe -SafeName SAFE -Description "New-Description" -NumberOfDaysRetention 10 -UseGen1API</dev:code>
         <dev:remarks>
           <maml:para>Updates description and number of days retention on SAFE using Gen1 API</maml:para>

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -9838,6 +9838,14 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <maml:linkText>Online Version:</maml:linkText>
         <maml:uri>https://pspas.pspete.dev/commands/Disable-PASPlatform</maml:uri>
       </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>https://pspas.pspete.dev/commands/Disable-PASUser</maml:linkText>
+        <maml:uri>https://pspas.pspete.dev/commands/Disable-PASUser</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/Disable-user.htm</maml:linkText>
+        <maml:uri>https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/Disable-user.htm</maml:uri>
+      </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
@@ -10302,6 +10310,14 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
       <maml:navigationLink>
         <maml:linkText>Online Version:</maml:linkText>
         <maml:uri>https://pspas.pspete.dev/commands/Enable-PASPlatform</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>https://pspas.pspete.dev/commands/Enable-PASUser</maml:linkText>
+        <maml:uri>https://pspas.pspete.dev/commands/Enable-PASUser</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/Enable-user.htm</maml:linkText>
+        <maml:uri>https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/Enable-user.htm</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -10775,7 +10791,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           </dev:type>
           <dev:defaultValue>0</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>savedFilter</maml:name>
           <maml:description>
             <maml:para>Specify a value matching one of the configured Saved Filters: 'Regular', 'Recently', 'New', 'Link', 'Deleted', 'PolicyFailures', 'AccessedByUsers', 'ModifiedByUsers', 'ModifiedByCPM', 'DisabledPasswordByUser', 'DisabledPasswordByCPM', 'ScheduledForChange', 'ScheduledForVerify', 'ScheduledForReconcile', 'SuccessfullyReconciled', 'FailedChange', 'FailedVerify', 'FailedReconcile', 'LockedOrNew', 'Locked', 'Favorites'</maml:para>
@@ -11041,7 +11057,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         </dev:type>
         <dev:defaultValue>0</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>savedFilter</maml:name>
         <maml:description>
           <maml:para>Specify a value matching one of the configured Saved Filters: 'Regular', 'Recently', 'New', 'Link', 'Deleted', 'PolicyFailures', 'AccessedByUsers', 'ModifiedByUsers', 'ModifiedByCPM', 'DisabledPasswordByUser', 'DisabledPasswordByCPM', 'ScheduledForChange', 'ScheduledForVerify', 'ScheduledForReconcile', 'SuccessfullyReconciled', 'FailedChange', 'FailedVerify', 'FailedReconcile', 'LockedOrNew', 'Locked', 'Favorites'</maml:para>

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -9730,6 +9730,118 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
+      <command:name>Disable-PASUser</command:name>
+      <command:verb>Disable</command:verb>
+      <command:noun>PASUser</command:noun>
+      <maml:description>
+        <maml:para>Disables a specific vault user.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Sets the status of an enabled vault user to disabled</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Disable-PASUser</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
+          <maml:name>id</maml:name>
+          <maml:description>
+            <maml:para>The unique numerical id of the user</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>0</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
+        <maml:name>id</maml:name>
+        <maml:description>
+          <maml:para>The unique numerical id of the user</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>0</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+        <maml:name>WhatIf</maml:name>
+        <maml:description>
+          <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>Disable-PASUser -id 1234</dev:code>
+        <dev:remarks>
+          <maml:para>Disables the vault user with id 1234</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>Online Version:</maml:linkText>
+        <maml:uri>https://pspas.pspete.dev/commands/Disable-PASPlatform</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
       <command:name>Enable-PASCPMAutoManagement</command:name>
       <command:verb>Enable</command:verb>
       <command:noun>PASCPMAutoManagement</command:noun>
@@ -10078,6 +10190,118 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
       <maml:navigationLink>
         <maml:linkText>https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/rest-api-activate-rotational-group-platform.htm</maml:linkText>
         <maml:uri>https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/rest-api-activate-rotational-group-platform.htm</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Enable-PASUser</command:name>
+      <command:verb>Enable</command:verb>
+      <command:noun>PASUser</command:noun>
+      <maml:description>
+        <maml:para>Enables a specific vault user.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Reenables a disabled vault user</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Enable-PASUser</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
+          <maml:name>id</maml:name>
+          <maml:description>
+            <maml:para>The unique numerical id of the user</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>0</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
+        <maml:name>id</maml:name>
+        <maml:description>
+          <maml:para>The unique numerical id of the user</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>0</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+        <maml:name>WhatIf</maml:name>
+        <maml:description>
+          <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>Enable-PASUser -id 1234</dev:code>
+        <dev:remarks>
+          <maml:para>Enables the vault user with id 1234</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>Online Version:</maml:linkText>
+        <maml:uri>https://pspas.pspete.dev/commands/Enable-PASPlatform</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -10551,6 +10775,19 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           </dev:type>
           <dev:defaultValue>0</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>savedFilter</maml:name>
+          <maml:description>
+            <maml:para>Specify a value matching one of the configured Saved Filters: 'Regular', 'Recently', 'New', 'Link', 'Deleted', 'PolicyFailures', 'AccessedByUsers', 'ModifiedByUsers', 'ModifiedByCPM', 'DisabledPasswordByUser', 'DisabledPasswordByCPM', 'ScheduledForChange', 'ScheduledForVerify', 'ScheduledForReconcile', 'SuccessfullyReconciled', 'FailedChange', 'FailedVerify', 'FailedReconcile', 'LockedOrNew', 'Locked', 'Favorites'</maml:para>
+            <maml:para>Requires minimum version of 12.6</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Get-PASAccount</maml:name>
@@ -10804,6 +11041,19 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         </dev:type>
         <dev:defaultValue>0</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>savedFilter</maml:name>
+        <maml:description>
+          <maml:para>Specify a value matching one of the configured Saved Filters: 'Regular', 'Recently', 'New', 'Link', 'Deleted', 'PolicyFailures', 'AccessedByUsers', 'ModifiedByUsers', 'ModifiedByCPM', 'DisabledPasswordByUser', 'DisabledPasswordByCPM', 'ScheduledForChange', 'ScheduledForVerify', 'ScheduledForReconcile', 'SuccessfullyReconciled', 'FailedChange', 'FailedVerify', 'FailedReconcile', 'LockedOrNew', 'Locked', 'Favorites'</maml:para>
+          <maml:para>Requires minimum version of 12.6</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
     </command:parameters>
     <command:inputTypes />
     <command:returnValues />
@@ -10883,6 +11133,14 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <dev:remarks>
           <maml:para>Returns all accounts matching "root", sorted by AccountName.</maml:para>
           <maml:para>Requires minimum version of 10.4</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 10 --------------------------</maml:title>
+        <dev:code>Get-PASAccount -savedFilter New</dev:code>
+        <dev:remarks>
+          <maml:para>Returns all accounts from the "New" Saved Filter</maml:para>
+          <maml:para>Requires minimum version of 12.6</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -11192,7 +11450,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           <maml:name>UseGen1API</maml:name>
           <maml:description>
             <maml:para>Specify to force usage the Gen1 API endpoint.</maml:para>
-            <maml:para>Should be specified for versions earlier than 10.5</maml:para>
+            <maml:para>This is based on the Get Account Groups By Safe API, introduced in PAS 10.5, depreciated in 12.6</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -11219,7 +11477,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <maml:name>UseGen1API</maml:name>
         <maml:description>
           <maml:para>Specify to force usage the Gen1 API endpoint.</maml:para>
-          <maml:para>Should be specified for versions earlier than 10.5</maml:para>
+          <maml:para>This is based on the Get Account Groups By Safe API, introduced in PAS 10.5, depreciated in 12.6</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -13224,7 +13482,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           <maml:name>filter</maml:name>
           <maml:description>
             <maml:para>Filter according to REST standard.</maml:para>
-            <maml:para>*depreciated parameter in psPAS - filter value will automatically be set with if groupType specified.</maml:para>
+            <maml:para>*depreciated parameter in psPAS - filter value will automatically be set if groupType specified.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -13275,6 +13533,35 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
       </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Get-PASGroup</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>includeMembers</maml:name>
+          <maml:description>
+            <maml:para>Specify $true to return vault group members</maml:para>
+            <maml:para>Defaults to $false due to performance considerations</maml:para>
+            <maml:para>Requires minimum version of 12.0</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>id</maml:name>
+          <maml:description>
+            <maml:para>The integer id value of the group to get details of. Requires minimum version of 12.6</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
     </command:syntax>
     <command:parameters>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
@@ -13293,7 +13580,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <maml:name>filter</maml:name>
         <maml:description>
           <maml:para>Filter according to REST standard.</maml:para>
-          <maml:para>*depreciated parameter in psPAS - filter value will automatically be set with if groupType specified.</maml:para>
+          <maml:para>*depreciated parameter in psPAS - filter value will automatically be set if groupType specified.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -13352,6 +13639,18 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
           <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>id</maml:name>
+        <maml:description>
+          <maml:para>The integer id value of the group to get details of. Requires minimum version of 12.6</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -13418,7 +13717,14 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <maml:title>-------------------------- EXAMPLE 8 --------------------------</maml:title>
         <dev:code>Get-PASGroup -groupName "Vault Admins" -includeMembers $true</dev:code>
         <dev:remarks>
-          <maml:para>Returns group matching name, includes vault group member details in result.</maml:para>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 9 --------------------------</maml:title>
+        <dev:code>Get-PASGroup -id 11</dev:code>
+        <dev:remarks>
+          <maml:para>Returns group with id 11. Requires minimum version of 12.6</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -31788,7 +32094,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>Description</maml:name>
           <maml:description>
             <maml:para>Updated Description for safe.</maml:para>
@@ -31813,7 +32119,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>ManagingCPM</maml:name>
           <maml:description>
             <maml:para>The Name of the CPM user to manage the safe.</maml:para>
@@ -31904,7 +32210,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>Description</maml:name>
           <maml:description>
             <maml:para>Updated Description for safe.</maml:para>
@@ -31929,7 +32235,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>ManagingCPM</maml:name>
           <maml:description>
             <maml:para>The Name of the CPM user to manage the safe.</maml:para>
@@ -32019,7 +32325,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>Description</maml:name>
           <maml:description>
             <maml:para>Updated Description for safe.</maml:para>
@@ -32044,7 +32350,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>ManagingCPM</maml:name>
           <maml:description>
             <maml:para>The Name of the CPM user to manage the safe.</maml:para>
@@ -32138,7 +32444,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>Description</maml:name>
           <maml:description>
             <maml:para>Updated Description for safe.</maml:para>
@@ -32163,7 +32469,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>ManagingCPM</maml:name>
           <maml:description>
             <maml:para>The Name of the CPM user to manage the safe.</maml:para>
@@ -32256,7 +32562,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>Description</maml:name>
         <maml:description>
           <maml:para>Updated Description for safe.</maml:para>
@@ -32281,7 +32587,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>ManagingCPM</maml:name>
         <maml:description>
           <maml:para>The Name of the CPM user to manage the safe.</maml:para>

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -218,7 +218,9 @@
 		'Revoke-PASJustInTimeAccess',
 		'Get-PASAccountDetail',
 		'Clear-PASLinkedAccount',
-		'Get-PASPlatformSummary'
+		'Get-PASPlatformSummary',
+		'Enable-PASUser',
+		'Disable-PASUser'
 	)
 
 	#AliasesToExport   = @()

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -16,7 +16,7 @@
 	# CompanyName       = ''
 
 	# Copyright statement for this module
-	Copyright         = '(c) 2017-2021 Pete Maan. All rights reserved.'
+	Copyright         = '(c) 2017-2022 Pete Maan. All rights reserved.'
 
 	# Description of the functionality provided by this module
 	Description       = 'Module for CyberArk Privileged Access Security Web Service REST API'

--- a/psPAS/psPAS.psm1
+++ b/psPAS/psPAS.psm1
@@ -30,30 +30,30 @@ param(
 }
 
 #Get function files
-Get-ChildItem $PSScriptRoot\ -Recurse -Include "*.ps1" -Exclude "*.ps1xml" |
+Get-ChildItem $PSScriptRoot\ -Recurse -Include '*.ps1' -Exclude '*.ps1xml' |
 
-ForEach-Object {
+	ForEach-Object {
 
-	if ($DotSourceModule) {
-		. $_.FullName
-	} else {
-		$ExecutionContext.InvokeCommand.InvokeScript(
-			$false,
-			(
-				[scriptblock]::Create(
-					[io.file]::ReadAllText(
-						$_.FullName,
-						[Text.Encoding]::UTF8
+		if ($DotSourceModule) {
+			. $_.FullName
+		} else {
+			$ExecutionContext.InvokeCommand.InvokeScript(
+				$false,
+				(
+					[scriptblock]::Create(
+						[io.file]::ReadAllText(
+							$_.FullName,
+							[Text.Encoding]::UTF8
+						)
 					)
-				)
-			),
-			$null,
-			$null
-		)
+				),
+				$null,
+				$null
+			)
+
+		}
 
 	}
 
-}
-
-[System.Version]$Version = "0.0"
+[System.Version]$Version = '0.0'
 Set-Variable -Name ExternalVersion -Value $Version -Scope Script


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
<!--
Please include a summary of the change and which issue is fixed & relevant motivation and context.
Put `Fixes #XXX` in your comment to link the issue that your PR fixes.
-->

### Module update to cover all CyberArk 12.6 API features

- New Commands
  - `Enable-PASUser`
    - New command, supported from 12.6
  - `Disable-PASUser`
    - New command, supported from 12.6
- Updates
  - `Get-PASAccount`
    - Added `savedFilter` parameter, supported from 12.6
  - `Get-PASGroup`
    - Added `id` parameter, supported from 12.6
    - Added `groupName` parameter, supported from 12.2.
  - `Get-PASAccountGroup`
    - Depreciated use of "Get Safe account groups" API
    - Makes ParameterSet based on `Get account group by Safe` API the default.
  - Updates URL formatting to include a forward slash (/) to end of URL for functions which may include a dot (.) via provided parameter values.
  - Updated documentation and help text.
  
Fixes #392 

## Type of change
<!--
Please select all relevant options:
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [X] Documentation update (psPAS website or command help content)
- [ ] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [X] Pester test(s) updated
- [X] Pester test(s) passing

**Test Configuration**:
- PowerShell version: 7.2.5
- CyberArk PAS version: 12.6
- OS Version: Win 11

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [X] My code follows the style guidelines of this project
- [X] I have followed the contributing guidelines.
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new test failures or errors
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [X] I have linked a related issue