### PR TITLE
ADD Dependancy on IdentityCommand module 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 - Continued development to encompass any new documented features of the CyberArk API.
 - psPAS v6.0...
 
+## **vNext**
+
+- Updates
+  - `New-PASSession`
+    - Adds Identity User Authentication
+    - Privilege Cloud Shared Services Authentication is via the CyberArk Identity Platform
+    - Update adds ability to use the pspete `IdentityCommand` module to satisfy Identity MFA challenges and obtain required authentication token to use against Privileged Cloud Shared Services.
+
 ## **5.6.135 (July 31st 2023)**
 
 ### Module update to cover all CyberArk 13.2 API features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@
 
 ## **vNext**
 
-- Updates
+- Updates & Breaking Change
   - `New-PASSession`
-    - Adds Identity User Authentication
-    - Privilege Cloud Shared Services Authentication is via the CyberArk Identity Platform
-    - Update adds ability to use the pspete `IdentityCommand` module to satisfy Identity MFA challenges and obtain required authentication token to use against Privileged Cloud Shared Services.
+    - **All Privilege Cloud Shared Services Authentication via the CyberArk Identity Platform now requires use of the pspete `IdentityCommand` module.**
+    - Adds Identity User Authentication, using the `IdentityCommand` module to satisfy Identity MFA challenges and obtain required authentication token to use against Privileged Cloud Shared Services.
+    - Adds logic to determine correct Identity tenant URL based on provided Privileged Cloud Subdomain value.
+    - Both Privileged Cloud API URL & Identity Portal URL are required to be specified if subdomain value is not provided.
 
 ## **5.6.135 (July 31st 2023)**
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Provide tenant ID and non-interactive API User credentials for authentication vi
 New-PASSession -TenantSubdomain YourPrivilegeCloudTenantID -Credential $ServiceUserCreds -ServiceUser
 ```
 
-Consult the vendor documentation for guidance on setting up a dedicated API Service user for non-interactive API user.
+Consult the vendor documentation for guidance on setting up a dedicated API Service user for non-interactive API use.
 
 ### Basic Operations
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,27 @@ $Cert = "0E199489C57E666115666D6E9990C2ACABDB6EDB"
 New-PASSession -UseSharedAuthentication -BaseURI https://pvwa.somedomain.com -CertificateThumbprint $Cert
 ```
 
+#### Shared Services Authentication
+
+##### Identity User
+
+Provide Identity User credentials and tenant details for authentication to CyberArk Identity for Privilege Cloud Shared Services:
+
+```
+New-PASSession -IdentityTenantURL https://SomeTenantName.id.cyberark.cloud -Credential $Cred -IdentityUser
+```
+
+This authentication flow requires use of the psPete `IdentityCommand` module, available from the Powershell Gallery & GitHub.
+
+##### Service User
+
+Provide tenant ID and non-interactive API User credentials for authentication via CyberArk Identity for Privilege Cloud Shared Services:
+
+```
+New-PASSession -TenantSubdomain YourPrivilegeCloudTenantID -Credential $ServiceUserCreds -ServiceUser
+```
+Consult the vendor documentation for guidance on setting up a dedicated API Service user for non-interactive API user.
+
 ### Basic Operations
 
 ![Logo][Logo]

--- a/README.md
+++ b/README.md
@@ -186,7 +186,13 @@ New-PASSession -UseSharedAuthentication -BaseURI https://pvwa.somedomain.com -Ce
 Provide Identity User credentials and tenant details for authentication to CyberArk Identity for Privilege Cloud Shared Services:
 
 ```
-New-PASSession -IdentityTenantURL https://SomeTenantName.id.cyberark.cloud -Credential $Cred -IdentityUser
+#using URL
+New-PASSession -IdentityTenantURL https://SomeTenantName.id.cyberark.cloud -PrivilegeCloudURL https://SomeTenant.privilegecloud.cyberark.cloud -Credential $Cred -IdentityUser
+```
+
+```
+#using subdomain
+New-PASSession -TenantSubdomain SomeTenantName -Credential $Cred -IdentityUser
 ```
 
 This authentication flow requires use of the psPete `IdentityCommand` module, available from the Powershell Gallery & GitHub.
@@ -1262,6 +1268,9 @@ Priority support could be considered for <a href="https://github.com/sponsors/ps
 
 Hat Tips:
 
