### PR TITLE
Depreciate Commands

### DIFF
--- a/Tests/Get-PASServerWebService.Tests.ps1
+++ b/Tests/Get-PASServerWebService.Tests.ps1
@@ -37,14 +37,14 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		BeforeEach {
 			Mock Invoke-PASRestMethod -MockWith {
 				[PSCustomObject]@{
-					'ServerName'            = 'Val1';
-					'ServerID'              = 'Val2';
-					'ApplicationName'       = 'AppName';
+					'ServerName'            = 'Val1'
+					'ServerID'              = 'Val2'
+					'ApplicationName'       = 'AppName'
 					'AuthenticationMethods' = 'SomeThing'
 				}
 			}
 
-			$response = Get-PASServerWebService -BaseURI 'https://SomeURL' -PVWAAppName SomeApp
+			$response = Get-PASServerWebService -BaseURI 'https://SomeURL' -PVWAAppName SomeApp -UseGen1API
 		}
 		Context 'Input' {
 
@@ -59,6 +59,18 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
 					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Verify"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'sends request to expected Gen2 endpoint' {
+
+				Get-PASServerWebService -BaseURI 'https://SomeURL' -PVWAAppName SomeApp
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/API/verify/"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Get-PASServerWebService.Tests.ps1
+++ b/Tests/Get-PASServerWebService.Tests.ps1
@@ -34,19 +34,21 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 	}
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
-		BeforeEach {
-			Mock Invoke-PASRestMethod -MockWith {
-				[PSCustomObject]@{
-					'ServerName'            = 'Val1'
-					'ServerID'              = 'Val2'
-					'ApplicationName'       = 'AppName'
-					'AuthenticationMethods' = 'SomeThing'
-				}
-			}
 
-			$response = Get-PASServerWebService -BaseURI 'https://SomeURL' -PVWAAppName SomeApp -UseGen1API
-		}
 		Context 'Input' {
+
+			BeforeEach {
+				Mock Invoke-PASRestMethod -MockWith {
+					[PSCustomObject]@{
+						'ServerName'            = 'Val1'
+						'ServerID'              = 'Val2'
+						'ApplicationName'       = 'AppName'
+						'AuthenticationMethods' = 'SomeThing'
+					}
+				}
+				$Script:BaseURI = 'https://SomeURL/SomeApp'
+				$response = Get-PASServerWebService -BaseURI 'https://SomeURL' -PVWAAppName SomeApp -UseGen1API
+			}
 
 			It 'sends request' {
 
@@ -58,9 +60,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Verify"
+					$URI -eq 'https://SomeURL/SomeApp/WebServices/PIMServices.svc/Verify'
 
-				} -Times 1 -Exactly -Scope It
+				} #-Times 1 -Exactly -Scope It
 
 			}
 
@@ -72,7 +74,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 					$URI -eq "$($Script:BaseURI)/API/verify/"
 
-				} -Times 1 -Exactly -Scope It
+				} #-Times 1 -Exactly -Scope It
 
 			}
 
