### PR TITLE
Release 5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 - Continued development to encompass any new documented features of the CyberArk API.
 - psPAS v6.0...
 
-## **5.5 (March 2023)
+## **5.5.110 (March 7th 2023)
+
+### Module update to cover all CyberArk 13.0 API features
 
 - New
   - Adds `Get-PASPTAGlobalCatalog` & `Add-PASPTAGlobalCatalog` commands, available for v13.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@
 - Continued development to encompass any new documented features of the CyberArk API.
 - psPAS v6.0...
 
+## **5.5 (March 2023)
+
+- New
+  - Adds `Get-PASPTAGlobalCatalog` & `Add-PASPTAGlobalCatalog` commands, available for v13.
+- Updates
+  - `New-PASSession`
+    - Adds Shared Services Auth Support
+    - Allows null or empty `OTPDelimiter` to be specified
+  - `Set-PASPTARule`
+    - Updates validation for parameter `id`
+  - `Get-PASComponentDetail`
+    - Adds `pta` as option for parameter `component`
+  - `Add-PASSafe`
+    - Allows `0` as valid value for parameter `NumberOfDaysRetention`
+  - `Add-PASSafeMember`
+    - Adds optional `memberType` parameter, accepted from 12.6 onward.
+- Other
+  - Allow UPN UserName format
+    - Updates the parameter validation logic of the `*-PASPublicSSHKey` functions to allow UPN style usernames to be specified and accepted.
+  - Updates `psPAS.CyberArk.Vault.OnboardingRule` format in line with expected output according to product documentation.
+  - Documentation update
+    - Correct version requirement information for the `Get-PASAccount` `searchType` parameter.
+
 ## **5.4.101 (November 20th 2022)**
 
 - Fix `Get-PASSafeMember`

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2022 Pete Maan
+Copyright (c) 2017-2023 Pete Maan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 # **psPAS: PowerShell Module for the CyberArk API**
 
-Through the PVWA REST API, administer CyberArk with PowerShell.
+Through the PVWA REST API, administer CyberArk PAS with PowerShell.
 
-contains all of the documented API capabilities up to CyberArk v12.6.
+contains all of the documented API capabilities up to CyberArk v13.0.
 
 Docs: [https://pspas.pspete.dev](https://pspas.pspete.dev)
 
@@ -938,7 +938,13 @@ Click the below dropdown to view the current list of psPAS functions and their m
 [`Publish-PASDiscoveredAccount`][Publish-PASDiscoveredAccount]                           |**12.6**            |Onboard Discovered Accounts
 [`Get-PASLinkedAccount`][Get-PASLinkedAccount]                                           |**12.2**            |Get details of linked accounts
 [`Add-PASPersonalAdminAccount`][Add-PASPersonalAdminAccount]                             |**12.6**            |Add Personal Admin Account (Privilege Cloud Only).
+[`Get-PASPTAGlobalCatalog`][Get-PASPTAGlobalCatalog]                                     |**13.0**            |Get Global Catalog connectivity details for PTA.
+[`Add-PASPTAGlobalCatalog`][Add-PASPTAGlobalCatalog]                                     |**13.0**            |Add Global Catalog connectivity details to PTA.
 
+[Get-PASPTAGlobalCatalog]:/psPAS/Functions/EventSecurity/Get-PASPTAGlobalCatalog
+[Add-PASPTAGlobalCatalog]:/psPAS/Functions/EventSecurity/Add-PASPTAGlobalCatalog
+[Disable-PASUser]:/psPAS/Functions/User/Disable-PASUser
+[Enable-PASUser]:/psPAS/Functions/User/Enable-PASUser
 [Get-PASLinkedAccount]:/psPAS/Functions/Accounts/Get-PASLinkedAccount
 [Add-PASPersonalAdminAccount]:/psPAS/Functions/Accounts/Add-PASPersonalAdminAccount
 [Publish-PASDiscoveredAccount]:/psPAS/Functions/Accounts/Publish-PASDiscoveredAccount

--- a/Tests/Add-PASPTAGlobalCatalog.Tests.ps1
+++ b/Tests/Add-PASPTAGlobalCatalog.Tests.ps1
@@ -1,0 +1,157 @@
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
+
+    BeforeAll {
+        #Get Current Directory
+        $Here = Split-Path -Parent $PSCommandPath
+
+        #Assume ModuleName from Repository Root folder
+        $ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+        #Resolve Path to Module Directory
+        $ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+        #Define Path to Module Manifest
+        $ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+        if ( -not (Get-Module -Name $ModuleName -All)) {
+
+            Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+        }
+
+        $Script:RequestBody = $null
+        $Script:BaseURI = 'https://SomeURL/SomeApp'
+        $Script:ExternalVersion = '0.0'
+        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+    }
+
+
+    AfterAll {
+
+        $Script:RequestBody = $null
+
+    }
+
+    InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+        BeforeEach {
+
+            Mock Invoke-PASRestMethod -MockWith {
+                [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
+
+            }
+
+            $SomePassword = $('Some_Password' | ConvertTo-SecureString -AsPlainText -Force)
+
+            $InputObj = [pscustomobject]@{
+                'ldap_certificate' = 'SomeCertValue'
+                'ldap_server'      = 'someserver.somedomain.com'
+                'ssl'              = $true
+                'ldap_port'        = '1234'
+                'upn'              = 'SomeUser@SomeDomain.com'
+                'ldapPassword'     = $SomePassword
+
+            }
+
+            $response = $InputObj | Add-PASPTAGlobalCatalog
+
+        }
+
+
+
+        Context 'Mandatory Parameters' {
+
+            $Parameters = @{Parameter = 'ldap_server' },
+            @{Parameter = 'ldap_port' },
+            @{Parameter = 'upn' },
+            @{Parameter = 'ldapPassword' }
+
+            It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
+
+                param($Parameter)
+
+				(Get-Command Add-PASPTAGlobalCatalog).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
+
+            }
+
+        }
+
+        Context 'Input' {
+
+            It 'sends request' {
+
+                Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+
+            }
+
+            It 'sends request to expected endpoint' {
+
+                Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+                    $URI -eq "$($Script:BaseURI)/API/pta/API/Administration/GCConnectivity"
+
+                } -Times 1 -Exactly -Scope It
+
+            }
+
+            It 'uses expected method' {
+
+                Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
+
+            }
+
+            It 'sends request with expected body' {
+
+                Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+                    $Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody) -ne $null
+
+                } -Times 1 -Exactly -Scope It
+
+            }
+
+            It 'has a request body with expected number of properties' {
+
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 2
+
+            }
+
+            It 'has expected properties value' {
+
+				($Script:RequestBody | Select-Object -ExpandProperty Properties | Get-Member -MemberType NoteProperty).length | Should -Be 5
+
+            }
+
+            It 'throws error if version requirement not met' {
+
+                $Script:ExternalVersion = '1.0'
+
+                { $InputObj | Add-PASPTAGlobalCatalog } | Should -Throw
+
+                $Script:ExternalVersion = '0.0'
+            }
+
+        }
+
+        Context 'Output' {
+
+            It 'provides output' {
+
+                $response | Should -Not -BeNullOrEmpty
+
+            }
+
+            It 'has output with expected number of properties' {
+
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
+
+            }
+
+        }
+
+    }
+
+}

--- a/Tests/Add-PASPublicSSHKey.Tests.ps1
+++ b/Tests/Add-PASPublicSSHKey.Tests.ps1
@@ -42,7 +42,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			$InputObj = [pscustomobject]@{
-				'UserName' = 'SomeUser'
+				'UserName' = 'SomeUser@domain.com'
 
 			}
 
@@ -80,7 +80,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/SomeUser/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys/"
+					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/SomeUser%40domain.com/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -136,7 +136,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'returns expected UserName property in response' {
 
-				$response.UserName | Should -Be 'SomeUser'
+				$response.UserName | Should -Be 'SomeUser@domain.com'
 
 			}
 

--- a/Tests/Add-PASSafeMember.Tests.ps1
+++ b/Tests/Add-PASSafeMember.Tests.ps1
@@ -217,6 +217,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 					'SafeName'                               = 'SomeSafe'
 					'MemberName'                             = 'SomeUser'
 					'SearchIn'                               = 'SomePlace'
+					'MemberType'                             = 'Group'
 					'UseAccounts'                            = $true
 					'RetrieveAccounts'                       = $true
 					'ListAccounts'                           = $true
@@ -283,7 +284,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'has a request body with expected number of properties' {
 
-				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 4
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 5
 
 			}
 

