### PR TITLE
5.3-Update-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Removal of depreciated `filter` parameters.
 - Documentation updates
 
-## **5.3.76 (August 2022)** ##
+## **5.3.76 (August 17th 2022)** ##
 
 -Updates
   - Set-PASUser / New-PASUser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,22 @@
 # psPAS
 
-## Planned Updates
+## Planned Updates / Unreleased
 
 - Continued development to encompass any new documented features of the CyberArk API.
 - psPAS v6.0...
+- Removal of depreciated `filter` parameters.
+- Documentation updates
 
-## **vNext (TBC)** ##
+## **5.3.76 (August 2022)** ##
+
+-Updates
+  - Set-PASUser / New-PASUser
+    - Adds `GUI` as available parameter value for `unAuthorizedInterfaces` parameter.
+- Gen1 API Specific
+  - Add-PASAccount / Set-PASAccount
+    - Fixes enumeration of dynamic properties for Gen1 requests.
+  - Reverts Gen1 specific URL update introduced in last release for "_user_" type commands.
+    - Removes forward slash (/) to end of request URL
 
 ## **5.3.69 (July 26th 2022)**
 

--- a/Tests/Get-PASUser.Tests.ps1
+++ b/Tests/Get-PASUser.Tests.ps1
@@ -70,7 +70,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/SomeUser/"
+					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/SomeUser"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Remove-PASUser.Tests.ps1
+++ b/Tests/Remove-PASUser.Tests.ps1
@@ -74,7 +74,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Remove-PASUser
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/ThatUser/"
+					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/ThatUser"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Set-PASUser.Tests.ps1
+++ b/Tests/Set-PASUser.Tests.ps1
@@ -82,7 +82,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/SomeUser/"
+					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/SomeUser"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Unblock-PASUser.Tests.ps1
+++ b/Tests/Unblock-PASUser.Tests.ps1
@@ -59,7 +59,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			It 'sends request to Classic API' {
 				Unblock-PASUser -UserName MrFatFingers -Suspended $false
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It -ParameterFilter {
-					$URI -eq 'https://SomeURL/SomeApp/WebServices/PIMServices.svc/Users/MrFatFingers/'
+					$URI -eq 'https://SomeURL/SomeApp/WebServices/PIMServices.svc/Users/MrFatFingers'
 				}
 
 			}

--- a/docs/collections/_pages/about.md
+++ b/docs/collections/_pages/about.md
@@ -14,7 +14,7 @@ Initially released in 2017, psPAS contains over 100 commands for the CyberArk RE
 
 The module is designed to be compatible with CyberArk from Version 9 onwards, providing CyberArk users with an accessible resource for automating simple day to day administration tasks as well as more complex requirements.
 
-The module can work in both PowerShell Core & PowerShell, meaning Windows, Linux, and macOS CyberArk automation is possible.
+The module can work in both PowerShell Core & Windows PowerShell, meaning Windows, Linux, and macOS CyberArk automation is possible.
 
 Using a shared set of commands for interacting with the CyberArk API provides many benefits:
 

--- a/psPAS/Functions/Accounts/Add-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Add-PASAccount.ps1
@@ -302,7 +302,7 @@ function Add-PASAccount {
 				}
 
 				#Add "non-base" parameter hashtable as value of "properties" on boundparameters object
