### PR TITLE
psPAS 6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 - Continued development to encompass any new documented features of the CyberArk API.
 - psPAS v6.0...
 
+## **vNext**
+
+- Updates & Breaking Change
+  - `New-PASSession`
+    - **All Privilege Cloud Shared Services Authentication via the CyberArk Identity Platform now requires use of the pspete `IdentityCommand` module.**
+    - Adds Identity User Authentication, using the `IdentityCommand` module to satisfy Identity MFA challenges and obtain required authentication token to use against Privileged Cloud Shared Services.
+    - Adds logic to determine correct Identity tenant URL based on provided Privileged Cloud Subdomain value.
+    - Both Privileged Cloud API URL & Identity Portal URL are required to be specified if subdomain value is not provided.
+
 ## **5.6.135 (July 31st 2023)**
 
 ### Module update to cover all CyberArk 13.2 API features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,18 @@
 ## Planned Updates / Unreleased
 
 - Continued development to encompass any new documented features of the CyberArk API.
-- psPAS v6.0...
+- psPAS v7.0...
 
-## **vNext**
+## **6.0.0**
 
-- Updates & Breaking Change
+- Update & Breaking Change
   - `New-PASSession`
-    - **All Privilege Cloud Shared Services Authentication via the CyberArk Identity Platform now requires use of the pspete `IdentityCommand` module.**
+    - **All Privilege Cloud Shared Services Authentication via the CyberArk Identity Platform now depends on the pspete `IdentityCommand` module.**
     - Adds Identity User Authentication, using the `IdentityCommand` module to satisfy Identity MFA challenges and obtain required authentication token to use against Privileged Cloud Shared Services.
     - Adds logic to determine correct Identity tenant URL based on provided Privileged Cloud Subdomain value.
     - Both Privileged Cloud API URL & Identity Portal URL are required to be specified if subdomain value is not provided.