--- a/Tests/Get-PASPTAGlobalCatalog.Tests.ps1
+++ b/Tests/Get-PASPTAGlobalCatalog.Tests.ps1
@@ -1,0 +1,99 @@
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
+
+    BeforeAll {
+        #Get Current Directory
+        $Here = Split-Path -Parent $PSCommandPath
+
+        #Assume ModuleName from Repository Root folder
+        $ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+        #Resolve Path to Module Directory
+        $ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+        #Define Path to Module Manifest
+        $ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+        if ( -not (Get-Module -Name $ModuleName -All)) {
+
+            Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+        }
+
+        $Script:RequestBody = $null
+        $Script:BaseURI = 'https://SomeURL/SomeApp'
+        $Script:ExternalVersion = '0.0'
+        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+    }
+
+
+    AfterAll {
+
+        $Script:RequestBody = $null
+
+    }
+
+    InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+        BeforeEach {
+            Mock Invoke-PASRestMethod -MockWith {
+                [PSCustomObject]@{'automaticRemediation' = [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' } }
+            }
+
+            $response = Get-PASPTAGlobalCatalog
+        }
+        Context 'Input' {
+
+            It 'sends request' {
+
+                Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+
+            }
+
+            It 'sends request to expected endpoint' {
+
+                Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+                    $URI -eq "$($Script:BaseURI)/API/pta/API/Administration/GCConnectivity"
+
+                } -Times 1 -Exactly -Scope It
+
+            }
+
+            It 'uses expected method' {
+
+                Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
+
+            }
+
+            It 'sends request with no body' {
+
+                Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+                    $Body -eq $null
+
+                } -Times 1 -Exactly -Scope It
+
+            }
+
+            It 'throws error if version requirement not met' {
+                $Script:ExternalVersion = '1.0'
+                { Get-PASPTAGlobalCatalog } | Should -Throw
+                $Script:ExternalVersion = '0.0'
+            }
+
+        }
+
+        Context 'Output' {
+
+            It 'provides output' {
+
+                $response | Should -Not -BeNullOrEmpty
+
+            }
+
+        }
+
+    }
+
+}

--- a/Tests/Get-PASPublicSSHKey.Tests.ps1
+++ b/Tests/Get-PASPublicSSHKey.Tests.ps1
@@ -41,7 +41,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			$InputObj = [pscustomobject]@{
-				'UserName' = 'SomeUser'
+				'UserName' = 'SomeUser@domain.com'
 
 			}
 			$response = $InputObj | Get-PASPublicSSHKey
@@ -75,7 +75,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/SomeUser/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys/"
+					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/SomeUser%40domain.com/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -119,7 +119,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'returns username property in response' {
 
-				$response.UserName | Should -Be SomeUser
+				$response.UserName | Should -Be SomeUser@domain.com
 
 			}
 

--- a/Tests/Invoke-PASRestMethod.Tests.ps1
+++ b/Tests/Invoke-PASRestMethod.Tests.ps1
@@ -270,6 +270,27 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			}
 
+			It 'reports privilege cloud errors' {
+				If ($IsCoreCLR) {
+					$targetObject = [pscustomobject]@{'RequestUri' = [pscustomobject]@{'Host' = 'https://subdomain.id.cyberark.cloud' } }
+					$errorDetails = $([pscustomobject]@{'error' = 'access_denied'; 'error_description' = 'invalid client creds or client not allowed' } | ConvertTo-Json)
+					$errorRecord = New-Object Management.Automation.ErrorRecord $exception, $errorID, $errorCategory, $targetObject
+					$errorRecord.ErrorDetails = $errorDetails
+					Mock Invoke-WebRequest { Throw $errorRecord }
+					{ Invoke-PASRestMethod @WebSession } | Should -Throw 'invalid client creds or client not allowed'
+				} Else { Set-ItResult -Inconclusive }
+			}
+
+			It 'reports privilege cloud errors  not returned as json' {
+				If ($IsCoreCLR) {
+					$errorDetails = 'Some Error Message'
+					$errorRecord = New-Object Management.Automation.ErrorRecord $exception, $errorID, $errorCategory, $targetObject
+					$errorRecord.ErrorDetails = $errorDetails
+					Mock Invoke-WebRequest { Throw $errorRecord }
+					{ Invoke-PASRestMethod @WebSession } | Should -Throw 'Some Error Message'
+				} Else { Set-ItResult -Inconclusive }
+			}
+
 		}
 
 	}

--- a/Tests/Remove-PASPublicSSHKey.Tests.ps1
+++ b/Tests/Remove-PASPublicSSHKey.Tests.ps1
@@ -41,7 +41,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			$InputObj = [pscustomobject]@{
-				'UserName' = 'SomeUser'
+				'UserName' = 'SomeUser@domain.com'
 				'KeyID'    = 'SomeKeyID'
 
 			}
@@ -76,7 +76,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/SomeUser/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys/SomeKeyID/"
+					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/SomeUser%40domain.com/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys/SomeKeyID/"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # version format
-version: 5.4.{build}
+version: 5.5.{build}
 
 environment:
   #GIT_TRACE: 1

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -174,6 +174,10 @@ commands:
         url: /commands/Get-PASPTARemediation
       - title: "Set-PASPTARemediation"
         url: /commands/Set-PASPTARemediation
+      - title: "Add-PASPTAGlobalCatalog"
+        url: /commands/Add-PASPTAGlobalCatalog
+      - title: "Get-PASPTAGlobalCatalog"
+        url: /commands/Get-PASPTAGlobalCatalog
 
   - title: "General"
     children:

