### PR TITLE
Patch-491

### DIFF
--- a/Tests/Get-NextLink.Tests.ps1
+++ b/Tests/Get-NextLink.Tests.ps1
@@ -83,6 +83,16 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			}
 
+			It 'includes SavedFilter in request' {
+
+				$InputObj | Get-NextLink -SavedFilter SomeFilter
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/SomeLink&SavedFilter=SomeFilter"
+
+				} -Times 10 -Exactly -Scope It
+			}
+
 			It 'outputs expected number of results' {
 
 				$results = $InputObj | Get-NextLink

--- a/psPAS/Functions/Accounts/Get-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccount.ps1
@@ -280,8 +280,11 @@ function Get-PASAccount {
 
 				default {
 
+					#Get default parameters to pass to Get-NextLink
+					$DefaultParams = $PSBoundParameters | Get-PASParameter -ParametersToKeep SavedFilter, TimeoutSec
+
 					#return list
-					$return = $Result | Get-NextLink -TimeoutSec $TimeoutSec
+					$return = $Result | Get-NextLink @DefaultParams
 
 					break
 


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
<!--
Please include a summary of the change and which issue is fixed & relevant motivation and context.
Put `Fixes #XXX` in your comment to link the issue that your PR fixes.
-->

When querying accounts with a `SavedFilter`, this update adds the `SavedFilter` value to any `NextLink` URL values which are followed to obtain the full result set.

Resolves issue where, if number of results of a `SavedFilter` are greater than the page size (either default or set via the `limit` parameter), only the URL of the first request sent includes the `SavedFilter` value.

Fixes #491

## Type of change
<!--
Please select all relevant options:
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [ ] Documentation update (psPAS website or command help content)
- [ ] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [X] Pester test(s) updated
- [X] Pester test(s) passing

**Test Configuration**:
- PowerShell version: 7
- CyberArk PAS version: 13.2
- OS Version: Win11

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [X] My code follows the style guidelines of this project
- [X] I have followed the contributing guidelines.
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new test failures or errors
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [X] I have linked a related issue