@@ -92,6 +94,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 		Context 'Output' {
 
+			BeforeEach {
+				Mock Invoke-PASRestMethod -MockWith {
+					[PSCustomObject]@{
+						'ServerName'            = 'Val1'
+						'ServerID'              = 'Val2'
+						'ApplicationName'       = 'AppName'
+						'AuthenticationMethods' = 'SomeThing'
+					}
+				}
+				$Script:BaseURI = 'https://SomeURL/SomeApp'
+				$response = Get-PASServerWebService -BaseURI 'https://SomeURL' -PVWAAppName SomeApp -UseGen1API
+			}
+
 			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
@@ -100,7 +115,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'has output with expected number of properties' {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should -Be 4
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 5
 
 			}
 

--- a/docs/collections/_commands/Add-PASPendingAccount.md
+++ b/docs/collections/_commands/Add-PASPendingAccount.md
@@ -30,6 +30,8 @@ as a pending account to the Accounts Feed.
 
 Users can identify privileged accounts and determine which are on-boarded to the vault.
 
+Depreciated from version 13.2
+
 ## EXAMPLES
 
 ### EXAMPLE 1

--- a/docs/collections/_commands/Get-PASAccountActivity.md
+++ b/docs/collections/_commands/Get-PASAccountActivity.md
@@ -21,6 +21,8 @@ Get-PASAccountActivity [-AccountID] <String> [<CommonParameters>]
 ## DESCRIPTION
 Returns activities for a specific account identified by its AccountID.
 
+Depreciated from version 13.2
+
 ## EXAMPLES
 
 ### EXAMPLE 1

--- a/docs/collections/_commands/Get-PASSafeShareLogo.md
+++ b/docs/collections/_commands/Get-PASSafeShareLogo.md
@@ -21,6 +21,8 @@ Get-PASSafeShareLogo [-ImageType] <String> [<CommonParameters>]
 ## DESCRIPTION
 Gets configuration details of logo displayed in the SafeShare WebGUI
 
+Depreciated from version 13.2
+
 ## EXAMPLES
 
 ### EXAMPLE 1

--- a/docs/collections/_commands/Get-PASServerWebService.md
+++ b/docs/collections/_commands/Get-PASServerWebService.md
@@ -16,7 +16,7 @@ Returns details of the Web Service
 
 ```
 Get-PASServerWebService [[-WebSession] <WebRequestSession>] [-BaseURI] <String> [[-PVWAAppName] <String>]
- [<CommonParameters>]
+ [-UseGen1API] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -80,6 +80,21 @@ Aliases:
 Required: False
 Position: 3
 Default value: PasswordVault
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -UseGen1API
+Force use of Gen1 API for request.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: UseClassicAPI
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```

--- a/docs/collections/_commands/Invoke-PASCPMOperation.md
+++ b/docs/collections/_commands/Invoke-PASCPMOperation.md
@@ -90,6 +90,8 @@ Invoke-PASCPMOperation -AccountID $ID -ChangeTask -ImmediateChangeByCPM Yes
 
 Marks an account for immediate change using the Gen1 API
 
+Depreciated from version 13.2
+
 ### EXAMPLE 4
 ```
 Invoke-PASCPMOperation -AccountID $ID -ChangeTask
@@ -259,6 +261,8 @@ Accept wildcard characters: False
 Yes/No value, dictating if the account will be scheduled for immediate change.
 
 Specify Yes to initiate a password change by CPM - Relevant for Gen1 API only.
+
+Depreciated from version 13.2
 
 ```yaml
 Type: String

--- a/psPAS/Functions/Accounts/Add-PASPendingAccount.ps1
+++ b/psPAS/Functions/Accounts/Add-PASPendingAccount.ps1
@@ -138,7 +138,10 @@ function Add-PASPendingAccount {
 		[string]$MachineOSFamily
 	)
 
-	BEGIN { }#begin
+	BEGIN {
+		#!Depreciated above 13.2
+		Assert-VersionRequirement -MaximumVersion 13.2
+	}#begin
 
 	PROCESS {
 

--- a/psPAS/Functions/Accounts/Get-PASAccountActivity.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccountActivity.ps1
@@ -12,7 +12,10 @@ function Get-PASAccountActivity {
 
 	)
 
-	BEGIN { }#begin
+	BEGIN {
+		#!Depreciated above 13.2
+		Assert-VersionRequirement -MaximumVersion 13.2
+	}#begin
 
 	PROCESS {
 

--- a/psPAS/Functions/Accounts/Invoke-PASCPMOperation.ps1
+++ b/psPAS/Functions/Accounts/Invoke-PASCPMOperation.ps1
@@ -127,6 +127,9 @@ function Invoke-PASCPMOperation {
 
 			'ChangeCredentials' {
 
+				#!Depreciated above 13.2
+				Assert-VersionRequirement -MaximumVersion 13.2
+
 				#add ImmediateChangeByCPM to header as key=value pair
 				$ThisRequest['WebSession'].Headers['ImmediateChangeByCPM'] = $ImmediateChangeByCPM
 

--- a/psPAS/Functions/ServerWebServices/Get-PASSafeShareLogo.ps1
+++ b/psPAS/Functions/ServerWebServices/Get-PASSafeShareLogo.ps1
@@ -9,7 +9,10 @@ function Get-PASSafeShareLogo {
 		[String]$ImageType
 	)
 
-	BEGIN { }#begin
+	BEGIN {
+		#!Depreciated above 13.2
+		Assert-VersionRequirement -MaximumVersion 13.2
+	}#begin
 
 	PROCESS {
 

--- a/psPAS/Functions/ServerWebServices/Get-PASServerWebService.ps1
+++ b/psPAS/Functions/ServerWebServices/Get-PASServerWebService.ps1
@@ -18,15 +18,42 @@ function Get-PASServerWebService {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = 'PasswordVault'
+		[string]$PVWAAppName = 'PasswordVault',
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'VerifyCredentials'
+		)]
+		[Alias('UseClassicAPI')]
+		[switch]$UseGen1API
+
 	)
 
 	BEGIN { }#begin
 
 	PROCESS {
 
-		#Create URL for request
-		$URI = "$BaseURI/$PVWAAppName/WebServices/PIMServices.svc/Verify"
+		switch ($PSBoundParameters.Keys) {
+
+			'UseGen1API' {
+				#!Depreciated above 13.2
+				Assert-VersionRequirement -MaximumVersion 13.2
+
+				#Create URL for request
+				$URI = "$BaseURI/$PVWAAppName/WebServices/PIMServices.svc/Verify"
+
+				Break
+			}
+
+			default {
+
+				#Create URL for request
+				$URI = "$BaseURI/$PVWAAppName/API/verify/"
+
+			}
+
+		}
 
 		#send request to web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $WebSession
@@ -34,7 +61,7 @@ function Get-PASServerWebService {
 		If ($null -ne $result) {
 
 			#return results
-			$result | Select-Object ServerName, ServerId, ApplicationName , AuthenticationMethods
+			$result | Select-Object ServerName, ServerId, ApplicationName , AuthenticationMethods, Features
 
 		}
 

--- a/psPAS/Functions/ServerWebServices/Get-PASServerWebService.ps1
+++ b/psPAS/Functions/ServerWebServices/Get-PASServerWebService.ps1
@@ -21,9 +21,8 @@ function Get-PASServerWebService {
 		[string]$PVWAAppName = 'PasswordVault',
 
 		[parameter(
-			Mandatory = $true,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = 'VerifyCredentials'
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
 		)]
 		[Alias('UseClassicAPI')]
 		[switch]$UseGen1API
@@ -43,7 +42,7 @@ function Get-PASServerWebService {
 				#Create URL for request
 				$URI = "$BaseURI/$PVWAAppName/WebServices/PIMServices.svc/Verify"
 
-				Break
+				break
 			}
 
 			default {

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -5288,6 +5288,7 @@ Add-PASDiscoveredAccount -UserName ServiceUser -Address 1.2.3.4 -discoveryDate (
     <maml:description>
       <maml:para>Enables an account or SSH key that is discovered by an external scanner to be added as a pending account to the Accounts Feed.</maml:para>
       <maml:para>Users can identify privileged accounts and determine which are on-boarded to the vault.</maml:para>
+      <maml:para>Depreciated from version 13.2</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -11616,6 +11617,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
     </command:details>
     <maml:description>
       <maml:para>Returns activities for a specific account identified by its AccountID.</maml:para>
+      <maml:para>Depreciated from version 13.2</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -17858,6 +17860,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
     </command:details>
     <maml:description>
       <maml:para>Gets configuration details of logo displayed in the SafeShare WebGUI</maml:para>
+      <maml:para>Depreciated from version 13.2</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -18018,6 +18021,17 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           </dev:type>
           <dev:defaultValue>PasswordVault</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="UseClassicAPI">
+          <maml:name>UseGen1API</maml:name>
+          <maml:description>
+            <maml:para>Force use of Gen1 API for request.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
@@ -18058,6 +18072,18 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           <maml:uri />
         </dev:type>
         <dev:defaultValue>PasswordVault</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="UseClassicAPI">
+        <maml:name>UseGen1API</maml:name>
+        <maml:description>
+          <maml:para>Force use of Gen1 API for request.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes />
@@ -19097,6 +19123,7 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
           <maml:description>
             <maml:para>Yes/No value, dictating if the account will be scheduled for immediate change.</maml:para>
             <maml:para>Specify Yes to initiate a password change by CPM - Relevant for Gen1 API only.</maml:para>
+            <maml:para>Depreciated from version 13.2</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -19510,6 +19537,7 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
         <maml:description>
           <maml:para>Yes/No value, dictating if the account will be scheduled for immediate change.</maml:para>
           <maml:para>Specify Yes to initiate a password change by CPM - Relevant for Gen1 API only.</maml:para>
+          <maml:para>Depreciated from version 13.2</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -19598,6 +19626,7 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
         <dev:code>Invoke-PASCPMOperation -AccountID $ID -ChangeTask -ImmediateChangeByCPM Yes</dev:code>
         <dev:remarks>
           <maml:para>Marks an account for immediate change using the Gen1 API</maml:para>
+          <maml:para>Depreciated from version 13.2</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
<!--
Please include a summary of the change and which issue is fixed & relevant motivation and context.
Put `Fixes #XXX` in your comment to link the issue that your PR fixes.
-->
Following the product release notes, adds 13.2 as the maximum supported version for commands or paramters/parametersets scheduled for depreciation:
- `Get-PASServerWebService` (Gen1)
- `Get-PASSafeShareLogo`
- `Invoke-PASCPMOperation` (Gen1)
- `Get-PASAccountActivity`
- `Add-PASPendingAccount`

Fixes #

## Type of change
<!--
Please select all relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [ ] Documentation update (psPAS website or command help content)
- [X] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [X] Pester test(s) updated
- [X] Pester test(s) passing

**Test Configuration**:
- PowerShell version: 7
- CyberArk PAS version: 13.2
- OS Version: Win11

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [X] My code follows the style guidelines of this project
- [X] I have followed the contributing guidelines.
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new test failures or errors
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [ ] I have linked a related issue