### PR TITLE
FIX invalid parameter expirationdate when adding application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
  - N/A
 
  ### Fixed
- - N/A
+ - `Add-PASApplication`
+   - Updates date format of `ExpirationDate` to `MM/dd/yyyy`. Resolves issue observed when sending date format of `MM-dd-yyyy`
 
 ## **6.0.21**
 

--- a/psPAS/Functions/Applications/Add-PASApplication.ps1
+++ b/psPAS/Functions/Applications/Add-PASApplication.ps1
@@ -91,7 +91,7 @@ function Add-PASApplication {
 		If ($PSBoundParameters.ContainsKey('ExpirationDate')) {
 
 			#Convert ExpiryDate to string in Required format
-			$Date = (Get-Date $ExpirationDate -Format MM-dd-yyyy).ToString()
+			$Date = (Get-Date $ExpirationDate -Format MM/dd/yyyy).ToString()
 
 			#Include date string in request
 			$boundParameters['ExpirationDate'] = $Date


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
<!--
Please include a summary of the change and which issue is fixed & relevant motivation and context.
Put `Fixes #XXX` in your comment to link the issue that your PR fixes.
-->
Updates date format of `ExpirationDate` to `MM/dd/yyyy`. Resolves issue observed when sending date format of `MM-dd-yyyy`
Fixes #501 

## Type of change
<!--
Please select all relevant options:
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [ ] Documentation update (psPAS website or command help content)
- [ ] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [ ] Pester test(s) updated
- [X] Pester test(s) passing

**Test Configuration**:
- PowerShell version: 7
- CyberArk PAS version: 13.2
- OS Version: Win11

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [X] My code follows the style guidelines of this project
- [X] I have followed the contributing guidelines.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new test failures or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have opened & linked a related issue
- [ ] I have linked a related issue