+    - Service User authentication for Shared Services introduced in recent previous versions requires installation of `IdentityCommand` module and specification of additional attribute.
+    - See [the docs](https://pspas.pspete.dev/docs/authentication/#shared-services-authentication) & [New-PASSession](https://pspas.pspete.dev/commands/New-PASSession) for full details.
 
 ## **5.6.135 (July 31st 2023)**
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,34 @@ $Cert = "0E199489C57E666115666D6E9990C2ACABDB6EDB"
 New-PASSession -UseSharedAuthentication -BaseURI https://pvwa.somedomain.com -CertificateThumbprint $Cert
 ```
 
+#### Shared Services Authentication
+
+**Privilege Cloud Shared Services authentication flows require use of the pspete `IdentityCommand` module, available from the Powershell Gallery & GitHub.**
+
+##### Identity User
+
+Provide Identity User credentials and tenant details for authentication to CyberArk Identity for Privilege Cloud Shared Services:
+
+```
+#using URL
+New-PASSession -IdentityTenantURL https://SomeTenantName.id.cyberark.cloud -PrivilegeCloudURL https://SomeTenant.privilegecloud.cyberark.cloud -Credential $Cred -IdentityUser
+```
+
+```
+#using subdomain
+New-PASSession -TenantSubdomain SomeTenantName -Credential $Cred -IdentityUser
+```
+
+##### Service User
+
+Provide tenant ID and non-interactive API User credentials for authentication via CyberArk Identity for Privilege Cloud Shared Services:
+
+```
+New-PASSession -TenantSubdomain YourPrivilegeCloudTenantID -Credential $ServiceUserCreds -ServiceUser
+```
+
+Consult the vendor documentation for guidance on setting up a dedicated API Service user for non-interactive API use.
+
 ### Basic Operations
 
 ![Logo][Logo]
@@ -1241,6 +1269,9 @@ Priority support could be considered for <a href="https://github.com/sponsors/ps
 
 Hat Tips:
 
+**Joe Garcia** ([infamousjoeg](https://github.com/infamousjoeg))
+for the unofficial API documentation, general API wizardry & knowledge sharing.
+
 **Jesse McWilliams**
 ([JesseMcWilliamss](https://github.com/JesseMcWilliams))
 For the infomration needed to add PKIPN authentication into `New-PASSession`
@@ -1259,9 +1290,6 @@ For the JSON formatting assistance.
 
 **Warren Frame**
 ([RamblingCookieMonster](https://github.com/RamblingCookieMonster)) for [Add-ObjectDetail.ps1](https://github.com/RamblingCookieMonster/PowerShell/blob/master/Add-ObjectDetail.ps1).
-
-**Joe Garcia** ([infamousjoeg](https://github.com/infamousjoeg))
-for the unofficial API documentation.
 
 Chapeau!
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ New-PASSession -UseSharedAuthentication -BaseURI https://pvwa.somedomain.com -Ce
 
 #### Shared Services Authentication
 
-**Privilege Cloud Shared Services authentication flows require use of the pspete `IdentityCommand` module, available from the Powershell Gallery & GitHub.**
+**Privilege Cloud Shared Services authentication flows require the pspete `IdentityCommand` module, available from the [Powershell Gallery](https://www.powershellgallery.com/packages/IdentityCommand) & [GitHub](https://github.com/pspete/IdentityCommand).**
 
 ##### Identity User
 

--- a/README.md
+++ b/README.md
@@ -946,18 +946,18 @@ Click the below dropdown to view the current list of psPAS functions and their m
 [`Get-PASPTARiskSummary`][Get-PASPTARiskSummary]                                         |**13.2**            |Get PTA Risk Summary
 [`New-PASRequestObject`][New-PASRequestObject]                                           |**---**             |Format an object to include in an request list
 
-[New-PASRequestObject]:/psPAS/Functions/Requests/New-PASRequestObject
-[Get-PASUserTypeInfo]:/psPAS/Functions/User/Get-PASUserTypeInfo
-[Get-PASPTARiskEvent]:/psPAS/Functions/EventSecurity/Get-PASPTARiskEvent
-[Set-PASPTARiskEvent]:/psPAS/Functions/EventSecurity/Set-PASPTARiskEvent
-[Get-PASPTARiskSummary]:/psPAS/Functions/EventSecurity/Get-PASPTARiskSummary
-[Get-PASPTAGlobalCatalog]:/psPAS/Functions/EventSecurity/Get-PASPTAGlobalCatalog
-[Add-PASPTAGlobalCatalog]:/psPAS/Functions/EventSecurity/Add-PASPTAGlobalCatalog
-[Disable-PASUser]:/psPAS/Functions/User/Disable-PASUser
-[Enable-PASUser]:/psPAS/Functions/User/Enable-PASUser
-[Get-PASLinkedAccount]:/psPAS/Functions/Accounts/Get-PASLinkedAccount
-[Add-PASPersonalAdminAccount]:/psPAS/Functions/Accounts/Add-PASPersonalAdminAccount
-[Publish-PASDiscoveredAccount]:/psPAS/Functions/Accounts/Publish-PASDiscoveredAccount
+[New-PASRequestObject]:/psPAS/Functions/Requests/New-PASRequestObject.ps1
+[Get-PASUserTypeInfo]:/psPAS/Functions/User/Get-PASUserTypeInfo.ps1
+[Get-PASPTARiskEvent]:/psPAS/Functions/EventSecurity/Get-PASPTARiskEvent.ps1
+[Set-PASPTARiskEvent]:/psPAS/Functions/EventSecurity/Set-PASPTARiskEvent.ps1
+[Get-PASPTARiskSummary]:/psPAS/Functions/EventSecurity/Get-PASPTARiskSummary.ps1
+[Get-PASPTAGlobalCatalog]:/psPAS/Functions/EventSecurity/Get-PASPTAGlobalCatalog.ps1
+[Add-PASPTAGlobalCatalog]:/psPAS/Functions/EventSecurity/Add-PASPTAGlobalCatalog.ps1
+[Disable-PASUser]:/psPAS/Functions/User/Disable-PASUser.ps1
+[Enable-PASUser]:/psPAS/Functions/User/Enable-PASUser.ps1
+[Get-PASLinkedAccount]:/psPAS/Functions/Accounts/Get-PASLinkedAccount.ps1
+[Add-PASPersonalAdminAccount]:/psPAS/Functions/Accounts/Add-PASPersonalAdminAccount.ps1
+[Publish-PASDiscoveredAccount]:/psPAS/Functions/Accounts/Publish-PASDiscoveredAccount.ps1
 [Get-PASPlatformSummary]:/psPAS/Functions/Platforms/Get-PASPlatformSummary.ps1
 [Add-PASOpenIDConnectProvider]:/psPAS/Functions/Authentication/Add-PASOpenIDConnectProvider.ps1
 [Get-PASOpenIDConnectProvider]:/psPAS/Functions/Authentication/Get-PASOpenIDConnectProvider.ps1

--- a/Tests/Find-SharedServicesURL.Tests.ps1
+++ b/Tests/Find-SharedServicesURL.Tests.ps1
@@ -1,0 +1,80 @@
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
+
+    BeforeAll {
+        #Get Current Directory
+        $Here = Split-Path -Parent $PSCommandPath
+
+        #Assume ModuleName from Repository Root folder
+        $ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+        #Resolve Path to Module Directory
+        $ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+        #Define Path to Module Manifest
+        $ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+        if ( -not (Get-Module -Name $ModuleName -All)) {
+
+            Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+        }
+
+    }
+
+    InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+        Context 'General Operations' {
+
+            BeforeEach {
+
+                Mock Invoke-PASRestMethod -MockWith {
+
+                    [pscustomobject]@{
+                        identity_user_portal = [pscustomobject]@{api = 'https://SubDomainABC.id.cyberark.cloud' }
+                        pcloud               = [pscustomobject]@{api = 'https://SomeSubDomain.privilegecloud.cyberark.cloud' }
+                    }
+
+                }
+
+            }
+
+            It 'sends request to expected endpoint when subdomain provided' {
+                Find-SharedServicesURL -subdomain somedomain
+                Assert-MockCalled -CommandName Invoke-PASRestMethod -Times 1 -ParameterFilter {
+                    $URI -eq 'https://platform-discovery.cyberark.cloud/api/v2/services/subdomain/somedomain'
+                } -Scope It -Exactly
+            }
+
+            It 'sends request to expected endpoint when url provided' {
+                Find-SharedServicesURL -url https://someotherdomain.cyberark.cloud
+                Assert-MockCalled -CommandName Invoke-PASRestMethod -Times 1 -ParameterFilter {
+                    $URI -eq 'https://platform-discovery.cyberark.cloud/api/v2/services/subdomain/someotherdomain'
+                } -Scope It -Exactly
+            }
+
+            It 'uses expected method' {
+                Find-SharedServicesURL -url https://someotherdomain.cyberark.cloud
+                Assert-MockCalled -CommandName Invoke-PASRestMethod -Times 1 -ParameterFilter {
+                    $Method -eq 'GET'
+                } -Scope It -Exactly
+            }
+
+            It 'outputs expected results' {
+                $results = Find-SharedServicesURL -url https://someotherdomain.cyberark.cloud
+                $results.pcloud.api | Should -Be 'https://SomeSubDomain.privilegecloud.cyberark.cloud'
+                $results.identity_user_portal.api | Should -Be 'https://SubDomainABC.id.cyberark.cloud'
+            }
+
+            It 'outputs filtered results when service is specified' {
+                Find-SharedServicesURL -subdomain somedomain -service pcloud | Should -Be 'https://SomeSubDomain.privilegecloud.cyberark.cloud'
+            }
+
+            It 'throws if specifed service detail is not included in results' {
+                { Find-SharedServicesURL -subdomain somedomain -service flows } | Should -Throw -ExpectedMessage 'URL for flows API not found'
+            }
+
+        }
+
+    }
+
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # version format
-version: 5.6.{build}
+version: 6.0.{build}
 
 environment:
   #GIT_TRACE: 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,8 @@ environment:
     secure: cWv4+OPfqRLSt7I4f+p3lEixKoYZzi42IDc7C4Kf+2WZW/dO+H+RBCM7m0Si2uuP
   github_email:
     secure: x5ljenzXfYXkzpEu9eX7AQvb3AkFbiXG2NndMzw9Zc4=
+  CODECOV_TOKEN:
+    secure: bLnfnH8+QlpeQgvoOrgrCLkOrgpOBMwfnjwtdVphoUE0YEeEdzP9/7dILfzpFGFg
   #sig_key:
     #secure: LPEv2aGCLb1WPw89OFF8gmhk5tVZtOAPaUJ9cAATBnD1+qREYmvh/fH53NbJSNP
   #PfxSecure:

--- a/build/test.ps1
+++ b/build/test.ps1
@@ -8,22 +8,15 @@ Import-Module $ManifestPath -Force
 #---------------------------------#
 # Run Pester Tests                #
 #---------------------------------#
-#$files = Get-Item 'pspas/**/*/*.ps1', 'pspas/**/*.ps1' | Select-Object -ExpandProperty FullName
-#$paths = @(
-#	'.\psPAS\Functions\*\*.ps1',
-#	'.\psPAS\Private\*.ps1'
-#)
+#$files = Get-ChildItem $(Join-Path $ENV:APPVEYOR_BUILD_FOLDER $env:APPVEYOR_PROJECT_NAME) -Include *.ps1 -Recurse | Select-Object -ExpandProperty FullName
 
 # get default from static property
 $configuration = [PesterConfiguration]::Default
 # assing properties & discover via intellisense
 $configuration.Run.Path = '.\Tests'
 $configuration.Run.PassThru = $true
-$configuration.CodeCoverage.Enabled = $false
-#$configuration.CodeCoverage.Path = $paths
-#$configuration.CodeCoverage.OutputEncoding = 'ascii'
-#$configuration.CodeCoverage.OutputFormat = 'JaCoCo'
-#$configuration.CodeCoverage.OutputPath = '.\JaCoCo_coverage.xml'
+#$configuration.CodeCoverage.Enabled = $true
+#$configuration.CodeCoverage.Path = $files
 $configuration.TestResult.Enabled = $true
 $configuration.TestResult.OutputFormat = 'NUnitXml'
 $configuration.TestResult.OutputPath = '.\TestResults.xml'
@@ -33,7 +26,7 @@ $result = Invoke-Pester -Configuration $configuration
 
 $res = $result | ConvertTo-Pester4Result
 
-Write-Host 'Uploading Test Results'
+Write-Host 'Uploading Test Results.'
 $null = (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", $(Resolve-Path .\TestResults.xml))
 
 Remove-Item -Path $(Resolve-Path .\TestResults.xml) -Force
@@ -41,20 +34,14 @@ Remove-Item -Path $(Resolve-Path .\TestResults.xml) -Force
 
 if ($env:APPVEYOR_REPO_COMMIT_AUTHOR -eq 'Pete Maan') {
 
-	#Write-Host 'Formating Code Coverage'
-	#$coverage = Format-Coverage -PesterResults $res -CoverallsApiToken $($env:coveralls_key) -BranchName $($env:APPVEYOR_REPO_BRANCH)
-
-	#$null = Export-CodeCovIoJson -CodeCoverage $res.CodeCoverage -RepoRoot $pwd -Path coverage.json
-
 	#Write-Host 'Publishing Code Coverage'
-	#$null = Publish-Coverage -Coverage $coverage
 
-	#$null = Invoke-WebRequest -Uri 'https://codecov.io/bash' -OutFile codecov.sh
+	#$ProgressPreference = 'SilentlyContinue'
+	#$null = Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -OutFile codecov.exe
+	#.\codecov.exe -t ${env:CODECOV_TOKEN} | Out-Null
 
-	#$null = bash codecov.sh -f .\JaCoCo_coverage.xml
-
-	#Remove-Item -Path $(Resolve-Path .\JaCoCo_coverage.xml) -Force
-	#Remove-Item -Path $(Resolve-Path .\codecov.sh) -Force
+	#Remove-Item -Path $(Resolve-Path .\coverage.xml) -Force
+	#Remove-Item -Path $(Resolve-Path .\codecov.exe) -Force
 
 }
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,0 @@
-fixes:
-  - "::psPAS/"

--- a/docs/collections/_commands/New-PASSession.md
+++ b/docs/collections/_commands/New-PASSession.md
@@ -21,18 +21,32 @@ New-PASSession [-Credential <PSCredential>] -BaseURI <String> [-newPassword <Sec
  [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-### SharedServices-URL
+### ISPSS-URL-ServiceUser
 ```
 New-PASSession -Credential <PSCredential> -IdentityTenantURL <String> -PrivilegeCloudURL <String>
- [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate <X509Certificate>] [-CertificateThumbprint <String>]
- [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-ServiceUser] [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate <X509Certificate>]
+ [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-### SharedServices-Subdomain
+### ISPSS-Subdomain-ServiceUser
 ```
-New-PASSession -Credential <PSCredential> -TenantSubdomain <String> [-IdentitySubdomain <String>]
- [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate <X509Certificate>] [-CertificateThumbprint <String>]
- [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
+New-PASSession -Credential <PSCredential> -TenantSubdomain <String> [-ServiceUser] [-PVWAAppName <String>]
+ [-SkipVersionCheck] [-Certificate <X509Certificate>] [-CertificateThumbprint <String>] [-SkipCertificateCheck]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### ISPSS-URL-IdentityUser
+```
+New-PASSession -Credential <PSCredential> -IdentityTenantURL <String> -PrivilegeCloudURL <String>
+ [-IdentityUser] [-PVWAAppName <String>] [-SkipVersionCheck] [-Certificate <X509Certificate>]
+ [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### ISPSS-Subdomain-IdentityUser
+```
+New-PASSession -Credential <PSCredential> -TenantSubdomain <String> [-IdentityUser] [-PVWAAppName <String>]
+ [-SkipVersionCheck] [-Certificate <X509Certificate>] [-CertificateThumbprint <String>] [-SkipCertificateCheck]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Gen1Radius
@@ -292,7 +306,9 @@ Authenticates to a CyberArk Vault using SAML authentication & Gen1 API.
 New-PASSession -TenantSubdomain PCloudTenantID -Credential $cred
 ```
 
-Authenticates to Privilege Cloud Shared Services, where 'PCloudTenantID' is a Subdomain configured for both Identity & Privilege Cloud portals.
+Authenticates to Privilege Cloud Shared Services, where 'PCloudTenantID' is the Subdomain configured for the Privilege Cloud portal.
+
+The subdomain value provided will be used to discover the identity portal URL.
 
 ### EXAMPLE 24
 ```
@@ -321,17 +337,52 @@ Logon with PKIPN auth, using a selected certificate stored on smart card.
 
 ### EXAMPLE 26
 ```
-New-PASSession -TenantSubdomain PCloudTenantID -IdentitySubdomain IdentityTenantID -Credential $cred
+New-PASSession -TenantSubdomain PCloudTenantID -Credential $cred -ServiceUser
 ```
 
-Authenticates to Privilege Cloud Shared Services, where subdomains for Identity & Privilege Cloud portals have not been configured to share the same value.
+Authenticates to Privilege Cloud Shared Services using an API Service User.
 
 ### EXAMPLE 27
 ```
-New-PASSession -IdentityTenantURL 'https://ABC123.id.cyberark.cloud' -PrivilegeCloudURL 'https://XYZ789.privilegecloud.cyberark.cloud' -Credential $cred
+New-PASSession -IdentityTenantURL 'https://ABC123.id.cyberark.cloud' -PrivilegeCloudURL 'https://XYZ789.privilegecloud.cyberark.cloud' -Credential $cred -ServiceUser
 ```
 
-Authenticates to Privilege Cloud Shared Services, specifying individual URL values for Identity & Privilege Cloud tenants.
+Authenticates to Privilege Cloud Shared Services using an API Service User, specifying individual URL values for Identity & Privilege Cloud tenants.
+
+### Example 28
+```
+New-PASSession -IdentityTenantURL https://SomeTenantName.id.cyberark.cloud -PrivilegeCloudURL 'https://XYZ789.privilegecloud.cyberark.cloud' -Credential $Cred -IdentityUser
+```
+
+Authenticates to Identity Shared Services using an Identity User and provides authenticated session to associated Privileged Cloud environment.
+
+Requires IdentityCommand module to be installed for authentication flow to complete.
+
+See: Get-Help IdentityCommand
+
+### Example 29
+```
+New-PASSession -TenantSubdomain YourTenantName -Credential $Cred -IdentityUser
+```
+
+Authenticates to Identity Shared Services using an Identity User and provides authenticated session to associated Privileged Cloud environment.
+
+Assumes a Shared Services URL of https://YourTenantName.id.cyberark.cloud
+
+Requires IdentityCommand module to be installed for authentication flow to complete.
+
+See: Get-Help IdentityCommand
+
+### Example 30
+```
+New-PASSession -IdentityTenantURL https://SomeTenantName.id.cyberark.cloud -Credential $Cred -PrivilegeCloudURL https://SomeName.privilegecloud.cyberark.cloud -IdentityUser
+```
+
+Authenticates to Identity Shared Services using an Identity User and provides authenticated session to specified Privileged Cloud environment.
+
+Requires IdentityCommand module to be installed for authentication flow to complete.
+
+See: Get-Help IdentityCommand
 
 ## PARAMETERS
 
@@ -352,7 +403,7 @@ Accept wildcard characters: False
 
 ```yaml
 Type: PSCredential
-Parameter Sets: SharedServices-URL, SharedServices-Subdomain, Gen2Radius
+Parameter Sets: ISPSS-URL-ServiceUser, ISPSS-Subdomain-ServiceUser, ISPSS-URL-IdentityUser, ISPSS-Subdomain-IdentityUser, Gen2Radius
 Aliases:
 
 Required: True
@@ -764,39 +815,19 @@ Accept wildcard characters: False
 ```
 
 ### -TenantSubdomain
-The subdomain name value of the Identity Shared Services / Privilege Cloud Tenant.
+The subdomain name value of the Shared Services Privilege Cloud Tenant.
 
-Where the Shared Services tenants for both Identity and Privilege Cloud have been configured to share identical subdomain names, use this parameter to specify the subdomain name.
+The value provided for the subdomain parameter will be used to discover the identity tenant api URL.
 
 - API operations will target URL: https://<TenantSubdomain>.privilegecloud.cyberark.cloud
-- Authentication will be performed against https://<TenantSubdomain>.id.cyberark.cloud
+- Authentication will be performed against https://<DiscoveredIdentitySubdomain>.id.cyberark.cloud
 
 ```yaml
 Type: String
-Parameter Sets: SharedServices-Subdomain
+Parameter Sets: ISPSS-Subdomain-ServiceUser, ISPSS-Subdomain-IdentityUser
 Aliases:
 
 Required: True
-Position: Named
-Default value: None
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
-### -IdentitySubdomain
-A subdomain name value for the Identity Tenant used for authentication into Privilege Cloud.
-
-Where the Shared Services tenants for Identity and Privilege Cloud have not been configured with identical subdomain names, use this parameter to specify the subdomain name for the Identity tenant.
-
-- Authentication will be performed against https://<IdentitySubdomain>.id.cyberark.cloud
-- API operations will target URL: https://<TenantSubdomain>.privilegecloud.cyberark.cloud
-
-```yaml
-Type: String
-Parameter Sets: SharedServices-Subdomain
-Aliases:
-
-Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)
@@ -812,7 +843,7 @@ E.G.:
 
 ```yaml
 Type: String
-Parameter Sets: SharedServices-URL
+Parameter Sets: ISPSS-URL-ServiceUser, ISPSS-URL-IdentityUser
 Aliases:
 
 Required: True
@@ -830,7 +861,41 @@ E.G.:
 
 ```yaml
 Type: String
-Parameter Sets: SharedServices-URL
+Parameter Sets: ISPSS-URL-ServiceUser, ISPSS-URL-IdentityUser
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -IdentityUser
+Specify switch parameter to authenticate with standard Interactive Identity User.
+
+Authentication process will require use of the IdentityCommand module.
+
+See: Get-Help IdentityCommand.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: ISPSS-URL-IdentityUser, ISPSS-Subdomain-IdentityUser
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ServiceUser
+Specify switch parameter to authenticate with Identity API Oauth Service User
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: ISPSS-URL-ServiceUser, ISPSS-Subdomain-ServiceUser
 Aliases:
 
 Required: True
@@ -862,3 +927,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/Shared%20Logon%20Authentication%20-%20Logon.htm#Sharedlogonauthentication](https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/Shared%20Logon%20Authentication%20-%20Logon.htm#Sharedlogonauthentication)
 
 [https://github.com/allynl93/PS-SAML-Interactive](https://github.com/allynl93/PS-SAML-Interactive)
+
+[https://github.com/pspete/IdentityCommand](https://github.com/pspete/IdentityCommand)

--- a/docs/collections/_docs/01-authentication.md
+++ b/docs/collections/_docs/01-authentication.md
@@ -2,7 +2,7 @@
 title: "Authentication"
 permalink: /docs/authentication/
 excerpt: "psPAS Authentication"
-last_modified_at: 2023-07-31T01:23:45-00:00
+last_modified_at: 2023-08-20T01:23:45-00:00
 ---
 
 _Everything begins with a **Logon**:_
@@ -136,24 +136,35 @@ New-PASSession -UseSharedAuthentication -BaseURI https://pvwa.somedomain.com -Ce
 
 ## Shared Services Authentication
 
+**Privilege Cloud Shared Services authentication flows require use of the pspete `IdentityCommand` module, available from the Powershell Gallery & GitHub.**
+
+### Identity User
+
+Provide Identity User credentials and tenant details for authentication to CyberArk Identity for Privilege Cloud Shared Services:
+
+```
+New-PASSession -IdentityTenantURL https://SomeTenantName.id.cyberark.cloud -PrivilegeCloudURL https://SomeTenant.privilegecloud.cyberark.cloud -Credential $Cred -IdentityUser
+```
+
+### Service User
+
 Provide tenant ID and non-interactive API User credentials for authentication via CyberArk Identity for Privilege Cloud Shared Services:
 
 ```
-New-PASSession -TenantSubdomain YourPrivilegeCloudTenantID -Credential $PCloudCreds
-```
-
-Most Shared Services implementations will be configured so that Identity and Privileged Cloud portal addresses share a common subdomain.
-
-Where this is not the case, and Identity and Privilege Cloud portals do not share an identical subdomain, these can be specified independently:
-
-```
-New-PASSession -TenantSubdomain PCloudTenantID -IdentitySubdomain IdentityTenantID -Credential $cred
-```
-
-For scenarios where Identity and Privilege Cloud portals are accessed using different URLs (i.e. 1st generation systems), the URLs can be specified instead on subdomain values:
-
-```
-New-PASSession -IdentityTenantURL 'https://ABC123.id.cyberark.cloud' -PrivilegeCloudURL 'https://XYZ789.privilegecloud.cyberark.cloud' -Credential $cred
+New-PASSession -TenantSubdomain YourPrivilegeCloudTenantID -Credential $ServiceUserCreds -ServiceUser
 ```
 
 Consult the vendor documentation for guidance on setting up a dedicated API Service user for non-interactive API use.
+
+### Tenant Subdomains & Portal URLs
+When providing a value for a privilege cloud tenant subdomain, this value is used to discover the identity tenant with which to authenticate:
+
+```
+New-PASSession -TenantSubdomain PCloudTenantID -Credential $cred -ServiceUser
+```
+
+If you encounter any issue authenticating with the module when providing a subdomain value, you can alternatively specify URL values for both your Identity portal, and Privilege Cloud API:
+
+```
+New-PASSession -IdentityTenantURL 'https://ABC123.id.cyberark.cloud' -PrivilegeCloudURL 'https://XYZ789.privilegecloud.cyberark.cloud' -Credential $cred -ServiceUser
+```

--- a/psPAS/Functions/Authentication/New-PASSession.ps1
+++ b/psPAS/Functions/Authentication/New-PASSession.ps1
@@ -28,13 +28,25 @@ function New-PASSession {
 			Mandatory = $true,
 			ValueFromPipeline = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = 'SharedServices-Subdomain'
+			ParameterSetName = 'ISPSS-Subdomain-IdentityUser'
 		)]
 		[Parameter(
 			Mandatory = $true,
 			ValueFromPipeline = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = 'SharedServices-URL'
+			ParameterSetName = 'ISPSS-URL-IdentityUser'
+		)]
+		[Parameter(
+			Mandatory = $true,
+			ValueFromPipeline = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'ISPSS-Subdomain-ServiceUser'
+		)]
+		[Parameter(
+			Mandatory = $true,
+			ValueFromPipeline = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'ISPSS-URL-ServiceUser'
 		)]
 		[ValidateNotNullOrEmpty()]
 		[PSCredential]$Credential,
@@ -43,7 +55,13 @@ function New-PASSession {
 			Mandatory = $true,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = 'SharedServices-Subdomain'
+			ParameterSetName = 'ISPSS-Subdomain-IdentityUser'
+		)]
+		[Parameter(
+			Mandatory = $true,
+			ValueFromPipeline = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'ISPSS-Subdomain-ServiceUser'
 		)]
 		[string]$TenantSubdomain,
 
@@ -98,18 +116,16 @@ function New-PASSession {
 		[string]$BaseURI,
 
 		[Parameter(
-			Mandatory = $false,
+			Mandatory = $true,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = 'SharedServices-Subdomain'
+			ParameterSetName = 'ISPSS-URL-IdentityUser'
 		)]
-		[string]$IdentitySubdomain,
-
 		[Parameter(
 			Mandatory = $true,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = 'SharedServices-URL'
+			ParameterSetName = 'ISPSS-URL-ServiceUser'
 		)]
 		[string]$IdentityTenantURL,
 
@@ -117,9 +133,43 @@ function New-PASSession {
 			Mandatory = $true,
 			ValueFromPipeline = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = 'SharedServices-URL'
+			ParameterSetName = 'ISPSS-URL-IdentityUser'
+		)]
+		[Parameter(
+			Mandatory = $true,
+			ValueFromPipeline = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'ISPSS-URL-ServiceUser'
 		)]
 		[string]$PrivilegeCloudURL,
+
+		[Parameter(
+			Mandatory = $true,
+			ValueFromPipeline = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'ISPSS-Subdomain-IdentityUser'
+		)]
+		[Parameter(
+			Mandatory = $true,
+			ValueFromPipeline = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'ISPSS-URL-IdentityUser'
+		)]
+		[switch]$IdentityUser,
+
+		[Parameter(
+			Mandatory = $true,
+			ValueFromPipeline = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'ISPSS-Subdomain-ServiceUser'
+		)]
+		[Parameter(
+			Mandatory = $true,
+			ValueFromPipeline = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'ISPSS-URL-ServiceUser'
+		)]
+		[switch]$ServiceUser,
 
 		[parameter(
 			Mandatory = $true,
@@ -398,7 +448,7 @@ function New-PASSession {
 
 		Switch ($PSCmdlet.ParameterSetName) {
 
-			'SharedServices-URL' {
+			( { $PSItem -match '^ISPSS-URL' } ) {
 
 				#Ensure URLs are in expected format
 				#Remove trailing space and PasswordVault (if provided in PrivilegeCloudURL)
@@ -406,45 +456,27 @@ function New-PASSession {
 				$PrivilegeCloudURL = $PrivilegeCloudURL -replace '/$', ''
 				$PrivilegeCloudURL = $PrivilegeCloudURL -replace '/PasswordVault$', ''
 
-				#Set Required URL Values for Request
-				$LogonRequest['Uri'] = "$IdentityTenantURL/oauth2/platformtoken"
-				$Uri = "$PrivilegeCloudURL/$PVWAAppName"
+			}
+
+			( { $PSItem -match '^ISPSS-SubDomain' } ) {
+
+				$SharedServicesURLs = Find-SharedServicesURL -subdomain $TenantSubdomain
+
+				$IdentityTenantURL = $SharedServicesURLs | Select-Object -ExpandProperty identity_user_portal | Select-Object -ExpandProperty api
+				$PrivilegeCloudURL = $SharedServicesURLs | Select-Object -ExpandProperty pcloud | Select-Object -ExpandProperty api
 
 			}
 
-			'SharedServices-Subdomain' {
+			( { $PSItem -match '^ISPSS-.*-.*User$' } ) {
 
-				#Most Shared Services subdomains for Identity & Privilege Cloud tenants will be identical
-				If ($PSBoundParameters.Keys -notcontains 'IdentitySubdomain') {
-					$IDSubdomain = $TenantSubdomain
-				} Else {
-					#If different, use specified subdomain for Identity
-					$IDSubdomain = $IdentitySubdomain
-				}
+				#IdentityUser/ServiceUser LogonRequest for New-IDSession/New-IDPlatformToken
+				$LogonRequest['Uri'] = $IdentityTenantURL
+				$LogonRequest['Credential'] = $Credential
 
-				$LogonRequest['Uri'] = "https://${IDSubdomain}.id.cyberark.cloud/oauth2/platformtoken"  #hardcode Shared Services auth
+				#URL for P Cloud API Operations
+				$Uri = "${PrivilegeCloudURL}/$PVWAAppName"
 
-				#Build URL
-				$Uri = "https://${TenantSubdomain}.privilegecloud.cyberark.cloud/$PVWAAppName"
-
-			}
-
-			( { $PSItem -match '^SharedServices-' } ) {
-
-				$Body = @{
-
-					grant_type    = 'client_credentials'
-					#Add user name from credential object
-					client_id     = $($Credential.UserName)
-					#Add decoded password value from credential object
-					client_secret = $($Credential.GetNetworkCredential().Password)
-
-				}
-
-				$LogonRequest['Body'] = $Body
-				$LogonRequest['ContentType'] = 'application/x-www-form-urlencoded'
 				break
-
 			}
 
 			'integrated' {
@@ -597,8 +629,30 @@ function New-PASSession {
 
 			try {
 
-				#Send Logon Request
-				$PASSession = Invoke-PASRestMethod @LogonRequest
+				switch ($PSCmdlet.ParameterSetName) {
+					( { $PSItem -match '^ISPSS' } ) {
+						#Check IdentityCommand module available
+						if (-not (Get-Module IdentityCommand)) {
+							try { Import-Module IdentityCommand -ErrorAction Stop }
+							catch { throw 'Failed to import IdentityCommand: Install the IdentityCommand Module and try again.' }
+						}
+					}
+					( { $PSItem -match '^ISPSS-.*-IdentityUser$' } ) {
+						#Perform Identity User Authentication using IdentityCommand module
+						$PASSession = New-IDSession -tenant_url $LogonRequest['Uri'] -Credential $LogonRequest['Credential']
+						break
+					}
+					( { $PSItem -match '^ISPSS-.*-ServiceUser$' } ) {
+						#Perform Identity User Authentication using IdentityCommand module
+						$PASSession = New-IDPlatformToken -tenant_url $LogonRequest['Uri'] -Credential $LogonRequest['Credential']
+						break
+					}
+					default {
+						#Send Logon Request
+						$PASSession = Invoke-PASRestMethod @LogonRequest
+						break
+					}
+				}
 
 				If ($null -ne $PASSession.UserName) {
 
@@ -685,6 +739,19 @@ function New-PASSession {
 
 							#Shared Service access_token.
 							$CyberArkLogonResult = "$($PASSession.token_type) $($PASSession.access_token)"
+
+							#Make the IdentityCommand WebSession available in the psPAS module scope
+							Set-Variable -Name WebSession -Value $($PSItem.GetWebSession()) -Scope Script
+
+						}
+
+						( { $null -ne $PSItem.Token } ) {
+
+							#Shared Services Identity User Bearer Token
+							$CyberArkLogonResult = "Bearer $($PASSession.Token)"
+
+							#Make the IdentityCommand WebSession available in the psPAS module scope
+							Set-Variable -Name WebSession -Value $($PSItem.GetWebSession()) -Scope Script
 
 						}
 

--- a/psPAS/Private/Find-SharedServicesURL.ps1
+++ b/psPAS/Private/Find-SharedServicesURL.ps1
@@ -1,0 +1,116 @@
+function Find-SharedServicesURL {
+    <#
+    .SYNOPSIS
+    Find URL details for ISPSS shared services
+
+    .DESCRIPTION
+    Given a shared services subdomain or URL value, returns details of URLs for available Shared Services.
+
+    .PARAMETER subdomain
+    The Shared Services subdomain to return service URL values of.
+
+    .PARAMETER url
+    The Shared Services URL to return service URL values of.
+
+    .PARAMETER service
+    Specify to return the API URL of a particular service.
+
+    .EXAMPLE
+    Find-SharedServicesURL -subdomain somedomain
+
+    .EXAMPLE
+    Find-SharedServicesURL -url https://someotherdomain.cyberark.cloud
+
+    .EXAMPLE
+    Find-SharedServicesURL -subdomain somedomain -service pcloud
+
+    .NOTES
+    Pete Maan 2023
+    #>
+    [CmdletBinding()]
+    Param(
+        [Parameter(
+            Mandatory = $true,
+            ValueFromPipeline = $true,
+            ParameterSetName = 'Subdomain'
+        )]
+        [string]$subdomain,
+
+        [Parameter(
+            Mandatory = $true,
+            ValueFromPipeline = $true,
+            ParameterSetName = 'URL'
+        )]
+        [string]$url,
+
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipeline = $true
+        )]
+        [ValidateSet(
+            'analytics',
+            'audit',
+            'cem',
+            'cloud_onboarding',
+            'component_manager',
+            'flows',
+            'idaptive_risk_analytics',
+            'identity_administration',
+            'identity_compliance',
+            'identity_user_portal',
+            'jit',
+            'pcloud',
+            'sca',
+            'secrets_hub',
+            'secrets_manager',
+            'session_monitoring'
+        )]
+        [string]$service
+    )
+
+    Begin {
+        $PlatformDiscoveryURL = 'https://platform-discovery.cyberark.cloud/api/v2/services/subdomain/'
+    }
+
+    Process {
+
+        if ($PSCmdlet.ParameterSetName -eq 'URL') {
+            $URIObject = [System.UriBuilder]::new($url)
+            $subdomain = $URIObject.host.Split('.') | Select-Object -First 1
+        }
+
+        $PlatformDiscoveryURL = $PlatformDiscoveryURL + $subdomain
+
+        $Result = Invoke-PASRestMethod -URI $PlatformDiscoveryURL -Method GET
+
+        If ($null -ne $Result) {
+
+            If ($PSBoundParameters.ContainsKey('service')) {
+
+                $Services = $Result | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name
+
+                If ($Services -notcontains $Service) {
+
+                    throw "URL for $service API not found"
+
+                }
+
+                Else {
+
+                    $Result | Select-Object -ExpandProperty $service | Select-Object -ExpandProperty api
+
+                }
+
+            } Else {
+
+                $Result
+
+            }
+
+        }
+
+    }
+
+    End {}
+
+}

--- a/psPAS/Private/Get-PASResponse.ps1
+++ b/psPAS/Private/Get-PASResponse.ps1
@@ -68,7 +68,7 @@ function Get-PASResponse {
 
 				}
 
-				'application/json; charset=utf-8' {
+				({ $PSItem -match 'application/json' }) {
 
 					#application/json content expected for most responses.
 

--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -242,9 +242,9 @@
 
 					try {
 
-						$ResponseException = $ResponseException | ConvertFrom-Json
-						$ErrorMessage = $ResponseException | Select-Object -ExpandProperty error_description
-						$ErrorID = $($ResponseException | Select-Object -ExpandProperty error)
+						$ThisException = $ResponseException | ConvertFrom-Json -ErrorAction Stop
+						$ErrorMessage = $ThisException | Select-Object -ExpandProperty error_description -ErrorAction Stop
+						$ErrorID = $($ThisException | Select-Object -ExpandProperty error -ErrorAction Stop)
 
 					} catch {
 

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -24471,6 +24471,17 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>ServiceUser</maml:name>
+          <maml:description>
+            <maml:para>Specify switch parameter to authenticate with Identity API Oauth Service User</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>New-PASSession</maml:name>
@@ -24577,10 +24588,88 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>TenantSubdomain</maml:name>
           <maml:description>
-            <maml:para>The subdomain name value of the Identity Shared Services / Privilege Cloud Tenant.</maml:para>
-            <maml:para>Where the Shared Services tenants for both Identity and Privilege Cloud have been configured to share identical subdomain names, use this parameter to specify the subdomain name.</maml:para>
+            <maml:para>The subdomain name value of the Shared Services Privilege Cloud Tenant.</maml:para>
+            <maml:para>The value provided for the subdomain parameter will be used to discover the identity tenant api URL.</maml:para>
             <maml:para>- API operations will target URL: https://&lt;TenantSubdomain&gt;.privilegecloud.cyberark.cloud</maml:para>
-            <maml:para>- Authentication will be performed against https://&lt;TenantSubdomain&gt;.id.cyberark.cloud</maml:para>
+            <maml:para>- Authentication will be performed against https://&lt;DiscoveredIdentitySubdomain&gt;.id.cyberark.cloud</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>ServiceUser</maml:name>
+          <maml:description>
+            <maml:para>Specify switch parameter to authenticate with Identity API Oauth Service User</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>New-PASSession</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>A Valid PSCredential object.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>PVWAAppName</maml:name>
+          <maml:description>
+            <maml:para>The name of the CyberArk PVWA Virtual Directory.</maml:para>
+            <maml:para>Defaults to PasswordVault</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>PasswordVault</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>SkipVersionCheck</maml:name>
+          <maml:description>
+            <maml:para>If the SkipVersionCheck switch is specified, Get-PASServer will not be called after successfully authenticating.</maml:para>
+            <maml:para>Get-PASServer is not supported before version 9.7.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Certificate</maml:name>
+          <maml:description>
+            <maml:para>See Invoke-WebRequest</maml:para>
+            <maml:para>Specifies the client certificate that is used for a secure web request.</maml:para>
+            <maml:para>Enter a variable that contains a certificate or a command or expression that gets the certificate.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">X509Certificate</command:parameterValue>
+          <dev:type>
+            <maml:name>X509Certificate</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>CertificateThumbprint</maml:name>
+          <maml:description>
+            <maml:para>See Invoke-WebRequest</maml:para>
+            <maml:para>The thumbprint of the certificate to use for client certificate authentication.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -24590,12 +24679,47 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
-          <maml:name>IdentitySubdomain</maml:name>
+          <maml:name>SkipCertificateCheck</maml:name>
           <maml:description>
-            <maml:para>A subdomain name value for the Identity Tenant used for authentication into Privilege Cloud.</maml:para>
-            <maml:para>Where the Shared Services tenants for Identity and Privilege Cloud have not been configured with identical subdomain names, use this parameter to specify the subdomain name for the Identity tenant.</maml:para>
-            <maml:para>- Authentication will be performed against https://&lt;IdentitySubdomain&gt;.id.cyberark.cloud</maml:para>
-            <maml:para>- API operations will target URL: https://&lt;TenantSubdomain&gt;.privilegecloud.cyberark.cloud</maml:para>
+            <maml:para>Skips certificate validation checks.</maml:para>
+            <maml:para>Using this parameter is not secure and is not recommended.</maml:para>
+            <maml:para>This switch is only intended to be used against known hosts using a self-signed certificate for testing purposes.</maml:para>
+            <maml:para>Use at your own risk.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>IdentityTenantURL</maml:name>
+          <maml:description>
+            <maml:para>Specify the URL value of the CyberArk Identity Portal to authenticate against.</maml:para>
+            <maml:para>E.G.: - https://&lt;identity-tenant-id&gt;.id.cyberark.cloud</maml:para>
+            <maml:para>- https://&lt;identity-tenant-id&gt;.my.idaptive.app</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -24603,6 +24727,163 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>PrivilegeCloudURL</maml:name>
+          <maml:description>
+            <maml:para>Specify the URL value used to access the CyberArk Privilege Cloud API.</maml:para>
+            <maml:para>E.G.: - https://&lt;subdomain&gt;.privilegecloud.cyberark.cloud</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>IdentityUser</maml:name>
+          <maml:description>
+            <maml:para>Specify switch parameter to authenticate with standard Interactive Identity User.</maml:para>
+            <maml:para>Authentication process will require use of the IdentityCommand module.</maml:para>
+            <maml:para>See: Get-Help IdentityCommand.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>New-PASSession</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>A Valid PSCredential object.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>PVWAAppName</maml:name>
+          <maml:description>
+            <maml:para>The name of the CyberArk PVWA Virtual Directory.</maml:para>
+            <maml:para>Defaults to PasswordVault</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>PasswordVault</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>SkipVersionCheck</maml:name>
+          <maml:description>
+            <maml:para>If the SkipVersionCheck switch is specified, Get-PASServer will not be called after successfully authenticating.</maml:para>
+            <maml:para>Get-PASServer is not supported before version 9.7.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Certificate</maml:name>
+          <maml:description>
+            <maml:para>See Invoke-WebRequest</maml:para>
+            <maml:para>Specifies the client certificate that is used for a secure web request.</maml:para>
+            <maml:para>Enter a variable that contains a certificate or a command or expression that gets the certificate.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">X509Certificate</command:parameterValue>
+          <dev:type>
+            <maml:name>X509Certificate</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>CertificateThumbprint</maml:name>
+          <maml:description>
+            <maml:para>See Invoke-WebRequest</maml:para>
+            <maml:para>The thumbprint of the certificate to use for client certificate authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>SkipCertificateCheck</maml:name>
+          <maml:description>
+            <maml:para>Skips certificate validation checks.</maml:para>
+            <maml:para>Using this parameter is not secure and is not recommended.</maml:para>
+            <maml:para>This switch is only intended to be used against known hosts using a self-signed certificate for testing purposes.</maml:para>
+            <maml:para>Use at your own risk.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>TenantSubdomain</maml:name>
+          <maml:description>
+            <maml:para>The subdomain name value of the Shared Services Privilege Cloud Tenant.</maml:para>
+            <maml:para>The value provided for the subdomain parameter will be used to discover the identity tenant api URL.</maml:para>
+            <maml:para>- API operations will target URL: https://&lt;TenantSubdomain&gt;.privilegecloud.cyberark.cloud</maml:para>
+            <maml:para>- Authentication will be performed against https://&lt;DiscoveredIdentitySubdomain&gt;.id.cyberark.cloud</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>IdentityUser</maml:name>
+          <maml:description>
+            <maml:para>Specify switch parameter to authenticate with standard Interactive Identity User.</maml:para>
+            <maml:para>Authentication process will require use of the IdentityCommand module.</maml:para>
+            <maml:para>See: Get-Help IdentityCommand.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
@@ -25988,25 +26269,10 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>TenantSubdomain</maml:name>
         <maml:description>
-          <maml:para>The subdomain name value of the Identity Shared Services / Privilege Cloud Tenant.</maml:para>
-          <maml:para>Where the Shared Services tenants for both Identity and Privilege Cloud have been configured to share identical subdomain names, use this parameter to specify the subdomain name.</maml:para>
+          <maml:para>The subdomain name value of the Shared Services Privilege Cloud Tenant.</maml:para>
+          <maml:para>The value provided for the subdomain parameter will be used to discover the identity tenant api URL.</maml:para>
           <maml:para>- API operations will target URL: https://&lt;TenantSubdomain&gt;.privilegecloud.cyberark.cloud</maml:para>
-          <maml:para>- Authentication will be performed against https://&lt;TenantSubdomain&gt;.id.cyberark.cloud</maml:para>
-        </maml:description>
-        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-        <dev:type>
-          <maml:name>String</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>None</dev:defaultValue>
-      </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
-        <maml:name>IdentitySubdomain</maml:name>
-        <maml:description>
-          <maml:para>A subdomain name value for the Identity Tenant used for authentication into Privilege Cloud.</maml:para>
-          <maml:para>Where the Shared Services tenants for Identity and Privilege Cloud have not been configured with identical subdomain names, use this parameter to specify the subdomain name for the Identity tenant.</maml:para>
-          <maml:para>- Authentication will be performed against https://&lt;IdentitySubdomain&gt;.id.cyberark.cloud</maml:para>
-          <maml:para>- API operations will target URL: https://&lt;TenantSubdomain&gt;.privilegecloud.cyberark.cloud</maml:para>
+          <maml:para>- Authentication will be performed against https://&lt;DiscoveredIdentitySubdomain&gt;.id.cyberark.cloud</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -26041,6 +26307,32 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>IdentityUser</maml:name>
+        <maml:description>
+          <maml:para>Specify switch parameter to authenticate with standard Interactive Identity User.</maml:para>
+          <maml:para>Authentication process will require use of the IdentityCommand module.</maml:para>
+          <maml:para>See: Get-Help IdentityCommand.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>ServiceUser</maml:name>
+        <maml:description>
+          <maml:para>Specify switch parameter to authenticate with Identity API Oauth Service User</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes />
@@ -26232,7 +26524,8 @@ New-PASSession -SAMLAuth -concurrentSession $true -BaseURI $baseURL -SAMLRespons
         <maml:title>-------------------------- EXAMPLE 23 --------------------------</maml:title>
         <dev:code>New-PASSession -TenantSubdomain PCloudTenantID -Credential $cred</dev:code>
         <dev:remarks>
-          <maml:para>Authenticates to Privilege Cloud Shared Services, where 'PCloudTenantID' is a Subdomain configured for both Identity &amp; Privilege Cloud portals.</maml:para>
+          <maml:para>Authenticates to Privilege Cloud Shared Services, where 'PCloudTenantID' is the Subdomain configured for the Privilege Cloud portal.</maml:para>
+          <maml:para>The subdomain value provided will be used to discover the identity portal URL.</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
@@ -26262,16 +26555,44 @@ New-PASSession -BaseURI $url -type PKIPN -Certificate $Cert</dev:code>
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 26 --------------------------</maml:title>
-        <dev:code>New-PASSession -TenantSubdomain PCloudTenantID -IdentitySubdomain IdentityTenantID -Credential $cred</dev:code>
+        <dev:code>New-PASSession -TenantSubdomain PCloudTenantID -Credential $cred -ServiceUser</dev:code>
         <dev:remarks>
-          <maml:para>Authenticates to Privilege Cloud Shared Services, where subdomains for Identity &amp; Privilege Cloud portals have not been configured to share the same value.</maml:para>
+          <maml:para>Authenticates to Privilege Cloud Shared Services using an API Service User.</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 27 --------------------------</maml:title>
-        <dev:code>New-PASSession -IdentityTenantURL 'https://ABC123.id.cyberark.cloud' -PrivilegeCloudURL 'https://XYZ789.privilegecloud.cyberark.cloud' -Credential $cred</dev:code>
+        <dev:code>New-PASSession -IdentityTenantURL 'https://ABC123.id.cyberark.cloud' -PrivilegeCloudURL 'https://XYZ789.privilegecloud.cyberark.cloud' -Credential $cred -ServiceUser</dev:code>
         <dev:remarks>
-          <maml:para>Authenticates to Privilege Cloud Shared Services, specifying individual URL values for Identity &amp; Privilege Cloud tenants.</maml:para>
+          <maml:para>Authenticates to Privilege Cloud Shared Services using an API Service User, specifying individual URL values for Identity &amp; Privilege Cloud tenants.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- Example 28 --------------------------</maml:title>
+        <dev:code>New-PASSession -IdentityTenantURL https://SomeTenantName.id.cyberark.cloud -PrivilegeCloudURL 'https://XYZ789.privilegecloud.cyberark.cloud' -Credential $Cred -IdentityUser</dev:code>
+        <dev:remarks>
+          <maml:para>Authenticates to Identity Shared Services using an Identity User and provides authenticated session to associated Privileged Cloud environment.</maml:para>
+          <maml:para>Requires IdentityCommand module to be installed for authentication flow to complete.</maml:para>
+          <maml:para>See: Get-Help IdentityCommand</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- Example 29 --------------------------</maml:title>
+        <dev:code>New-PASSession -TenantSubdomain YourTenantName -Credential $Cred -IdentityUser</dev:code>
+        <dev:remarks>
+          <maml:para>Authenticates to Identity Shared Services using an Identity User and provides authenticated session to associated Privileged Cloud environment.</maml:para>
+          <maml:para>Assumes a Shared Services URL of https://YourTenantName.id.cyberark.cloud</maml:para>
+          <maml:para>Requires IdentityCommand module to be installed for authentication flow to complete.</maml:para>
+          <maml:para>See: Get-Help IdentityCommand</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- Example 30 --------------------------</maml:title>
+        <dev:code>New-PASSession -IdentityTenantURL https://SomeTenantName.id.cyberark.cloud -Credential $Cred -PrivilegeCloudURL https://SomeName.privilegecloud.cyberark.cloud -IdentityUser</dev:code>
+        <dev:remarks>
+          <maml:para>Authenticates to Identity Shared Services using an Identity User and provides authenticated session to specified Privileged Cloud environment.</maml:para>
+          <maml:para>Requires IdentityCommand module to be installed for authentication flow to complete.</maml:para>
+          <maml:para>See: Get-Help IdentityCommand</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -26299,6 +26620,10 @@ New-PASSession -BaseURI $url -type PKIPN -Certificate $Cert</dev:code>
       <maml:navigationLink>
         <maml:linkText>https://github.com/allynl93/PS-SAML-Interactive</maml:linkText>
         <maml:uri>https://github.com/allynl93/PS-SAML-Interactive</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>https://github.com/pspete/IdentityCommand</maml:linkText>
+        <maml:uri>https://github.com/pspete/IdentityCommand</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description

**Introducing [`IdentityCommand`](https://github.com/pspete/IdentityCommand)**

- Update & Breaking Change
  - `New-PASSession`
    - **All Privilege Cloud Shared Services Authentication via the CyberArk Identity Platform now depends on the pspete `IdentityCommand` module.**
    - Adds Identity User Authentication, using the `IdentityCommand` module to satisfy Identity MFA challenges and obtain required authentication token to use against Privileged Cloud Shared Services.
    - Adds logic to determine correct Identity tenant URL based on provided Privileged Cloud Subdomain value.
    - Both Privileged Cloud API URL & Identity Portal URL are required to be specified if subdomain value is not provided.
    - Service User authentication for Shared Services introduced in recent previous versions requires installation of `IdentityCommand` module and specification of additional attribute.
    - See [the docs](https://pspas.pspete.dev/docs/authentication/#shared-services-authentication) & [New-PASSession](https://pspas.pspete.dev/commands/New-PASSession) for full details.

Fixes #

## Type of change
<!--
Please select all relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that makes existing functionality work differently)
- [X] Documentation update (psPAS website or command help content)
- [ ] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [X] Pester test(s) updated
- [X] Pester test(s) passing

**Test Configuration**:
- PowerShell version: 7
- CyberArk PAS version: 13.2
- OS Version: Windows 11

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [X] My code follows the style guidelines of this project
- [X] I have followed the contributing guidelines.
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new test failures or errors
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [ ] I have linked a related issue