+**Joe Garcia** ([infamousjoeg](https://github.com/infamousjoeg))
+for the unofficial API documentation, general API wizardry & knowledge sharing.
+
 **Jesse McWilliams**
 ([JesseMcWilliamss](https://github.com/JesseMcWilliams))
 For the infomration needed to add PKIPN authentication into `New-PASSession`
@@ -1280,9 +1289,6 @@ For the JSON formatting assistance.
 
 **Warren Frame**
 ([RamblingCookieMonster](https://github.com/RamblingCookieMonster)) for [Add-ObjectDetail.ps1](https://github.com/RamblingCookieMonster/PowerShell/blob/master/Add-ObjectDetail.ps1).
-
-**Joe Garcia** ([infamousjoeg](https://github.com/infamousjoeg))
-for the unofficial API documentation.
 
 Chapeau!
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ New-PASSession -UseSharedAuthentication -BaseURI https://pvwa.somedomain.com -Ce
 
 #### Shared Services Authentication
 
-**Privilege Cloud Shared Services authentication flows require use of the psPete `IdentityCommand` module, available from the Powershell Gallery & GitHub.**
+**Privilege Cloud Shared Services authentication flows require use of the pspete `IdentityCommand` module, available from the Powershell Gallery & GitHub.**
 
 ##### Identity User
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ New-PASSession -UseSharedAuthentication -BaseURI https://pvwa.somedomain.com -Ce
 
 #### Shared Services Authentication
 
+**Privilege Cloud Shared Services authentication flows require use of the psPete `IdentityCommand` module, available from the Powershell Gallery & GitHub.**
+
 ##### Identity User
 
 Provide Identity User credentials and tenant details for authentication to CyberArk Identity for Privilege Cloud Shared Services:
@@ -195,8 +197,6 @@ New-PASSession -IdentityTenantURL https://SomeTenantName.id.cyberark.cloud -Priv
 New-PASSession -TenantSubdomain SomeTenantName -Credential $Cred -IdentityUser
 ```
 
-This authentication flow requires use of the psPete `IdentityCommand` module, available from the Powershell Gallery & GitHub.
-
 ##### Service User
 
 Provide tenant ID and non-interactive API User credentials for authentication via CyberArk Identity for Privilege Cloud Shared Services:
@@ -204,6 +204,7 @@ Provide tenant ID and non-interactive API User credentials for authentication vi
 ```
 New-PASSession -TenantSubdomain YourPrivilegeCloudTenantID -Credential $ServiceUserCreds -ServiceUser
 ```
+
 Consult the vendor documentation for guidance on setting up a dedicated API Service user for non-interactive API user.
 
 ### Basic Operations

--- a/Tests/Find-SharedServicesURL.Tests.ps1
+++ b/Tests/Find-SharedServicesURL.Tests.ps1
@@ -1,0 +1,80 @@
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
+
+    BeforeAll {
+        #Get Current Directory
+        $Here = Split-Path -Parent $PSCommandPath
+
+        #Assume ModuleName from Repository Root folder
+        $ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+        #Resolve Path to Module Directory
+        $ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+        #Define Path to Module Manifest
+        $ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+        if ( -not (Get-Module -Name $ModuleName -All)) {
+
+            Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+        }
+
+    }
+
+    InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+        Context 'General Operations' {
+
+            BeforeEach {
+
+                Mock Invoke-PASRestMethod -MockWith {
+
+                    [pscustomobject]@{
+                        identity_user_portal = [pscustomobject]@{api = 'https://SubDomainABC.id.cyberark.cloud' }
+                        pcloud               = [pscustomobject]@{api = 'https://SomeSubDomain.privilegecloud.cyberark.cloud' }
+                    }
+
+                }
+
+            }
+
+            It 'sends request to expected endpoint when subdomain provided' {
+                Find-SharedServicesURL -subdomain somedomain
+                Assert-MockCalled -CommandName Invoke-PASRestMethod -Times 1 -ParameterFilter {
+                    $URI -eq 'https://platform-discovery.cyberark.cloud/api/v2/services/subdomain/somedomain'
+                } -Scope It -Exactly
+            }
+
+            It 'sends request to expected endpoint when url provided' {
+                Find-SharedServicesURL -url https://someotherdomain.cyberark.cloud
+                Assert-MockCalled -CommandName Invoke-PASRestMethod -Times 1 -ParameterFilter {
+                    $URI -eq 'https://platform-discovery.cyberark.cloud/api/v2/services/subdomain/someotherdomain'
+                } -Scope It -Exactly
+            }
+
+            It 'uses expected method' {
+                Find-SharedServicesURL -url https://someotherdomain.cyberark.cloud
+                Assert-MockCalled -CommandName Invoke-PASRestMethod -Times 1 -ParameterFilter {
+                    $Method -eq 'GET'
+                } -Scope It -Exactly
+            }
+
+            It 'outputs expected results' {
+                $results = Find-SharedServicesURL -url https://someotherdomain.cyberark.cloud
+                $results.pcloud.api | Should -Be 'https://SomeSubDomain.privilegecloud.cyberark.cloud'
+                $results.identity_user_portal.api | Should -Be 'https://SubDomainABC.id.cyberark.cloud'
+            }
+
+            It 'outputs filtered results when service is specified' {
+                Find-SharedServicesURL -subdomain somedomain -service pcloud | Should -Be 'https://SomeSubDomain.privilegecloud.cyberark.cloud'
+            }
+
+            It 'throws if specifed service detail is not included in results' {
+                { Find-SharedServicesURL -subdomain somedomain -service flows } | Should -Throw -ExpectedMessage 'URL for flows API not found'
+            }
+
+        }
+
+    }
+
+}

--- a/Tests/New-PASSession.Tests.ps1
+++ b/Tests/New-PASSession.Tests.ps1
@@ -884,6 +884,10 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 					}
 				}
 
+				Mock Get-Module -MockWith {}
+
+				Mock Import-Module -MockWith {}
+
 				$Credentials = New-Object System.Management.Automation.PSCredential ('SomeUser', $(ConvertTo-SecureString 'SomePassword' -AsPlainText -Force))
 
 				$Script:ExternalVersion = '0.0'
@@ -967,6 +971,10 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 					}
 
 				}
+
+				Mock Get-Module -MockWith {}
+
+				Mock Import-Module -MockWith {}
 
 				$Credentials = New-Object System.Management.Automation.PSCredential ('SomeUser', $(ConvertTo-SecureString 'SomePassword' -AsPlainText -Force))
 

--- a/Tests/New-PASSession.Tests.ps1
+++ b/Tests/New-PASSession.Tests.ps1
@@ -1027,11 +1027,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 					param($tenant_url,
 						$Credential)
 				}
-				$mockResult = [PSCustomObject] @{
-					Property1 = 'Value1'
-					Property2 = 'Value2'
-					Headers   = @{}
-				}
+				$mockResult = New-Object -TypeName Microsoft.PowerShell.Commands.WebRequestSession
 
 				$mockGetWebSessionMethod = {
 					# count the invocation and store it on the mock object
@@ -1116,11 +1112,8 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 					param($tenant_url,
 						$Credential)
 				}
-				$mockResult = [PSCustomObject] @{
-					Property1 = 'Value1'
-					Property2 = 'Value2'
-					Headers   = @{}
-				}
+				$mockResult = New-Object -TypeName Microsoft.PowerShell.Commands.WebRequestSession
+
 
 				$mockGetWebSessionMethod = {
 					# count the invocation and store it on the mock object

--- a/Tests/New-PASSession.Tests.ps1
+++ b/Tests/New-PASSession.Tests.ps1
@@ -900,10 +900,31 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$URI -eq 'https://Some.Identity.Portal/oauth2/platformtoken'
+
+				} -Times 1 -Exactly -Scope It
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
 					$ContentType -eq 'application/x-www-form-urlencoded'
+
+				} -Times 1 -Exactly -Scope It
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
 					$Body['client_id'] -eq 'SomeUser'
+
+				} -Times 1 -Exactly -Scope It
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
 					$Body['client_secret'] -eq 'SomePassword'
+
+				} -Times 1 -Exactly -Scope It
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
 					$Body['grant_type'] -eq 'client_credentials'
+
 				} -Times 1 -Exactly -Scope It
 
 			}
@@ -917,7 +938,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'sets expected authorization header' {
 
-				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -ServiceUser
+				$Credentials | New-PASSession -IdentityTenantURL 'https://Some.Identity.Portal/' -PrivilegeCloudURL 'https://Some.PCloud.Portal/PasswordVault' -ServiceUser
 				$Script:WebSession.Headers['Authorization'] | Should -Be 'Bearer AAAAAAA\\\REEEAAAAALLLLYYYYY\\\\LOOOOONNNNGGGGG\\\ACCCCCEEEEEEEESSSSSSS\\\\\\TTTTTOOOOOKKKKKEEEEEN'
 
 			}
@@ -939,6 +960,15 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 					[PSCustomObject]@{
 						ExternalVersion = '0.0'
 					}
+				}
+
+				Mock Find-SharedServicesURL -MockWith {
+
+					[pscustomobject]@{
+						identity_user_portal = [pscustomobject]@{api = 'https://SomeSubDomain.id.cyberark.cloud' }
+						pcloud               = [pscustomobject]@{api = 'https://SomeSubDomain.privilegecloud.cyberark.cloud' }
+					}
+
 				}
 
 				$Credentials = New-Object System.Management.Automation.PSCredential ('SomeUser', $(ConvertTo-SecureString 'SomePassword' -AsPlainText -Force))
@@ -966,10 +996,10 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'sends request to expected identity endpoint' {
 
-				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -IdentitySubdomain SomeIDDomain -ServiceUser
+				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -ServiceUser
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq 'https://SomeIDDomain.id.cyberark.cloud/oauth2/platformtoken'
+					$URI -eq 'https://SomeSubDomain.id.cyberark.cloud/oauth2/platformtoken'
 
 				} -Times 1 -Exactly -Scope It
 
@@ -987,10 +1017,31 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$URI -eq 'https://SomeSubDomain.id.cyberark.cloud/oauth2/platformtoken'
+
+				} -Times 1 -Exactly -Scope It
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
 					$ContentType -eq 'application/x-www-form-urlencoded'
+
+				} -Times 1 -Exactly -Scope It
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
 					$Body['client_id'] -eq 'SomeUser'
+
+				} -Times 1 -Exactly -Scope It
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
 					$Body['client_secret'] -eq 'SomePassword'
+
+				} -Times 1 -Exactly -Scope It
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
 					$Body['grant_type'] -eq 'client_credentials'
+
 				} -Times 1 -Exactly -Scope It
 
 			}
@@ -1004,7 +1055,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'sets expected BaseURI when identity subdomain specified' {
 
-				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -IdentitySubdomain SomeIDDomain -ServiceUser
+				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -ServiceUser
 				$Script:BaseURI | Should -Be 'https://SomeSubDomain.privilegecloud.cyberark.cloud/PasswordVault'
 
 			}
@@ -1065,13 +1116,13 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'sends request' {
 
-				$Credentials | New-PASSession -IdentityTenantURL 'https://SomeIdentityPortal.id.cyberark.cloud/' -IdentityUser
+				$Credentials | New-PASSession -IdentityTenantURL 'https://SomeIdentityPortal.id.cyberark.cloud/' -PrivilegeCloudURL 'https://Some.PCloud.Portal/PasswordVault' -IdentityUser
 				Assert-MockCalled New-IDSession -Times 1 -Exactly -Scope It -ModuleName psPAS
 
 			}
 
 			It 'sends request to expected tenant_url' {
-				$Credentials | New-PASSession -IdentityTenantURL 'https://SomeIdentityPortal.id.cyberark.cloud' -IdentityUser
+				$Credentials | New-PASSession -IdentityTenantURL 'https://SomeIdentityPortal.id.cyberark.cloud' -PrivilegeCloudURL 'https://Some.PCloud.Portal/' -IdentityUser
 				Assert-MockCalled New-IDSession -ParameterFilter {
 
 					$tenant_url -eq 'https://SomeIdentityPortal.id.cyberark.cloud'
@@ -1082,7 +1133,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'sets expected default BaseURI' {
 
-				$Credentials | New-PASSession -IdentityTenantURL 'https://SomeIdentityPortal.id.cyberark.cloud/' -IdentityUser
+				$Credentials | New-PASSession -IdentityTenantURL 'https://SomeIdentityPortal.id.cyberark.cloud/' -PrivilegeCloudURL 'https://SomeIdentityPortal.privilegecloud.cyberark.cloud/' -IdentityUser
 				$Script:BaseURI | Should -Be 'https://SomeIdentityPortal.privilegecloud.cyberark.cloud/PasswordVault'
 
 			}
@@ -1096,7 +1147,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'sets expected authorization header' {
 
-				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -IdentityUser
+				$Credentials | New-PASSession -IdentityTenantURL 'https://SomeIdentityPortal.id.cyberark.cloud/' -PrivilegeCloudURL 'https://Some.PCloud.Portal/' -IdentityUser
 				$Script:WebSession.Headers['Authorization'] | Should -Be 'Bearer AAAAAAA\\\REEEAAAAALLLLYYYYY\\\\LOOOOONNNNGGGGG\\\ACCCCCEEEEEEEESSSSSSS\\\\\\TTTTTOOOOOKKKKKEEEEEN'
 
 			}
@@ -1142,6 +1193,15 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Mock Import-Module -MockWith {}
 
+				Mock Find-SharedServicesURL -MockWith {
+
+					[pscustomobject]@{
+						identity_user_portal = [pscustomobject]@{api = 'https://SomeSubDomain.id.cyberark.cloud' }
+						pcloud               = [pscustomobject]@{api = 'https://SomeSubDomain.privilegecloud.cyberark.cloud' }
+					}
+
+				}
+
 				$Credentials = New-Object System.Management.Automation.PSCredential ('SomeUser', $(ConvertTo-SecureString 'SomePassword' -AsPlainText -Force))
 
 				$Script:ExternalVersion = '0.0'
@@ -1168,13 +1228,6 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			It 'sets expected BaseURI' {
 
 				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -IdentityUser
-				$Script:BaseURI | Should -Be 'https://SomeSubDomain.privilegecloud.cyberark.cloud/PasswordVault'
-
-			}
-
-			It 'sets expected BaseURI when identity subdomain specified' {
-
-				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -IdentitySubdomain SomeIDDomain -IdentityUser
 				$Script:BaseURI | Should -Be 'https://SomeSubDomain.privilegecloud.cyberark.cloud/PasswordVault'
 
 			}

--- a/Tests/New-PASSession.Tests.ps1
+++ b/Tests/New-PASSession.Tests.ps1
@@ -848,7 +848,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 		}
 
-		Context 'SharedServices-URL' {
+		Context 'SharedServices-URL-ServiceUser' {
 
 			BeforeEach {
 
@@ -873,13 +873,13 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'sends request' {
-				$Credentials | New-PASSession -IdentityTenantURL 'https://Some.Identity.Portal/' -PrivilegeCloudURL 'https://Some.PCloud.Portal/PasswordVault'
+				$Credentials | New-PASSession -IdentityTenantURL 'https://Some.Identity.Portal/' -PrivilegeCloudURL 'https://Some.PCloud.Portal/PasswordVault' -ServiceUser
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
 			It 'sends request to expected endpoint' {
-				$Credentials | New-PASSession -IdentityTenantURL 'https://Some.Identity.Portal' -PrivilegeCloudURL 'https://Some.PCloud.Portal/'
+				$Credentials | New-PASSession -IdentityTenantURL 'https://Some.Identity.Portal' -PrivilegeCloudURL 'https://Some.PCloud.Portal/' -ServiceUser
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$URI -eq 'https://Some.Identity.Portal/oauth2/platformtoken'
@@ -889,14 +889,14 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'uses expected method' {
-				$Credentials | New-PASSession -IdentityTenantURL 'https://Some.Identity.Portal/' -PrivilegeCloudURL 'https://Some.PCloud.Portal/PasswordVault'
+				$Credentials | New-PASSession -IdentityTenantURL 'https://Some.Identity.Portal/' -PrivilegeCloudURL 'https://Some.PCloud.Portal/PasswordVault' -ServiceUser
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It 'sends expected request to expected endpoint' {
 
-				$Credentials | New-PASSession -IdentityTenantURL 'https://Some.Identity.Portal/' -PrivilegeCloudURL 'https://Some.PCloud.Portal/PasswordVault'
+				$Credentials | New-PASSession -IdentityTenantURL 'https://Some.Identity.Portal/' -PrivilegeCloudURL 'https://Some.PCloud.Portal/PasswordVault' -ServiceUser
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$URI -eq 'https://Some.Identity.Portal/oauth2/platformtoken'
@@ -910,21 +910,21 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'sets expected BaseURI' {
 
-				$Credentials | New-PASSession -IdentityTenantURL 'https://Some.Identity.Portal/' -PrivilegeCloudURL 'https://Some.PCloud.Portal/PasswordVault'
+				$Credentials | New-PASSession -IdentityTenantURL 'https://Some.Identity.Portal/' -PrivilegeCloudURL 'https://Some.PCloud.Portal/PasswordVault' -ServiceUser
 				$Script:BaseURI | Should -Be 'https://Some.PCloud.Portal/PasswordVault'
 
 			}
 
 			It 'sets expected authorization header' {
 
-				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain
+				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -ServiceUser
 				$Script:WebSession.Headers['Authorization'] | Should -Be 'Bearer AAAAAAA\\\REEEAAAAALLLLYYYYY\\\\LOOOOONNNNGGGGG\\\ACCCCCEEEEEEEESSSSSSS\\\\\\TTTTTOOOOOKKKKKEEEEEN'
 
 			}
 
 		}
 
-		Context 'SharedServices-Subdomain' {
+		Context 'SharedServices-Subdomain-ServiceUser' {
 
 			BeforeEach {
 
@@ -949,13 +949,13 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'sends request' {
-				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain
+				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -ServiceUser
 				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
 
 			}
 
 			It 'sends request to expected endpoint' {
-				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain
+				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -ServiceUser
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$URI -eq 'https://SomeSubDomain.id.cyberark.cloud/oauth2/platformtoken'
@@ -966,7 +966,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'sends request to expected identity endpoint' {
 
-				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -IdentitySubdomain SomeIDDomain
+				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -IdentitySubdomain SomeIDDomain -ServiceUser
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$URI -eq 'https://SomeIDDomain.id.cyberark.cloud/oauth2/platformtoken'
@@ -976,14 +976,14 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'uses expected method' {
-				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain
+				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -ServiceUser
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
 
 			}
 
 			It 'sends expected request to expected endpoint' {
 
-				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain
+				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -ServiceUser
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$URI -eq 'https://SomeSubDomain.id.cyberark.cloud/oauth2/platformtoken'
@@ -997,21 +997,198 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'sets expected BaseURI' {
 
-				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain
+				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -ServiceUser
 				$Script:BaseURI | Should -Be 'https://SomeSubDomain.privilegecloud.cyberark.cloud/PasswordVault'
 
 			}
 
 			It 'sets expected BaseURI when identity subdomain specified' {
 
-				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -IdentitySubdomain SomeIDDomain
+				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -IdentitySubdomain SomeIDDomain -ServiceUser
 				$Script:BaseURI | Should -Be 'https://SomeSubDomain.privilegecloud.cyberark.cloud/PasswordVault'
 
 			}
 
 			It 'sets expected authorization header' {
 
-				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain
+				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -ServiceUser
+				$Script:WebSession.Headers['Authorization'] | Should -Be 'Bearer AAAAAAA\\\REEEAAAAALLLLYYYYY\\\\LOOOOONNNNGGGGG\\\ACCCCCEEEEEEEESSSSSSS\\\\\\TTTTTOOOOOKKKKKEEEEEN'
+
+			}
+
+		}
+
+		Context 'SharedServices-URL-IdentityUser' {
+
+			BeforeEach {
+
+				function New-IDSession {
+					[CmdletBinding()]
+					param($tenant_url,
+						$Credential)
+				}
+				$mockResult = [PSCustomObject] @{
+					Property1 = 'Value1'
+					Property2 = 'Value2'
+					Headers   = @{}
+				}
+
+				$mockGetWebSessionMethod = {
+					# count the invocation and store it on the mock object
+					# to avoid using script:scoped variables
+					$this.GetWebSessionInvoked++
+
+					# return the result object as the real method would
+					$mockResult
+				}
+
+				$mockIDSessionObject = [PSCustomObject] @{
+					GetWebSessionInvoked = 0
+					'Token'              = 'AAAAAAA\\\REEEAAAAALLLLYYYYY\\\\LOOOOONNNNGGGGG\\\ACCCCCEEEEEEEESSSSSSS\\\\\\TTTTTOOOOOKKKKKEEEEEN'
+				}
+
+				$mockIDSessionObject | Add-Member -MemberType ScriptMethod -Name GetWebSession -Value $mockGetWebSessionMethod
+				Mock New-IDSession { $mockIDSessionObject }
+
+				Mock Get-PASServer -MockWith {
+					[PSCustomObject]@{
+						ExternalVersion = '0.0'
+					}
+				}
+
+				Mock Get-Module -MockWith {}
+
+				Mock Import-Module -MockWith {}
+
+				$Credentials = New-Object System.Management.Automation.PSCredential ('SomeUser', $(ConvertTo-SecureString 'SomePassword' -AsPlainText -Force))
+
+				$Script:ExternalVersion = '0.0'
+				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+			}
+
+			It 'sends request' {
+
+				$Credentials | New-PASSession -IdentityTenantURL 'https://SomeIdentityPortal.id.cyberark.cloud/' -IdentityUser
+				Assert-MockCalled New-IDSession -Times 1 -Exactly -Scope It -ModuleName psPAS
+
+			}
+
+			It 'sends request to expected tenant_url' {
+				$Credentials | New-PASSession -IdentityTenantURL 'https://SomeIdentityPortal.id.cyberark.cloud' -IdentityUser
+				Assert-MockCalled New-IDSession -ParameterFilter {
+
+					$tenant_url -eq 'https://SomeIdentityPortal.id.cyberark.cloud'
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'sets expected default BaseURI' {
+
+				$Credentials | New-PASSession -IdentityTenantURL 'https://SomeIdentityPortal.id.cyberark.cloud/' -IdentityUser
+				$Script:BaseURI | Should -Be 'https://SomeIdentityPortal.privilegecloud.cyberark.cloud/PasswordVault'
+
+			}
+
+			It 'sets expected custom BaseURI' {
+
+				$Credentials | New-PASSession -IdentityTenantURL 'https://SomeIdentityPortal.id.cyberark.cloud/' -PrivilegeCloudURL 'https://Some.PCloud.Portal/' -IdentityUser
+				$Script:BaseURI | Should -Be 'https://Some.PCloud.Portal/PasswordVault'
+
+			}
+
+			It 'sets expected authorization header' {
+
+				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -IdentityUser
+				$Script:WebSession.Headers['Authorization'] | Should -Be 'Bearer AAAAAAA\\\REEEAAAAALLLLYYYYY\\\\LOOOOONNNNGGGGG\\\ACCCCCEEEEEEEESSSSSSS\\\\\\TTTTTOOOOOKKKKKEEEEEN'
+
+			}
+
+		}
+
+		Context 'SharedServices-Subdomain-IdentityUser' {
+
+			BeforeEach {
+
+				function New-IDSession {
+					[CmdletBinding()]
+					param($tenant_url,
+						$Credential)
+				}
+				$mockResult = [PSCustomObject] @{
+					Property1 = 'Value1'
+					Property2 = 'Value2'
+					Headers   = @{}
+				}
+
+				$mockGetWebSessionMethod = {
+					# count the invocation and store it on the mock object
+					# to avoid using script:scoped variables
+					$this.GetWebSessionInvoked++
+
+					# return the result object as the real method would
+					$mockResult
+				}
+
+				$mockIDSessionObject = [PSCustomObject] @{
+					GetWebSessionInvoked = 0
+					'Token'              = 'AAAAAAA\\\REEEAAAAALLLLYYYYY\\\\LOOOOONNNNGGGGG\\\ACCCCCEEEEEEEESSSSSSS\\\\\\TTTTTOOOOOKKKKKEEEEEN'
+				}
+
+				$mockIDSessionObject | Add-Member -MemberType ScriptMethod -Name GetWebSession -Value $mockGetWebSessionMethod
+				Mock New-IDSession { $mockIDSessionObject }
+
+				Mock Get-PASServer -MockWith {
+					[PSCustomObject]@{
+						ExternalVersion = '0.0'
+					}
+				}
+
+				Mock Get-Module -MockWith {}
+
+				Mock Import-Module -MockWith {}
+
+				$Credentials = New-Object System.Management.Automation.PSCredential ('SomeUser', $(ConvertTo-SecureString 'SomePassword' -AsPlainText -Force))
+
+				$Script:ExternalVersion = '0.0'
+				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+			}
+
+			It 'sends request' {
+				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -IdentityUser
+				Assert-MockCalled New-IDSession -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'sends request to expected tenant_url' {
+				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -IdentityUser
+				Assert-MockCalled New-IDSession -ParameterFilter {
+
+					$tenant_url -eq 'https://SomeSubDomain.id.cyberark.cloud'
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'sets expected BaseURI' {
+
+				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -IdentityUser
+				$Script:BaseURI | Should -Be 'https://SomeSubDomain.privilegecloud.cyberark.cloud/PasswordVault'
+
+			}
+
+			It 'sets expected BaseURI when identity subdomain specified' {
+
+				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -IdentitySubdomain SomeIDDomain -IdentityUser
+				$Script:BaseURI | Should -Be 'https://SomeSubDomain.privilegecloud.cyberark.cloud/PasswordVault'
+
+			}
+
+			It 'sets expected authorization header' {
+
+				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -IdentityUser
 				$Script:WebSession.Headers['Authorization'] | Should -Be 'Bearer AAAAAAA\\\REEEAAAAALLLLYYYYY\\\\LOOOOONNNNGGGGG\\\ACCCCCEEEEEEEESSSSSSS\\\\\\TTTTTOOOOOKKKKKEEEEEN'
 
 			}

--- a/Tests/New-PASSession.Tests.ps1
+++ b/Tests/New-PASSession.Tests.ps1
@@ -852,12 +852,31 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			BeforeEach {
 
-				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{
-						'token_type'   = 'Bearer'
-						'access_token' = 'AAAAAAA\\\REEEAAAAALLLLYYYYY\\\\LOOOOONNNNGGGGG\\\ACCCCCEEEEEEEESSSSSSS\\\\\\TTTTTOOOOOKKKKKEEEEEN'
-					}
+				function New-IDPlatformToken {
+					[CmdletBinding()]
+					param($tenant_url,
+						$Credential)
 				}
+				$mockResult = New-Object -TypeName Microsoft.PowerShell.Commands.WebRequestSession
+
+
+				$mockGetWebSessionMethod = {
+					# count the invocation and store it on the mock object
+					# to avoid using script:scoped variables
+					$this.GetWebSessionInvoked++
+
+					# return the result object as the real method would
+					$mockResult
+				}
+
+				$mockIDSessionObject = [PSCustomObject] @{
+					GetWebSessionInvoked = 0
+					'access_token'       = 'AAAAAAA\\\REEEAAAAALLLLYYYYY\\\\LOOOOONNNNGGGGG\\\ACCCCCEEEEEEEESSSSSSS\\\\\\TTTTTOOOOOKKKKKEEEEEN'
+					'token_type'         = 'Bearer'
+				}
+
+				$mockIDSessionObject | Add-Member -MemberType ScriptMethod -Name GetWebSession -Value $mockGetWebSessionMethod
+				Mock New-IDPlatformToken { $mockIDSessionObject }
 
 				Mock Get-PASServer -MockWith {
 					[PSCustomObject]@{
@@ -874,56 +893,15 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'sends request' {
 				$Credentials | New-PASSession -IdentityTenantURL 'https://Some.Identity.Portal/' -PrivilegeCloudURL 'https://Some.PCloud.Portal/PasswordVault' -ServiceUser
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+				Assert-MockCalled New-IDPlatformToken -Times 1 -Exactly -Scope It
 
 			}
 
-			It 'sends request to expected endpoint' {
+			It 'sends request to expected tenant_url' {
 				$Credentials | New-PASSession -IdentityTenantURL 'https://Some.Identity.Portal' -PrivilegeCloudURL 'https://Some.PCloud.Portal/' -ServiceUser
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+				Assert-MockCalled New-IDPlatformToken -ParameterFilter {
 
-					$URI -eq 'https://Some.Identity.Portal/oauth2/platformtoken'
-
-				} -Times 1 -Exactly -Scope It
-
-			}
-
-			It 'uses expected method' {
-				$Credentials | New-PASSession -IdentityTenantURL 'https://Some.Identity.Portal/' -PrivilegeCloudURL 'https://Some.PCloud.Portal/PasswordVault' -ServiceUser
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
-
-			}
-
-			It 'sends expected request to expected endpoint' {
-
-				$Credentials | New-PASSession -IdentityTenantURL 'https://Some.Identity.Portal/' -PrivilegeCloudURL 'https://Some.PCloud.Portal/PasswordVault' -ServiceUser
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-
-					$URI -eq 'https://Some.Identity.Portal/oauth2/platformtoken'
-
-				} -Times 1 -Exactly -Scope It
-
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-
-					$ContentType -eq 'application/x-www-form-urlencoded'
-
-				} -Times 1 -Exactly -Scope It
-
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-
-					$Body['client_id'] -eq 'SomeUser'
-
-				} -Times 1 -Exactly -Scope It
-
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-
-					$Body['client_secret'] -eq 'SomePassword'
-
-				} -Times 1 -Exactly -Scope It
-
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-
-					$Body['grant_type'] -eq 'client_credentials'
+					$tenant_url -eq 'https://Some.Identity.Portal'
 
 				} -Times 1 -Exactly -Scope It
 
@@ -949,12 +927,31 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			BeforeEach {
 
-				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{
-						'token_type'   = 'Bearer'
-						'access_token' = 'AAAAAAA\\\REEEAAAAALLLLYYYYY\\\\LOOOOONNNNGGGGG\\\ACCCCCEEEEEEEESSSSSSS\\\\\\TTTTTOOOOOKKKKKEEEEEN'
-					}
+				function New-IDPlatformToken {
+					[CmdletBinding()]
+					param($tenant_url,
+						$Credential)
 				}
+				$mockResult = New-Object -TypeName Microsoft.PowerShell.Commands.WebRequestSession
+
+
+				$mockGetWebSessionMethod = {
+					# count the invocation and store it on the mock object
+					# to avoid using script:scoped variables
+					$this.GetWebSessionInvoked++
+
+					# return the result object as the real method would
+					$mockResult
+				}
+
+				$mockIDSessionObject = [PSCustomObject] @{
+					GetWebSessionInvoked = 0
+					'access_token'       = 'AAAAAAA\\\REEEAAAAALLLLYYYYY\\\\LOOOOONNNNGGGGG\\\ACCCCCEEEEEEEESSSSSSS\\\\\\TTTTTOOOOOKKKKKEEEEEN'
+					'token_type'         = 'Bearer'
+				}
+
+				$mockIDSessionObject | Add-Member -MemberType ScriptMethod -Name GetWebSession -Value $mockGetWebSessionMethod
+				Mock New-IDPlatformToken { $mockIDSessionObject }
 
 				Mock Get-PASServer -MockWith {
 					[PSCustomObject]@{
@@ -980,67 +977,15 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'sends request' {
 				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -ServiceUser
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+				Assert-MockCalled New-IDPlatformToken -Times 1 -Exactly -Scope It
 
 			}
 
-			It 'sends request to expected endpoint' {
+			It 'sends request to expected tenant_url' {
 				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -ServiceUser
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+				Assert-MockCalled New-IDPlatformToken -ParameterFilter {
 
-					$URI -eq 'https://SomeSubDomain.id.cyberark.cloud/oauth2/platformtoken'
-
-				} -Times 1 -Exactly -Scope It
-
-			}
-
-			It 'sends request to expected identity endpoint' {
-
-				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -ServiceUser
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-
-					$URI -eq 'https://SomeSubDomain.id.cyberark.cloud/oauth2/platformtoken'
-
-				} -Times 1 -Exactly -Scope It
-
-			}
-
-			It 'uses expected method' {
-				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -ServiceUser
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
-
-			}
-
-			It 'sends expected request to expected endpoint' {
-
-				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -ServiceUser
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-
-					$URI -eq 'https://SomeSubDomain.id.cyberark.cloud/oauth2/platformtoken'
-
-				} -Times 1 -Exactly -Scope It
-
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-
-					$ContentType -eq 'application/x-www-form-urlencoded'
-
-				} -Times 1 -Exactly -Scope It
-
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-
-					$Body['client_id'] -eq 'SomeUser'
-
-				} -Times 1 -Exactly -Scope It
-
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-
-					$Body['client_secret'] -eq 'SomePassword'
-
-				} -Times 1 -Exactly -Scope It
-
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-
-					$Body['grant_type'] -eq 'client_credentials'
+					$tenant_url -eq 'https://SomeSubDomain.id.cyberark.cloud'
 
 				} -Times 1 -Exactly -Scope It
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,8 @@ environment:
     secure: cWv4+OPfqRLSt7I4f+p3lEixKoYZzi42IDc7C4Kf+2WZW/dO+H+RBCM7m0Si2uuP
   github_email:
     secure: x5ljenzXfYXkzpEu9eX7AQvb3AkFbiXG2NndMzw9Zc4=
+  CODECOV_TOKEN:
+    secure: bLnfnH8+QlpeQgvoOrgrCLkOrgpOBMwfnjwtdVphoUE0YEeEdzP9/7dILfzpFGFg
   #sig_key:
     #secure: LPEv2aGCLb1WPw89OFF8gmhk5tVZtOAPaUJ9cAATBnD1+qREYmvh/fH53NbJSNP
   #PfxSecure:

--- a/build/test.ps1
+++ b/build/test.ps1
@@ -26,7 +26,7 @@ $result = Invoke-Pester -Configuration $configuration
 
 $res = $result | ConvertTo-Pester4Result
 
-Write-Host 'Uploading Test Results'
+Write-Host 'Uploading Test Results.'
 $null = (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", $(Resolve-Path .\TestResults.xml))
 
 Remove-Item -Path $(Resolve-Path .\TestResults.xml) -Force

--- a/build/test.ps1
+++ b/build/test.ps1
@@ -8,15 +8,15 @@ Import-Module $ManifestPath -Force
 #---------------------------------#
 # Run Pester Tests                #
 #---------------------------------#
-$files = Get-ChildItem $(Join-Path $ENV:APPVEYOR_BUILD_FOLDER $env:APPVEYOR_PROJECT_NAME) -Include *.ps1 -Recurse | Select-Object -ExpandProperty FullName
+#$files = Get-ChildItem $(Join-Path $ENV:APPVEYOR_BUILD_FOLDER $env:APPVEYOR_PROJECT_NAME) -Include *.ps1 -Recurse | Select-Object -ExpandProperty FullName
 
 # get default from static property
 $configuration = [PesterConfiguration]::Default
 # assing properties & discover via intellisense
 $configuration.Run.Path = '.\Tests'
 $configuration.Run.PassThru = $true
-$configuration.CodeCoverage.Enabled = $true
-$configuration.CodeCoverage.Path = $files
+#$configuration.CodeCoverage.Enabled = $true
+#$configuration.CodeCoverage.Path = $files
 $configuration.TestResult.Enabled = $true
 $configuration.TestResult.OutputFormat = 'NUnitXml'
 $configuration.TestResult.OutputPath = '.\TestResults.xml'
@@ -34,14 +34,14 @@ Remove-Item -Path $(Resolve-Path .\TestResults.xml) -Force
 
 if ($env:APPVEYOR_REPO_COMMIT_AUTHOR -eq 'Pete Maan') {
 
-	Write-Host 'Publishing Code Coverage'
+	#Write-Host 'Publishing Code Coverage'
 
-	$ProgressPreference = 'SilentlyContinue'
-	$null = Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -OutFile codecov.exe
-	.\codecov.exe -t ${env:CODECOV_TOKEN} | Out-Null
+	#$ProgressPreference = 'SilentlyContinue'
+	#$null = Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -OutFile codecov.exe
+	#.\codecov.exe -t ${env:CODECOV_TOKEN} | Out-Null
 
-	Remove-Item -Path $(Resolve-Path .\coverage.xml) -Force
-	Remove-Item -Path $(Resolve-Path .\codecov.exe) -Force
+	#Remove-Item -Path $(Resolve-Path .\coverage.xml) -Force
+	#Remove-Item -Path $(Resolve-Path .\codecov.exe) -Force
 
 }
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,0 @@
-fixes:
-  - "::psPAS/"

--- a/docs/collections/_commands/New-PASSession.md
+++ b/docs/collections/_commands/New-PASSession.md
@@ -21,18 +21,32 @@ New-PASSession [-Credential <PSCredential>] -BaseURI <String> [-newPassword <Sec
  [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-### SharedServices-URL
+### ISPSS-URL-ServiceUser
 ```
 New-PASSession -Credential <PSCredential> -IdentityTenantURL <String> -PrivilegeCloudURL <String>
- [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate <X509Certificate>] [-CertificateThumbprint <String>]
- [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-ServiceUser] [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate <X509Certificate>]
+ [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-### SharedServices-Subdomain
+### ISPSS-Subdomain-ServiceUser
 ```
 New-PASSession -Credential <PSCredential> -TenantSubdomain <String> [-IdentitySubdomain <String>]
- [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate <X509Certificate>] [-CertificateThumbprint <String>]
- [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-ServiceUser] [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate <X509Certificate>]
+ [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### ISPSS-URL-IdentityUser
+```
+New-PASSession -Credential <PSCredential> -IdentityTenantURL <String> [-PrivilegeCloudURL <String>]
+ [-IdentityUser] [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate <X509Certificate>]
+ [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### ISPSS-Subdomain-IdentityUser
+```
+New-PASSession -Credential <PSCredential> -TenantSubdomain <String> [-IdentitySubdomain <String>]
+ [-IdentityUser] [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate <X509Certificate>]
+ [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Gen1Radius
@@ -321,17 +335,54 @@ Logon with PKIPN auth, using a selected certificate stored on smart card.
 
 ### EXAMPLE 26
 ```
-New-PASSession -TenantSubdomain PCloudTenantID -IdentitySubdomain IdentityTenantID -Credential $cred
+New-PASSession -TenantSubdomain PCloudTenantID -IdentitySubdomain IdentityTenantID -Credential $cred -ServiceUser
 ```
 
-Authenticates to Privilege Cloud Shared Services, where subdomains for Identity & Privilege Cloud portals have not been configured to share the same value.
+Authenticates to Privilege Cloud Shared Services using an API Service User, where subdomains for Identity & Privilege Cloud portals have not been configured to share the same value.
 
 ### EXAMPLE 27
 ```
-New-PASSession -IdentityTenantURL 'https://ABC123.id.cyberark.cloud' -PrivilegeCloudURL 'https://XYZ789.privilegecloud.cyberark.cloud' -Credential $cred
+New-PASSession -IdentityTenantURL 'https://ABC123.id.cyberark.cloud' -PrivilegeCloudURL 'https://XYZ789.privilegecloud.cyberark.cloud' -Credential $cred -ServiceUser
 ```
 
-Authenticates to Privilege Cloud Shared Services, specifying individual URL values for Identity & Privilege Cloud tenants.
+Authenticates to Privilege Cloud Shared Services using an API Service User, specifying individual URL values for Identity & Privilege Cloud tenants.
+
+### Example 28
+```
+New-PASSession -IdentityTenantURL https://SomeTenantName.id.cyberark.cloud -Credential $Cred -IdentityUser
+```
+
+Authenticates to Identity Shared Services using an Identity User and provides authenticated session to associated Privileged Cloud environment.
+
+Assumes a Privileged Cloud API URL of https://SomeTenantName.privilegecloud.cyberark.cloud
+
+Requires IdentityCommand module to be installed for authentication flow to complete.
+
+See: Get-Help IdentityCommand
+
+### Example 29
+```
+New-PASSession -TenantSubdomain YourTenantName -Credential $Cred -IdentityUser
+```
+
+Authenticates to Identity Shared Services using an Identity User and provides authenticated session to associated Privileged Cloud environment.
+
+Assumes a Shared Services URL of https://YourTenantName.id.cyberark.cloud
+
+Requires IdentityCommand module to be installed for authentication flow to complete.
+
+See: Get-Help IdentityCommand
+
+### Example 30
+```
+New-PASSession -IdentityTenantURL https://SomeTenantName.id.cyberark.cloud -Credential $Cred --PrivilegeCloudURL https://SomeName.privilegecloud.cyberark.cloud -IdentityUser
+```
+
+Authenticates to Identity Shared Services using an Identity User and provides authenticated session to specified Privileged Cloud environment.
+
+Requires IdentityCommand module to be installed for authentication flow to complete.
+
+See: Get-Help IdentityCommand
 
 ## PARAMETERS
 
@@ -352,7 +403,7 @@ Accept wildcard characters: False
 
 ```yaml
 Type: PSCredential
-Parameter Sets: SharedServices-URL, SharedServices-Subdomain, Gen2Radius
+Parameter Sets: ISPSS-URL-ServiceUser, ISPSS-Subdomain-ServiceUser, ISPSS-URL-IdentityUser, ISPSS-Subdomain-IdentityUser, Gen2Radius
 Aliases:
 
 Required: True
@@ -773,7 +824,7 @@ Where the Shared Services tenants for both Identity and Privilege Cloud have bee
 
 ```yaml
 Type: String
-Parameter Sets: SharedServices-Subdomain
+Parameter Sets: ISPSS-Subdomain-ServiceUser, ISPSS-Subdomain-IdentityUser
 Aliases:
 
 Required: True
@@ -786,14 +837,14 @@ Accept wildcard characters: False
 ### -IdentitySubdomain
 A subdomain name value for the Identity Tenant used for authentication into Privilege Cloud.
 
-Where the Shared Services tenants for Identity and Privilege Cloud have not been configured with identical subdomain names, use this parameter to specify the subdomain name for the Identity tenant.
+Where the Shared Services tenants for Identity and Privilege Cloud have been configured with different subdomain names, use this parameter to specify the subdomain name for the Identity tenant.
 
 - Authentication will be performed against https://<IdentitySubdomain>.id.cyberark.cloud
 - API operations will target URL: https://<TenantSubdomain>.privilegecloud.cyberark.cloud
 
 ```yaml
 Type: String
-Parameter Sets: SharedServices-Subdomain
+Parameter Sets: ISPSS-Subdomain-ServiceUser, ISPSS-Subdomain-IdentityUser
 Aliases:
 
 Required: False
@@ -812,7 +863,7 @@ E.G.:
 
 ```yaml
 Type: String
-Parameter Sets: SharedServices-URL
+Parameter Sets: ISPSS-URL-ServiceUser, ISPSS-URL-IdentityUser
 Aliases:
 
 Required: True
@@ -830,7 +881,53 @@ E.G.:
 
 ```yaml
 Type: String
-Parameter Sets: SharedServices-URL
+Parameter Sets: ISPSS-URL-ServiceUser
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+```yaml
+Type: String
+Parameter Sets: ISPSS-URL-IdentityUser
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -IdentityUser
+Specify switch parameter to authenticate with standard Interactive Identity User.
+
+Authentication process will require use of the IdentityCommand module.
+
+See: Get-Help IdentityCommand.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: ISPSS-URL-IdentityUser, ISPSS-Subdomain-IdentityUser
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ServiceUser
+Specify switch parameter to authenticate with Identity API Oauth Service User
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: ISPSS-URL-ServiceUser, ISPSS-Subdomain-ServiceUser
 Aliases:
 
 Required: True

--- a/docs/collections/_commands/New-PASSession.md
+++ b/docs/collections/_commands/New-PASSession.md
@@ -30,23 +30,23 @@ New-PASSession -Credential <PSCredential> -IdentityTenantURL <String> -Privilege
 
 ### ISPSS-Subdomain-ServiceUser
 ```
-New-PASSession -Credential <PSCredential> -TenantSubdomain <String> [-IdentitySubdomain <String>]
- [-ServiceUser] [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate <X509Certificate>]
- [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
+New-PASSession -Credential <PSCredential> -TenantSubdomain <String> [-ServiceUser] [-PVWAAppName <String>]
+ [-SkipVersionCheck] [-Certificate <X509Certificate>] [-CertificateThumbprint <String>] [-SkipCertificateCheck]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ISPSS-URL-IdentityUser
 ```
-New-PASSession -Credential <PSCredential> -IdentityTenantURL <String> [-PrivilegeCloudURL <String>]
+New-PASSession -Credential <PSCredential> -IdentityTenantURL <String> -PrivilegeCloudURL <String>
  [-IdentityUser] [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate <X509Certificate>]
  [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ISPSS-Subdomain-IdentityUser
 ```
-New-PASSession -Credential <PSCredential> -TenantSubdomain <String> [-IdentitySubdomain <String>]
- [-IdentityUser] [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate <X509Certificate>]
- [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
+New-PASSession -Credential <PSCredential> -TenantSubdomain <String> [-IdentityUser] [-PVWAAppName <String>]
+ [-SkipVersionCheck] [-Certificate <X509Certificate>] [-CertificateThumbprint <String>] [-SkipCertificateCheck]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Gen1Radius
@@ -306,7 +306,9 @@ Authenticates to a CyberArk Vault using SAML authentication & Gen1 API.
 New-PASSession -TenantSubdomain PCloudTenantID -Credential $cred
 ```
 
-Authenticates to Privilege Cloud Shared Services, where 'PCloudTenantID' is a Subdomain configured for both Identity & Privilege Cloud portals.
+Authenticates to Privilege Cloud Shared Services, where 'PCloudTenantID' is the Subdomain configured for the Privilege Cloud portal.
+
+The subdomain value provided will be used to discover the identity portal URL.
 
 ### EXAMPLE 24
 ```
@@ -335,10 +337,10 @@ Logon with PKIPN auth, using a selected certificate stored on smart card.
 
 ### EXAMPLE 26
 ```
-New-PASSession -TenantSubdomain PCloudTenantID -IdentitySubdomain IdentityTenantID -Credential $cred -ServiceUser
+New-PASSession -TenantSubdomain PCloudTenantID -Credential $cred -ServiceUser
 ```
 
-Authenticates to Privilege Cloud Shared Services using an API Service User, where subdomains for Identity & Privilege Cloud portals have not been configured to share the same value.
+Authenticates to Privilege Cloud Shared Services using an API Service User.
 
 ### EXAMPLE 27
 ```
@@ -349,12 +351,10 @@ Authenticates to Privilege Cloud Shared Services using an API Service User, spec
 
 ### Example 28
 ```
-New-PASSession -IdentityTenantURL https://SomeTenantName.id.cyberark.cloud -Credential $Cred -IdentityUser
+New-PASSession -IdentityTenantURL https://SomeTenantName.id.cyberark.cloud -PrivilegeCloudURL 'https://XYZ789.privilegecloud.cyberark.cloud' -Credential $Cred -IdentityUser
 ```
 
 Authenticates to Identity Shared Services using an Identity User and provides authenticated session to associated Privileged Cloud environment.
-
-Assumes a Privileged Cloud API URL of https://SomeTenantName.privilegecloud.cyberark.cloud
 
 Requires IdentityCommand module to be installed for authentication flow to complete.
 
@@ -375,7 +375,7 @@ See: Get-Help IdentityCommand
 
 ### Example 30
 ```
-New-PASSession -IdentityTenantURL https://SomeTenantName.id.cyberark.cloud -Credential $Cred --PrivilegeCloudURL https://SomeName.privilegecloud.cyberark.cloud -IdentityUser
+New-PASSession -IdentityTenantURL https://SomeTenantName.id.cyberark.cloud -Credential $Cred -PrivilegeCloudURL https://SomeName.privilegecloud.cyberark.cloud -IdentityUser
 ```
 
 Authenticates to Identity Shared Services using an Identity User and provides authenticated session to specified Privileged Cloud environment.
@@ -815,12 +815,12 @@ Accept wildcard characters: False
 ```
 
 ### -TenantSubdomain
-The subdomain name value of the Identity Shared Services / Privilege Cloud Tenant.
+The subdomain name value of the Shared Services Privilege Cloud Tenant.
 
-Where the Shared Services tenants for both Identity and Privilege Cloud have been configured to share identical subdomain names, use this parameter to specify the subdomain name.
+The value provided for the subdomain parameter will be used to discover the identity tenant api URL.
 
 - API operations will target URL: https://<TenantSubdomain>.privilegecloud.cyberark.cloud
-- Authentication will be performed against https://<TenantSubdomain>.id.cyberark.cloud
+- Authentication will be performed against https://<DiscoveredIdentitySubdomain>.id.cyberark.cloud
 
 ```yaml
 Type: String
@@ -828,26 +828,6 @@ Parameter Sets: ISPSS-Subdomain-ServiceUser, ISPSS-Subdomain-IdentityUser
 Aliases:
 
 Required: True
-Position: Named
-Default value: None
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
-### -IdentitySubdomain
-A subdomain name value for the Identity Tenant used for authentication into Privilege Cloud.
-
-Where the Shared Services tenants for Identity and Privilege Cloud have been configured with different subdomain names, use this parameter to specify the subdomain name for the Identity tenant.
-
-- Authentication will be performed against https://<IdentitySubdomain>.id.cyberark.cloud
-- API operations will target URL: https://<TenantSubdomain>.privilegecloud.cyberark.cloud
-
-```yaml
-Type: String
-Parameter Sets: ISPSS-Subdomain-ServiceUser, ISPSS-Subdomain-IdentityUser
-Aliases:
-
-Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)
@@ -881,22 +861,10 @@ E.G.:
 
 ```yaml
 Type: String
-Parameter Sets: ISPSS-URL-ServiceUser
+Parameter Sets: ISPSS-URL-ServiceUser, ISPSS-URL-IdentityUser
 Aliases:
 
 Required: True
-Position: Named
-Default value: None
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
-```yaml
-Type: String
-Parameter Sets: ISPSS-URL-IdentityUser
-Aliases:
-
-Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)
@@ -959,3 +927,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/Shared%20Logon%20Authentication%20-%20Logon.htm#Sharedlogonauthentication](https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/Shared%20Logon%20Authentication%20-%20Logon.htm#Sharedlogonauthentication)
 
 [https://github.com/allynl93/PS-SAML-Interactive](https://github.com/allynl93/PS-SAML-Interactive)
+
+[https://github.com/pspete/IdentityCommand](https://github.com/pspete/IdentityCommand)

--- a/docs/collections/_docs/01-authentication.md
+++ b/docs/collections/_docs/01-authentication.md
@@ -136,7 +136,7 @@ New-PASSession -UseSharedAuthentication -BaseURI https://pvwa.somedomain.com -Ce
 
 ## Shared Services Authentication
 
-Privilege Cloud Shared Services authentication flows require use of the psPete `IdentityCommand` module, available from the Powershell Gallery & GitHub.
+**Privilege Cloud Shared Services authentication flows require use of the pspete `IdentityCommand` module, available from the Powershell Gallery & GitHub.**
 
 ### Identity User
 

--- a/docs/collections/_docs/01-authentication.md
+++ b/docs/collections/_docs/01-authentication.md
@@ -141,7 +141,7 @@ New-PASSession -UseSharedAuthentication -BaseURI https://pvwa.somedomain.com -Ce
 Provide Identity User credentials and tenant details for authentication to CyberArk Identity for Privilege Cloud Shared Services:
 
 ```
-New-PASSession -IdentityTenantURL https://SomeTenantName.id.cyberark.cloud -Credential $Cred -IdentityUser
+New-PASSession -IdentityTenantURL https://SomeTenantName.id.cyberark.cloud -PrivilegeCloudURL https://SomeTenant.privilegecloud.cyberark.cloud -Credential $Cred -IdentityUser
 ```
 
 This authentication flow requires use of the psPete `IdentityCommand` module, available from the Powershell Gallery & GitHub.
@@ -156,15 +156,13 @@ New-PASSession -TenantSubdomain YourPrivilegeCloudTenantID -Credential $ServiceU
 Consult the vendor documentation for guidance on setting up a dedicated API Service user for non-interactive API user.
 
 ### Tenant Subdomains & Portal URLs
-Most Shared Services implementations will be configured so that Identity and Privileged Cloud portal addresses share a common subdomain.
-
-Where this is not the case, and Identity and Privilege Cloud portals do not share an identical subdomain, these can be specified independently:
+When providing a value for a privilege cloud tenant subdomain, this value is used to discover the identity tenant with which to authenticate:
 
 ```
-New-PASSession -TenantSubdomain PCloudTenantID -IdentitySubdomain IdentityTenantID -Credential $cred -ServiceUser
+New-PASSession -TenantSubdomain PCloudTenantID -Credential $cred -ServiceUser
 ```
 
-For scenarios where Identity and Privilege Cloud portals are accessed using different URLs (i.e. 1st generation systems), the URLs can be specified instead on subdomain values:
+If you encounter any issue authenticating with the module when providing a subdomain value, you can alternatively specify URL values for both your Identity portal, and Privilege Cloud API:
 
 ```
 New-PASSession -IdentityTenantURL 'https://ABC123.id.cyberark.cloud' -PrivilegeCloudURL 'https://XYZ789.privilegecloud.cyberark.cloud' -Credential $cred -ServiceUser

--- a/docs/collections/_docs/01-authentication.md
+++ b/docs/collections/_docs/01-authentication.md
@@ -2,7 +2,7 @@
 title: "Authentication"
 permalink: /docs/authentication/
 excerpt: "psPAS Authentication"
-last_modified_at: 2023-08-06T01:23:45-00:00
+last_modified_at: 2023-08-20T01:23:45-00:00
 ---
 
 _Everything begins with a **Logon**:_
@@ -136,6 +136,8 @@ New-PASSession -UseSharedAuthentication -BaseURI https://pvwa.somedomain.com -Ce
 
 ## Shared Services Authentication
 
+Privilege Cloud Shared Services authentication flows require use of the psPete `IdentityCommand` module, available from the Powershell Gallery & GitHub.
+
 ### Identity User
 
 Provide Identity User credentials and tenant details for authentication to CyberArk Identity for Privilege Cloud Shared Services:
@@ -144,8 +146,6 @@ Provide Identity User credentials and tenant details for authentication to Cyber
 New-PASSession -IdentityTenantURL https://SomeTenantName.id.cyberark.cloud -PrivilegeCloudURL https://SomeTenant.privilegecloud.cyberark.cloud -Credential $Cred -IdentityUser
 ```
 
-This authentication flow requires use of the psPete `IdentityCommand` module, available from the Powershell Gallery & GitHub.
-
 ### Service User
 
 Provide tenant ID and non-interactive API User credentials for authentication via CyberArk Identity for Privilege Cloud Shared Services:
@@ -153,6 +153,7 @@ Provide tenant ID and non-interactive API User credentials for authentication vi
 ```
 New-PASSession -TenantSubdomain YourPrivilegeCloudTenantID -Credential $ServiceUserCreds -ServiceUser
 ```
+
 Consult the vendor documentation for guidance on setting up a dedicated API Service user for non-interactive API user.
 
 ### Tenant Subdomains & Portal URLs

--- a/docs/collections/_docs/01-authentication.md
+++ b/docs/collections/_docs/01-authentication.md
@@ -2,7 +2,7 @@
 title: "Authentication"
 permalink: /docs/authentication/
 excerpt: "psPAS Authentication"
-last_modified_at: 2023-07-31T01:23:45-00:00
+last_modified_at: 2023-08-06T01:23:45-00:00
 ---
 
 _Everything begins with a **Logon**:_
@@ -136,24 +136,36 @@ New-PASSession -UseSharedAuthentication -BaseURI https://pvwa.somedomain.com -Ce
 
 ## Shared Services Authentication
 
+### Identity User
+
+Provide Identity User credentials and tenant details for authentication to CyberArk Identity for Privilege Cloud Shared Services:
+
+```
+New-PASSession -IdentityTenantURL https://SomeTenantName.id.cyberark.cloud -Credential $Cred -IdentityUser
+```
+
+This authentication flow requires use of the psPete `IdentityCommand` module, available from the Powershell Gallery & GitHub.
+
+### Service User
+
 Provide tenant ID and non-interactive API User credentials for authentication via CyberArk Identity for Privilege Cloud Shared Services:
 
 ```
-New-PASSession -TenantSubdomain YourPrivilegeCloudTenantID -Credential $PCloudCreds
+New-PASSession -TenantSubdomain YourPrivilegeCloudTenantID -Credential $ServiceUserCreds -ServiceUser
 ```
+Consult the vendor documentation for guidance on setting up a dedicated API Service user for non-interactive API user.
 
+### Tenant Subdomains & Portal URLs
 Most Shared Services implementations will be configured so that Identity and Privileged Cloud portal addresses share a common subdomain.
 
 Where this is not the case, and Identity and Privilege Cloud portals do not share an identical subdomain, these can be specified independently:
 
 ```
-New-PASSession -TenantSubdomain PCloudTenantID -IdentitySubdomain IdentityTenantID -Credential $cred
+New-PASSession -TenantSubdomain PCloudTenantID -IdentitySubdomain IdentityTenantID -Credential $cred -ServiceUser
 ```
 
 For scenarios where Identity and Privilege Cloud portals are accessed using different URLs (i.e. 1st generation systems), the URLs can be specified instead on subdomain values:
 
 ```
-New-PASSession -IdentityTenantURL 'https://ABC123.id.cyberark.cloud' -PrivilegeCloudURL 'https://XYZ789.privilegecloud.cyberark.cloud' -Credential $cred
+New-PASSession -IdentityTenantURL 'https://ABC123.id.cyberark.cloud' -PrivilegeCloudURL 'https://XYZ789.privilegecloud.cyberark.cloud' -Credential $cred -ServiceUser
 ```
-
-Consult the vendor documentation for guidance on setting up a dedicated API Service user for non-interactive API use.

--- a/docs/collections/_docs/01-authentication.md
+++ b/docs/collections/_docs/01-authentication.md
@@ -154,7 +154,7 @@ Provide tenant ID and non-interactive API User credentials for authentication vi
 New-PASSession -TenantSubdomain YourPrivilegeCloudTenantID -Credential $ServiceUserCreds -ServiceUser
 ```
 
-Consult the vendor documentation for guidance on setting up a dedicated API Service user for non-interactive API user.
+Consult the vendor documentation for guidance on setting up a dedicated API Service user for non-interactive API use.
 
 ### Tenant Subdomains & Portal URLs
 When providing a value for a privilege cloud tenant subdomain, this value is used to discover the identity tenant with which to authenticate:

--- a/psPAS/Private/Find-SharedServicesURL.ps1
+++ b/psPAS/Private/Find-SharedServicesURL.ps1
@@ -1,0 +1,116 @@
+function Find-SharedServicesURL {
+    <#
+    .SYNOPSIS
+    Find URL details for ISPSS shared services
+
+    .DESCRIPTION
+    Given a shared services subdomain or URL value, returns details of URLs for available Shared Services.
+
+    .PARAMETER subdomain
+    The Shared Services subdomain to return service URL values of.
+
+    .PARAMETER url
+    The Shared Services URL to return service URL values of.
+
+    .PARAMETER service
+    Specify to return the API URL of a particular service.
+
+    .EXAMPLE
+    Find-SharedServicesURL -subdomain somedomain
+
+    .EXAMPLE
+    Find-SharedServicesURL -url https://someotherdomain.cyberark.cloud
+
+    .EXAMPLE
+    Find-SharedServicesURL -subdomain somedomain -service pcloud
+
+    .NOTES
+    Pete Maan 2023
+    #>
+    [CmdletBinding()]
+    Param(
+        [Parameter(
+            Mandatory = $true,
+            ValueFromPipeline = $true,
+            ParameterSetName = 'Subdomain'
+        )]
+        [string]$subdomain,
+
+        [Parameter(
+            Mandatory = $true,
+            ValueFromPipeline = $true,
+            ParameterSetName = 'URL'
+        )]
+        [string]$url,
+
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $true
+        )]
+        [ValidateSet(
+            'analytics',
+            'audit',
+            'cem',
+            'cloud_onboarding',
+            'component_manager',
+            'flows',
+            'idaptive_risk_analytics',
+            'identity_administration',
+            'identity_compliance',
+            'identity_user_portal',
+            'jit',
+            'pcloud',
+            'sca',
+            'secrets_hub',
+            'secrets_manager',
+            'session_monitoring'
+        )]
+        [string]$service
+    )
+
+    Begin {
+        $PlatformDiscoveryURL = 'https://platform-discovery.cyberark.cloud/api/v2/services/subdomain/'
+    }
+
+    Process {
+
+        if ($PSCmdlet.ParameterSetName -eq 'URL') {
+            $URIObject = [System.UriBuilder]::new($url)
+            $subdomain = $URIObject.host.Split('.') | Select-Object -First 1
+        }
+
+        $PlatformDiscoveryURL = $PlatformDiscoveryURL + $subdomain
+
+        $Result = Invoke-PASRestMethod -URI $PlatformDiscoveryURL -Method GET
+
+        If ($null -ne $Result) {
+
+            If ($PSBoundParameters.ContainsKey('service')) {
+
+                $Services = $Result | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name
+
+                If ($Services -notcontains $Service) {
+
+                    throw "URL for $service API not found"
+
+                }
+
+                Else {
+
+                    $Result | Select-Object -ExpandProperty $service | Select-Object -ExpandProperty api
+
+                }
+
+            } Else {
+
+                $Result
+
+            }
+
+        }
+
+    }
+
+    End {}
+
+}

--- a/psPAS/Private/Get-PASResponse.ps1
+++ b/psPAS/Private/Get-PASResponse.ps1
@@ -68,7 +68,7 @@ function Get-PASResponse {
 
 				}
 
-				'application/json; charset=utf-8' {
+				({ $PSItem -match 'application/json' }) {
 
 					#application/json content expected for most responses.
 

--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -242,9 +242,9 @@
 
 					try {
 
-						$ResponseException = $ResponseException | ConvertFrom-Json
-						$ErrorMessage = $ResponseException | Select-Object -ExpandProperty error_description
-						$ErrorID = $($ResponseException | Select-Object -ExpandProperty error)
+						$ThisException = $ResponseException | ConvertFrom-Json -ErrorAction Stop
+						$ErrorMessage = $ThisException | Select-Object -ExpandProperty error_description -ErrorAction Stop
+						$ErrorID = $($ThisException | Select-Object -ExpandProperty error -ErrorAction Stop)
 
 					} catch {
 

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -24588,25 +24588,10 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>TenantSubdomain</maml:name>
           <maml:description>
-            <maml:para>The subdomain name value of the Identity Shared Services / Privilege Cloud Tenant.</maml:para>
-            <maml:para>Where the Shared Services tenants for both Identity and Privilege Cloud have been configured to share identical subdomain names, use this parameter to specify the subdomain name.</maml:para>
+            <maml:para>The subdomain name value of the Shared Services Privilege Cloud Tenant.</maml:para>
+            <maml:para>The value provided for the subdomain parameter will be used to discover the identity tenant api URL.</maml:para>
             <maml:para>- API operations will target URL: https://&lt;TenantSubdomain&gt;.privilegecloud.cyberark.cloud</maml:para>
-            <maml:para>- Authentication will be performed against https://&lt;TenantSubdomain&gt;.id.cyberark.cloud</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
-          <maml:name>IdentitySubdomain</maml:name>
-          <maml:description>
-            <maml:para>A subdomain name value for the Identity Tenant used for authentication into Privilege Cloud.</maml:para>
-            <maml:para>Where the Shared Services tenants for Identity and Privilege Cloud have been configured with different subdomain names, use this parameter to specify the subdomain name for the Identity tenant.</maml:para>
-            <maml:para>- Authentication will be performed against https://&lt;IdentitySubdomain&gt;.id.cyberark.cloud</maml:para>
-            <maml:para>- API operations will target URL: https://&lt;TenantSubdomain&gt;.privilegecloud.cyberark.cloud</maml:para>
+            <maml:para>- Authentication will be performed against https://&lt;DiscoveredIdentitySubdomain&gt;.id.cyberark.cloud</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -24743,7 +24728,7 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>PrivilegeCloudURL</maml:name>
           <maml:description>
             <maml:para>Specify the URL value used to access the CyberArk Privilege Cloud API.</maml:para>
@@ -24875,25 +24860,10 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>TenantSubdomain</maml:name>
           <maml:description>
-            <maml:para>The subdomain name value of the Identity Shared Services / Privilege Cloud Tenant.</maml:para>
-            <maml:para>Where the Shared Services tenants for both Identity and Privilege Cloud have been configured to share identical subdomain names, use this parameter to specify the subdomain name.</maml:para>
+            <maml:para>The subdomain name value of the Shared Services Privilege Cloud Tenant.</maml:para>
+            <maml:para>The value provided for the subdomain parameter will be used to discover the identity tenant api URL.</maml:para>
             <maml:para>- API operations will target URL: https://&lt;TenantSubdomain&gt;.privilegecloud.cyberark.cloud</maml:para>
-            <maml:para>- Authentication will be performed against https://&lt;TenantSubdomain&gt;.id.cyberark.cloud</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
-          <maml:name>IdentitySubdomain</maml:name>
-          <maml:description>
-            <maml:para>A subdomain name value for the Identity Tenant used for authentication into Privilege Cloud.</maml:para>
-            <maml:para>Where the Shared Services tenants for Identity and Privilege Cloud have been configured with different subdomain names, use this parameter to specify the subdomain name for the Identity tenant.</maml:para>
-            <maml:para>- Authentication will be performed against https://&lt;IdentitySubdomain&gt;.id.cyberark.cloud</maml:para>
-            <maml:para>- API operations will target URL: https://&lt;TenantSubdomain&gt;.privilegecloud.cyberark.cloud</maml:para>
+            <maml:para>- Authentication will be performed against https://&lt;DiscoveredIdentitySubdomain&gt;.id.cyberark.cloud</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -26299,25 +26269,10 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>TenantSubdomain</maml:name>
         <maml:description>
-          <maml:para>The subdomain name value of the Identity Shared Services / Privilege Cloud Tenant.</maml:para>
-          <maml:para>Where the Shared Services tenants for both Identity and Privilege Cloud have been configured to share identical subdomain names, use this parameter to specify the subdomain name.</maml:para>
+          <maml:para>The subdomain name value of the Shared Services Privilege Cloud Tenant.</maml:para>
+          <maml:para>The value provided for the subdomain parameter will be used to discover the identity tenant api URL.</maml:para>
           <maml:para>- API operations will target URL: https://&lt;TenantSubdomain&gt;.privilegecloud.cyberark.cloud</maml:para>
-          <maml:para>- Authentication will be performed against https://&lt;TenantSubdomain&gt;.id.cyberark.cloud</maml:para>
-        </maml:description>
-        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-        <dev:type>
-          <maml:name>String</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>None</dev:defaultValue>
-      </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
-        <maml:name>IdentitySubdomain</maml:name>
-        <maml:description>
-          <maml:para>A subdomain name value for the Identity Tenant used for authentication into Privilege Cloud.</maml:para>
-          <maml:para>Where the Shared Services tenants for Identity and Privilege Cloud have been configured with different subdomain names, use this parameter to specify the subdomain name for the Identity tenant.</maml:para>
-          <maml:para>- Authentication will be performed against https://&lt;IdentitySubdomain&gt;.id.cyberark.cloud</maml:para>
-          <maml:para>- API operations will target URL: https://&lt;TenantSubdomain&gt;.privilegecloud.cyberark.cloud</maml:para>
+          <maml:para>- Authentication will be performed against https://&lt;DiscoveredIdentitySubdomain&gt;.id.cyberark.cloud</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -26569,7 +26524,8 @@ New-PASSession -SAMLAuth -concurrentSession $true -BaseURI $baseURL -SAMLRespons
         <maml:title>-------------------------- EXAMPLE 23 --------------------------</maml:title>
         <dev:code>New-PASSession -TenantSubdomain PCloudTenantID -Credential $cred</dev:code>
         <dev:remarks>
-          <maml:para>Authenticates to Privilege Cloud Shared Services, where 'PCloudTenantID' is a Subdomain configured for both Identity &amp; Privilege Cloud portals.</maml:para>
+          <maml:para>Authenticates to Privilege Cloud Shared Services, where 'PCloudTenantID' is the Subdomain configured for the Privilege Cloud portal.</maml:para>
+          <maml:para>The subdomain value provided will be used to discover the identity portal URL.</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
@@ -26599,9 +26555,9 @@ New-PASSession -BaseURI $url -type PKIPN -Certificate $Cert</dev:code>
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 26 --------------------------</maml:title>
-        <dev:code>New-PASSession -TenantSubdomain PCloudTenantID -IdentitySubdomain IdentityTenantID -Credential $cred -ServiceUser</dev:code>
+        <dev:code>New-PASSession -TenantSubdomain PCloudTenantID -Credential $cred -ServiceUser</dev:code>
         <dev:remarks>
-          <maml:para>Authenticates to Privilege Cloud Shared Services using an API Service User, where subdomains for Identity &amp; Privilege Cloud portals have not been configured to share the same value.</maml:para>
+          <maml:para>Authenticates to Privilege Cloud Shared Services using an API Service User.</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
@@ -26613,10 +26569,9 @@ New-PASSession -BaseURI $url -type PKIPN -Certificate $Cert</dev:code>
       </command:example>
       <command:example>
         <maml:title>-------------------------- Example 28 --------------------------</maml:title>
-        <dev:code>New-PASSession -IdentityTenantURL https://SomeTenantName.id.cyberark.cloud -Credential $Cred -IdentityUser</dev:code>
+        <dev:code>New-PASSession -IdentityTenantURL https://SomeTenantName.id.cyberark.cloud -PrivilegeCloudURL 'https://XYZ789.privilegecloud.cyberark.cloud' -Credential $Cred -IdentityUser</dev:code>
         <dev:remarks>
           <maml:para>Authenticates to Identity Shared Services using an Identity User and provides authenticated session to associated Privileged Cloud environment.</maml:para>
-          <maml:para>Assumes a Privileged Cloud API URL of https://SomeTenantName.privilegecloud.cyberark.cloud</maml:para>
           <maml:para>Requires IdentityCommand module to be installed for authentication flow to complete.</maml:para>
           <maml:para>See: Get-Help IdentityCommand</maml:para>
         </dev:remarks>
@@ -26633,7 +26588,7 @@ New-PASSession -BaseURI $url -type PKIPN -Certificate $Cert</dev:code>
       </command:example>
       <command:example>
         <maml:title>-------------------------- Example 30 --------------------------</maml:title>
-        <dev:code>New-PASSession -IdentityTenantURL https://SomeTenantName.id.cyberark.cloud -Credential $Cred --PrivilegeCloudURL https://SomeName.privilegecloud.cyberark.cloud -IdentityUser</dev:code>
+        <dev:code>New-PASSession -IdentityTenantURL https://SomeTenantName.id.cyberark.cloud -Credential $Cred -PrivilegeCloudURL https://SomeName.privilegecloud.cyberark.cloud -IdentityUser</dev:code>
         <dev:remarks>
           <maml:para>Authenticates to Identity Shared Services using an Identity User and provides authenticated session to specified Privileged Cloud environment.</maml:para>
           <maml:para>Requires IdentityCommand module to be installed for authentication flow to complete.</maml:para>
@@ -26665,6 +26620,10 @@ New-PASSession -BaseURI $url -type PKIPN -Certificate $Cert</dev:code>
       <maml:navigationLink>
         <maml:linkText>https://github.com/allynl93/PS-SAML-Interactive</maml:linkText>
         <maml:uri>https://github.com/allynl93/PS-SAML-Interactive</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>https://github.com/pspete/IdentityCommand</maml:linkText>
+        <maml:uri>https://github.com/pspete/IdentityCommand</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -24471,6 +24471,17 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>ServiceUser</maml:name>
+          <maml:description>
+            <maml:para>Specify switch parameter to authenticate with Identity API Oauth Service User</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>New-PASSession</maml:name>
@@ -24593,7 +24604,7 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
           <maml:name>IdentitySubdomain</maml:name>
           <maml:description>
             <maml:para>A subdomain name value for the Identity Tenant used for authentication into Privilege Cloud.</maml:para>
-            <maml:para>Where the Shared Services tenants for Identity and Privilege Cloud have not been configured with identical subdomain names, use this parameter to specify the subdomain name for the Identity tenant.</maml:para>
+            <maml:para>Where the Shared Services tenants for Identity and Privilege Cloud have been configured with different subdomain names, use this parameter to specify the subdomain name for the Identity tenant.</maml:para>
             <maml:para>- Authentication will be performed against https://&lt;IdentitySubdomain&gt;.id.cyberark.cloud</maml:para>
             <maml:para>- API operations will target URL: https://&lt;TenantSubdomain&gt;.privilegecloud.cyberark.cloud</maml:para>
           </maml:description>
@@ -24603,6 +24614,306 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>ServiceUser</maml:name>
+          <maml:description>
+            <maml:para>Specify switch parameter to authenticate with Identity API Oauth Service User</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>New-PASSession</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>A Valid PSCredential object.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>PVWAAppName</maml:name>
+          <maml:description>
+            <maml:para>The name of the CyberArk PVWA Virtual Directory.</maml:para>
+            <maml:para>Defaults to PasswordVault</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>PasswordVault</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>SkipVersionCheck</maml:name>
+          <maml:description>
+            <maml:para>If the SkipVersionCheck switch is specified, Get-PASServer will not be called after successfully authenticating.</maml:para>
+            <maml:para>Get-PASServer is not supported before version 9.7.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Certificate</maml:name>
+          <maml:description>
+            <maml:para>See Invoke-WebRequest</maml:para>
+            <maml:para>Specifies the client certificate that is used for a secure web request.</maml:para>
+            <maml:para>Enter a variable that contains a certificate or a command or expression that gets the certificate.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">X509Certificate</command:parameterValue>
+          <dev:type>
+            <maml:name>X509Certificate</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>CertificateThumbprint</maml:name>
+          <maml:description>
+            <maml:para>See Invoke-WebRequest</maml:para>
+            <maml:para>The thumbprint of the certificate to use for client certificate authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>SkipCertificateCheck</maml:name>
+          <maml:description>
+            <maml:para>Skips certificate validation checks.</maml:para>
+            <maml:para>Using this parameter is not secure and is not recommended.</maml:para>
+            <maml:para>This switch is only intended to be used against known hosts using a self-signed certificate for testing purposes.</maml:para>
+            <maml:para>Use at your own risk.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>IdentityTenantURL</maml:name>
+          <maml:description>
+            <maml:para>Specify the URL value of the CyberArk Identity Portal to authenticate against.</maml:para>
+            <maml:para>E.G.: - https://&lt;identity-tenant-id&gt;.id.cyberark.cloud</maml:para>
+            <maml:para>- https://&lt;identity-tenant-id&gt;.my.idaptive.app</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>PrivilegeCloudURL</maml:name>
+          <maml:description>
+            <maml:para>Specify the URL value used to access the CyberArk Privilege Cloud API.</maml:para>
+            <maml:para>E.G.: - https://&lt;subdomain&gt;.privilegecloud.cyberark.cloud</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>IdentityUser</maml:name>
+          <maml:description>
+            <maml:para>Specify switch parameter to authenticate with standard Interactive Identity User.</maml:para>
+            <maml:para>Authentication process will require use of the IdentityCommand module.</maml:para>
+            <maml:para>See: Get-Help IdentityCommand.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>New-PASSession</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>A Valid PSCredential object.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>PVWAAppName</maml:name>
+          <maml:description>
+            <maml:para>The name of the CyberArk PVWA Virtual Directory.</maml:para>
+            <maml:para>Defaults to PasswordVault</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>PasswordVault</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>SkipVersionCheck</maml:name>
+          <maml:description>
+            <maml:para>If the SkipVersionCheck switch is specified, Get-PASServer will not be called after successfully authenticating.</maml:para>
+            <maml:para>Get-PASServer is not supported before version 9.7.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Certificate</maml:name>
+          <maml:description>
+            <maml:para>See Invoke-WebRequest</maml:para>
+            <maml:para>Specifies the client certificate that is used for a secure web request.</maml:para>
+            <maml:para>Enter a variable that contains a certificate or a command or expression that gets the certificate.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">X509Certificate</command:parameterValue>
+          <dev:type>
+            <maml:name>X509Certificate</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>CertificateThumbprint</maml:name>
+          <maml:description>
+            <maml:para>See Invoke-WebRequest</maml:para>
+            <maml:para>The thumbprint of the certificate to use for client certificate authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>SkipCertificateCheck</maml:name>
+          <maml:description>
+            <maml:para>Skips certificate validation checks.</maml:para>
+            <maml:para>Using this parameter is not secure and is not recommended.</maml:para>
+            <maml:para>This switch is only intended to be used against known hosts using a self-signed certificate for testing purposes.</maml:para>
+            <maml:para>Use at your own risk.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>TenantSubdomain</maml:name>
+          <maml:description>
+            <maml:para>The subdomain name value of the Identity Shared Services / Privilege Cloud Tenant.</maml:para>
+            <maml:para>Where the Shared Services tenants for both Identity and Privilege Cloud have been configured to share identical subdomain names, use this parameter to specify the subdomain name.</maml:para>
+            <maml:para>- API operations will target URL: https://&lt;TenantSubdomain&gt;.privilegecloud.cyberark.cloud</maml:para>
+            <maml:para>- Authentication will be performed against https://&lt;TenantSubdomain&gt;.id.cyberark.cloud</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>IdentitySubdomain</maml:name>
+          <maml:description>
+            <maml:para>A subdomain name value for the Identity Tenant used for authentication into Privilege Cloud.</maml:para>
+            <maml:para>Where the Shared Services tenants for Identity and Privilege Cloud have been configured with different subdomain names, use this parameter to specify the subdomain name for the Identity tenant.</maml:para>
+            <maml:para>- Authentication will be performed against https://&lt;IdentitySubdomain&gt;.id.cyberark.cloud</maml:para>
+            <maml:para>- API operations will target URL: https://&lt;TenantSubdomain&gt;.privilegecloud.cyberark.cloud</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>IdentityUser</maml:name>
+          <maml:description>
+            <maml:para>Specify switch parameter to authenticate with standard Interactive Identity User.</maml:para>
+            <maml:para>Authentication process will require use of the IdentityCommand module.</maml:para>
+            <maml:para>See: Get-Help IdentityCommand.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
@@ -26004,7 +26315,7 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
         <maml:name>IdentitySubdomain</maml:name>
         <maml:description>
           <maml:para>A subdomain name value for the Identity Tenant used for authentication into Privilege Cloud.</maml:para>
-          <maml:para>Where the Shared Services tenants for Identity and Privilege Cloud have not been configured with identical subdomain names, use this parameter to specify the subdomain name for the Identity tenant.</maml:para>
+          <maml:para>Where the Shared Services tenants for Identity and Privilege Cloud have been configured with different subdomain names, use this parameter to specify the subdomain name for the Identity tenant.</maml:para>
           <maml:para>- Authentication will be performed against https://&lt;IdentitySubdomain&gt;.id.cyberark.cloud</maml:para>
           <maml:para>- API operations will target URL: https://&lt;TenantSubdomain&gt;.privilegecloud.cyberark.cloud</maml:para>
         </maml:description>
@@ -26041,6 +26352,32 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>IdentityUser</maml:name>
+        <maml:description>
+          <maml:para>Specify switch parameter to authenticate with standard Interactive Identity User.</maml:para>
+          <maml:para>Authentication process will require use of the IdentityCommand module.</maml:para>
+          <maml:para>See: Get-Help IdentityCommand.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>ServiceUser</maml:name>
+        <maml:description>
+          <maml:para>Specify switch parameter to authenticate with Identity API Oauth Service User</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes />
@@ -26262,16 +26599,45 @@ New-PASSession -BaseURI $url -type PKIPN -Certificate $Cert</dev:code>
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 26 --------------------------</maml:title>
-        <dev:code>New-PASSession -TenantSubdomain PCloudTenantID -IdentitySubdomain IdentityTenantID -Credential $cred</dev:code>
+        <dev:code>New-PASSession -TenantSubdomain PCloudTenantID -IdentitySubdomain IdentityTenantID -Credential $cred -ServiceUser</dev:code>
         <dev:remarks>
-          <maml:para>Authenticates to Privilege Cloud Shared Services, where subdomains for Identity &amp; Privilege Cloud portals have not been configured to share the same value.</maml:para>
+          <maml:para>Authenticates to Privilege Cloud Shared Services using an API Service User, where subdomains for Identity &amp; Privilege Cloud portals have not been configured to share the same value.</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 27 --------------------------</maml:title>
-        <dev:code>New-PASSession -IdentityTenantURL 'https://ABC123.id.cyberark.cloud' -PrivilegeCloudURL 'https://XYZ789.privilegecloud.cyberark.cloud' -Credential $cred</dev:code>
+        <dev:code>New-PASSession -IdentityTenantURL 'https://ABC123.id.cyberark.cloud' -PrivilegeCloudURL 'https://XYZ789.privilegecloud.cyberark.cloud' -Credential $cred -ServiceUser</dev:code>
         <dev:remarks>
-          <maml:para>Authenticates to Privilege Cloud Shared Services, specifying individual URL values for Identity &amp; Privilege Cloud tenants.</maml:para>
+          <maml:para>Authenticates to Privilege Cloud Shared Services using an API Service User, specifying individual URL values for Identity &amp; Privilege Cloud tenants.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- Example 28 --------------------------</maml:title>
+        <dev:code>New-PASSession -IdentityTenantURL https://SomeTenantName.id.cyberark.cloud -Credential $Cred -IdentityUser</dev:code>
+        <dev:remarks>
+          <maml:para>Authenticates to Identity Shared Services using an Identity User and provides authenticated session to associated Privileged Cloud environment.</maml:para>
+          <maml:para>Assumes a Privileged Cloud API URL of https://SomeTenantName.privilegecloud.cyberark.cloud</maml:para>
+          <maml:para>Requires IdentityCommand module to be installed for authentication flow to complete.</maml:para>
+          <maml:para>See: Get-Help IdentityCommand</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- Example 29 --------------------------</maml:title>
+        <dev:code>New-PASSession -TenantSubdomain YourTenantName -Credential $Cred -IdentityUser</dev:code>
+        <dev:remarks>
+          <maml:para>Authenticates to Identity Shared Services using an Identity User and provides authenticated session to associated Privileged Cloud environment.</maml:para>
+          <maml:para>Assumes a Shared Services URL of https://YourTenantName.id.cyberark.cloud</maml:para>
+          <maml:para>Requires IdentityCommand module to be installed for authentication flow to complete.</maml:para>
+          <maml:para>See: Get-Help IdentityCommand</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- Example 30 --------------------------</maml:title>
+        <dev:code>New-PASSession -IdentityTenantURL https://SomeTenantName.id.cyberark.cloud -Credential $Cred --PrivilegeCloudURL https://SomeName.privilegecloud.cyberark.cloud -IdentityUser</dev:code>
+        <dev:remarks>
+          <maml:para>Authenticates to Identity Shared Services using an Identity User and provides authenticated session to specified Privileged Cloud environment.</maml:para>
+          <maml:para>Requires IdentityCommand module to be installed for authentication flow to complete.</maml:para>
+          <maml:para>See: Get-Help IdentityCommand</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
<!--
Please include a summary of the change and which issue is fixed & relevant motivation and context.
Put `Fixes #XXX` in your comment to link the issue that your PR fixes.
-->
Abstracts all Privilege Cloud Shared Services authentication operations to the IdentityCommand module.

- Updates & Breaking Change
  - `New-PASSession`
    - **All Privilege Cloud Shared Services Authentication via the CyberArk Identity Platform now requires use of the pspete `IdentityCommand` module.**
    - Adds Identity User Authentication, using the `IdentityCommand` module to satisfy Identity MFA challenges and obtain required authentication token to use against Privileged Cloud Shared Services.
    - Adds logic to determine correct Identity tenant URL based on provided Privileged Cloud Subdomain value.
    - Both Privileged Cloud API URL & Identity Portal URL are required to be specified if subdomain value is not provided.

Required Parameter changes in New-PASSession make this a breaking change for Shared Services authentication flows.
PAS Self-Hosted flows are unaffected.

Fixes #

## Type of change
<!--
Please select all relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that makes existing functionality work differently)
- [X] Documentation update (psPAS website or command help content)
- [ ] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [X] Pester test(s) updated
- [X] Pester test(s) passing

**Test Configuration**:
- PowerShell version: 7
- CyberArk PAS version: 13.2
- OS Version: Win 11

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [X] My code follows the style guidelines of this project
- [X] I have followed the contributing guidelines.
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new test failures or errors
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [ ] I have linked a related issue