### PR TITLE
6.0 Update 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@
 - Continued development to encompass any new documented features of the CyberArk API.
 - psPAS v7.0...
 
+## **6.0.18**
+
+### Added
+- N/A
+
+### Changed
+- `Set-PASSafe`
+  - Allows `0` as valid value for parameter `NumberOfDaysRetention`
+- `Get-PASServerWebService`
+  - Depreciates Gen1 endpoint from 13.2. Adds Gen2 endpoint as default.
+- `Get-PASSafeShareLogo`
+  - Depreciates command from 13.2.
+- `Invoke-PASCPMOperation`
+  - Depreciates Gen1 endpoint from 13.2.
+- `Get-PASAccountActivity`
+  - Depreciates command from 13.2.
+- `Add-PASPendingAccount`
+  - Depreciates command from 13.2.
+
+### Fixed
+- `Get-PASAccount`
+  - Resolves issue where, if number of results of a `SavedFilter` are greater than the page size (either default or set via the `limit` parameter), only the URL of the first request sent would include the SavedFilter value.
+
 ## **6.0.4**
 
 - Updated

--- a/Tests/Get-NextLink.Tests.ps1
+++ b/Tests/Get-NextLink.Tests.ps1
@@ -83,6 +83,16 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			}
 
+			It 'includes SavedFilter in request' {
+
+				$InputObj | Get-NextLink -SavedFilter SomeFilter
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/SomeLink&SavedFilter=SomeFilter"
+
+				} -Times 10 -Exactly -Scope It
+			}
+
 			It 'outputs expected number of results' {
 
 				$results = $InputObj | Get-NextLink

--- a/Tests/Get-PASServerWebService.Tests.ps1
+++ b/Tests/Get-PASServerWebService.Tests.ps1
@@ -34,19 +34,21 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 	}
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
-		BeforeEach {
-			Mock Invoke-PASRestMethod -MockWith {
-				[PSCustomObject]@{
-					'ServerName'            = 'Val1';
-					'ServerID'              = 'Val2';
-					'ApplicationName'       = 'AppName';
-					'AuthenticationMethods' = 'SomeThing'
-				}
-			}
 
-			$response = Get-PASServerWebService -BaseURI 'https://SomeURL' -PVWAAppName SomeApp
-		}
 		Context 'Input' {
+
+			BeforeEach {
+				Mock Invoke-PASRestMethod -MockWith {
+					[PSCustomObject]@{
+						'ServerName'            = 'Val1'
+						'ServerID'              = 'Val2'
+						'ApplicationName'       = 'AppName'
+						'AuthenticationMethods' = 'SomeThing'
+					}
+				}
+				$Script:BaseURI = 'https://SomeURL/SomeApp'
+				$response = Get-PASServerWebService -BaseURI 'https://SomeURL' -PVWAAppName SomeApp -UseGen1API
+			}
 
 			It 'sends request' {
 
@@ -58,9 +60,21 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Verify"
+					$URI -eq 'https://SomeURL/SomeApp/WebServices/PIMServices.svc/Verify'
 
-				} -Times 1 -Exactly -Scope It
+				} #-Times 1 -Exactly -Scope It
+
+			}
+
+			It 'sends request to expected Gen2 endpoint' {
+
+				Get-PASServerWebService -BaseURI 'https://SomeURL' -PVWAAppName SomeApp
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:BaseURI)/API/verify/"
+
+				} #-Times 1 -Exactly -Scope It
 
 			}
 