--- a/docs/collections/_commands/Add-PASPTAGlobalCatalog.md
+++ b/docs/collections/_commands/Add-PASPTAGlobalCatalog.md
@@ -1,0 +1,146 @@
+---
+external help file: psPAS-help.xml
+Module Name: psPAS
+online version: https://pspas.pspete.dev/commands/Add-PASPTAGlobalCatalog
+schema: 2.0.0
+category: PSPAS
+title: Add-PASPTAGlobalCatalog
+---
+
+# Add-PASPTAGlobalCatalog
+
+## SYNOPSIS
+
+Adds Global Catalog connectivity details to the PTA.
+
+To run this method, you must be a member of the Vault Admins or Security Admins group.
+
+## SYNTAX
+
+```
+Add-PASPTAGlobalCatalog [[-ldap_certificate] <String>] [-ldap_server] <String> [[-ssl] <Boolean>]
+ [-ldap_port] <Int32> [-upn] <String> [-ldapPassword] <SecureString> [<CommonParameters>]
+```
+
+## DESCRIPTION
+Adds Global Catalog connectivity details to the PTA Administration to broaden and increase the accuracy of Security Events detections.
+
+Requires membership of the Vault Admins or Security Admins group.
+Requires minimum version of 13.0.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+Add-PASPTAGlobalCatalog -ldap_certificate $Base64Cert -ldap_server GC.domain.com -ssl $true -ldap_port 3269 -upn user@domain.com -ldapPassword $SecureString
+```
+
+Adds Global Catalog to PTA configuration
+
+## PARAMETERS
+
+### -ldap_certificate
+Base-64 encoded X.509 SSL certificate of the Global Catalog server - without cert header/footer --BEGIN/END.
+Must be specified if `ssl` parameter is specified as `true`.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ldap_server
+The Global Catalog server address in FQDN format.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ssl
+Whether to use a secure connection when connecting to Global Catalog.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: False
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ldap_port
+The server port number of the Global Catalog. The default Global Catalog ports are 3268 (LDAP) and 3269 (LDAPS).
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 4
+Default value: 0
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -upn
+The User Principle Name of the Active Directory bind user that will be used to connect and query the Global Catalog.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 5
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ldapPassword
+The credentials of the Active Directory bind user that will be used to connect and query the Global Catalog.
+
+```yaml
+Type: SecureString
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 6
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[https://pspas.pspete.dev/commands/Add-PASPTAGlobalCatalog](https://pspas.pspete.dev/commands/Add-PASPTAGlobalCatalog)
+
+[https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Add-Global-Catalog.htm](https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Add-Global-Catalog.htm)

--- a/docs/collections/_commands/Add-PASSafeMember.md
+++ b/docs/collections/_commands/Add-PASSafeMember.md
@@ -24,7 +24,7 @@ Add-PASSafeMember -SafeName <String> -MemberName <String> [-SearchIn <String>]
  [-UnlockAccounts <Boolean>] [-ManageSafe <Boolean>] [-ManageSafeMembers <Boolean>] [-BackupSafe <Boolean>]
  [-ViewAuditLog <Boolean>] [-ViewSafeMembers <Boolean>] [-requestsAuthorizationLevel1 <Boolean>]
  [-requestsAuthorizationLevel2 <Boolean>] [-AccessWithoutConfirmation <Boolean>] [-CreateFolders <Boolean>]
- [-DeleteFolders <Boolean>] [-MoveAccountsAndFolders <Boolean>] [<CommonParameters>]
+ [-DeleteFolders <Boolean>] [-MoveAccountsAndFolders <Boolean>] [-memberType <String>] [<CommonParameters>]
 ```
 
 ### Gen1
@@ -611,6 +611,25 @@ Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -memberType
+The member type.
+
+Accepts Values: User, Group
+
+Minimum required version 12.6
+
+```yaml
+Type: String
+Parameter Sets: Gen2
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 

--- a/docs/collections/_commands/Get-PASAccount.md
+++ b/docs/collections/_commands/Get-PASAccount.md
@@ -64,7 +64,7 @@ Get-PASAccount -search XUser -searchType startswith
 
 Returns all accounts starting with "XUser".
 
-Requires minimum version of 10.4
+Requires minimum version of 11.2
 
 ### EXAMPLE 3
 ```
@@ -179,7 +179,7 @@ Accept wildcard characters: False
 ### -searchType
 Get accounts that either contain or start with the value specified in the Search parameter.
 
-Requires minimum version of 10.4
+Requires minimum version of 11.2
 
 ```yaml
 Type: String

--- a/docs/collections/_commands/Get-PASPTAGlobalCatalog.md
+++ b/docs/collections/_commands/Get-PASPTAGlobalCatalog.md
@@ -1,0 +1,50 @@
+---
+external help file: psPAS-help.xml
+Module Name: psPAS
+online version: https://pspas.pspete.dev/commands/Get-PASPTAGlobalCatalog
+schema: 2.0.0
+category: PSPAS
+title: Get-PASPTAGlobalCatalog
+---
+
+# Get-PASPTAGlobalCatalog
+
+## SYNOPSIS
+Get Global Catalog connectivity details from PTA.
+
+## SYNTAX
+
+```
+Get-PASPTAGlobalCatalog [<CommonParameters>]
+```
+
+## DESCRIPTION
+Returns the Global Catalog connectivity details as set in PTA Administration.
+Membership of either Vault Admins or Security Admins group is required.
+Requires minimum version of 13.0.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+Get-PASPTAGlobalCatalog
+```
+
+Returns Global Catalog configuration details from PTA
+
+## PARAMETERS
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[https://pspas.pspete.dev/commands/Get-PASPTAGlobalCatalog](https://pspas.pspete.dev/commands/Get-PASPTAGlobalCatalog)
+
+[https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Get-Global-Catalog.htm](https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Get-Global-Catalog.htm)

--- a/docs/collections/_commands/New-PASAccountObject.md
+++ b/docs/collections/_commands/New-PASAccountObject.md
@@ -323,7 +323,7 @@ Accept wildcard characters: False
 ```
 
 ### -PersonalAdminAccount
-{{ Fill PersonalAdminAccount Description }}
+TBC
 
 ```yaml
 Type: SwitchParameter

--- a/docs/collections/_commands/New-PASSession.md
+++ b/docs/collections/_commands/New-PASSession.md
@@ -16,62 +16,67 @@ Authenticates a user to CyberArk Vault/API.
 
 ### Gen2 (Default)
 ```
-New-PASSession -Credential <PSCredential> [-newPassword <SecureString>] [-type <String>]
- [-concurrentSession <Boolean>] -BaseURI <String> [-PVWAAppName <String>] [-SkipVersionCheck]
+New-PASSession -Credential <PSCredential> -BaseURI <String> [-newPassword <SecureString>] [-type <String>]
+ [-concurrentSession <Boolean>] [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate <X509Certificate>]
+ [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### SharedServices
+```
+New-PASSession -Credential <PSCredential> -TenantSubdomain <String> [-PVWAAppName <String>] [-SkipVersionCheck]
  [-Certificate <X509Certificate>] [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
 ### Gen1Radius
 ```
-New-PASSession -Credential <PSCredential> [-UseGen1API] -useRadiusAuthentication <Boolean> [-OTP <String>]
- [-OTPMode <String>] [-OTPDelimiter <String>] [-RadiusChallenge <String>] [-connectionNumber <Int32>]
- -BaseURI <String> [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate <X509Certificate>]
+New-PASSession -Credential <PSCredential> -BaseURI <String> [-UseGen1API] -useRadiusAuthentication <Boolean>
+ [-OTP <String>] [-OTPMode <String>] [-OTPDelimiter <String>] [-RadiusChallenge <String>]
+ [-connectionNumber <Int32>] [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate <X509Certificate>]
  [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Gen1
 ```
-New-PASSession -Credential <PSCredential> [-UseGen1API] [-newPassword <SecureString>]
- [-connectionNumber <Int32>] -BaseURI <String> [-PVWAAppName <String>] [-SkipVersionCheck]
- [-Certificate <X509Certificate>] [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+New-PASSession -Credential <PSCredential> -BaseURI <String> [-UseGen1API] [-newPassword <SecureString>]
+ [-connectionNumber <Int32>] [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate <X509Certificate>]
+ [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Gen2Radius
 ```
-New-PASSession -Credential <PSCredential> [-type <String>] [-OTP <String>] [-OTPMode <String>]
- [-OTPDelimiter <String>] [-RadiusChallenge <String>] [-concurrentSession <Boolean>] -BaseURI <String>
+New-PASSession -Credential <PSCredential> -BaseURI <String> [-type <String>] [-OTP <String>]
+ [-OTPMode <String>] [-OTPDelimiter <String>] [-RadiusChallenge <String>] [-concurrentSession <Boolean>]
  [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate <X509Certificate>] [-CertificateThumbprint <String>]
  [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-### Gen1SAML
+### integrated
 ```
-New-PASSession [-UseGen1API] -SAMLResponse <String> -BaseURI <String> [-PVWAAppName <String>]
- [-SkipVersionCheck] [-Certificate <X509Certificate>] [-CertificateThumbprint <String>] [-SkipCertificateCheck]
- [-WhatIf] [-Confirm] [<CommonParameters>]
-```
-
-### Gen2SAML
-```
-New-PASSession [-SAMLAuth] [-SAMLResponse <String>] [-concurrentSession <Boolean>] -BaseURI <String>
+New-PASSession -BaseURI <String> [-UseDefaultCredentials] [-concurrentSession <Boolean>]
  [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate <X509Certificate>] [-CertificateThumbprint <String>]
  [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### shared
 ```
-New-PASSession [-UseSharedAuthentication] -BaseURI <String> [-PVWAAppName <String>] [-SkipVersionCheck]
+New-PASSession -BaseURI <String> [-UseSharedAuthentication] [-PVWAAppName <String>] [-SkipVersionCheck]
  [-Certificate <X509Certificate>] [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
-### integrated
+### Gen2SAML
 ```
-New-PASSession [-UseDefaultCredentials] [-concurrentSession <Boolean>] -BaseURI <String>
+New-PASSession -BaseURI <String> [-SAMLAuth] [-SAMLResponse <String>] [-concurrentSession <Boolean>]
  [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate <X509Certificate>] [-CertificateThumbprint <String>]
  [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### Gen1SAML
+```
+New-PASSession -BaseURI <String> [-UseGen1API] -SAMLResponse <String> [-PVWAAppName <String>]
+ [-SkipVersionCheck] [-Certificate <X509Certificate>] [-CertificateThumbprint <String>] [-SkipCertificateCheck]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -80,16 +85,16 @@ session data to be used in future API calls.
 
 Users can also set a new password via the authentication process.
 
-By default, the Gen2 API is used, and version 10 is expected.
+By default, the Gen2 API is used, meaning a recent version of CyberArk is expected.
 
 Use the -UseGen1API switch parameter to target the Gen1 API endpoint.
 
-Windows authentication requires at least version 10.4
+Windows authentication requires at least CyberArk PAS version 10.4
 
-LDAP, RADIUS, SAML, and shared authentication all require a minimum version of 9.7.
+LDAP, RADIUS, SAML, and shared authentication all require a minimum CyberArk version of 9.7.
 
 Versions of CyberArk prior to 9.7:
-- The only authentication mechanism supported is CyberArk.
+- only the CyberArk authentication mechanism is supported.
 - newPassword Parameter is not supported.
 - useRadiusAuthentication Parameter is not supported.
 - connectionNumber Parameter is not supported.
@@ -101,7 +106,7 @@ Versions of CyberArk prior to 9.7:
 New-PASSession -Credential $cred -BaseURI https://PVWA -type LDAP
 ```
 
-Logon to Version 10 with LDAP credential
+Logon with LDAP credential
 
 ### EXAMPLE 2
 ```
@@ -115,14 +120,14 @@ Establish a concurrent session
 New-PASSession -Credential $cred -BaseURI https://PVWA -type CyberArk
 ```
 
-Logon to Version 10 with CyberArk credential
+Logon with local CyberArk user credential
 
 ### EXAMPLE 4
 ```
 New-PASSession -BaseURI https://PVWA -UseDefaultCredentials
 ```
 
-Logon to Version 10 with Windows Integrated Authentication
+Logon using Windows Integrated Authentication
 
 ### EXAMPLE 5
 ```
@@ -159,7 +164,7 @@ Perform saml sso authentication from version 11.4
 New-PASSession -Credential $cred -BaseURI https://PVWA -type RADIUS
 ```
 
-Logon to Version 10 using RADIUS
+Logon using RADIUS
 
 ### EXAMPLE 10
 ```
@@ -173,7 +178,7 @@ Logon using RADIUS via the Gen1 API
 New-PASSession -Credential $cred -BaseURI https://PVWA -type RADIUS -OTP 123456
 ```
 
-Logon to Version 10 using RADIUS (Challenge) & OTP (Response)
+Logon using RADIUS (Challenge) & OTP (Response)
 
 ### EXAMPLE 12
 ```
@@ -199,7 +204,7 @@ Logon with PKI auth, using a selected certificate stored on local machine or sma
 New-PASSession -Credential $cred -BaseURI https://PVWA -type RADIUS -OTP push -OTPMode Append
 ```
 
-Logon to Version 10 using RADIUS & DUO Push Authentication (working with DUO 2FA Append Mode Configuration)
+Logon to using RADIUS & DUO Push Authentication (working with DUO 2FA Append Mode Configuration)
 
 ### EXAMPLE 14
 ```
@@ -221,7 +226,7 @@ $Certificate = Get-ChildItem -Path Cert:\CurrentUser\My | Where-Object {$PSItem.
 New-PASSession -Credential $cred -BaseURI https://PVWA -type LDAP -Certificate $Certificate
 ```
 
-Logon to Version 10 with LDAP credential & Client Certificate
+Logon using LDAP credential & Client Certificate
 
 ### EXAMPLE 17
 ```
@@ -278,6 +283,20 @@ New-PASSession -SAMLResponse $SAMLToken -UseGen1API -BaseURI https://PVWA.domain
 
 Authenticates to a CyberArk Vault using SAML authentication & Gen1 API.
 
+### EXAMPLE 23
+```
+New-PASSession -TenantSubdomain PCloudTenantID -Credential $cred
+```
+
+Authenticates to Privilege Cloud Shared Services.
+
+### EXAMPLE 24
+```
+New-PASSession -Credential $cred -BaseURI https://PVWA -type RADIUS -OTP 123456 -OTPMode Append -OTPDelimiter $null
+```
+
+Logon to using RADIUS & provide password appended with OTP, with no delimiter separating the password & OTP values.
+
 ## PARAMETERS
 
 ### -Credential
@@ -285,7 +304,7 @@ A Valid PSCredential object.
 
 ```yaml
 Type: PSCredential
-Parameter Sets: Gen2, Gen2Radius
+Parameter Sets: Gen2, SharedServices, Gen2Radius
 Aliases:
 
 Required: True
@@ -346,10 +365,10 @@ The PS-SAML-Interactive can be used to get this value (see related links).
 
 ```yaml
 Type: String
-Parameter Sets: Gen1SAML
+Parameter Sets: Gen2SAML
 Aliases: SAMLToken
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)
@@ -358,10 +377,10 @@ Accept wildcard characters: False
 
 ```yaml
 Type: String
-Parameter Sets: Gen2SAML
+Parameter Sets: Gen1SAML
 Aliases: SAMLToken
 
-Required: False
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)
@@ -399,7 +418,7 @@ Accept wildcard characters: False
 ```
 
 ### -type
-When using the version 10 API endpoint, specify the type of authentication to use.
+When using the Gen2 API, specify the type of authentication to use.
 
 Valid values are:
 - CyberArk
@@ -511,7 +530,7 @@ Minimum version required 11.3
 
 ```yaml
 Type: Boolean
-Parameter Sets: Gen2, Gen2Radius, Gen2SAML, integrated
+Parameter Sets: Gen2, Gen2Radius, integrated, Gen2SAML
 Aliases:
 
 Required: False
@@ -548,7 +567,7 @@ Do not include "/PasswordVault/"
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: Gen2, Gen1Radius, Gen1, Gen2Radius, integrated, shared, Gen2SAML, Gen1SAML
 Aliases:
 
 Required: True
@@ -698,6 +717,21 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+### -TenantSubdomain
+The subdomain name value of the Identity Shared Services / Privilege Cloud Tenant
+
+```yaml
+Type: String
+Parameter Sets: SharedServices
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
@@ -710,6 +744,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [https://pspas.pspete.dev/commands/New-PASSession](https://pspas.pspete.dev/commands/New-PASSession)
+
+[https://docs.cyberark.com/Product-Doc/OnlineHelp/PrivCloud-SS/Latest/en/Content/ISPSS/ISPSS-API-Authentication.htm](https://docs.cyberark.com/Product-Doc/OnlineHelp/PrivCloud-SS/Latest/en/Content/ISPSS/ISPSS-API-Authentication.htm)
 
 [https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/CyberArk%20Authentication%20-%20Logon_v10.htm#CyberArkLDAPRadiusWindows](https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/CyberArk%20Authentication%20-%20Logon_v10.htm#CyberArkLDAPRadiusWindows)
 

--- a/docs/collections/_commands/Set-PASPTARule.md
+++ b/docs/collections/_commands/Set-PASPTARule.md
@@ -15,7 +15,7 @@ Updates an existing Risky Activity rule to PTA
 ## SYNTAX
 
 ```
-Set-PASPTARule [-id] <Int32> [-category] <String> [-regex] <String> [-score] <Int32> [-description] <String>
+Set-PASPTARule [-id] <String> [-category] <String> [-regex] <String> [-score] <Int32> [-description] <String>
  [-response] <String> [-active] <Boolean> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -37,7 +37,7 @@ Updates rule 66 in PTA
 The unique ID of the rule.
 
 ```yaml
-Type: Int32
+Type: String
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/collections/_docs/01-authentication.md
+++ b/docs/collections/_docs/01-authentication.md
@@ -2,7 +2,7 @@
 title: "Authentication"
 permalink: /docs/authentication/
 excerpt: "psPAS Authentication"
-last_modified_at: 2022-09-24T01:23:45-00:00
+last_modified_at: 2023-03-06T01:23:45-00:00
 ---
 
 _Everything begins with a **Logon**:_
@@ -117,3 +117,10 @@ $Cert = "0E199489C57E666115666D6E9990C2ACABDB6EDB"
 New-PASSession -UseSharedAuthentication -BaseURI https://pvwa.somedomain.com -CertificateThumbprint $Cert
 ```
 
+## Shared Services Authentication
+
+Provide tenant ID and credentials for authentication via CyberArk Identity for Privilege Cloud Shared Services:
+
+```
+New-PASSession -TenantSubdomain YourPrivilegeCloudTenantID -Credential $PCloudCreds
+```

--- a/docs/collections/_docs/10-compatibility.md
+++ b/docs/collections/_docs/10-compatibility.md
@@ -2,7 +2,7 @@
 title: "Compatibility"
 permalink: /docs/compatibility/
 excerpt: "Module Compatibility"
-last_modified_at: 2022-09-25T01:23:45-00:00
+last_modified_at: 2023-03-06T01:23:45-00:00
 toc: false
 ---
 
@@ -95,7 +95,7 @@ If version requirement criteria are not met, operations may be prevented.
 [`Get-PASSafeShareLogo`][Get-PASSafeShareLogo]                                           | **9.7**                                            |Returns details of SafeShare Logo
 [`Get-PASServer`][Get-PASServer]                                                         | **9.7**                                            |Returns details of the Web Service Server
 [`Get-PASServerWebService`][Get-PASServerWebService]                                     | **9.7**                                            |Returns details of the Web Service
-[`Get-PASComponentDetail`][Get-PASComponentDetail]                                       | **10.1**                                           |Returns details about component instances.
+[`Get-PASComponentDetail`][Get-PASComponentDetail]                                       | **10.1** ([Notes](#get-pascomponentdetail))        |Returns details about component instances.
 [`Get-PASComponentSummary`][Get-PASComponentSummary]                                     | **10.1**                                           |Returns consolidated information about components.
 [`Add-PASGroupMember`][Add-PASGroupMember]                                               | **9.7** ([Notes](#add-pasgroupmember))             |Adds a user as a group member
 [`Get-PASLoggedOnUser`][Get-PASLoggedOnUser]                                             | **9.7**                                            |Returns details of the logged on user
@@ -178,7 +178,11 @@ If version requirement criteria are not met, operations may be prevented.
 [`Publish-PASDiscoveredAccount`][Publish-PASDiscoveredAccount]                           |**12.6**                                            |Onboard Discovered Accounts
 [`Get-PASLinkedAccount`][Get-PASLinkedAccount]                                           |**12.2**                                            |Get details of linked accounts
 [`Add-PASPersonalAdminAccount`][Add-PASPersonalAdminAccount]                             |**12.6**                                            |Add Personal Admin Account (Privilege Cloud Only).
+[`Get-PASPTAGlobalCatalog`][Get-PASPTAGlobalCatalog]                                     |**13.0**                                            |Get Global Catalog connectivity details for PTA.
+[`Add-PASPTAGlobalCatalog`][Add-PASPTAGlobalCatalog]                                     |**13.0**                                            |Add Global Catalog connectivity details to PTA.
 
+[Get-PASPTAGlobalCatalog]:/commands/Get-PASPTAGlobalCatalog
+[Add-PASPTAGlobalCatalog]:/commands/Add-PASPTAGlobalCatalog
 [Get-PASLinkedAccount]:/commands/Get-PASLinkedAccount
 [Add-PASPersonalAdminAccount]:/commands/Add-PASPersonalAdminAccount
 [Publish-PASDiscoveredAccount]:/commands/Publish-PASDiscoveredAccount
@@ -600,3 +604,7 @@ If version requirement criteria are not met, operations may be prevented.
 ### Set-PASSafe
 
 - Version 12.2 introduced new API endpoint
+
+### Get-PASComponentDetail
+
+- Version 12 adds pta as target component

--- a/docs/collections/_pages/commands.md
+++ b/docs/collections/_pages/commands.md
@@ -2,7 +2,7 @@
 title: "psPAS + API Command Reference"
 permalink: /commands/
 excerpt: "Command Reference"
-last_modified_at: 2022-09-25T01:23:45-00:00
+last_modified_at: 2023-03-06T01:23:45-00:00
 toc: false
 layout: single-mod
 classes: wide
@@ -201,6 +201,8 @@ A psPAS command may not appear in the below list due to it not being explicitly 
 [Extended Account Overview][Extended Account Overview]                                               | [Get-PASAccountDetail][Get-PASAccountDetail]
 [Enable User][Enable User]                                                                           | [Enable-PASUser][Enable-PASUser]
 [Disable User][Disable User]                                                                         | [Disable-PASUser][Disable-PASUser]
+[Get Global Catalog connectivity details][Get Global Catalog connectivity details]                   | [Get-PASPTAGlobalCatalog][Get-PASPTAGlobalCatalog]
+[Add Global Catalog connectivity details][Add Global Catalog connectivity details]                   | [Add-PASPTAGlobalCatalog][Add-PASPTAGlobalCatalog]
 
 [Get-PASDiscoveredAccount]:/commands/Get-PASDiscoveredAccount
 [Start-PASAccountImportJob]:/commands/Start-PASAccountImportJob
@@ -345,7 +347,11 @@ A psPAS command may not appear in the below list due to it not being explicitly 
 [Get-PASAccountDetail]:/commands/Get-PASAccountDetail
 [Enable-PASUser]:/commands/Enable-PASUser
 [Disable-PASUser]:/commands/Disable-PASUser
+[Get-PASPTAGlobalCatalog]:/commands/Get-PASPTAGlobalCatalog
+[Add-PASPTAGlobalCatalog]:/commands/Add-PASPTAGlobalCatalog
 
+[Get Global Catalog connectivity details]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Get-Global-Catalog.htm
+[Add Global Catalog connectivity details]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Add-Global-Catalog.htm
 [Enable User]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/Enable-user.htm?tocpath=Developer%7CREST%20APIs%7CUser%20management%7CUsers%7C_____8
 [Disable User]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/Disable-user.htm?tocpath=Developer%7CREST%20APIs%7CUser%20management%7CUsers%7C_____9
 [Extended Account Overview]:https://documenter.getpostman.com/view/998920/RzZ9Gz1U#d20c01c2-f7fc-4717-bf10-d8c51cb11411

--- a/docs/collections/_posts/2022-10-10-new-passession-deep-dive.md
+++ b/docs/collections/_posts/2022-10-10-new-passession-deep-dive.md
@@ -2,7 +2,7 @@
 title:  "New-PASSession Deep Dive"
 date:   2022-10-10 00:00:00
 tags:
-  - pspAS Article
+  - psPAS Article
   - New-PASSession
   - Deep Dive
   - Invoke-PASRestMethod

--- a/docs/collections/_posts/2023-03-06-pspas-release-5-5.md
+++ b/docs/collections/_posts/2023-03-06-pspas-release-5-5.md
@@ -16,7 +16,9 @@ tags:
   - Remove-PASPublicSSHKey
 ---
 
-## **5.5 (March 2023)
+## **5.5.110 (March 7th 2023)
+
+### Module update to cover all CyberArk 13.0 API features
 
 - New
   - Adds `Get-PASPTAGlobalCatalog` & `Add-PASPTAGlobalCatalog` commands, available for v13.

--- a/docs/collections/_posts/2023-03-06-pspas-release-5-5.md
+++ b/docs/collections/_posts/2023-03-06-pspas-release-5-5.md
@@ -1,0 +1,41 @@
+---
+title:  "psPAS Release 5.5"
+date:   2023-03-06 00:00:00
+tags:
+  - Release Notes
+  - New-PASSession
+  - Get-PASPTAGlobalCatalog
+  - Add-PASPTAGlobalCatalog
+  - Set-PASPTARule
+  - Get-PASComponentDetail
+  - Add-PASSafe
+  - Add-PASSafeMember
+  - Get-PASAccount
+  - Add-PASPublicSSHKey
+  - Get-PASPublicSSHKey
+  - Remove-PASPublicSSHKey
+---
+
+## **5.5 (March 2023)
+
+- New
+  - Adds `Get-PASPTAGlobalCatalog` & `Add-PASPTAGlobalCatalog` commands, available for v13.
+- Updates
+  - `New-PASSession`
+    - Adds Shared Services Auth Support
+    - Allows null or empty `OTPDelimiter` to be specified
+  - `Set-PASPTARule`
+    - Updates validation for parameter `id`
+  - `Get-PASComponentDetail`
+    - Adds `pta` as option for parameter `component`
+  - `Add-PASSafe`
+    - Allows `0` as valid value for parameter `NumberOfDaysRetention`
+  - `Add-PASSafeMember`
+    - Adds optional `memberType` parameter, accepted from 12.6 onward.
+- Other
+  - Allow UPN UserName format
+    - Updates the parameter validation logic of the `*-PASPublicSSHKey` functions to allow UPN style usernames to be specified and accepted.
+  - Updates `psPAS.CyberArk.Vault.OnboardingRule` format in line with expected output according to product documentation.
+  - Documentation update
+    - Correct version requirement information for the `Get-PASAccount` `searchType` parameter.
+

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -345,9 +345,9 @@
       }
     },
     "decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
       "dev": true
     },
     "define-properties": {

--- a/psPAS/Functions/Authentication/Add-PASPublicSSHKey.ps1
+++ b/psPAS/Functions/Authentication/Add-PASPublicSSHKey.ps1
@@ -6,7 +6,7 @@ function Add-PASPublicSSHKey {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateScript( { $_ -notmatch '.*(%|\&|\+|\.).*' })]
+		[ValidateScript( { $_ -notmatch '.*(%|\&|\+).*' })]
 		[string]$UserName,
 
 		[parameter(

--- a/psPAS/Functions/Authentication/Get-PASPublicSSHKey.ps1
+++ b/psPAS/Functions/Authentication/Get-PASPublicSSHKey.ps1
@@ -6,7 +6,7 @@ function Get-PASPublicSSHKey {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateScript( { $_ -notmatch '.*(%|\&|\+|\.).*' })]
+		[ValidateScript( { $_ -notmatch '.*(%|\&|\+).*' })]
 		[string]$UserName
 
 	)

--- a/psPAS/Functions/Authentication/Remove-PASPublicSSHKey.ps1
+++ b/psPAS/Functions/Authentication/Remove-PASPublicSSHKey.ps1
@@ -6,7 +6,7 @@ function Remove-PASPublicSSHKey {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[ValidateScript( { $_ -notmatch '.*(%|\&|\+|\.).*' })]
+		[ValidateScript( { $_ -notmatch '.*(%|\&|\+).*' })]
 		[string]$UserName,
 
 		[parameter(

--- a/psPAS/Functions/EventSecurity/Add-PASPTAGlobalCatalog.ps1
+++ b/psPAS/Functions/EventSecurity/Add-PASPTAGlobalCatalog.ps1
@@ -1,0 +1,84 @@
+# .ExternalHelp psPAS-help.xml
+Function Add-PASPTAGlobalCatalog {
+    [CmdletBinding()]
+    param(
+        [parameter(
+            Mandatory = $false,
+            ValueFromPipelinebyPropertyName = $true
+        )]
+        [string]$ldap_certificate,
+
+        [parameter(
+            Mandatory = $true,
+            ValueFromPipelinebyPropertyName = $true
+        )]
+        [string]$ldap_server,
+
+        [parameter(
+            Mandatory = $false,
+            ValueFromPipelinebyPropertyName = $true
+        )]
+        [boolean]$ssl,
+
+        [parameter(
+            Mandatory = $true,
+            ValueFromPipelinebyPropertyName = $true
+        )]
+        [int]$ldap_port,
+
+        [parameter(
+            Mandatory = $true,
+            ValueFromPipelinebyPropertyName = $true
+        )]
+        [string]$upn,
+
+        [parameter(
+            Mandatory = $true,
+            ValueFromPipelinebyPropertyName = $true
+        )]
+        [securestring]$ldapPassword
+
+    )
+
+    BEGIN {
+
+        Assert-VersionRequirement -RequiredVersion 13.0
+
+    }#begin
+
+    PROCESS {
+
+        #Create URL for Request
+        $URI = "$Script:BaseURI/API/pta/API/Administration/GCConnectivity"
+
+        #Get Parameters for request body
+        $boundParameters = $PSBoundParameters | Get-PASParameter
+
+        #deal with Password SecureString
+        If ($PSBoundParameters.ContainsKey('ldapPassword')) {
+
+            #Include decoded password in request
+            $boundParameters['ldapPassword'] = $(ConvertTo-InsecureString -SecureString $ldapPassword)
+
+        }
+
+        $boundParameters['properties'] = $($boundParameters | Get-PASParameter -ParametersToRemove ldap_certificate)
+
+        #Create body of request
+        $body = $boundParameters | Get-PASParameter -ParametersToKeep ldap_certificate, properties | ConvertTo-Json
+
+        #send request to PAS web service
+        $result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+
+        If ($null -ne $result) {
+
+            #Return Results
+            $result
+
+        }
+
+    }#process
+
+    END { }#end
+
+}

--- a/psPAS/Functions/EventSecurity/Get-PASPTAGlobalCatalog.ps1
+++ b/psPAS/Functions/EventSecurity/Get-PASPTAGlobalCatalog.ps1
@@ -1,0 +1,29 @@
+# .ExternalHelp psPAS-help.xml
+Function Get-PASPTAGlobalCatalog {
+    [CmdletBinding()]
+    param(	)
+
+    BEGIN {
+        Assert-VersionRequirement -RequiredVersion 13.0
+    }#begin
+
+    PROCESS {
+
+        #Create request URL
+        $URI = "$Script:BaseURI/API/pta/API/Administration/GCConnectivity"
+
+        #Send request to web service
+        $result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+
+        If ($null -ne $result) {
+
+            #Return Results
+            $result
+
+        }
+
+    }#process
+
+    END { }#end
+
+}

--- a/psPAS/Functions/EventSecurity/Set-PASPTARule.ps1
+++ b/psPAS/Functions/EventSecurity/Set-PASPTARule.ps1
@@ -6,7 +6,8 @@ Function Set-PASPTARule {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[int]$id,
+		[ValidateRange(1, [int]::MaxValue)]
+		[string]$id,
 
 		[parameter(
 			Mandatory = $true,

--- a/psPAS/Functions/SafeMembers/Add-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Add-PASSafeMember.ps1
@@ -187,6 +187,16 @@ function Add-PASSafeMember {
 		[boolean]$MoveAccountsAndFolders,
 
 		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'Gen2'
+		)]
+		[ValidateNotNullOrEmpty()]
+		[ValidateSet('User', 'Group')]
+
+		[string]$memberType,
+
+		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $false,
 			ParameterSetName = 'Gen1'
@@ -198,7 +208,7 @@ function Add-PASSafeMember {
 
 		#array for parameter names which appear in the top-tier of the JSON object
 		$keysToKeep = [Collections.Generic.List[String]]@(
-			'MemberName', 'SearchIn', 'MembershipExpirationDate', 'Permissions'
+			'MemberName', 'SearchIn', 'MembershipExpirationDate', 'Permissions', 'MemberType'
 		)
 
 	}#begin
@@ -249,6 +259,12 @@ function Add-PASSafeMember {
 
 				#Create URL for request
 				$URI = "$Script:BaseURI/api/Safes/$($SafeName | Get-EscapedString)/Members"
+
+				If ($PSBoundParameters.ContainsKey('MemberType')) {
+
+					Assert-VersionRequirement -RequiredVersion 12.6
+
+				}
 
 				If ($PSBoundParameters.ContainsKey('MembershipExpirationDate')) {
 

--- a/psPAS/Functions/Safes/Add-PASSafe.ps1
+++ b/psPAS/Functions/Safes/Add-PASSafe.ps1
@@ -59,7 +59,7 @@ function Add-PASSafe {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'NumberOfDaysRetention'
 		)]
-		[ValidateRange(1, 3650)]
+		[ValidateRange(0, 3650)]
 		[int]$NumberOfDaysRetention,
 
 		[parameter(

--- a/psPAS/Functions/SystemHealth/Get-PASComponentDetail.ps1
+++ b/psPAS/Functions/SystemHealth/Get-PASComponentDetail.ps1
@@ -7,7 +7,7 @@ Function Get-PASComponentDetail {
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateNotNullOrEmpty()]
-		[ValidateSet('PVWA', 'SessionManagement', 'CPM', 'AIM')]
+		[ValidateSet('PVWA', 'SessionManagement', 'CPM', 'AIM', 'PTA')]
 		[string]$ComponentID
 
 	)
@@ -17,6 +17,12 @@ Function Get-PASComponentDetail {
 	}#begin
 
 	PROCESS {
+
+		if ($PSBoundParameters['ComponentID'] -eq 'PTA') {
+
+			Assert-VersionRequirement -RequiredVersion 12.0
+
+		}
 
 		#Create URL for request
 		$URI = "$Script:BaseURI/api/ComponentsMonitoringDetails/$ComponentID"

--- a/psPAS/Functions/User/Remove-PASUser.ps1
+++ b/psPAS/Functions/User/Remove-PASUser.ps1
@@ -36,6 +36,8 @@ function Remove-PASUser {
 
 				$URI = "$Script:BaseURI/api/Users/$id"
 
+				$User = $id
+
 				break
 
 			}
@@ -47,13 +49,15 @@ function Remove-PASUser {
 				#Create URL for request
 				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)"
 
+				$User = $UserName
+
 				break
 
 			}
 
 		}
 
-		if ($PSCmdlet.ShouldProcess($UserName, 'Delete User')) {
+		if ($PSCmdlet.ShouldProcess($User, 'Delete User')) {
 
 			#send request to web service
 			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -6171,6 +6171,198 @@ Add-PASDiscoveredAccount -UserName ServiceUser -Address 1.2.3.4 -discoveryDate (
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
+      <command:name>Add-PASPTAGlobalCatalog</command:name>
+      <command:verb>Add</command:verb>
+      <command:noun>PASPTAGlobalCatalog</command:noun>
+      <maml:description>
+        <maml:para>Adds Global Catalog connectivity details to the PTA.</maml:para>
+        <maml:para>To run this method, you must be a member of the Vault Admins or Security Admins group.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Adds Global Catalog connectivity details to the PTA Administration to broaden and increase the accuracy of Security Events detections.</maml:para>
+      <maml:para>Requires membership of the Vault Admins or Security Admins group. Requires minimum version of 13.0.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Add-PASPTAGlobalCatalog</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
+          <maml:name>ldap_certificate</maml:name>
+          <maml:description>
+            <maml:para>Base-64 encoded X.509 SSL certificate of the Global Catalog server - without cert header/footer --BEGIN/END. Must be specified if `ssl` parameter is specified as `true`.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
+          <maml:name>ldap_server</maml:name>
+          <maml:description>
+            <maml:para>The Global Catalog server address in FQDN format.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
+          <maml:name>ssl</maml:name>
+          <maml:description>
+            <maml:para>Whether to use a secure connection when connecting to Global Catalog.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
+          <maml:name>ldap_port</maml:name>
+          <maml:description>
+            <maml:para>The server port number of the Global Catalog. The default Global Catalog ports are 3268 (LDAP) and 3269 (LDAPS).</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>0</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
+          <maml:name>upn</maml:name>
+          <maml:description>
+            <maml:para>The User Principle Name of the Active Directory bind user that will be used to connect and query the Global Catalog.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
+          <maml:name>ldapPassword</maml:name>
+          <maml:description>
+            <maml:para>The credentials of the Active Directory bind user that will be used to connect and query the Global Catalog.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
+          <dev:type>
+            <maml:name>SecureString</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
+        <maml:name>ldap_certificate</maml:name>
+        <maml:description>
+          <maml:para>Base-64 encoded X.509 SSL certificate of the Global Catalog server - without cert header/footer --BEGIN/END. Must be specified if `ssl` parameter is specified as `true`.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
+        <maml:name>ldap_server</maml:name>
+        <maml:description>
+          <maml:para>The Global Catalog server address in FQDN format.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
+        <maml:name>ssl</maml:name>
+        <maml:description>
+          <maml:para>Whether to use a secure connection when connecting to Global Catalog.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
+        <dev:type>
+          <maml:name>Boolean</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
+        <maml:name>ldap_port</maml:name>
+        <maml:description>
+          <maml:para>The server port number of the Global Catalog. The default Global Catalog ports are 3268 (LDAP) and 3269 (LDAPS).</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>0</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
+        <maml:name>upn</maml:name>
+        <maml:description>
+          <maml:para>The User Principle Name of the Active Directory bind user that will be used to connect and query the Global Catalog.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
+        <maml:name>ldapPassword</maml:name>
+        <maml:description>
+          <maml:para>The credentials of the Active Directory bind user that will be used to connect and query the Global Catalog.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
+        <dev:type>
+          <maml:name>SecureString</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>Add-PASPTAGlobalCatalog -ldap_certificate $Base64Cert -ldap_server GC.domain.com -ssl $true -ldap_port 3269 -upn user@domain.com -ldapPassword $SecureString</dev:code>
+        <dev:remarks>
+          <maml:para>Adds Global Catalog to PTA configuration</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>https://pspas.pspete.dev/commands/Add-PASPTAGlobalCatalog</maml:linkText>
+        <maml:uri>https://pspas.pspete.dev/commands/Add-PASPTAGlobalCatalog</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Add-Global-Catalog.htm</maml:linkText>
+        <maml:uri>https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Add-Global-Catalog.htm</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
       <command:name>Add-PASPTARule</command:name>
       <command:verb>Add</command:verb>
       <command:noun>PASPTARule</command:noun>
@@ -7740,6 +7932,20 @@ Add-PASDiscoveredAccount -UserName ServiceUser -Address 1.2.3.4 -discoveryDate (
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>memberType</maml:name>
+          <maml:description>
+            <maml:para>The member type.</maml:para>
+            <maml:para>Accepts Values: User, Group</maml:para>
+            <maml:para>Minimum required version 12.6</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
@@ -8107,6 +8313,20 @@ Add-PASDiscoveredAccount -UserName ServiceUser -Address 1.2.3.4 -discoveryDate (
           <maml:uri />
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>memberType</maml:name>
+        <maml:description>
+          <maml:para>The member type.</maml:para>
+          <maml:para>Accepts Values: User, Group</maml:para>
+          <maml:para>Minimum required version 12.6</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes />
@@ -10859,7 +11079,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           <maml:name>searchType</maml:name>
           <maml:description>
             <maml:para>Get accounts that either contain or start with the value specified in the Search parameter.</maml:para>
-            <maml:para>Requires minimum version of 10.4</maml:para>
+            <maml:para>Requires minimum version of 11.2</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -11035,7 +11255,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <maml:name>searchType</maml:name>
         <maml:description>
           <maml:para>Get accounts that either contain or start with the value specified in the Search parameter.</maml:para>
-          <maml:para>Requires minimum version of 10.4</maml:para>
+          <maml:para>Requires minimum version of 11.2</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -11184,7 +11404,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <dev:code>Get-PASAccount -search XUser -searchType startswith</dev:code>
         <dev:remarks>
           <maml:para>Returns all accounts starting with "XUser".</maml:para>
-          <maml:para>Requires minimum version of 10.4</maml:para>
+          <maml:para>Requires minimum version of 11.2</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
@@ -15949,6 +16169,51 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
+      <command:name>Get-PASPTAGlobalCatalog</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>PASPTAGlobalCatalog</command:noun>
+      <maml:description>
+        <maml:para>Get Global Catalog connectivity details from PTA.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Returns the Global Catalog connectivity details as set in PTA Administration. Membership of either Vault Admins or Security Admins group is required. Requires minimum version of 13.0.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Get-PASPTAGlobalCatalog</maml:name>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters />
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>Get-PASPTAGlobalCatalog</dev:code>
+        <dev:remarks>
+          <maml:para>Returns Global Catalog configuration details from PTA</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>https://pspas.pspete.dev/commands/Get-PASPTAGlobalCatalog</maml:linkText>
+        <maml:uri>https://pspas.pspete.dev/commands/Get-PASPTAGlobalCatalog</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Get-Global-Catalog.htm</maml:linkText>
+        <maml:uri>https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Get-Global-Catalog.htm</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
       <command:name>Get-PASPTARemediation</command:name>
       <command:verb>Get</command:verb>
       <command:noun>PASPTARemediation</command:noun>
@@ -19411,7 +19676,7 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>PersonalAdminAccount</maml:name>
           <maml:description>
-            <maml:para>{{ Fill PersonalAdminAccount Description }}</maml:para>
+            <maml:para>TBC</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -19618,7 +19883,7 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>PersonalAdminAccount</maml:name>
         <maml:description>
-          <maml:para>{{ Fill PersonalAdminAccount Description }}</maml:para>
+          <maml:para>TBC</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -22453,11 +22718,11 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
     <maml:description>
       <maml:para>Facilitates user authentication to a CyberArk Vault and retains an authentication token as well as webrequest session data to be used in future API calls.</maml:para>
       <maml:para>Users can also set a new password via the authentication process.</maml:para>
-      <maml:para>By default, the Gen2 API is used, and version 10 is expected.</maml:para>
+      <maml:para>By default, the Gen2 API is used, meaning a recent version of CyberArk is expected.</maml:para>
       <maml:para>Use the -UseGen1API switch parameter to target the Gen1 API endpoint.</maml:para>
-      <maml:para>Windows authentication requires at least version 10.4</maml:para>
-      <maml:para>LDAP, RADIUS, SAML, and shared authentication all require a minimum version of 9.7.</maml:para>
-      <maml:para>Versions of CyberArk prior to 9.7: - The only authentication mechanism supported is CyberArk.</maml:para>
+      <maml:para>Windows authentication requires at least CyberArk PAS version 10.4</maml:para>
+      <maml:para>LDAP, RADIUS, SAML, and shared authentication all require a minimum CyberArk version of 9.7.</maml:para>
+      <maml:para>Versions of CyberArk prior to 9.7: - only the CyberArk authentication mechanism is supported.</maml:para>
       <maml:para>- newPassword Parameter is not supported.</maml:para>
       <maml:para>- useRadiusAuthentication Parameter is not supported.</maml:para>
       <maml:para>- connectionNumber Parameter is not supported.</maml:para>
@@ -22492,7 +22757,7 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>type</maml:name>
           <maml:description>
-            <maml:para>When using the version 10 API endpoint, specify the type of authentication to use.</maml:para>
+            <maml:para>When using the Gen2 API, specify the type of authentication to use.</maml:para>
             <maml:para>Valid values are: - CyberArk</maml:para>
             <maml:para>- LDAP</maml:para>
             <maml:para>- Windows</maml:para>
@@ -22637,9 +22902,124 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>PVWAAppName</maml:name>
+          <maml:description>
+            <maml:para>The name of the CyberArk PVWA Virtual Directory.</maml:para>
+            <maml:para>Defaults to PasswordVault</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>PasswordVault</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>SkipVersionCheck</maml:name>
+          <maml:description>
+            <maml:para>If the SkipVersionCheck switch is specified, Get-PASServer will not be called after successfully authenticating.</maml:para>
+            <maml:para>Get-PASServer is not supported before version 9.7.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Certificate</maml:name>
+          <maml:description>
+            <maml:para>See Invoke-WebRequest</maml:para>
+            <maml:para>Specifies the client certificate that is used for a secure web request.</maml:para>
+            <maml:para>Enter a variable that contains a certificate or a command or expression that gets the certificate.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">X509Certificate</command:parameterValue>
+          <dev:type>
+            <maml:name>X509Certificate</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>CertificateThumbprint</maml:name>
+          <maml:description>
+            <maml:para>See Invoke-WebRequest</maml:para>
+            <maml:para>The thumbprint of the certificate to use for client certificate authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>SkipCertificateCheck</maml:name>
+          <maml:description>
+            <maml:para>Skips certificate validation checks.</maml:para>
+            <maml:para>Using this parameter is not secure and is not recommended.</maml:para>
+            <maml:para>This switch is only intended to be used against known hosts using a self-signed certificate for testing purposes.</maml:para>
+            <maml:para>Use at your own risk.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>TenantSubdomain</maml:name>
+          <maml:description>
+            <maml:para>The subdomain name value of the Identity Shared Services / Privilege Cloud Tenant</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>New-PASSession</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>A Valid PSCredential object.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>type</maml:name>
           <maml:description>
-            <maml:para>When using the version 10 API endpoint, specify the type of authentication to use.</maml:para>
+            <maml:para>When using the Gen2 API, specify the type of authentication to use.</maml:para>
             <maml:para>Valid values are: - CyberArk</maml:para>
             <maml:para>- LDAP</maml:para>
             <maml:para>- Windows</maml:para>
@@ -23737,7 +24117,7 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="SAMLToken">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="SAMLToken">
         <maml:name>SAMLResponse</maml:name>
         <maml:description>
           <maml:para>SAML response token that identifies the session, encoded in BASE 64.</maml:para>
@@ -23777,7 +24157,7 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>type</maml:name>
         <maml:description>
-          <maml:para>When using the version 10 API endpoint, specify the type of authentication to use.</maml:para>
+          <maml:para>When using the Gen2 API, specify the type of authentication to use.</maml:para>
           <maml:para>Valid values are: - CyberArk</maml:para>
           <maml:para>- LDAP</maml:para>
           <maml:para>- Windows</maml:para>
@@ -24000,6 +24380,18 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>TenantSubdomain</maml:name>
+        <maml:description>
+          <maml:para>The subdomain name value of the Identity Shared Services / Privilege Cloud Tenant</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
     </command:parameters>
     <command:inputTypes />
     <command:returnValues />
@@ -24013,7 +24405,7 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
         <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
         <dev:code>New-PASSession -Credential $cred -BaseURI https://PVWA -type LDAP</dev:code>
         <dev:remarks>
-          <maml:para>Logon to Version 10 with LDAP credential</maml:para>
+          <maml:para>Logon with LDAP credential</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
@@ -24027,14 +24419,14 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
         <maml:title>-------------------------- EXAMPLE 3 --------------------------</maml:title>
         <dev:code>New-PASSession -Credential $cred -BaseURI https://PVWA -type CyberArk</dev:code>
         <dev:remarks>
-          <maml:para>Logon to Version 10 with CyberArk credential</maml:para>
+          <maml:para>Logon with local CyberArk user credential</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 4 --------------------------</maml:title>
         <dev:code>New-PASSession -BaseURI https://PVWA -UseDefaultCredentials</dev:code>
         <dev:remarks>
-          <maml:para>Logon to Version 10 with Windows Integrated Authentication</maml:para>
+          <maml:para>Logon using Windows Integrated Authentication</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
@@ -24069,7 +24461,7 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
         <maml:title>-------------------------- EXAMPLE 9 --------------------------</maml:title>
         <dev:code>New-PASSession -Credential $cred -BaseURI https://PVWA -type RADIUS</dev:code>
         <dev:remarks>
-          <maml:para>Logon to Version 10 using RADIUS</maml:para>
+          <maml:para>Logon using RADIUS</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
@@ -24083,7 +24475,7 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
         <maml:title>-------------------------- EXAMPLE 11 --------------------------</maml:title>
         <dev:code>New-PASSession -Credential $cred -BaseURI https://PVWA -type RADIUS -OTP 123456</dev:code>
         <dev:remarks>
-          <maml:para>Logon to Version 10 using RADIUS (Challenge) &amp; OTP (Response)</maml:para>
+          <maml:para>Logon using RADIUS (Challenge) &amp; OTP (Response)</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
@@ -24109,7 +24501,7 @@ New-PASSession -Credential $cred -BaseURI $url -type PKI -Certificate $Cert</dev
         <maml:title>-------------------------- EXAMPLE 13 --------------------------</maml:title>
         <dev:code>New-PASSession -Credential $cred -BaseURI https://PVWA -type RADIUS -OTP push -OTPMode Append</dev:code>
         <dev:remarks>
-          <maml:para>Logon to Version 10 using RADIUS &amp; DUO Push Authentication (working with DUO 2FA Append Mode Configuration)</maml:para>
+          <maml:para>Logon to using RADIUS &amp; DUO Push Authentication (working with DUO 2FA Append Mode Configuration)</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
@@ -24131,7 +24523,7 @@ New-PASSession -Credential $cred -BaseURI $url -type PKI -Certificate $Cert</dev
         <dev:code>$Certificate = Get-ChildItem -Path Cert:\CurrentUser\My | Where-Object {$PSItem.Subject -match "CN=SomeUser"}
 New-PASSession -Credential $cred -BaseURI https://PVWA -type LDAP -Certificate $Certificate</dev:code>
         <dev:remarks>
-          <maml:para>Logon to Version 10 with LDAP credential &amp; Client Certificate</maml:para>
+          <maml:para>Logon using LDAP credential &amp; Client Certificate</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
@@ -24186,11 +24578,29 @@ New-PASSession -SAMLAuth -concurrentSession $true -BaseURI $baseURL -SAMLRespons
           <maml:para>Authenticates to a CyberArk Vault using SAML authentication &amp; Gen1 API.</maml:para>
         </dev:remarks>
       </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 23 --------------------------</maml:title>
+        <dev:code>New-PASSession -TenantSubdomain PCloudTenantID -Credential $cred</dev:code>
+        <dev:remarks>
+          <maml:para>Authenticates to Privilege Cloud Shared Services.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 24 --------------------------</maml:title>
+        <dev:code>New-PASSession -Credential $cred -BaseURI https://PVWA -type RADIUS -OTP 123456 -OTPMode Append -OTPDelimiter $null</dev:code>
+        <dev:remarks>
+          <maml:para>Logon to using RADIUS &amp; provide password appended with OTP, with no delimiter separating the password &amp; OTP values.</maml:para>
+        </dev:remarks>
+      </command:example>
     </command:examples>
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>https://pspas.pspete.dev/commands/New-PASSession</maml:linkText>
         <maml:uri>https://pspas.pspete.dev/commands/New-PASSession</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>https://docs.cyberark.com/Product-Doc/OnlineHelp/PrivCloud-SS/Latest/en/Content/ISPSS/ISPSS-API-Authentication.htm</maml:linkText>
+        <maml:uri>https://docs.cyberark.com/Product-Doc/OnlineHelp/PrivCloud-SS/Latest/en/Content/ISPSS/ISPSS-API-Authentication.htm</maml:uri>
       </maml:navigationLink>
       <maml:navigationLink>
         <maml:linkText>https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/CyberArk%20Authentication%20-%20Logon_v10.htm#CyberArkLDAPRadiusWindows</maml:linkText>
@@ -32221,9 +32631,9 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           <maml:description>
             <maml:para>The unique ID of the rule.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
-            <maml:name>Int32</maml:name>
+            <maml:name>String</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -32334,9 +32744,9 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         <maml:description>
           <maml:para>The unique ID of the rule.</maml:para>
         </maml:description>
-        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
-          <maml:name>Int32</maml:name>
+          <maml:name>String</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -16,7 +16,7 @@
 	# CompanyName       = ''
 
 	# Copyright statement for this module
-	Copyright         = '(c) 2017-2022 Pete Maan. All rights reserved.'
+	Copyright         = '(c) 2017-2023 Pete Maan. All rights reserved.'
 
 	# Description of the functionality provided by this module
 	Description       = 'Module for CyberArk Privileged Access Security Web Service REST API'
@@ -223,7 +223,9 @@
 		'Disable-PASUser',
 		'Publish-PASDiscoveredAccount',
 		'Get-PASLinkedAccount',
-		'Add-PASPersonalAdminAccount'
+		'Add-PASPersonalAdminAccount',
+		'Add-PASPTAGlobalCatalog',
+		'Get-PASPTAGlobalCatalog'
 	)
 
 	#AliasesToExport   = @()

--- a/psPAS/xml/psPAS.CyberArk.Vault.OnboardingRule.Formats.ps1xml
+++ b/psPAS/xml/psPAS.CyberArk.Vault.OnboardingRule.Formats.ps1xml
@@ -40,6 +40,50 @@
 								</ItemSelectionCondition>
 								<PropertyName>TargetSafeName</PropertyName>
 							</ListItem>
+							<ListItem>
+								<PropertyName>IsAdminIDFilter</PropertyName>
+							</ListItem>
+							<ListItem>
+								<PropertyName>MachineTypeFilter</PropertyName>
+							</ListItem>
+							<ListItem>
+								<PropertyName>SystemTypeFilter</PropertyName>
+							</ListItem>
+							<ListItem>
+								<PropertyName>UserNameFilter</PropertyName>
+							</ListItem>
+							<ListItem>
+								<Label>CreationTime</Label>
+								<ScriptBlock>(get-date 1/1/1970).addseconds($_.CreationTime)</ScriptBlock>
+							</ListItem>
+							<ListItem>
+								<PropertyName>RulePrecedence</PropertyName>
+							</ListItem>
+							<ListItem>
+								<PropertyName>UserNameMethod</PropertyName>
+							</ListItem>
+							<ListItem>
+								<PropertyName>AddressFilter</PropertyName>
+							</ListItem>
+							<ListItem>
+								<PropertyName>AddressMethod</PropertyName>
+							</ListItem>
+							<ListItem>
+								<PropertyName>AccountCategoryFilter</PropertyName>
+							</ListItem>
+							<ListItem>
+								<PropertyName>AccountCategoryFilter</PropertyName>
+							</ListItem>
+							<ListItem>
+								<PropertyName>RuleDescription</PropertyName>
+							</ListItem>
+							<ListItem>
+								<PropertyName>ReconcileAccountId</PropertyName>
+							</ListItem>
+							<ListItem>
+								<Label>LastOnboardedTime</Label>
+								<ScriptBlock>(get-date 1/1/1970).addseconds($_.LastOnboardedTime)</ScriptBlock>
+							</ListItem>
 						</ListItems>
 					</ListEntry>
 				</ListEntries>

--- a/psPAS/xml/psPAS.CyberArk.Vault.Safe.Formats.ps1xml
+++ b/psPAS/xml/psPAS.CyberArk.Vault.Safe.Formats.ps1xml
@@ -211,6 +211,9 @@
 								<PropertyName>memberName</PropertyName>
 							</ListItem>
 							<ListItem>
+								<PropertyName>memberType</PropertyName>
+							</ListItem>
+							<ListItem>
 								<PropertyName>safeUrlId</PropertyName>
 							</ListItem>
 							<ListItem>


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description

## Release 5.5

### Module update to cover all CyberArk 13.0 API features

- New
  - Adds `Get-PASPTAGlobalCatalog` & `Add-PASPTAGlobalCatalog` commands, available for v13.
- Updates
  - `New-PASSession`
    - Adds Shared Services Auth Support
    - Allows null or empty `OTPDelimiter` to be specified
  - `Set-PASPTARule`
    - Updates validation for parameter `id`
  - `Get-PASComponentDetail`
    - Adds `pta` as option for parameter `component`
  - `Add-PASSafe`
    - Allows `0` as valid value for parameter `NumberOfDaysRetention`
  - `Add-PASSafeMember`
    - Adds optional `memberType` parameter, accepted from 12.6 onward.
- Other
  - Allow UPN UserName format
    - Updates the parameter validation logic of the `*-PASPublicSSHKey` functions to allow UPN style usernames to be specified and accepted.
  - Updates `psPAS.CyberArk.Vault.OnboardingRule` format in line with expected output according to product documentation.
  - Documentation update
    - Correct version requirement information for the `Get-PASAccount` `searchType` parameter.
    
resolves #402 
fixes #443 
fixes #445
resolves #446 
resolves #449 
closes #450 
closes #453 
closes #455

## Type of change
<!--
Please select all relevant options:
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [X] Documentation update (psPAS website or command help content)
- [ ] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [X] Pester test(s) updated
- [X] Pester test(s) passing

**Test Configuration**:
- PowerShell version: 7
- CyberArk PAS version: 13
- OS Version: 11

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [X] My code follows the style guidelines of this project
- [X] I have followed the contributing guidelines.
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new test failures or errors
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [X] I have linked a related issue