-				$boundParameters['properties'] = [Collections.Generic.List[String]]@($properties.getenumerator() | ForEach-Object { $_ })
+				$boundParameters['properties'] = [Collections.Generic.List[Object]]@($properties.getenumerator() | ForEach-Object { $_ })
 
 				#Create body of request
 				$body = @{

--- a/psPAS/Functions/Accounts/Set-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Set-PASAccount.ps1
@@ -175,7 +175,7 @@ function Set-PASAccount {
 
 					#Format "Properties" parameter value.
 					#Array of key=value pairs required for JSON convertion
-					$boundParameters['Properties'] = [Collections.Generic.List[String]]@($boundParameters['Properties'].getenumerator() |
+					$boundParameters['Properties'] = [Collections.Generic.List[Object]]@($boundParameters['Properties'].getenumerator() |
 
 							ForEach-Object { $_ })
 

--- a/psPAS/Functions/User/Get-PASUser.ps1
+++ b/psPAS/Functions/User/Get-PASUser.ps1
@@ -153,7 +153,7 @@ function Get-PASUser {
 				Assert-VersionRequirement -MaximumVersion 12.3
 
 				#Create URL for request
-				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)/"
+				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)"
 
 				$TypeName = 'psPAS.CyberArk.Vault.User'
 

--- a/psPAS/Functions/User/New-PASUser.ps1
+++ b/psPAS/Functions/User/New-PASUser.ps1
@@ -40,7 +40,7 @@ function New-PASUser {
 			ParameterSetName = 'Gen2'
 		)]
 		[ValidateSet('PIMSU', 'PSM', 'PSMP', 'PVWA', 'WINCLIENT', 'PTA', 'PACLI', 'NAPI', 'XAPI', 'HTTPGW',
-			'EVD', 'PIMSu', 'AIMApp', 'CPM', 'PVWAApp', 'PSMApp', 'AppPrv', 'AIMApp', 'PSMPApp')]
+			'EVD', 'PIMSu', 'AIMApp', 'CPM', 'PVWAApp', 'PSMApp', 'AppPrv', 'AIMApp', 'PSMPApp', 'GUI')]
 		[string[]]$unAuthorizedInterfaces,
 
 		[parameter(

--- a/psPAS/Functions/User/Remove-PASUser.ps1
+++ b/psPAS/Functions/User/Remove-PASUser.ps1
@@ -45,7 +45,7 @@ function Remove-PASUser {
 				Assert-VersionRequirement -MaximumVersion 12.3
 
 				#Create URL for request
-				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)/"
+				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)"
 
 				break
 

--- a/psPAS/Functions/User/Set-PASUser.ps1
+++ b/psPAS/Functions/User/Set-PASUser.ps1
@@ -55,7 +55,7 @@ function Set-PASUser {
 			ParameterSetName = 'Gen2'
 		)]
 		[ValidateSet('PIMSU', 'PSM', 'PSMP', 'PVWA', 'WINCLIENT', 'PTA', 'PACLI', 'NAPI', 'XAPI', 'HTTPGW',
-			'EVD', 'PIMSu', 'AIMApp', 'CPM', 'PVWAApp', 'PSMApp', 'AppPrv', 'AIMApp', 'PSMPApp')]
+			'EVD', 'PIMSu', 'AIMApp', 'CPM', 'PVWAApp', 'PSMApp', 'AppPrv', 'AIMApp', 'PSMPApp', 'GUI')]
 		[string[]]$unAuthorizedInterfaces,
 
 		[parameter(
@@ -438,7 +438,7 @@ function Set-PASUser {
 				}
 
 				#Create URL for request
-				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)/"
+				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)"
 
 				$TypeName = 'psPAS.CyberArk.Vault.User'
 

--- a/psPAS/Functions/User/Unblock-PASUser.ps1
+++ b/psPAS/Functions/User/Unblock-PASUser.ps1
@@ -53,7 +53,7 @@ function Unblock-PASUser {
 				Assert-VersionRequirement -MaximumVersion 12.3
 
 				#Create request
-				$Request['URI'] = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)/"
+				$Request['URI'] = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)"
 				$Request['Method'] = 'PUT'
 				$Request['Body'] = $PSBoundParameters | Get-PASParameter -ParametersToRemove UserName | ConvertTo-Json
 


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
<!--
Please include a summary of the change and which issue is fixed & relevant motivation and context.
Put `Fixes #XXX` in your comment to link the issue that your PR fixes.
-->

- Updates
  - Set-PASUser / New-PASUser
    - Adds `GUI` as available parameter value for `unAuthorizedInterfaces` parameter.
- Gen1 API Specific
  - Add-PASAccount / Set-PASAccount
    - Fixes enumeration of dynamic properties for Gen1 requests.
  - Reverts Gen1 specific URL update introduced in last release for "_user_" type commands.
    - Removes forward slash (/) to end of request URL

## Type of change
<!--
Please select all relevant options:
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [ ] Documentation update (psPAS website or command help content)
- [ ] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [X] Pester test(s) updated
- [X] Pester test(s) passing

**Test Configuration**:
- PowerShell version: 7.2.5
- CyberArk PAS version: 11.5 & 12.6
- OS Version:  Win 11

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [X] My code follows the style guidelines of this project
- [X] I have followed the contributing guidelines.
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new test failures or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [ ] I have linked a related issue