@@ -80,6 +94,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 		Context 'Output' {
 
+			BeforeEach {
+				Mock Invoke-PASRestMethod -MockWith {
+					[PSCustomObject]@{
+						'ServerName'            = 'Val1'
+						'ServerID'              = 'Val2'
+						'ApplicationName'       = 'AppName'
+						'AuthenticationMethods' = 'SomeThing'
+					}
+				}
+				$Script:BaseURI = 'https://SomeURL/SomeApp'
+				$response = Get-PASServerWebService -BaseURI 'https://SomeURL' -PVWAAppName SomeApp -UseGen1API
+			}
+
 			It 'provides output' {
 
 				$response | Should -Not -BeNullOrEmpty
@@ -88,7 +115,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'has output with expected number of properties' {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should -Be 4
+				($response | Get-Member -MemberType NoteProperty).length | Should -Be 5
 
 			}
 

--- a/docs/collections/_commands/Add-PASPendingAccount.md
+++ b/docs/collections/_commands/Add-PASPendingAccount.md
@@ -30,6 +30,8 @@ as a pending account to the Accounts Feed.
 
 Users can identify privileged accounts and determine which are on-boarded to the vault.
 
+Depreciated from version 13.2
+
 ## EXAMPLES
 
 ### EXAMPLE 1

--- a/docs/collections/_commands/Get-PASAccountActivity.md
+++ b/docs/collections/_commands/Get-PASAccountActivity.md
@@ -21,6 +21,8 @@ Get-PASAccountActivity [-AccountID] <String> [<CommonParameters>]
 ## DESCRIPTION
 Returns activities for a specific account identified by its AccountID.
 
+Depreciated from version 13.2
+
 ## EXAMPLES
 
 ### EXAMPLE 1

--- a/docs/collections/_commands/Get-PASSafeShareLogo.md
+++ b/docs/collections/_commands/Get-PASSafeShareLogo.md
@@ -21,6 +21,8 @@ Get-PASSafeShareLogo [-ImageType] <String> [<CommonParameters>]
 ## DESCRIPTION
 Gets configuration details of logo displayed in the SafeShare WebGUI
 
+Depreciated from version 13.2
+
 ## EXAMPLES
 
 ### EXAMPLE 1

--- a/docs/collections/_commands/Get-PASServerWebService.md
+++ b/docs/collections/_commands/Get-PASServerWebService.md
@@ -16,7 +16,7 @@ Returns details of the Web Service
 
 ```
 Get-PASServerWebService [[-WebSession] <WebRequestSession>] [-BaseURI] <String> [[-PVWAAppName] <String>]
- [<CommonParameters>]
+ [-UseGen1API] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -80,6 +80,21 @@ Aliases:
 Required: False
 Position: 3
 Default value: PasswordVault
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -UseGen1API
+Force use of Gen1 API for request.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: UseClassicAPI
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```

--- a/docs/collections/_commands/Invoke-PASCPMOperation.md
+++ b/docs/collections/_commands/Invoke-PASCPMOperation.md
@@ -90,6 +90,8 @@ Invoke-PASCPMOperation -AccountID $ID -ChangeTask -ImmediateChangeByCPM Yes
 
 Marks an account for immediate change using the Gen1 API
 
+Depreciated from version 13.2
+
 ### EXAMPLE 4
 ```
 Invoke-PASCPMOperation -AccountID $ID -ChangeTask
@@ -259,6 +261,8 @@ Accept wildcard characters: False
 Yes/No value, dictating if the account will be scheduled for immediate change.
 
 Specify Yes to initiate a password change by CPM - Relevant for Gen1 API only.
+
+Depreciated from version 13.2
 
 ```yaml
 Type: String

--- a/docs/collections/_commands/Set-PASSafe.md
+++ b/docs/collections/_commands/Set-PASSafe.md
@@ -194,7 +194,7 @@ Accept wildcard characters: False
 ### -NumberOfDaysRetention
 The number of days for which password versions are saved in the Safe.
 
-- Minimum Value: 1
+- Minimum Value: 0
 - Maximum Value: 3650
 Specify either this parameter or NumberOfVersionsRetention
 

--- a/docs/collections/_posts/2023-09-06-pspas-release-6-0.md
+++ b/docs/collections/_posts/2023-09-06-pspas-release-6-0.md
@@ -1,0 +1,57 @@
+---
+title:  "psPAS Release 6.0"
+date:   2023-10-06 00:00:00
+tags:
+  - Release Notes
+  - New-PASSession
+  - IdentityCommand
+  - Add-PASSafeMember
+  - Set-PASSafe
+  - Get-PASServerWebService
+  - Get-PASSafeShareLogo
+  - Invoke-PASCPMOperation
+  - Get-PASAccountActivity
+  - Add-PASPendingAccount
+  - Get-PASAccount
+
+---
+
+## **6.0.18**
+
+### Added
+- N/A
+
+### Changed
+- `Set-PASSafe`
+  - Allows `0` as valid value for parameter `NumberOfDaysRetention`
+- `Get-PASServerWebService`
+  - Depreciates Gen1 endpoint from 13.2. Adds Gen2 endpoint as default.
+- `Get-PASSafeShareLogo`
+  - Depreciates command from 13.2.
+- `Invoke-PASCPMOperation`
+  - Depreciates Gen1 endpoint from 13.2.
+- `Get-PASAccountActivity`
+  - Depreciates command from 13.2.
+- `Add-PASPendingAccount`
+  - Depreciates command from 13.2.
+
+### Fixed
+- `Get-PASAccount`
+  - Resolves issue where, if number of results of a `SavedFilter` are greater than the page size (either default or set via the `limit` parameter), only the URL of the first request sent would include the SavedFilter value.
+
+## **6.0.4**
+
+- Updated
+  - `Add-PASSafeMember`
+    - Adds 'Role' to acceptable values in ParameterSet for `memberType` parameter
+
+## **6.0.0**
+
+- Update & Breaking Change
+  - `New-PASSession`
+    - **All Privilege Cloud Shared Services Authentication via the CyberArk Identity Platform now depends on the pspete `IdentityCommand` module.**
+    - Adds Identity User Authentication, using the `IdentityCommand` module to satisfy Identity MFA challenges and obtain required authentication token to use against Privileged Cloud Shared Services.
+    - Adds logic to determine correct Identity tenant URL based on provided Privileged Cloud Subdomain value.
+    - Both Privileged Cloud API URL & Identity Portal URL are required to be specified if subdomain value is not provided.
+    - Service User authentication for Shared Services introduced in recent previous versions requires installation of `IdentityCommand` module and specification of additional attribute.
+    - See [the docs](https://pspas.pspete.dev/docs/authentication/#shared-services-authentication) & [New-PASSession](https://pspas.pspete.dev/commands/New-PASSession) for full details.

--- a/psPAS/Functions/Accounts/Add-PASPendingAccount.ps1
+++ b/psPAS/Functions/Accounts/Add-PASPendingAccount.ps1
@@ -138,7 +138,10 @@ function Add-PASPendingAccount {
 		[string]$MachineOSFamily
 	)
 
-	BEGIN { }#begin
+	BEGIN {
+		#!Depreciated above 13.2
+		Assert-VersionRequirement -MaximumVersion 13.2
+	}#begin
 
 	PROCESS {
 

--- a/psPAS/Functions/Accounts/Get-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccount.ps1
@@ -280,8 +280,11 @@ function Get-PASAccount {
 
 				default {
 
+					#Get default parameters to pass to Get-NextLink
+					$DefaultParams = $PSBoundParameters | Get-PASParameter -ParametersToKeep SavedFilter, TimeoutSec
+
 					#return list
-					$return = $Result | Get-NextLink -TimeoutSec $TimeoutSec
+					$return = $Result | Get-NextLink @DefaultParams
 
 					break
 

--- a/psPAS/Functions/Accounts/Get-PASAccountActivity.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccountActivity.ps1
@@ -12,7 +12,10 @@ function Get-PASAccountActivity {
 
 	)
 
-	BEGIN { }#begin
+	BEGIN {
+		#!Depreciated above 13.2
+		Assert-VersionRequirement -MaximumVersion 13.2
+	}#begin
 
 	PROCESS {
 

--- a/psPAS/Functions/Accounts/Invoke-PASCPMOperation.ps1
+++ b/psPAS/Functions/Accounts/Invoke-PASCPMOperation.ps1
@@ -127,6 +127,9 @@ function Invoke-PASCPMOperation {
 
 			'ChangeCredentials' {
 
+				#!Depreciated above 13.2
+				Assert-VersionRequirement -MaximumVersion 13.2
+
 				#add ImmediateChangeByCPM to header as key=value pair
 				$ThisRequest['WebSession'].Headers['ImmediateChangeByCPM'] = $ImmediateChangeByCPM
 

--- a/psPAS/Functions/Safes/Set-PASSafe.ps1
+++ b/psPAS/Functions/Safes/Set-PASSafe.ps1
@@ -75,7 +75,7 @@ function Set-PASSafe {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Gen1-NumberOfDaysRetention'
 		)]
-		[ValidateRange(1, 3650)]
+		[ValidateRange(0, 3650)]
 		[int]$NumberOfDaysRetention,
 
 		[parameter(

--- a/psPAS/Functions/ServerWebServices/Get-PASSafeShareLogo.ps1
+++ b/psPAS/Functions/ServerWebServices/Get-PASSafeShareLogo.ps1
@@ -9,7 +9,10 @@ function Get-PASSafeShareLogo {
 		[String]$ImageType
 	)
 
-	BEGIN { }#begin
+	BEGIN {
+		#!Depreciated above 13.2
+		Assert-VersionRequirement -MaximumVersion 13.2
+	}#begin
 
 	PROCESS {
 

--- a/psPAS/Functions/ServerWebServices/Get-PASServerWebService.ps1
+++ b/psPAS/Functions/ServerWebServices/Get-PASServerWebService.ps1
@@ -18,15 +18,41 @@ function Get-PASServerWebService {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[string]$PVWAAppName = 'PasswordVault'
+		[string]$PVWAAppName = 'PasswordVault',
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[Alias('UseClassicAPI')]
+		[switch]$UseGen1API
+
 	)
 
 	BEGIN { }#begin
 
 	PROCESS {
 
-		#Create URL for request
-		$URI = "$BaseURI/$PVWAAppName/WebServices/PIMServices.svc/Verify"
+		switch ($PSBoundParameters.Keys) {
+
+			'UseGen1API' {
+				#!Depreciated above 13.2
+				Assert-VersionRequirement -MaximumVersion 13.2
+
+				#Create URL for request
+				$URI = "$BaseURI/$PVWAAppName/WebServices/PIMServices.svc/Verify"
+
+				break
+			}
+
+			default {
+
+				#Create URL for request
+				$URI = "$BaseURI/$PVWAAppName/API/verify/"
+
+			}
+
+		}
 
 		#send request to web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $WebSession
@@ -34,7 +60,7 @@ function Get-PASServerWebService {
 		If ($null -ne $result) {
 
 			#return results
-			$result | Select-Object ServerName, ServerId, ApplicationName , AuthenticationMethods
+			$result | Select-Object ServerName, ServerId, ApplicationName , AuthenticationMethods, Features
 
 		}
 

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -35458,7 +35458,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           <maml:name>NumberOfDaysRetention</maml:name>
           <maml:description>
             <maml:para>The number of days for which password versions are saved in the Safe.</maml:para>
-            <maml:para>- Minimum Value: 1</maml:para>
+            <maml:para>- Minimum Value: 0</maml:para>
             <maml:para>- Maximum Value: 3650</maml:para>
             <maml:para>Specify either this parameter or NumberOfVersionsRetention</maml:para>
           </maml:description>
@@ -35577,7 +35577,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           <maml:name>NumberOfDaysRetention</maml:name>
           <maml:description>
             <maml:para>The number of days for which password versions are saved in the Safe.</maml:para>
-            <maml:para>- Minimum Value: 1</maml:para>
+            <maml:para>- Minimum Value: 0</maml:para>
             <maml:para>- Maximum Value: 3650</maml:para>
             <maml:para>Specify either this parameter or NumberOfVersionsRetention</maml:para>
           </maml:description>
@@ -35707,7 +35707,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         <maml:name>NumberOfDaysRetention</maml:name>
         <maml:description>
           <maml:para>The number of days for which password versions are saved in the Safe.</maml:para>
-          <maml:para>- Minimum Value: 1</maml:para>
+          <maml:para>- Minimum Value: 0</maml:para>
           <maml:para>- Maximum Value: 3650</maml:para>
           <maml:para>Specify either this parameter or NumberOfVersionsRetention</maml:para>
         </maml:description>

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -5288,6 +5288,7 @@ Add-PASDiscoveredAccount -UserName ServiceUser -Address 1.2.3.4 -discoveryDate (
     <maml:description>
       <maml:para>Enables an account or SSH key that is discovered by an external scanner to be added as a pending account to the Accounts Feed.</maml:para>
       <maml:para>Users can identify privileged accounts and determine which are on-boarded to the vault.</maml:para>
+      <maml:para>Depreciated from version 13.2</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -11616,6 +11617,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
     </command:details>
     <maml:description>
       <maml:para>Returns activities for a specific account identified by its AccountID.</maml:para>
+      <maml:para>Depreciated from version 13.2</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -17858,6 +17860,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
     </command:details>
     <maml:description>
       <maml:para>Gets configuration details of logo displayed in the SafeShare WebGUI</maml:para>
+      <maml:para>Depreciated from version 13.2</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -18018,6 +18021,17 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           </dev:type>
           <dev:defaultValue>PasswordVault</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="UseClassicAPI">
+          <maml:name>UseGen1API</maml:name>
+          <maml:description>
+            <maml:para>Force use of Gen1 API for request.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
@@ -18058,6 +18072,18 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           <maml:uri />
         </dev:type>
         <dev:defaultValue>PasswordVault</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="UseClassicAPI">
+        <maml:name>UseGen1API</maml:name>
+        <maml:description>
+          <maml:para>Force use of Gen1 API for request.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes />
@@ -19097,6 +19123,7 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
           <maml:description>
             <maml:para>Yes/No value, dictating if the account will be scheduled for immediate change.</maml:para>
             <maml:para>Specify Yes to initiate a password change by CPM - Relevant for Gen1 API only.</maml:para>
+            <maml:para>Depreciated from version 13.2</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -19510,6 +19537,7 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
         <maml:description>
           <maml:para>Yes/No value, dictating if the account will be scheduled for immediate change.</maml:para>
           <maml:para>Specify Yes to initiate a password change by CPM - Relevant for Gen1 API only.</maml:para>
+          <maml:para>Depreciated from version 13.2</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -19598,6 +19626,7 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
         <dev:code>Invoke-PASCPMOperation -AccountID $ID -ChangeTask -ImmediateChangeByCPM Yes</dev:code>
         <dev:remarks>
           <maml:para>Marks an account for immediate change using the Gen1 API</maml:para>
+          <maml:para>Depreciated from version 13.2</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
<!--
Please include a summary of the change and which issue is fixed & relevant motivation and context.
Put `Fixes #XXX` in your comment to link the issue that your PR fixes.
-->

### Changed
- `Set-PASSafe`
  - Allows `0` as valid value for parameter `NumberOfDaysRetention`
- `Get-PASServerWebService`
  - Depreciates Gen1 endpoint from 13.2. Adds Gen2 endpoint as default.
- `Get-PASSafeShareLogo`
  - Depreciates command from 13.2.
- `Invoke-PASCPMOperation`
  - Depreciates Gen1 endpoint from 13.2.
- `Get-PASAccountActivity`
  - Depreciates command from 13.2.
- `Add-PASPendingAccount`
  - Depreciates command from 13.2.

### Fixed
- `Get-PASAccount`
  - Resolves issue where, if number of results of a `SavedFilter` are greater than the page size (either default or set via the `limit` parameter), only the URL of the first request sent would include the SavedFilter value.
  - 
Fixes #493 
Fixes #491

## Type of change
<!--
Please select all relevant options:
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [X] Documentation update (psPAS website or command help content)
- [X] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [X] Pester test(s) updated
- [X] Pester test(s) passing

**Test Configuration**:
- PowerShell version: 7
- CyberArk PAS version: 13.2
- OS Version: Win 11

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [X] My code follows the style guidelines of this project
- [X] I have followed the contributing guidelines.
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new test failures or errors
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [X] I have linked a related issue