### PR TITLE
psPAS 6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,36 @@
 ### Added
 - N/A
 
+## **6.2.##**
+
+### Added
+- N/A
+
+### Updated
+- `Get-PASSession`
+  - makes additional information available to users running the command
+    - authentication time
+    - session length
+    - last command and result data
+    - last error details
+- `New-PASPSMSession`
+  - RDP and PSMGW connections will be automatically opened when issuing  connection request.
+- `New-PASSession`
+  - Adds logic around getting the logged on user name for either self-hosted or privilege cloud deployments
+- PSM Session Data Formats
+  - Adds `Start` & `End` to standard table view output
+  - Formats `Start` & `End` as standard datetime instead of unixtime.
+
+### Fixed
+- `Add-PASGroupMember`,`Remove-PASGroup`,`Set-PASGroup`
+  - Standardises name of `ID` parameter.
+  - Adds `GroupID` alias to `ID` parameter.
+
+## **6.1.62**
+
+### Added
+- N/A
+
 ### Updated
 - `Get-PASPSMRecording`
   - Removes `Offset` Parameter

--- a/Tests/Add-PASAccount.Tests.ps1
+++ b/Tests/Add-PASAccount.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -115,7 +125,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 					'remoteMachines'                   = 'someMachine'
 					'accessRestrictedToRemoteMachines' = $false
 				}
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 
 			}
 
@@ -133,7 +143,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Account"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Account"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -145,7 +155,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Accounts"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Accounts"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -237,9 +247,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'throws error if version requirement not met' {
 
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObjV10 | Add-PASAccount } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 
 			}
 
@@ -269,7 +279,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 					'automaticManagementEnabled' = $true
 					'remoteMachines'             = 'someMachine'
 				}
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 
 			}
 

--- a/Tests/Add-PASAccountACL.Tests.ps1
+++ b/Tests/Add-PASAccountACL.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -84,7 +94,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Account/ServerA.domain.com|root|UNIXSSH/PrivilegedCommands/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Account/ServerA.domain.com|root|UNIXSSH/PrivilegedCommands/"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Add-PASAccountGroupMember.Tests.ps1
+++ b/Tests/Add-PASAccountGroupMember.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -80,7 +90,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/AccountGroups/88_8/Members"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/AccountGroups/88_8/Members"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -111,10 +121,10 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObj | Add-PASAccountGroupMember } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Add-PASAllowedReferrer.Tests.ps1
+++ b/Tests/Add-PASAllowedReferrer.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -54,7 +64,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/AccessRestriction/AllowedReferrers"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Configuration/AccessRestriction/AllowedReferrers"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -77,9 +87,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Add-PASAllowedReferrer -referrerURL 'SomeURLValue' } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Add-PASApplication.Tests.ps1
+++ b/Tests/Add-PASApplication.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -87,7 +97,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Applications"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Applications"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Add-PASApplicationAuthenticationMethod.Tests.ps1
+++ b/Tests/Add-PASApplicationAuthenticationMethod.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -79,7 +89,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Applications/SomeApplication/Authentications/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Applications/SomeApplication/Authentications/"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Add-PASAuthenticationMethod.Tests.ps1
+++ b/Tests/Add-PASAuthenticationMethod.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -54,7 +64,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/AuthenticationMethods"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Configuration/AuthenticationMethods"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -75,9 +85,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Add-PASAuthenticationMethod -id SomeID } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Add-PASDirectory.Tests.ps1
+++ b/Tests/Add-PASDirectory.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -66,7 +76,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/LDAP/Directories"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Configuration/LDAP/Directories"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -97,10 +107,10 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObj | Add-PASDirectory } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Add-PASDiscoveredAccount.Tests.ps1
+++ b/Tests/Add-PASDiscoveredAccount.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -79,7 +89,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Add-PASDiscoveredAccount
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/DiscoveredAccounts"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/DiscoveredAccounts"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -118,11 +128,11 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.2'
+				$psPASSession.ExternalVersion = '1.2'
 
 				{ $InputObj | Add-PASDiscoveredAccount } | Should -Throw
 
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 
 			}
 

--- a/Tests/Add-PASGroupMember.Tests.ps1
+++ b/Tests/Add-PASGroupMember.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -85,7 +95,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Groups/SomeGroup/Users/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Groups/SomeGroup/Users/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -97,7 +107,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/UserGroups/$($InputObjV10.groupId)/Members"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/UserGroups/$($InputObjV10.groupId)/Members"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -160,13 +170,13 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 
 				{ $InputObjV10 | Add-PASGroupMember } | Should -Throw
 
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 
 			}
 

--- a/Tests/Add-PASOpenIDConnectProvider.Tests.ps1
+++ b/Tests/Add-PASOpenIDConnectProvider.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -36,7 +46,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		BeforeEach {
-			$Script:ExternalVersion = '0.0'
+			$psPASSession.ExternalVersion = '0.0'
 
 			Mock Invoke-PASRestMethod -MockWith {
 				[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
@@ -70,7 +80,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/OIDC/Providers"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Configuration/OIDC/Providers"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -95,9 +105,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObject | Add-PASOpenIDConnectProvider } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Add-PASPTAExcludedTarget.Tests.ps1
+++ b/Tests/Add-PASPTAExcludedTarget.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -80,7 +90,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/api/pta/API/Administration/properties/CidrExclusionList"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/api/pta/API/Administration/properties/CidrExclusionList"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -112,11 +122,11 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
             It 'throws error if version requirement not met' {
 
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
 
                 { $InputObj | Add-PASPTAExcludedTarget } | Should -Throw
 
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }

--- a/Tests/Add-PASPTAGlobalCatalog.Tests.ps1
+++ b/Tests/Add-PASPTAGlobalCatalog.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -89,7 +99,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/API/pta/API/Administration/GCConnectivity"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/API/pta/API/Administration/GCConnectivity"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -127,11 +137,11 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
             It 'throws error if version requirement not met' {
 
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
 
                 { $InputObj | Add-PASPTAGlobalCatalog } | Should -Throw
 
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }

--- a/Tests/Add-PASPTAIncludedTarget.Tests.ps1
+++ b/Tests/Add-PASPTAIncludedTarget.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+            BaseURI            = 'https://SomeURL/SomeApp'
+            User               = $null
+            ExternalVersion    = [System.Version]'0.0'
+            WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+            StartTime          = $null
+            ElapsedTime        = $null
+            LastCommand        = $null
+            LastCommandTime    = $null
+            LastCommandResults = $null
+        }
+
+        New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -80,7 +90,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/api/pta/API/Administration/properties/CidrInclusionList"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/api/pta/API/Administration/properties/CidrInclusionList"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -112,11 +122,11 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
             It 'throws error if version requirement not met' {
 
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
 
                 { $InputObj | Add-PASPTAIncludedTarget } | Should -Throw
 
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }

--- a/Tests/Add-PASPTAPrivilegedGroup.Tests.ps1
+++ b/Tests/Add-PASPTAPrivilegedGroup.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -82,7 +92,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/API/pta/API/configuration/properties/PrivilegedDomainGroupsList"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/API/pta/API/configuration/properties/PrivilegedDomainGroupsList"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -114,11 +124,11 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
             It 'throws error if version requirement not met' {
 
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
 
                 { $InputObj | Add-PASPTAPrivilegedGroup } | Should -Throw
 
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }

--- a/Tests/Add-PASPTAPrivilegedUser.Tests.ps1
+++ b/Tests/Add-PASPTAPrivilegedUser.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -82,7 +92,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/API/pta/API/configuration/properties/PrivilegedUsersList"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/API/pta/API/configuration/properties/PrivilegedUsersList"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -114,11 +124,11 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
             It 'throws error if version requirement not met' {
 
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
 
                 { $InputObj | Add-PASPTAPrivilegedUser } | Should -Throw
 
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }

--- a/Tests/Add-PASPTARule.Tests.ps1
+++ b/Tests/Add-PASPTARule.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -92,7 +102,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/pta/API/Settings/RiskyActivity/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/pta/API/Settings/RiskyActivity/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -135,11 +145,11 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'throws error if version requirement not met' {
 
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 
 				{ $InputObj | Add-PASPTARule } | Should -Throw
 
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Add-PASPendingAccount.Tests.ps1
+++ b/Tests/Add-PASPendingAccount.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -98,7 +108,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled 'Invoke-PASRestMethod' -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/PendingAccounts"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/PendingAccounts"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Add-PASPersonalAdminAccount.Tests.ps1
+++ b/Tests/Add-PASPersonalAdminAccount.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -49,7 +59,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
                     'secret'   = $secureString
                 }
 
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
 
             }
 
@@ -67,7 +77,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/api/Accounts/PersonalAdminAccount"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/api/Accounts/PersonalAdminAccount"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -95,9 +105,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
             It 'throws error if version requirement not met' {
 
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
                 { $InputObj | Add-PASPersonalAdminAccount } | Should -Throw
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
 
             }
 
@@ -123,7 +133,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
                     'userName' = 'SomeUser'
                     'secret'   = $secureString
                 }
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
 
             }
 

--- a/Tests/Add-PASPolicyACL.Tests.ps1
+++ b/Tests/Add-PASPolicyACL.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -85,7 +95,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Policy/UNIXSSH/PrivilegedCommands/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Policy/UNIXSSH/PrivilegedCommands/"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Add-PASPublicSSHKey.Tests.ps1
+++ b/Tests/Add-PASPublicSSHKey.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -80,7 +90,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/SomeUser%40domain.com/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Users/SomeUser%40domain.com/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys/"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Add-PASSafe.Tests.ps1
+++ b/Tests/Add-PASSafe.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -100,7 +110,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Safes"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Safes"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -159,7 +169,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Safes"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Safes"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -189,9 +199,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			}
 			It 'throws error if version 12.0 requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Add-PASSafe -SafeName SomeSafe -NumberOfVersionsRetention 1 } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Add-PASSafeMember.Tests.ps1
+++ b/Tests/Add-PASSafeMember.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -140,7 +150,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Safes/SomeSafe/Members"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Safes/SomeSafe/Members"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -183,9 +193,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version exceeds 12.2' {
-				$Script:ExternalVersion = '12.3'
+				$psPASSession.ExternalVersion = '12.3'
 				{ Find-PASSafe } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}
@@ -258,7 +268,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Safes/SomeSafe/Members"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Safes/SomeSafe/Members"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -289,9 +299,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObj | Add-PASSafeMember } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Approve-PASRequest.Tests.ps1
+++ b/Tests/Approve-PASRequest.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -45,7 +55,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			Mock Invoke-PASRestMethod -MockWith {
 
 			}
-			$Script:ExternalVersion = '9.10'
+			$psPASSession.ExternalVersion = '9.10'
 			$response = $InputObj | Approve-PASRequest
 		}
 
@@ -80,7 +90,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/IncomingRequests/24_68/Confirm"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/IncomingRequests/24_68/Confirm"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -111,9 +121,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObj | Approve-PASRequest } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Assert-VersionRequirement.Tests.ps1
+++ b/Tests/Assert-VersionRequirement.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 

--- a/Tests/Clear-PASDiscoveredAccountList.Tests.ps1
+++ b/Tests/Clear-PASDiscoveredAccountList.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -36,7 +46,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
     InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
         BeforeEach {
-            $Script:ExternalVersion = '0.0'
+            $psPASSession.ExternalVersion = '0.0'
 
             Mock Invoke-PASRestMethod -MockWith {
 
@@ -58,7 +68,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/api/DiscoveredAccounts"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/api/DiscoveredAccounts"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -71,9 +81,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             }
 
             It 'throws error if version requirement not met' {
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
                 { $InputObject | Clear-PASDiscoveredAccountList } | Should -Throw
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }

--- a/Tests/Clear-PASLinkedAccount.Tests.ps1
+++ b/Tests/Clear-PASLinkedAccount.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -36,7 +46,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
     InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
         BeforeEach {
-            $Script:ExternalVersion = '0.0'
+            $psPASSession.ExternalVersion = '0.0'
 
             Mock Invoke-PASRestMethod -MockWith {
 
@@ -58,7 +68,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/api/Accounts/12_34/LinkAccount/2"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/api/Accounts/12_34/LinkAccount/2"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -71,9 +81,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             }
 
             It 'throws error if version requirement not met' {
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
                 { $InputObject | Clear-PASLinkedAccount -AccountID 12_34 -extraPasswordIndex 2 } | Should -Throw
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }

--- a/Tests/Clear-PASPrivateSSHKey.Tests.ps1
+++ b/Tests/Clear-PASPrivateSSHKey.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -36,7 +46,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
     InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
         BeforeEach {
-            $Script:ExternalVersion = '0.0'
+            $psPASSession.ExternalVersion = '0.0'
 
             Mock Invoke-PASRestMethod -MockWith {
 
@@ -58,7 +68,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/api/Users/Secret/SSHKeys/ClearCache"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/api/Users/Secret/SSHKeys/ClearCache"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -71,9 +81,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             }
 
             It 'throws error if version requirement not met' {
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
                 { $InputObject | Clear-PASPrivateSSHKey } | Should -Throw
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }

--- a/Tests/Close-PASSession.Tests.ps1
+++ b/Tests/Close-PASSession.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -60,7 +70,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/auth/Cyberark/CyberArkAuthenticationService.svc/Logoff"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/auth/Cyberark/CyberArkAuthenticationService.svc/Logoff"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -83,7 +93,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$response = Close-PASSession
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Auth/Logoff"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Auth/Logoff"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -94,7 +104,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$response = Close-PASSession -SAMLAuthentication
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/auth/SAML/SAMLAuthenticationService.svc/Logoff"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/auth/SAML/SAMLAuthenticationService.svc/Logoff"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -105,7 +115,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$response = Close-PASSession -SharedAuthentication
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/auth/Shared/RestfulAuthenticationService.svc/Logoff"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/auth/Shared/RestfulAuthenticationService.svc/Logoff"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Compare-MaximumVersion.Tests.ps1
+++ b/Tests/Compare-MaximumVersion.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 

--- a/Tests/Compare-MinimumVersion.Tests.ps1
+++ b/Tests/Compare-MinimumVersion.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 

--- a/Tests/Connect-PASPSMSession.Tests.ps1
+++ b/Tests/Connect-PASPSMSession.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -54,9 +64,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			BeforeEach {
 
-				$Script:BaseURI = 'https://SomeURL/SomeApp'
-				$Script:ExternalVersion = '0.0'
-				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+				$Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+				$psPASSession.ExternalVersion = '0.0'
+				$psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 				Mock Invoke-PASRestMethod -MockWith {
 
@@ -82,7 +92,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Connect-PASPSMSession
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/LiveSessions/SomeSession/monitor"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/LiveSessions/SomeSession/monitor"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -127,9 +137,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '9.8'
+				$psPASSession.ExternalVersion = '9.8'
 				{ $InputObj | Connect-PASPSMSession -ConnectionMethod RDP } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}
@@ -138,9 +148,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			BeforeEach {
 
-				$Script:BaseURI = 'https://SomeURL/SomeApp'
-				$Script:ExternalVersion = '0.0'
-				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+				$Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+				$psPASSession.ExternalVersion = '0.0'
+				$psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 				Mock Invoke-PASRestMethod -MockWith {
 

--- a/Tests/ConvertFrom-KeyValuePair.Tests.ps1
+++ b/Tests/ConvertFrom-KeyValuePair.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 

--- a/Tests/ConvertTo-BulkFilterItem.Tests.ps1
+++ b/Tests/ConvertTo-BulkFilterItem.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 

--- a/Tests/ConvertTo-ConnectionParam.Tests.ps1
+++ b/Tests/ConvertTo-ConnectionParam.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 

--- a/Tests/ConvertTo-FilterString.Tests.ps1
+++ b/Tests/ConvertTo-FilterString.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 

--- a/Tests/ConvertTo-InsecureString.Tests.ps1
+++ b/Tests/ConvertTo-InsecureString.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 

--- a/Tests/ConvertTo-QueryString.Tests.ps1
+++ b/Tests/ConvertTo-QueryString.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 

--- a/Tests/ConvertTo-SortedPermission.Tests.ps1
+++ b/Tests/ConvertTo-SortedPermission.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 

--- a/Tests/ConvertTo-UnixTime.Tests.ps1
+++ b/Tests/ConvertTo-UnixTime.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 

--- a/Tests/Copy-PASPlatform.Tests.ps1
+++ b/Tests/Copy-PASPlatform.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '11.4'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'11.4'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -80,7 +90,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Platforms/targets/1234/duplicate"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Platforms/targets/1234/duplicate"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -90,7 +100,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$response = $InputObj | Copy-PASPlatform -DependentPlatform
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Platforms/dependents/1234/duplicate"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Platforms/dependents/1234/duplicate"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -101,7 +111,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$response = $InputObj | Copy-PASPlatform -RotationalGroup
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Platforms/rotationalGroups/1234/duplicate"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Platforms/rotationalGroups/1234/duplicate"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -112,7 +122,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$response = $InputObj | Copy-PASPlatform -GroupPlatform
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Platforms/groups/1234/duplicate"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Platforms/groups/1234/duplicate"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -143,9 +153,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '11.0'
+				$psPASSession.ExternalVersion = '11.0'
 				{ $InputObj | Copy-PASPlatform -GroupPlatform } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}
@@ -154,7 +164,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			BeforeEach {
 
-				$Script:ExternalVersion = '11.4'
+				$psPASSession.ExternalVersion = '11.4'
 				Mock Invoke-PASRestMethod -MockWith {
 					[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
 				}

--- a/Tests/Deny-PASRequest.Tests.ps1
+++ b/Tests/Deny-PASRequest.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -79,7 +89,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/IncomingRequests/24_68/Reject"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/IncomingRequests/24_68/Reject"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -110,9 +120,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObj | Deny-PASRequest } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Disable-PASCPMAutoManagement.Tests.ps1
+++ b/Tests/Disable-PASCPMAutoManagement.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -71,11 +81,11 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'throws error if version requirement not met' {
 
-				$Script:ExternalVersion = '1.2'
+				$psPASSession.ExternalVersion = '1.2'
 
 				{ $InputObj | Disable-PASCPMAutoManagement } | Should -Throw
 
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 
 			}
 

--- a/Tests/Disable-PASPlatform.Tests.ps1
+++ b/Tests/Disable-PASPlatform.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -77,7 +87,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Disable-PASPlatform -TargetPlatform
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Platforms/targets/1234/deactivate"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Platforms/targets/1234/deactivate"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -87,7 +97,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Disable-PASPlatform -GroupPlatform
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Platforms/groups/1234/deactivate"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Platforms/groups/1234/deactivate"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -97,7 +107,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Disable-PASPlatform -RotationalGroup
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Platforms/rotationalGroups/1234/deactivate"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Platforms/rotationalGroups/1234/deactivate"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Disable-PASUser.Tests.ps1
+++ b/Tests/Disable-PASUser.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -74,7 +84,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
                 Disable-PASUser -id 1234
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/API/Users/1234/disable/"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/API/Users/1234/disable/"
 
                 } -Times 1 -Exactly -Scope It
 

--- a/Tests/Enable-PASCPMAutoManagement.Tests.ps1
+++ b/Tests/Enable-PASCPMAutoManagement.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -69,10 +79,10 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.2'
+				$psPASSession.ExternalVersion = '1.2'
 
 				{ $InputObj | Enable-PASCPMAutoManagement } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Enable-PASPlatform.Tests.ps1
+++ b/Tests/Enable-PASPlatform.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -77,7 +87,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Enable-PASPlatform -TargetPlatform
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Platforms/targets/1234/activate"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Platforms/targets/1234/activate"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -87,7 +97,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Enable-PASPlatform -GroupPlatform
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Platforms/groups/1234/activate"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Platforms/groups/1234/activate"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -97,7 +107,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Enable-PASPlatform -RotationalGroup
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Platforms/rotationalGroups/1234/activate"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Platforms/rotationalGroups/1234/activate"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Enable-PASUser.Tests.ps1
+++ b/Tests/Enable-PASUser.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -74,7 +84,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
                 Enable-PASUser -id 1234
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/API/Users/1234/enable/"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/API/Users/1234/enable/"
 
                 } -Times 1 -Exactly -Scope It
 

--- a/Tests/Export-PASPSMRecording.Tests.ps1
+++ b/Tests/Export-PASPSMRecording.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -96,7 +106,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Export-PASPSMRecording
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Recordings/SomeID/Play"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Recordings/SomeID/Play"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -115,10 +125,10 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '10.5'
+				$psPASSession.ExternalVersion = '10.5'
 
 				{ $InputObj | Export-PASPSMRecording } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Export-PASPlatform.Tests.ps1
+++ b/Tests/Export-PASPlatform.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -80,7 +90,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Platforms/SomePlatform/Export?platformID=SomePlatform"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Platforms/SomePlatform/Export?platformID=SomePlatform"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -93,9 +103,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Export-PASPlatform -PlatformID SomePlatform -path "$env:Temp\testExport.zip" } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Find-PASSafe.Tests.ps1
+++ b/Tests/Find-PASSafe.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -37,9 +47,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 		Context 'Input' {
 
-			$Script:BaseURI = 'https://SomeURL/SomeApp'
-			$Script:ExternalVersion = '0.0'
-			$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			$Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+			$psPASSession.ExternalVersion = '0.0'
+			$psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 			BeforeEach {
 
@@ -61,7 +71,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Safes?limit=25"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Safes?limit=25"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -73,7 +83,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Safes?limit=25&search=SomeQuery"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Safes?limit=25&search=SomeQuery"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -92,15 +102,15 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Find-PASSafe } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 			It 'throws error if version exceeds 11.7' {
-				$Script:ExternalVersion = '11.8'
+				$psPASSession.ExternalVersion = '11.8'
 				{ Find-PASSafe } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 			It 'sends expected number of requests' {

--- a/Tests/Format-PASUserObject.Tests.ps1
+++ b/Tests/Format-PASUserObject.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 

--- a/Tests/Get-ByteArray.Tests.ps1
+++ b/Tests/Get-ByteArray.Tests.ps1
@@ -21,9 +21,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 

--- a/Tests/Get-EscapedString.Tests.ps1
+++ b/Tests/Get-EscapedString.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 

--- a/Tests/Get-NextLink.Tests.ps1
+++ b/Tests/Get-NextLink.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -88,7 +98,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Get-NextLink -SavedFilter SomeFilter
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/SomeLink&SavedFilter=SomeFilter"
+					$URI -eq "$($Script:psPASSession.BaseURI)/SomeLink&SavedFilter=SomeFilter"
 
 				} -Times 10 -Exactly -Scope It
 			}

--- a/Tests/Get-PASAccount.Tests.ps1
+++ b/Tests/Get-PASAccount.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -75,7 +85,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Accounts?search=SearchTerm"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Accounts?search=SearchTerm"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -87,7 +97,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Accounts?filter=safeName%20eq%20SomeSafe"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Accounts?filter=safeName%20eq%20SomeSafe"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -99,7 +109,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Accounts?filter=modificationTime%20gte%201577836800"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Accounts?filter=modificationTime%20gte%201577836800"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -111,8 +121,8 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					($URI -eq "$($Script:BaseURI)/api/Accounts?filter=modificationTime%20gte%201577836800%20AND%20safeName%20eq%20SomeSafe") -or
-					($URI -eq "$($Script:BaseURI)/api/Accounts?filter=safeName%20eq%20SomeSafe%20AND%20modificationTime%20gte%201577836800")
+					($URI -eq "$($Script:psPASSession.BaseURI)/api/Accounts?filter=modificationTime%20gte%201577836800%20AND%20safeName%20eq%20SomeSafe") -or
+					($URI -eq "$($Script:psPASSession.BaseURI)/api/Accounts?filter=safeName%20eq%20SomeSafe%20AND%20modificationTime%20gte%201577836800")
 
 				} -Times 1 -Exactly -Scope It
 
@@ -123,7 +133,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				Get-PASAccount -id 'SomeID'
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-					$URI -eq "$($Script:BaseURI)/api/Accounts/SomeID"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Accounts/SomeID"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -134,8 +144,8 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				Get-PASAccount -Keywords SomeValue -Safe SomeSafe
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-					(($URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Accounts?Keywords=SomeValue&Safe=SomeSafe") -or
-						($URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Accounts?Safe=SomeSafe&Keywords=SomeValue"))
+					(($URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Accounts?Keywords=SomeValue&Safe=SomeSafe") -or
+						($URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Accounts?Safe=SomeSafe&Keywords=SomeValue"))
 
 				} -Times 1 -Exactly -Scope It
 
@@ -159,9 +169,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'throws error if version requirement not met' {
 
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Get-PASAccount -id 'SomeID' } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 
 			}
 

--- a/Tests/Get-PASAccountACL.Tests.ps1
+++ b/Tests/Get-PASAccountACL.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -84,7 +94,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Account/ServerA.domain.com|root|UNIXSSH/PrivilegedCommands/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Account/ServerA.domain.com|root|UNIXSSH/PrivilegedCommands/"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Get-PASAccountActivity.Tests.ps1
+++ b/Tests/Get-PASAccountActivity.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -83,7 +93,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Accounts/66_6/Activities"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Accounts/66_6/Activities"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -134,7 +144,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Accounts/66_6/Activities"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Accounts/66_6/Activities"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Get-PASAccountDetail.Tests.ps1
+++ b/Tests/Get-PASAccountDetail.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -89,7 +99,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/api/ExtendedAccounts/66_6/overview"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/api/ExtendedAccounts/66_6/overview"
 
                 } -Times 1 -Exactly -Scope It
 

--- a/Tests/Get-PASAccountGroup.Tests.ps1
+++ b/Tests/Get-PASAccountGroup.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -30,7 +40,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 	AfterAll {
 
 		$Script:RequestBody = $null
-		$Script:ExternalVersion = '0.0'
+		$psPASSession.ExternalVersion = '0.0'
 
 	}
 
@@ -53,7 +63,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		Context 'Input' {
 
 			AfterEach {
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 			It 'sends request' {
@@ -66,7 +76,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/AccountGroups?Safe=SomeSafe"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/AccountGroups?Safe=SomeSafe"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -85,9 +95,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObj | Get-PASAccountGroup } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 			It 'sends request to expected endpoint - Gen1 ParameterSet' {
@@ -96,16 +106,16 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Safes/SomeSafe/AccountGroups"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Safes/SomeSafe/AccountGroups"
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Get-PASAccountGroup -Safe 'SomeSafe' } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}
@@ -113,7 +123,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		Context 'Output' {
 
 			AfterEach {
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 			It 'provides output' {

--- a/Tests/Get-PASAccountGroupMember.Tests.ps1
+++ b/Tests/Get-PASAccountGroupMember.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -78,7 +88,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/AccountGroups/32_1/Members"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/AccountGroups/32_1/Members"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -97,9 +107,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObj | Get-PASAccountGroupMember } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Get-PASAccountImportJob.Tests.ps1
+++ b/Tests/Get-PASAccountImportJob.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -59,7 +69,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				Get-PASAccountImportJob
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/bulkactions/accounts"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/bulkactions/accounts"
 
 				} -Times 1 -Exactly -Scope It
 			}
@@ -68,7 +78,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				Get-PASAccountImportJob -id 1234
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/bulkactions/accounts/1234"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/bulkactions/accounts/1234"
 
 				} -Times 1 -Exactly -Scope It
 			}
@@ -79,10 +89,10 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '11.5'
+				$psPASSession.ExternalVersion = '11.5'
 
 				{ $InputObj | Get-PASAccountImportJob } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Get-PASAccountPassword.Tests.ps1
+++ b/Tests/Get-PASAccountPassword.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -30,7 +40,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 	AfterAll {
 
 		$Script:RequestBody = $null
-		#$Script:ExternalVersion = '0.0'
+		#$psPASSession.ExternalVersion = '0.0'
 	}
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
@@ -67,11 +77,11 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws if version requirement not met' {
-				$Script:ExternalVersion = '1.1'
+				$psPASSession.ExternalVersion = '1.1'
 
 				{ $InputObject | Get-PASAccountPassword } | Should -Throw -ExpectedMessage 'CyberArk 1.1 does not meet the minimum version requirement of 10.1 for Get-PASAccountPassword (using ParameterSet: Gen2)'
 
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 
 			}
 

--- a/Tests/Get-PASAccountPasswordVersion.Tests.ps1
+++ b/Tests/Get-PASAccountPasswordVersion.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -37,9 +47,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
         Context 'Input' {
 
-            $Script:BaseURI = 'https://SomeURL/SomeApp'
-            $Script:ExternalVersion = '0.0'
-            $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+            $Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+            $psPASSession.ExternalVersion = '0.0'
+            $psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
             BeforeEach {
 
@@ -69,7 +79,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/api/Accounts/12_3/Secret/Versions"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/api/Accounts/12_3/Secret/Versions"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -81,7 +91,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/api/Accounts/12_3/Secret/Versions?showTemporary=True"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/api/Accounts/12_3/Secret/Versions?showTemporary=True"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -100,9 +110,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             }
 
             It 'throws error if version requirement not met' {
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
                 { Get-PASAccountPasswordVersion -AccountID 12_3 } | Should -Throw
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }

--- a/Tests/Get-PASAccountSSHKey.Tests.ps1
+++ b/Tests/Get-PASAccountSSHKey.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -39,7 +49,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			BeforeEach {
 
-				$Script:ExternalVersion = 11.5
+				$psPASSession.ExternalVersion = 11.5
 
 				Mock Invoke-PASRestMethod -MockWith { 'PrivateSSHKey!' }
 
@@ -57,7 +67,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws if version requirement not met' {
-				$Script:ExternalVersion = 1.1
+				$psPASSession.ExternalVersion = 1.1
 
 				{ $InputObject | Get-PASAccountSSHKey } | Should -Throw
 

--- a/Tests/Get-PASAllowedReferrer.Tests.ps1
+++ b/Tests/Get-PASAllowedReferrer.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -54,7 +64,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/AccessRestriction/AllowedReferrers"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Configuration/AccessRestriction/AllowedReferrers"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -73,9 +83,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Get-PASAllowedReferrer } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Get-PASApplication.Tests.ps1
+++ b/Tests/Get-PASApplication.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -64,7 +74,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Applications/SomeApplication/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Applications/SomeApplication/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -86,7 +96,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Get-PASApplication
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Applications?AppID=SomeApplication"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Applications?AppID=SomeApplication"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Get-PASApplicationAuthenticationMethod.Tests.ps1
+++ b/Tests/Get-PASApplicationAuthenticationMethod.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -80,7 +90,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Applications/SomeApplication/Authentications/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Applications/SomeApplication/Authentications/"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Get-PASAuthenticationMethod.Tests.ps1
+++ b/Tests/Get-PASAuthenticationMethod.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -54,7 +64,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/AuthenticationMethods/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Configuration/AuthenticationMethods/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -66,7 +76,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/AuthenticationMethods/SomeMethod"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Configuration/AuthenticationMethods/SomeMethod"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -85,9 +95,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Get-PASAuthenticationMethod } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Get-PASComponentDetail.Tests.ps1
+++ b/Tests/Get-PASComponentDetail.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -73,7 +83,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/ComponentsMonitoringDetails/PVWA"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/ComponentsMonitoringDetails/PVWA"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -92,9 +102,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Get-PASComponentDetail -ComponentID PVWA } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Get-PASComponentSummary.Tests.ps1
+++ b/Tests/Get-PASComponentSummary.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -57,7 +67,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/ComponentsMonitoringSummary"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/ComponentsMonitoringSummary"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -76,9 +86,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Get-PASComponentSummary } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Get-PASConnectionComponent.Tests.ps1
+++ b/Tests/Get-PASConnectionComponent.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -54,7 +64,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/PSM/Connectors"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/PSM/Connectors"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -73,9 +83,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Get-PASConnectionComponent } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Get-PASDirectory.Tests.ps1
+++ b/Tests/Get-PASDirectory.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -57,7 +67,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/LDAP/Directories/SomeDir/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Configuration/LDAP/Directories/SomeDir/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -76,9 +86,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Get-PASDirectory } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Get-PASDirectoryMapping.Tests.ps1
+++ b/Tests/Get-PASDirectoryMapping.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -78,7 +88,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/LDAP/Directories/SomeDirectory/Mappings/SomeMapping/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Configuration/LDAP/Directories/SomeDirectory/Mappings/SomeMapping/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -97,9 +107,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObj | Get-PASDirectoryMapping } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Get-PASDiscoveredAccount.Tests.ps1
+++ b/Tests/Get-PASDiscoveredAccount.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -60,7 +70,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				Get-PASDiscoveredAccount
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/DiscoveredAccounts"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/DiscoveredAccounts"
 
 				} -Times 1 -Exactly -Scope It
 			}
@@ -69,7 +79,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				Get-PASDiscoveredAccount -id 456
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/DiscoveredAccounts/456"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/DiscoveredAccounts/456"
 
 				} -Times 1 -Exactly -Scope It
 			}
@@ -77,8 +87,8 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			It 'sends expected filter' {
 				Get-PASDiscoveredAccount -privileged $true -AccountEnabled $true
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-					($URI -eq "$($Script:BaseURI)/api/DiscoveredAccounts?filter=privileged%20eq%20True%20AND%20AccountEnabled%20eq%20True" -or
-					$URI -eq "$($Script:BaseURI)/api/DiscoveredAccounts?filter=AccountEnabled%20eq%20True%20AND%20privileged%20eq%20True")
+					($URI -eq "$($Script:psPASSession.BaseURI)/api/DiscoveredAccounts?filter=privileged%20eq%20True%20AND%20AccountEnabled%20eq%20True" -or
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/DiscoveredAccounts?filter=AccountEnabled%20eq%20True%20AND%20privileged%20eq%20True")
 
 				} -Times 1 -Exactly -Scope It
 			}
@@ -86,8 +96,8 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			It 'sends expected query' {
 				Get-PASDiscoveredAccount -search something -searchType startswith
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-					($URI -eq "$($Script:BaseURI)/api/DiscoveredAccounts?search=something&searchType=startswith" -or
-					$URI -eq "$($Script:BaseURI)/api/DiscoveredAccounts?searchType=startswith&search=something")
+					($URI -eq "$($Script:psPASSession.BaseURI)/api/DiscoveredAccounts?search=something&searchType=startswith" -or
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/DiscoveredAccounts?searchType=startswith&search=something")
 
 				} -Times 1 -Exactly -Scope It
 			}
@@ -95,8 +105,8 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			It 'sends expected query & filter' {
 				Get-PASDiscoveredAccount -search something -privileged $true
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-					($URI -eq "$($Script:BaseURI)/api/DiscoveredAccounts?search=something&filter=privileged%20eq%20True" -or
-					$URI -eq "$($Script:BaseURI)/api/DiscoveredAccounts?filter=privileged%20eq%20True&search=something")
+					($URI -eq "$($Script:psPASSession.BaseURI)/api/DiscoveredAccounts?search=something&filter=privileged%20eq%20True" -or
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/DiscoveredAccounts?filter=privileged%20eq%20True&search=something")
 
 				} -Times 1 -Exactly -Scope It
 			}
@@ -112,10 +122,10 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '11.5'
+				$psPASSession.ExternalVersion = '11.5'
 
 				{ Get-PASDiscoveredAccount } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Get-PASGroup.Tests.ps1
+++ b/Tests/Get-PASGroup.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -53,7 +63,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				Get-PASGroup
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/UserGroups"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/UserGroups"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -63,7 +73,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				Get-PASGroup -id 666
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/UserGroups/666/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/UserGroups/666/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -73,7 +83,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				Get-PASGroup -groupType Vault -search 'Search Term'
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					($URI -eq "$($Script:BaseURI)/API/UserGroups?search=Search%20Term&filter=groupType%20eq%20Vault") -or ($URI -eq "$($Script:BaseURI)/API/UserGroups?filter=groupType%20eq%20Vault&search=Search%20Term")
+					($URI -eq "$($Script:psPASSession.BaseURI)/API/UserGroups?search=Search%20Term&filter=groupType%20eq%20Vault") -or ($URI -eq "$($Script:psPASSession.BaseURI)/API/UserGroups?filter=groupType%20eq%20Vault&search=Search%20Term")
 
 				} -Times 1 -Exactly -Scope It
 
@@ -92,11 +102,11 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.2'
+				$psPASSession.ExternalVersion = '1.2'
 
 				{ Get-PASGroup } | Should -Throw
 
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 
 			}
 

--- a/Tests/Get-PASLinkedAccount.Tests.ps1
+++ b/Tests/Get-PASLinkedAccount.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -85,7 +95,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/api/ExtendedAccounts/66_6/LinkedAccounts"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/api/ExtendedAccounts/66_6/LinkedAccounts"
 
                 } -Times 1 -Exactly -Scope It
 

--- a/Tests/Get-PASLinkedGroup.Tests.ps1
+++ b/Tests/Get-PASLinkedGroup.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -89,7 +99,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/api/ExtendedAccounts/66_6/LinkedAccounts"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/api/ExtendedAccounts/66_6/LinkedAccounts"
 
                 } -Times 1 -Exactly -Scope It
 

--- a/Tests/Get-PASLoggedOnUser.Tests.ps1
+++ b/Tests/Get-PASLoggedOnUser.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -56,7 +66,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/User"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/User"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Get-PASOnboardingRule.Tests.ps1
+++ b/Tests/Get-PASOnboardingRule.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -60,7 +70,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/AutomaticOnboardingRules?Names=SomeRule,SomeRule2"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/AutomaticOnboardingRules?Names=SomeRule,SomeRule2"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -79,9 +89,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObj | Get-PASOnboardingRule } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Get-PASOpenIDConnectProvider.Tests.ps1
+++ b/Tests/Get-PASOpenIDConnectProvider.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -36,7 +46,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		BeforeEach {
-			$Script:ExternalVersion = '0.0'
+			$psPASSession.ExternalVersion = '0.0'
 
 			Mock Invoke-PASRestMethod -MockWith {
 
@@ -60,7 +70,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/OIDC/Providers/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Configuration/OIDC/Providers/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -72,7 +82,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/OIDC/Providers/idValue"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Configuration/OIDC/Providers/idValue"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -91,9 +101,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObject | Get-PASOpenIDConnectProvider } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Get-PASPSMRecording.Tests.ps1
+++ b/Tests/Get-PASPSMRecording.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -48,9 +58,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				}
 
-				$Script:BaseURI = 'https://SomeURL/SomeApp'
-				$Script:ExternalVersion = '0.0'
-				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+				$Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+				$psPASSession.ExternalVersion = '0.0'
+				$psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 			}
 
 			It 'sends request' {
@@ -63,7 +73,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Get-PASPSMRecording
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Recordings?Limit=9"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Recordings?Limit=9"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -74,7 +84,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				#311212800 1674345600
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Recordings?ToTime=1674345600"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Recordings?ToTime=1674345600"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -84,7 +94,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				Get-PASPSMRecording -FromTime (Get-Date -Year 1979 -Month 11 -Day 12 -Hour 0 -Minute 0 -Second 0 -Millisecond 0)
 				#311212800 1674345600
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-					$URI -eq "$($Script:BaseURI)/API/Recordings?fromTime=311212800"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Recordings?fromTime=311212800"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -108,22 +118,22 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Recordings/SomeID"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Recordings/SomeID"
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObj | Get-PASPSMRecording } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 			It 'throws error if version requirement not met when querying by ID' {
-				$Script:ExternalVersion = '10.5'
+				$psPASSession.ExternalVersion = '10.5'
 				{ Get-PASPSMRecording -RecordingID SomeID } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}
@@ -140,9 +150,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				}
 
-				$Script:BaseURI = 'https://SomeURL/SomeApp'
-				$Script:ExternalVersion = '0.0'
-				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+				$Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+				$psPASSession.ExternalVersion = '0.0'
+				$psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 			}
 			It 'provides output' {
 

--- a/Tests/Get-PASPSMRecordingActivity.Tests.ps1
+++ b/Tests/Get-PASPSMRecordingActivity.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -72,7 +82,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Get-PASPSMRecordingActivity
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Recordings/SomeID/activities"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Recordings/SomeID/activities"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -91,11 +101,11 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '10.5'
+				$psPASSession.ExternalVersion = '10.5'
 
 				{ $InputObj | Get-PASPSMRecordingActivity } | Should -Throw
 
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 
 			}
 

--- a/Tests/Get-PASPSMRecordingProperty.Tests.ps1
+++ b/Tests/Get-PASPSMRecordingProperty.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -72,7 +82,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Get-PASPSMRecordingProperty
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Recordings/SomeID/properties"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Recordings/SomeID/properties"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -91,10 +101,10 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '10.5'
+				$psPASSession.ExternalVersion = '10.5'
 
 				{ $InputObj | Get-PASPSMRecordingProperty } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Get-PASPSMServer.Tests.ps1
+++ b/Tests/Get-PASPSMServer.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -54,7 +64,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/PSM/Servers"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/PSM/Servers"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -73,9 +83,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Get-PASPSMServer } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Get-PASPSMSession.Tests.ps1
+++ b/Tests/Get-PASPSMSession.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -49,9 +59,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				}
 
-				$Script:BaseURI = 'https://SomeURL/SomeApp'
-				$Script:ExternalVersion = '0.0'
-				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+				$Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+				$psPASSession.ExternalVersion = '0.0'
+				$psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 			}
 
@@ -65,7 +75,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Get-PASPSMSession
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/LiveSessions?Limit=9"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/LiveSessions?Limit=9"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -73,9 +83,10 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'uses expected FromTime value' {
 				Get-PASPSMSession -FromTime (Get-Date -Year 1979 -Month 11 -Day 12 -Hour 0 -Minute 0 -Second 0 -Millisecond 0)
-				#311212800 1674345600
+				#311212800 1674345600 311212800
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-					$URI -eq "$($Script:BaseURI)/API/LiveSessions?fromTime=311212800"
+
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/LiveSessions?FromTime=311212800"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -85,7 +96,8 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				Get-PASPSMSession -ToTime (Get-Date -Year 2023 -Day 22 -Month 1 -Hour 0 -Minute 0 -Second 0 -Millisecond 0)
 				#311212800 1674345600
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-					$URI -eq "$($Script:BaseURI)/API/LiveSessions?ToTime=1674345600"
+
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/LiveSessions?ToTime=1674345600"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -109,23 +121,23 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/LiveSessions/SomeID"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/LiveSessions/SomeID"
 
 				} -Times 1 -Exactly -Scope It
 
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObj | Get-PASPSMSession } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 			It 'throws error if version requirement not met when querying by ID' {
-				$Script:ExternalVersion = '10.5'
+				$psPASSession.ExternalVersion = '10.5'
 				{ Get-PASPSMSession -liveSessionId SomeID } | Should -Throw
 
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}
@@ -143,9 +155,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				}
 
-				$Script:BaseURI = 'https://SomeURL/SomeApp'
-				$Script:ExternalVersion = '0.0'
-				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+				$Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+				$psPASSession.ExternalVersion = '0.0'
+				$psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 			}
 			It 'provides output' {

--- a/Tests/Get-PASPSMSessionActivity.Tests.ps1
+++ b/Tests/Get-PASPSMSessionActivity.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -72,7 +82,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Get-PASPSMSessionActivity
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/LiveSessions/SomeID/activities"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/LiveSessions/SomeID/activities"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -91,10 +101,10 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '10.5'
+				$psPASSession.ExternalVersion = '10.5'
 
 				{ $InputObj | Get-PASPSMSessionActivity } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 
 			}
 

--- a/Tests/Get-PASPSMSessionProperty.Tests.ps1
+++ b/Tests/Get-PASPSMSessionProperty.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -72,7 +82,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Get-PASPSMSessionProperty
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/LiveSessions/SomeID/properties"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/LiveSessions/SomeID/properties"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -91,10 +101,10 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '10.5'
+				$psPASSession.ExternalVersion = '10.5'
 
 				{ $InputObj | Get-PASPSMSessionProperty } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 
 			}
 

--- a/Tests/Get-PASPTAEvent.Tests.ps1
+++ b/Tests/Get-PASPTAEvent.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -43,9 +53,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 					[PSCustomObject]@{'addsaferesult' = [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' } }
 				}
 
-				$Script:BaseURI = 'https://SomeURL/SomeApp'
-				$Script:ExternalVersion = '0.0'
-				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+				$Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+				$psPASSession.ExternalVersion = '0.0'
+				$psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 			}
 
@@ -59,7 +69,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				Get-PASPTAEvent -fromUpdateDate 1-1-1979
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -match "$($Script:BaseURI)/API/pta/API/Events/"
+					$URI -match "$($Script:psPASSession.BaseURI)/API/pta/API/Events/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -92,9 +102,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Get-PASPTAEvent } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}
@@ -106,9 +116,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 					[PSCustomObject]@{'addsaferesult' = [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' } }
 				}
 
-				$Script:BaseURI = 'https://SomeURL/SomeApp'
-				$Script:ExternalVersion = '0.0'
-				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+				$Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+				$psPASSession.ExternalVersion = '0.0'
+				$psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 			}
 			It 'provides output' {

--- a/Tests/Get-PASPTAExcludedTarget.Tests.ps1
+++ b/Tests/Get-PASPTAExcludedTarget.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -58,7 +68,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/API/pta/API/administration"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/API/pta/API/administration"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -81,9 +91,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             }
 
             It 'throws error if version requirement not met' {
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
                 { Get-PASPTAExcludedTarget } | Should -Throw
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }
@@ -100,9 +110,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
                     }
                 }
 
-                $Script:BaseURI = 'https://SomeURL/SomeApp'
-                $Script:ExternalVersion = '0.0'
-                $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                $Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+                $psPASSession.ExternalVersion = '0.0'
+                $psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
             }
             It 'provides output' {

--- a/Tests/Get-PASPTAGlobalCatalog.Tests.ps1
+++ b/Tests/Get-PASPTAGlobalCatalog.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -54,7 +64,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/API/pta/API/Administration/GCConnectivity"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/API/pta/API/Administration/GCConnectivity"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -77,9 +87,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             }
 
             It 'throws error if version requirement not met' {
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
                 { Get-PASPTAGlobalCatalog } | Should -Throw
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }

--- a/Tests/Get-PASPTAIncludedTarget.Tests.ps1
+++ b/Tests/Get-PASPTAIncludedTarget.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -58,7 +68,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/API/pta/API/administration"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/API/pta/API/administration"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -81,9 +91,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             }
 
             It 'throws error if version requirement not met' {
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
                 { Get-PASPTAIncludedTarget } | Should -Throw
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }
@@ -100,9 +110,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
                     }
                 }
 
-                $Script:BaseURI = 'https://SomeURL/SomeApp'
-                $Script:ExternalVersion = '0.0'
-                $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                $Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+                $psPASSession.ExternalVersion = '0.0'
+                $psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
             }
             It 'provides output' {

--- a/Tests/Get-PASPTAPrivilegedGroup.Tests.ps1
+++ b/Tests/Get-PASPTAPrivilegedGroup.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -57,7 +67,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/API/pta/API/configuration"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/API/pta/API/configuration"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -80,9 +90,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             }
 
             It 'throws error if version requirement not met' {
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
                 { Get-PASPTAPrivilegedGroup } | Should -Throw
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }
@@ -98,9 +108,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
                     }
                 }
 
-                $Script:BaseURI = 'https://SomeURL/SomeApp'
-                $Script:ExternalVersion = '0.0'
-                $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                $Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+                $psPASSession.ExternalVersion = '0.0'
+                $psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
             }
             It 'provides output' {

--- a/Tests/Get-PASPTAPrivilegedUser.Tests.ps1
+++ b/Tests/Get-PASPTAPrivilegedUser.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -57,7 +67,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/API/pta/API/configuration"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/API/pta/API/configuration"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -80,9 +90,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             }
 
             It 'throws error if version requirement not met' {
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
                 { Get-PASPTAPrivilegedUser } | Should -Throw
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }
@@ -98,9 +108,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
                     }
                 }
 
-                $Script:BaseURI = 'https://SomeURL/SomeApp'
-                $Script:ExternalVersion = '0.0'
-                $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                $Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+                $psPASSession.ExternalVersion = '0.0'
+                $psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
             }
             It 'provides output' {

--- a/Tests/Get-PASPTARemediation.Tests.ps1
+++ b/Tests/Get-PASPTARemediation.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -54,7 +64,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/pta/API/Settings"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/pta/API/Settings"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -77,9 +87,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Get-PASPTARemediation } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Get-PASPTARiskEvent.Tests.ps1
+++ b/Tests/Get-PASPTARiskEvent.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -43,9 +53,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 }
 
-                $Script:BaseURI = 'https://SomeURL/SomeApp'
-                $Script:ExternalVersion = '0.0'
-                $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                $Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+                $psPASSession.ExternalVersion = '0.0'
+                $psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
             }
 
@@ -59,7 +69,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
                 Get-PASPTARiskEvent
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -match "$($Script:BaseURI)/API/pta/API/Risks/RisksEvents/"
+                    $URI -match "$($Script:psPASSession.BaseURI)/API/pta/API/Risks/RisksEvents/"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -69,7 +79,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
                 Get-PASPTARiskEvent -FromTime (Get-Date -Year 1979 -Month 11 -Day 12 -Hour 0 -Minute 0 -Second 0 -Millisecond 0) -ToTime (Get-Date -Year 2023 -Day 22 -Month 1 -Hour 0 -Minute 0 -Second 0 -Millisecond 0)
                 #311212800000 1674345600000
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-                    $URI -eq "$($Script:BaseURI)/API/pta/API/Risks/RisksEvents/?filter=detectionTime%20BETWEEN%20%22311212800000%22%20TO%20%221674345600000%22"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/API/pta/API/Risks/RisksEvents/?filter=detectionTime%20BETWEEN%20%22311212800000%22%20TO%20%221674345600000%22"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -78,7 +88,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             It 'uses expected date filter - before date' {
                 Get-PASPTARiskEvent -ToTime (Get-Date -Year 2023 -Day 22 -Month 1 -Hour 0 -Minute 0 -Second 0 -Millisecond 0) #1674345600000
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-                    $URI -eq "$($Script:BaseURI)/API/pta/API/Risks/RisksEvents/?filter=detectionTime%20lte%20%221674345600000%22"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/API/pta/API/Risks/RisksEvents/?filter=detectionTime%20lte%20%221674345600000%22"
 
                 } -Times 1 -Exactly -Scope It
             }
@@ -86,7 +96,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             It 'uses expected date filter - after date' {
                 Get-PASPTARiskEvent -FromTime (Get-Date -Year 2023 -Day 22 -Month 1 -Hour 0 -Minute 0 -Second 0 -Millisecond 0) #1674345600000
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-                    $URI -eq "$($Script:BaseURI)/API/pta/API/Risks/RisksEvents/?filter=detectionTime%20gte%20%221674345600000%22"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/API/pta/API/Risks/RisksEvents/?filter=detectionTime%20gte%20%221674345600000%22"
 
                 } -Times 1 -Exactly -Scope It
             }
@@ -108,9 +118,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             }
 
             It 'throws error if version requirement not met' {
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
                 { Get-PASPTARiskEvent } | Should -Throw
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }
@@ -126,9 +136,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
                     }
                 }
 
-                $Script:BaseURI = 'https://SomeURL/SomeApp'
-                $Script:ExternalVersion = '0.0'
-                $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                $Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+                $psPASSession.ExternalVersion = '0.0'
+                $psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
             }
             It 'provides output' {

--- a/Tests/Get-PASPTARiskSummary.Tests.ps1
+++ b/Tests/Get-PASPTARiskSummary.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -43,9 +53,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
                     [PSCustomObject]@{'addsaferesult' = [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' } }
                 }
 
-                $Script:BaseURI = 'https://SomeURL/SomeApp'
-                $Script:ExternalVersion = '0.0'
-                $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                $Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+                $psPASSession.ExternalVersion = '0.0'
+                $psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
             }
 
@@ -59,7 +69,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
                 Get-PASPTARiskSummary
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -match "$($Script:BaseURI)/API/pta/API/Risks/Summary/"
+                    $URI -match "$($Script:psPASSession.BaseURI)/API/pta/API/Risks/Summary/"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -82,9 +92,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             }
 
             It 'throws error if version requirement not met' {
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
                 { Get-PASPTARiskSummary } | Should -Throw
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }
@@ -96,9 +106,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
                     [PSCustomObject]@{'addsaferesult' = [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' } }
                 }
 
-                $Script:BaseURI = 'https://SomeURL/SomeApp'
-                $Script:ExternalVersion = '0.0'
-                $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                $Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+                $psPASSession.ExternalVersion = '0.0'
+                $psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
             }
             It 'provides output' {

--- a/Tests/Get-PASPTARule.Tests.ps1
+++ b/Tests/Get-PASPTARule.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -53,7 +63,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/pta/API/Settings"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/pta/API/Settings"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -76,9 +86,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Get-PASPTARule } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Get-PASParameter.Tests.ps1
+++ b/Tests/Get-PASParameter.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 

--- a/Tests/Get-PASPlatform.Tests.ps1
+++ b/Tests/Get-PASPlatform.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -64,7 +74,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Platforms/SomeName/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Platforms/SomeName/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -83,9 +93,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObj | Get-PASPlatform } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}
@@ -132,9 +142,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '10.0'
+				$psPASSession.ExternalVersion = '10.0'
 				{ $InputObj | Get-PASPlatform } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}
@@ -172,7 +182,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Platforms/targets"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Platforms/targets"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -184,7 +194,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Platforms/dependents"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Platforms/dependents"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -196,7 +206,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Platforms/groups"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Platforms/groups"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -208,7 +218,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Platforms/rotationalGroups"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Platforms/rotationalGroups"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -221,9 +231,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '11.3'
+				$psPASSession.ExternalVersion = '11.3'
 				{ Get-PASPlatform } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Get-PASPlatformPSMConfig.Tests.ps1
+++ b/Tests/Get-PASPlatformPSMConfig.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -54,7 +64,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Platforms/Targets/42/PrivilegedSessionManagement"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Platforms/Targets/42/PrivilegedSessionManagement"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -73,9 +83,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Get-PASPlatformPSMConfig -ID 42 } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Get-PASPlatformSafe.Tests.ps1
+++ b/Tests/Get-PASPlatformSafe.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -85,7 +95,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Platforms/SomeName/Safes/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Platforms/SomeName/Safes/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -98,9 +108,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '10.0'
+				$psPASSession.ExternalVersion = '10.0'
 				{ $InputObj | Get-PASPlatformSafe } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Get-PASPlatformSummary.Tests.ps1
+++ b/Tests/Get-PASPlatformSummary.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -54,7 +64,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/API/Platforms/Targets/SystemTypes"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/API/Platforms/Targets/SystemTypes"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -73,9 +83,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             }
 
             It 'throws error if version requirement not met' {
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
                 { Get-PASPlatformSummary } | Should -Throw
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }

--- a/Tests/Get-PASPolicyACL.Tests.ps1
+++ b/Tests/Get-PASPolicyACL.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -76,7 +86,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Policy/UNIXSSH/PrivilegedCommands/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Policy/UNIXSSH/PrivilegedCommands/"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Get-PASPublicSSHKey.Tests.ps1
+++ b/Tests/Get-PASPublicSSHKey.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -75,7 +85,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/SomeUser%40domain.com/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Users/SomeUser%40domain.com/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys/"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Get-PASRequest.Tests.ps1
+++ b/Tests/Get-PASRequest.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -74,8 +84,8 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -match ("$($Script:BaseURI)/API/MyRequests?OnlyWaiting=True&Expired=True" -or
-						"$($Script:BaseURI)/API/MyRequests?Expired=True&OnlyWaiting=True")
+					$URI -match ("$($Script:psPASSession.BaseURI)/API/MyRequests?OnlyWaiting=True&Expired=True" -or
+						"$($Script:psPASSession.BaseURI)/API/MyRequests?Expired=True&OnlyWaiting=True")
 
 				} -Times 1 -Exactly -Scope It
 
@@ -94,9 +104,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Get-PASRequest -RequestType MyRequests -OnlyWaiting $true -Expired $true } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}
@@ -115,8 +125,8 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -match ("$($Script:BaseURI)/API/IncomingRequests?OnlyWaiting=True&Expired=True" -or
-						"$($Script:BaseURI)/API/IncomingRequests?Expired=True&OnlyWaiting=True")
+					$URI -match ("$($Script:psPASSession.BaseURI)/API/IncomingRequests?OnlyWaiting=True&Expired=True" -or
+						"$($Script:psPASSession.BaseURI)/API/IncomingRequests?Expired=True&OnlyWaiting=True")
 
 				} -Times 1 -Exactly -Scope It
 
@@ -152,7 +162,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -match "$($Script:BaseURI)/API/bulkactions/123"
+					$URI -match "$($Script:psPASSession.BaseURI)/API/bulkactions/123"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -171,9 +181,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '13.0'
+				$psPASSession.ExternalVersion = '13.0'
 				{ Get-PASRequest -id 123 -DisplayExtendedItems $true } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Get-PASRequestDetail.Tests.ps1
+++ b/Tests/Get-PASRequestDetail.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -73,7 +83,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/MyRequests/SomeID"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/MyRequests/SomeID"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -92,9 +102,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObj | Get-PASRequestDetail -RequestType MyRequests } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}
@@ -113,7 +123,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/IncomingRequests/SomeID"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/IncomingRequests/SomeID"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Get-PASResponse.Tests.ps1
+++ b/Tests/Get-PASResponse.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 

--- a/Tests/Get-PASSafe.Tests.ps1
+++ b/Tests/Get-PASSafe.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -62,7 +72,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Safes"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Safes"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -82,9 +92,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'throws if version exceeds 12.2' {
 
-				$Script:ExternalVersion = '12.3'
+				$psPASSession.ExternalVersion = '12.3'
 				{ Get-PASSafe -FindAll -UseGen1API } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 
 			}
 
@@ -108,7 +118,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Safes/SomeSafe"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Safes/SomeSafe"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -128,9 +138,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'throws if version exceeds 12.2' {
 
-				$Script:ExternalVersion = '12.3'
+				$psPASSession.ExternalVersion = '12.3'
 				{ Get-PASSafe -SafeName SomeSafe -UseGen1API } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 
 			}
 
@@ -154,7 +164,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Safes?query=SomeSafe"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Safes?query=SomeSafe"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -174,9 +184,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'throws if version exceeds 12.2' {
 
-				$Script:ExternalVersion = '12.3'
+				$psPASSession.ExternalVersion = '12.3'
 				{ Get-PASSafe -query 'SomeSafe' } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 
 			}
 
@@ -208,7 +218,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Safes"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Safes"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -220,7 +230,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Safes?search=SomeSafe"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Safes?search=SomeSafe"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -239,15 +249,15 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version 12.0 requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Get-PASSafe -search SomeSafe } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 			It 'throws error if version 12.1 requirement not met' {
-				$Script:ExternalVersion = '12.0'
+				$psPASSession.ExternalVersion = '12.0'
 				{ Get-PASSafe -search SomeSafe -extendedDetails $false } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 
@@ -278,7 +288,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Safes/SomeSafe?includeAccounts=True"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Safes/SomeSafe?includeAccounts=True"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -297,9 +307,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version 12.2 requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Get-PASSafe -search SomeSafe } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Get-PASSafeMember.Tests.ps1
+++ b/Tests/Get-PASSafeMember.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -60,7 +70,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Safes/SomeSafe/Members"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Safes/SomeSafe/Members"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -72,7 +82,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Safes/SomeSafe/Members/SomeMember/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Safes/SomeSafe/Members/SomeMember/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -94,9 +104,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'throws for PUT method if version exceeds 12.3' {
 
-				$Script:ExternalVersion = '12.4'
+				$psPASSession.ExternalVersion = '12.4'
 				{ Get-PASSafeMember -SafeName SomeSafe -MemberName SomeMember -UseGen1API } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 
 			}
 
@@ -133,7 +143,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Safes/SomeSafe/Members"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Safes/SomeSafe/Members"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -145,7 +155,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Safes/SomeSafe/Members/SomeMember/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Safes/SomeSafe/Members/SomeMember/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -157,8 +167,8 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					($URI -eq "$($Script:BaseURI)/api/Safes/SomeSafe/Members?filter=memberType%20eq%20user&search=SomeMember") -or
-					($URI -eq "$($Script:BaseURI)/api/Safes/SomeSafe/Members?search=SomeMember&filter=memberType%20eq%20user")
+					($URI -eq "$($Script:psPASSession.BaseURI)/api/Safes/SomeSafe/Members?filter=memberType%20eq%20user&search=SomeMember") -or
+					($URI -eq "$($Script:psPASSession.BaseURI)/api/Safes/SomeSafe/Members?search=SomeMember&filter=memberType%20eq%20user")
 
 				} -Times 1 -Exactly -Scope It
 			}
@@ -176,21 +186,21 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version 12.0 requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Get-PASSafeMember -SafeName SomeSafe } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 			It 'throws error if version 12.1 requirement not met' {
-				$Script:ExternalVersion = '12.0'
+				$psPASSession.ExternalVersion = '12.0'
 				{ Get-PASSafeMember -SafeName SomeSafe -search SomeMember } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 			It 'throws error if version 12.2 requirement not met' {
-				$Script:ExternalVersion = '12.0'
+				$psPASSession.ExternalVersion = '12.0'
 				{ Get-PASSafeMember -SafeName SomeSafe -MemberName SomeMember } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 			It 'corrctly formats nexLink, Limit & Offset URL values' {
@@ -384,19 +394,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					($URI -eq "$($Script:BaseURI)/api/Safes/SomeSafe/Members?filter=includePredefinedUsers%20eq%20True")
+					($URI -eq "$($Script:psPASSession.BaseURI)/api/Safes/SomeSafe/Members?filter=includePredefinedUsers%20eq%20True")
 
 				} -Times 1 -Exactly -Scope It
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					($URI -eq "$($Script:BaseURI)/api/Safes/SomeSafe/Members?filter=includePredefinedUsers%20eq%20True&limit=25&OffSet=25")
+					($URI -eq "$($Script:psPASSession.BaseURI)/api/Safes/SomeSafe/Members?filter=includePredefinedUsers%20eq%20True&limit=25&OffSet=25")
 
 				} -Times 1 -Exactly -Scope It
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					($URI -eq "$($Script:BaseURI)/api/Safes/SomeSafe/Members?filter=includePredefinedUsers%20eq%20True&limit=25&OffSet=50")
+					($URI -eq "$($Script:psPASSession.BaseURI)/api/Safes/SomeSafe/Members?filter=includePredefinedUsers%20eq%20True&limit=25&OffSet=50")
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Get-PASSafeShareLogo.Tests.ps1
+++ b/Tests/Get-PASSafeShareLogo.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -68,7 +78,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Logo?type=Square"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Logo?type=Square"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Get-PASServer.Tests.ps1
+++ b/Tests/Get-PASServer.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -54,7 +64,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Server"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Server"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Get-PASServerWebService.Tests.ps1
+++ b/Tests/Get-PASServerWebService.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -46,7 +56,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 						'AuthenticationMethods' = 'SomeThing'
 					}
 				}
-				$Script:BaseURI = 'https://SomeURL/SomeApp'
+				$Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
 				$response = Get-PASServerWebService -BaseURI 'https://SomeURL' -PVWAAppName SomeApp -UseGen1API
 			}
 
@@ -72,7 +82,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/verify/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/verify/"
 
 				} #-Times 1 -Exactly -Scope It
 
@@ -103,7 +113,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 						'AuthenticationMethods' = 'SomeThing'
 					}
 				}
-				$Script:BaseURI = 'https://SomeURL/SomeApp'
+				$Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
 				$response = Get-PASServerWebService -BaseURI 'https://SomeURL' -PVWAAppName SomeApp -UseGen1API
 			}
 

--- a/Tests/Get-PASSession.Tests.ps1
+++ b/Tests/Get-PASSession.Tests.ps1
@@ -30,6 +30,8 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			LastCommand        = $null
 			LastCommandTime    = $null
 			LastCommandResults = $null
+			LastError          = $null
+			LastErrorTime      = $null
 		}
 
 		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
@@ -58,7 +60,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'has output with expected number of properties' {
 
-				$response.Keys.Count | Should -Be 9
+				$response.Keys.Count | Should -Be 11
 
 			}
 

--- a/Tests/Get-PASSession.Tests.ps1
+++ b/Tests/Get-PASSession.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $((Get-Date).AddMinutes(-5))
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -36,7 +46,6 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 		BeforeEach {
 
-
 			$response = Get-PASSession
 		}
 		Context 'Standard Operation' {
@@ -49,7 +58,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'has output with expected number of properties' {
 
-				($response | Get-Member -MemberType NoteProperty).length | Should -Be 3
+				$response.Keys.Count | Should -Be 9
 
 			}
 

--- a/Tests/Get-PASUser.Tests.ps1
+++ b/Tests/Get-PASUser.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -70,7 +80,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/SomeUser"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Users/SomeUser"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -82,8 +92,8 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					(($URI -eq "$($Script:BaseURI)/api/Users?Search=SomeUser&ComponentUser=True") -or
-						($URI -eq "$($Script:BaseURI)/api/Users?ComponentUser=True&Search=SomeUser"))
+					(($URI -eq "$($Script:psPASSession.BaseURI)/api/Users?Search=SomeUser&ComponentUser=True") -or
+						($URI -eq "$($Script:psPASSession.BaseURI)/api/Users?ComponentUser=True&Search=SomeUser"))
 
 				} -Times 1 -Exactly -Scope It
 
@@ -95,7 +105,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Users/123"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Users/123"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -114,31 +124,31 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 
 				{ $InputObjV10 | Get-PASUser } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 
 			}
 
 			It 'throws error if version 10.9 requirement not met' {
-				$Script:ExternalVersion = '10.9'
+				$psPASSession.ExternalVersion = '10.9'
 
 				{ Get-PASUser -id 123 } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 
 			}
 
 			It 'throws error if version 12.1 requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Get-PASUser -id 123 -ExtendedDetails $true } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 			It 'throws error if version 13.2 requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Get-PASUser -UserStatus Suspended -source LDAP } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Get-PASUserLoginInfo.Tests.ps1
+++ b/Tests/Get-PASUserLoginInfo.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -54,7 +64,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/LoginsInfo"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/LoginsInfo"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -73,9 +83,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Get-PASUserLoginInfo } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Get-PASUserTypeInfo.Tests.ps1
+++ b/Tests/Get-PASUserTypeInfo.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -54,7 +64,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/API/UserTypes/"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/API/UserTypes/"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -73,9 +83,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             }
 
             It 'throws error if version requirement not met' {
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
                 { Get-PASUserTypeInfo } | Should -Throw
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }

--- a/Tests/Get-ParentFunction.Tests.ps1
+++ b/Tests/Get-ParentFunction.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 

--- a/Tests/Get-SessionClone.Tests.ps1
+++ b/Tests/Get-SessionClone.Tests.ps1
@@ -1,0 +1,96 @@
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
+
+    BeforeAll {
+
+        #Get Current Directory
+        $Here = Split-Path -Parent $PSCommandPath
+
+        #Assume ModuleName from Repository Root folder
+        $ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+        #Resolve Path to Module Directory
+        $ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+        #Define Path to Module Manifest
+        $ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+        if ( -not (Get-Module -Name $ModuleName -All)) {
+
+            Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+        }
+
+        $Script:RequestBody = $null
+
+    }
+
+
+    AfterAll {
+
+        $Script:RequestBody = $null
+
+    }
+
+    InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+        Context 'Mandatory Parameters' {
+
+            $Parameters = @{Parameter = 'InputObject' }
+
+            It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
+
+                param($Parameter)
+
+				(Get-Command Get-SessionClone).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
+
+            }
+
+        }
+
+        Context 'General' {
+
+            BeforeAll {
+                $psPASSession = [ordered]@{
+                    BaseURI            = 'https://SomeURL/SomeApp'
+                    User               = 'SomeUser'
+                    ExternalVersion    = [System.Version]'0.0'
+                    WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                    StartTime          = (Get-Date).AddMinutes(-5)
+                    ElapsedTime        = '{0:HH:mm:ss}' -f [datetime](Get-Date)
+                    LastCommand        = (Get-Variable MyInvocation).Value
+                    LastCommandTime    = (Get-Date).AddMinutes(-1)
+                    LastCommandResults = @{'TestProperty' = 'TestValue' }
+                }
+
+                New-Variable -Name object -Value $psPASSession -Scope Script -Force
+                $script:Clone = Get-SessionClone -InputObject $script:object
+            }
+
+            It 'returns output of expected type' {
+
+                $script:Clone | Should -BeOfType 'System.Collections.Specialized.OrderedDictionary'
+
+            }
+            It 'produces expected output properties' {
+
+                $script:Clone.keys | Should -HaveCount 9
+
+            }
+
+            It 'produces output that does not reference the input instance' {
+
+                [System.Object]::ReferenceEquals($script:object, $script:Clone) | Should -BeFalse
+
+            }
+
+            It 'outputs nested hashtable property that does not reference the input instance' {
+
+                [System.Object]::ReferenceEquals($script:object.LastCommandResults, $script:Clone.LastCommandResults) | Should -BeFalse
+
+            }
+
+        }
+
+    }
+
+}

--- a/Tests/Hide-SecretValue.Tests.ps1
+++ b/Tests/Hide-SecretValue.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 

--- a/Tests/Import-PASConnectionComponent.Tests.ps1
+++ b/Tests/Import-PASConnectionComponent.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -88,7 +98,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/ConnectionComponents/Import"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/ConnectionComponents/Import"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -125,9 +135,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Import-PASConnectionComponent -ImportFile $($file.name) } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Import-PASPlatform.Tests.ps1
+++ b/Tests/Import-PASPlatform.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -89,7 +99,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Platforms/Import"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Platforms/Import"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -126,9 +136,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Import-PASPlatform -ImportFile $($file.name) } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 

--- a/Tests/Invoke-PASCPMOperation.Tests.ps1
+++ b/Tests/Invoke-PASCPMOperation.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -45,9 +55,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$Password = 'SomePassword' | ConvertTo-SecureString -AsPlainText -Force
 
 				$Script:RequestBody = $null
-				$Script:BaseURI = 'https://SomeURL/SomeApp'
-				$Script:ExternalVersion = '0.0'
-				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+				$Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+				$psPASSession.ExternalVersion = '0.0'
+				$psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 			}
 
 			It 'sends verify request to expected api endpoint' {

--- a/Tests/Invoke-PASRestMethod.Tests.ps1
+++ b/Tests/Invoke-PASRestMethod.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -164,12 +174,12 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'sets WebSession variable in the module scope' {
 				Invoke-PASRestMethod @SessionVariable
-				$Script:WebSession | Should -Not -BeNullOrEmpty
+				$psPASSession.WebSession | Should -Not -BeNullOrEmpty
 			}
 
 			It 'returns WebSession sessionvariable value' {
 				Invoke-PASRestMethod @SessionVariable
-				$Script:WebSession.Headers['Test'] | Should -Be 'OK'
+				$psPASSession.WebSession.Headers['Test'] | Should -Be 'OK'
 			}
 
 			It 'sends output to Get-PASResponse' {

--- a/Tests/New-PASAccountGroup.Tests.ps1
+++ b/Tests/New-PASAccountGroup.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -79,7 +89,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/AccountGroups/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/AccountGroups/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -110,9 +120,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObj | New-PASAccountGroup } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/New-PASAccountObject.Tests.ps1
+++ b/Tests/New-PASAccountObject.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 

--- a/Tests/New-PASAccountPassword.Tests.ps1
+++ b/Tests/New-PASAccountPassword.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -37,9 +47,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
         Context 'Input' {
 
-            $Script:BaseURI = 'https://SomeURL/SomeApp'
-            $Script:ExternalVersion = '0.0'
-            $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+            $Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+            $psPASSession.ExternalVersion = '0.0'
+            $psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
             BeforeEach {
 
@@ -63,7 +73,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/api/Accounts/12_3/Secret/Generate"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/api/Accounts/12_3/Secret/Generate"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -82,9 +92,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             }
 
             It 'throws error if version requirement not met' {
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
                 { New-PASAccountPassword -AccountID 12_3 } | Should -Throw
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }

--- a/Tests/New-PASDirectoryMapping.Tests.ps1
+++ b/Tests/New-PASDirectoryMapping.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -54,22 +64,22 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'does not throw - v10.4 parameterset' {
-				$Script:ExternalVersion = '10.4'
+				$psPASSession.ExternalVersion = '10.4'
 				{ $InputObj | New-PASDirectoryMapping -MappingAuthorizations RestoreAllSafes } | Should -Not -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 
 			It 'does not throw - v10.7 parameterset' {
-				$Script:ExternalVersion = '10.7'
+				$psPASSession.ExternalVersion = '10.7'
 				{ $InputObj | New-PASDirectoryMapping -VaultGroups Group1, Group2 } | Should -Not -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 			It 'does not throw - v10.10 parameterset' {
-				$Script:ExternalVersion = '10.10'
+				$psPASSession.ExternalVersion = '10.10'
 				{ $InputObj | New-PASDirectoryMapping -UserActivityLogPeriod 10 } | Should -Not -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 			It 'sends request' {
@@ -82,7 +92,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | New-PASDirectoryMapping -MappingAuthorizations RestoreAllSafes
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/LDAP/Directories/SomeDirectory/Mappings/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Configuration/LDAP/Directories/SomeDirectory/Mappings/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -95,33 +105,33 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObj | New-PASDirectoryMapping -MappingAuthorizations RestoreAllSafes, BackupAllSafes } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '10.6'
+				$psPASSession.ExternalVersion = '10.6'
 				{ $InputObj | New-PASDirectoryMapping -VaultGroups 'Group1', 'Group2' } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '10.9'
+				$psPASSession.ExternalVersion = '10.9'
 				{ $InputObj | New-PASDirectoryMapping -MappingAuthorizations RestoreAllSafes, BackupAllSafes -VaultGroups 'Group1', 'Group2' -UserActivityLogPeriod 10 } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 			It 'does not throw if version requirement met' {
-				$Script:ExternalVersion = '10.10'
+				$psPASSession.ExternalVersion = '10.10'
 				{ $InputObj | New-PASDirectoryMapping -MappingAuthorizations RestoreAllSafes, BackupAllSafes -VaultGroups 'Group1', 'Group2' -UserActivityLogPeriod 10 } | Should -Not -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '13.9'
+				$psPASSession.ExternalVersion = '13.9'
 				{ $InputObj | New-PASDirectoryMapping -MappingAuthorizations RestoreAllSafes, BackupAllSafes -VaultGroups 'Group1', 'Group2' -UserActivityLogPeriod 10 -UsedQuota 10 } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/New-PASGroup.Tests.ps1
+++ b/Tests/New-PASGroup.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -59,7 +69,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObject | New-PASGroup
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/UserGroups"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/UserGroups"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -82,11 +92,11 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.2'
+				$psPASSession.ExternalVersion = '1.2'
 
 				{ $InputObject | New-PASGroup } | Should -Throw
 
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 
 			}
 

--- a/Tests/New-PASOnboardingRule.Tests.ps1
+++ b/Tests/New-PASOnboardingRule.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -81,7 +91,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/AutomaticOnboardingRules"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/AutomaticOnboardingRules"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -112,9 +122,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if minimum version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObj | New-PASOnboardingRule } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 			It 'accepts alternative parameterset input' {
@@ -138,9 +148,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 					'SystemTypeFilter' = 'Windows'
 
 				}
-				$Script:ExternalVersion = '10.1.0'
+				$psPASSession.ExternalVersion = '10.1.0'
 				{ $InputObj | New-PASOnboardingRule } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 

--- a/Tests/New-PASPSMSession.Tests.ps1
+++ b/Tests/New-PASPSMSession.Tests.ps1
@@ -220,33 +220,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 		}
 
-		Context 'Output' {
-
-
-			BeforeEach {
-				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{'PSMGWRequest' = 'VAL1'; 'PSMGWURL' = 'Val2'; 'Prop3' = 'Val3' }
-				}
-
-				$InputObj = [pscustomobject]@{
-
-					'AccountID'           = '99_9'
-					'ConnectionComponent' = 'SomeConnectionComponent'
-
-				}
-
-				$Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
-				$psPASSession.ExternalVersion = '0.0'
-				$psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
-
-				Mock Out-PASFile -MockWith { }
-			}
-
-			It 'outputs PSMGW connection information' {
-				$InputObj | New-PASPSMSession -ConnectionMethod PSMGW | Should -Not -Be Null
-			}
-
-		}
+		#TODO Test RDP/PSMGW Invoke-Item + Related Files
 
 	}
 

--- a/Tests/New-PASPSMSession.Tests.ps1
+++ b/Tests/New-PASPSMSession.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -73,9 +83,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				}
 
-				$Script:BaseURI = 'https://SomeURL/SomeApp'
-				$Script:ExternalVersion = '0.0'
-				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+				$Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+				$psPASSession.ExternalVersion = '0.0'
+				$psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 				Mock Out-PASFile -MockWith { }
 			}
@@ -98,7 +108,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Accounts/99_9/PSMConnect"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Accounts/99_9/PSMConnect"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -159,16 +169,16 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met for RDP connection method' {
-				$Script:ExternalVersion = '9.8'
+				$psPASSession.ExternalVersion = '9.8'
 				{ $InputObj | New-PASPSMSession -ConnectionMethod RDP } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 			It 'throws error if version requirement not met for PSMGW connection method' {
 
-				$Script:ExternalVersion = '9.10'
+				$psPASSession.ExternalVersion = '9.10'
 				{ $InputObj | New-PASPSMSession -ConnectionMethod PSMGW } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 			It 'sends request to expected endpoint for AdHocConnect' {
@@ -176,7 +186,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$AdHocObj | New-PASPSMSession -ConnectionMethod RDP -PSMRemoteMachine 'SomeServer'
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Accounts/AdHocConnect"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Accounts/AdHocConnect"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -203,9 +213,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met for AdHocConnect' {
-				$Script:ExternalVersion = '10.4'
+				$psPASSession.ExternalVersion = '10.4'
 				{ $AdHocObj | New-PASPSMSession -ConnectionMethod PSMGW } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}
@@ -225,9 +235,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				}
 
-				$Script:BaseURI = 'https://SomeURL/SomeApp'
-				$Script:ExternalVersion = '0.0'
-				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+				$Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+				$psPASSession.ExternalVersion = '0.0'
+				$psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 				Mock Out-PASFile -MockWith { }
 			}

--- a/Tests/New-PASPrivateSSHKey.Tests.ps1
+++ b/Tests/New-PASPrivateSSHKey.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -36,7 +46,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
     InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
         BeforeEach {
-            $Script:ExternalVersion = '0.0'
+            $psPASSession.ExternalVersion = '0.0'
 
             Mock Invoke-PASRestMethod -MockWith {
                 [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
@@ -64,7 +74,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/api/Users/Secret/SSHKeys/Cache"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/api/Users/Secret/SSHKeys/Cache"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -85,9 +95,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             }
 
             It 'throws error if version requirement not met' {
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
                 { $InputObject | New-PASPrivateSSHKey } | Should -Throw
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }
@@ -116,7 +126,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/api/Users/123/Secret/SSHKeys/Cache"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/api/Users/123/Secret/SSHKeys/Cache"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -137,9 +147,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             }
 
             It 'throws error if version requirement not met' {
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
                 { $InputObject | New-PASPrivateSSHKey } | Should -Throw
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }

--- a/Tests/New-PASRequest.Tests.ps1
+++ b/Tests/New-PASRequest.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -80,7 +90,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/MyRequests"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/MyRequests"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -129,9 +139,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObj | New-PASRequest } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 			It 'has request body with expected BulkItems property' {

--- a/Tests/New-PASRequestObject.Tests.ps1
+++ b/Tests/New-PASRequestObject.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 

--- a/Tests/New-PASUser.Tests.ps1
+++ b/Tests/New-PASUser.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -88,7 +98,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Users"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -157,7 +167,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Users"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Users"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -188,10 +198,10 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 
 				{ $InputObj | New-PASUser } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 
 			}
 

--- a/Tests/Out-PASFile.Tests.ps1
+++ b/Tests/Out-PASFile.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 

--- a/Tests/Publish-PASDiscoveredAccount.Tests.ps1
+++ b/Tests/Publish-PASDiscoveredAccount.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -60,7 +70,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
                 $InputObject | Publish-PASDiscoveredAccount
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/api/DiscoveredAccounts/66_6/Onboard"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/api/DiscoveredAccounts/66_6/Onboard"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -83,11 +93,11 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             }
 
             It 'throws error if version requirement not met' {
-                $Script:ExternalVersion = '1.2'
+                $psPASSession.ExternalVersion = '1.2'
 
                 { $InputObject | Publish-PASDiscoveredAccount } | Should -Throw
 
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
 
             }
 

--- a/Tests/Remove-PASAccount.Tests.ps1
+++ b/Tests/Remove-PASAccount.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -79,7 +89,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Accounts/11_1"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Accounts/11_1"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -126,7 +136,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				#$response = $InputObj | Remove-PASAccount
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Accounts/11_1"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Accounts/11_1"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -145,9 +155,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObj | Remove-PASAccount } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Remove-PASAccountACL.Tests.ps1
+++ b/Tests/Remove-PASAccountACL.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -83,7 +93,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Account/ServerA.domain.com|root|UNIXSSH/PrivilegedCommands/22/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Account/ServerA.domain.com|root|UNIXSSH/PrivilegedCommands/22/"
 				} -Times 1 -Exactly -Scope It
 
 			}

--- a/Tests/Remove-PASAccountGroupMember.Tests.ps1
+++ b/Tests/Remove-PASAccountGroupMember.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -76,7 +86,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/AccountGroups/88_8/Members/99_9"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/AccountGroups/88_8/Members/99_9"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -95,9 +105,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObj | Remove-PASAccountGroupMember } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Remove-PASApplication.Tests.ps1
+++ b/Tests/Remove-PASApplication.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -74,7 +84,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Applications/SomeApplication/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Applications/SomeApplication/"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Remove-PASApplicationAuthenticationMethod.Tests.ps1
+++ b/Tests/Remove-PASApplicationAuthenticationMethod.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -76,7 +86,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Applications/SomeApplication/Authentications/SomeAuth"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Applications/SomeApplication/Authentications/SomeAuth"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Remove-PASAuthenticationMethod.Tests.ps1
+++ b/Tests/Remove-PASAuthenticationMethod.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -36,7 +46,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		BeforeEach {
-			$Script:ExternalVersion = '0.0'
+			$psPASSession.ExternalVersion = '0.0'
 
 			Mock Invoke-PASRestMethod -MockWith {
 				[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
@@ -64,7 +74,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/AuthenticationMethods/idValue"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Configuration/AuthenticationMethods/idValue"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -77,9 +87,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObject | Remove-PASAuthenticationMethod } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Remove-PASDirectory.Tests.ps1
+++ b/Tests/Remove-PASDirectory.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -52,7 +62,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		Context 'Input' {
 
 			BeforeEach {
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 				Mock Invoke-PASRestMethod -MockWith { }
 
 				$response = Remove-PASDirectory -id SomeDir
@@ -69,7 +79,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/LDAP/Directories/SomeDir/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Configuration/LDAP/Directories/SomeDir/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -88,9 +98,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Get-PASDirectory } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}
@@ -98,7 +108,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		Context 'Output' {
 
 			BeforeEach {
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 				Mock Invoke-PASRestMethod -MockWith { }
 
 				$response = Remove-PASDirectory -id SomeDir

--- a/Tests/Remove-PASDirectoryMapping.Tests.ps1
+++ b/Tests/Remove-PASDirectoryMapping.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -53,7 +63,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		Context 'Input' {
 
 			BeforeEach {
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 				Mock Invoke-PASRestMethod -MockWith { }
 
 				$response = Remove-PASDirectoryMapping -DirectoryName SomeDir -MappingID 99
@@ -70,7 +80,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/LDAP/Directories/SomeDir/Mappings/99/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Configuration/LDAP/Directories/SomeDir/Mappings/99/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -89,9 +99,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Get-PASDirectory } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}
@@ -99,7 +109,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		Context 'Output' {
 
 			BeforeEach {
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 				Mock Invoke-PASRestMethod -MockWith { }
 
 				$response = Remove-PASDirectoryMapping -DirectoryName SomeDir -MappingID 99

--- a/Tests/Remove-PASGroup.Tests.ps1
+++ b/Tests/Remove-PASGroup.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '11.5'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'11.5'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -73,7 +83,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			It 'sends request to expected endpoint' {
 				Remove-PASGroup -GroupID 1234
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-					$URI -eq "$($Script:BaseURI)/API/UserGroups/1234"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/UserGroups/1234"
 				}-Times 1 -Exactly -Scope It
 			}
 

--- a/Tests/Remove-PASGroup.Tests.ps1
+++ b/Tests/Remove-PASGroup.Tests.ps1
@@ -58,7 +58,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 		Context 'Mandatory Parameters' {
 
-			$Parameters = @{Parameter = 'GroupID' }
+			$Parameters = @{Parameter = 'ID' }
 
 			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 

--- a/Tests/Remove-PASGroupMember.Tests.ps1
+++ b/Tests/Remove-PASGroupMember.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -55,7 +65,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			BeforeEach {
 
 				Mock Invoke-PASRestMethod -MockWith { }
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 			It 'sends request' {
@@ -68,7 +78,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				Remove-PASGroupMember -GroupID X1_Y2 -Member TargetUser
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/UserGroups/X1_Y2/members/TargetUser/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/UserGroups/X1_Y2/members/TargetUser/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -87,10 +97,10 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.2'
+				$psPASSession.ExternalVersion = '1.2'
 
 				{ Remove-PASGroupMember -GroupID X1_Y2 -Member TargetUser } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Remove-PASOnboardingRule.Tests.ps1
+++ b/Tests/Remove-PASOnboardingRule.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -75,7 +85,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/AutomaticOnboardingRules/SomeRule/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/AutomaticOnboardingRules/SomeRule/"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Remove-PASOpenIDConnectProvider.Tests.ps1
+++ b/Tests/Remove-PASOpenIDConnectProvider.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -36,7 +46,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		BeforeEach {
-			$Script:ExternalVersion = '0.0'
+			$psPASSession.ExternalVersion = '0.0'
 
 			Mock Invoke-PASRestMethod -MockWith {
 				[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
@@ -64,7 +74,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/OIDC/Providers/idValue"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Configuration/OIDC/Providers/idValue"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -77,9 +87,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObject | Remove-PASOpenIDConnectProvider } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Remove-PASPTAExcludedTarget.Tests.ps1
+++ b/Tests/Remove-PASPTAExcludedTarget.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -72,7 +82,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/api/pta/API/Administration/properties/CidrExclusionList/999"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/api/pta/API/Administration/properties/CidrExclusionList/999"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -91,9 +101,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             }
 
             It 'throws error if version requirement not met' {
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
                 { $InputObj | Remove-PASPTAExcludedTarget } | Should -Throw
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }

--- a/Tests/Remove-PASPTAIncludedTarget.Tests.ps1
+++ b/Tests/Remove-PASPTAIncludedTarget.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -74,7 +84,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/api/pta/API/Administration/properties/CidrInclusionList/999"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/api/pta/API/Administration/properties/CidrInclusionList/999"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -93,9 +103,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             }
 
             It 'throws error if version requirement not met' {
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
                 { $InputObj | Remove-PASPTAIncludedTarget } | Should -Throw
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }

--- a/Tests/Remove-PASPTAPrivilegedGroup.Tests.ps1
+++ b/Tests/Remove-PASPTAPrivilegedGroup.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -74,7 +84,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/API/pta/API/configuration/properties/PrivilegedDomainGroupsList/999"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/API/pta/API/configuration/properties/PrivilegedDomainGroupsList/999"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -93,9 +103,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             }
 
             It 'throws error if version requirement not met' {
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
                 { $InputObj | Remove-PASPTAPrivilegedGroup } | Should -Throw
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }

--- a/Tests/Remove-PASPTAPrivilegedUser.Tests.ps1
+++ b/Tests/Remove-PASPTAPrivilegedUser.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -74,7 +84,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/API/pta/API/configuration/properties/PrivilegedUsersList/999"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/API/pta/API/configuration/properties/PrivilegedUsersList/999"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -93,9 +103,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             }
 
             It 'throws error if version requirement not met' {
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
                 { $InputObj | Remove-PASPTAPrivilegedUser } | Should -Throw
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }

--- a/Tests/Remove-PASPlatform.Tests.ps1
+++ b/Tests/Remove-PASPlatform.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -78,7 +88,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Remove-PASPlatform -TargetPlatform
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Platforms/targets/1234"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Platforms/targets/1234"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -88,7 +98,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Remove-PASPlatform -DependentPlatform
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Platforms/dependents/1234"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Platforms/dependents/1234"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -98,7 +108,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Remove-PASPlatform -GroupPlatform
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Platforms/groups/1234"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Platforms/groups/1234"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -108,7 +118,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Remove-PASPlatform -RotationalGroup
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Platforms/rotationalGroups/1234"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Platforms/rotationalGroups/1234"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Remove-PASPolicyACL.Tests.ps1
+++ b/Tests/Remove-PASPolicyACL.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -76,7 +86,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Policy/UNIXSSH/PrivilegedCommands/22/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Policy/UNIXSSH/PrivilegedCommands/22/"
 				} -Times 1 -Exactly -Scope It
 
 			}

--- a/Tests/Remove-PASPrivateSSHKey.Tests.ps1
+++ b/Tests/Remove-PASPrivateSSHKey.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -36,7 +46,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
     InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
         BeforeEach {
-            $Script:ExternalVersion = '0.0'
+            $psPASSession.ExternalVersion = '0.0'
 
             Mock Invoke-PASRestMethod -MockWith {
             }
@@ -61,7 +71,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/api/Users/Secret/SSHKeys/Cache"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/api/Users/Secret/SSHKeys/Cache"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -74,9 +84,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             }
 
             It 'throws error if version requirement not met' {
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
                 { $InputObject | Remove-PASPrivateSSHKey } | Should -Throw
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }
@@ -105,7 +115,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/api/Users/123/Secret/SSHKeys/Cache"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/api/Users/123/Secret/SSHKeys/Cache"
 
                 } -Times 1 -Exactly -Scope It
 

--- a/Tests/Remove-PASPublicSSHKey.Tests.ps1
+++ b/Tests/Remove-PASPublicSSHKey.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -76,7 +86,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/SomeUser%40domain.com/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys/SomeKeyID/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Users/SomeUser%40domain.com/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys/SomeKeyID/"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Remove-PASRequest.Tests.ps1
+++ b/Tests/Remove-PASRequest.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -74,7 +84,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/MyRequests/99_9"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/MyRequests/99_9"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -93,9 +103,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObj | Remove-PASRequest } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Remove-PASSafe.Tests.ps1
+++ b/Tests/Remove-PASSafe.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -78,7 +88,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Safes/SomeSafe"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Safes/SomeSafe"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -98,9 +108,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'throws if version exceeds 12.2' {
 
-				$Script:ExternalVersion = '12.3'
+				$psPASSession.ExternalVersion = '12.3'
 				{ Get-PASSafe -SafeName SomeSafe -UseGen1API } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 
 			}
 
@@ -133,7 +143,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Safes/SomeSafe"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Safes/SomeSafe"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -152,9 +162,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version 12.1 requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Get-PASSafe -search SomeSafe } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Remove-PASSafeMember.Tests.ps1
+++ b/Tests/Remove-PASSafeMember.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -81,7 +91,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Safes/SomeSafe/members/SomeUser/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Safes/SomeSafe/members/SomeUser/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -119,7 +129,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Safes/SomeSafe/Members/SomeUser/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Safes/SomeSafe/Members/SomeUser/"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Remove-PASUser.Tests.ps1
+++ b/Tests/Remove-PASUser.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -74,7 +84,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Remove-PASUser
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/ThatUser"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Users/ThatUser"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -84,7 +94,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				Remove-PASUser -id 1234
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Users/1234"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Users/1234"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Request-PASJustInTimeAccess.Tests.ps1
+++ b/Tests/Request-PASJustInTimeAccess.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -76,7 +86,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Accounts/22_2/RevokeAdministrativeAccess"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Accounts/22_2/RevokeAdministrativeAccess"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Resume-PASPSMSession.Tests.ps1
+++ b/Tests/Resume-PASPSMSession.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -77,7 +87,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/LiveSessions/SomeSessionID/Resume"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/LiveSessions/SomeSessionID/Resume"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -96,9 +106,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObj | Resume-PASPSMSession } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Revoke-PASJustInTimeAccess.Tests.ps1
+++ b/Tests/Revoke-PASJustInTimeAccess.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -76,7 +86,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Accounts/22_2/RevokeAdministrativeAccess"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Accounts/22_2/RevokeAdministrativeAccess"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Send-RADIUSResponse.Tests.ps1
+++ b/Tests/Send-RADIUSResponse.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -82,7 +92,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
                     'Message'      = 'SomeMessage'
                 }
 
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
 
 
             }

--- a/Tests/Set-PASAccount.Tests.ps1
+++ b/Tests/Set-PASAccount.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -107,7 +117,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObjV10 | Set-PASAccount -op Remove -path '/somepath' -value SomeValue
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Accounts/12_3"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Accounts/12_3"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -117,7 +127,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObjV10 | Set-PASAccount -operations $MultiOps
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Accounts/12_3"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Accounts/12_3"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -183,7 +193,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Set-PASAccount -Properties @{'Prop1' = 'Val1'; 'Prop2' = 'Val2'; 'Prop3' = 'Val3' }
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Accounts/12_3"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Accounts/12_3"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Set-PASAuthenticationMethod.Tests.ps1
+++ b/Tests/Set-PASAuthenticationMethod.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -54,7 +64,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/AuthenticationMethods/SomeID"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Configuration/AuthenticationMethods/SomeID"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -75,9 +85,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Set-PASAuthenticationMethod -ID SomeID } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Set-PASDirectoryMapping.Tests.ps1
+++ b/Tests/Set-PASDirectoryMapping.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -63,7 +73,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Set-PASDirectoryMapping -MappingAuthorizations AddUpdateUsers, ActivateUsers
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/LDAP/Directories/SomeDirectory/Mappings/SomeMappingID/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Configuration/LDAP/Directories/SomeDirectory/Mappings/SomeMappingID/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -76,21 +86,21 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObj | Set-PASDirectoryMapping } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '10.9'
+				$psPASSession.ExternalVersion = '10.9'
 				{ $InputObj | Set-PASDirectoryMapping -UserActivityLogPeriod 10 } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '13.9'
+				$psPASSession.ExternalVersion = '13.9'
 				{ $InputObj | Set-PASDirectoryMapping -UsedQuota 10 } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Set-PASDirectoryMappingOrder.Tests.ps1
+++ b/Tests/Set-PASDirectoryMappingOrder.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 

--- a/Tests/Set-PASGroup.Tests.ps1
+++ b/Tests/Set-PASGroup.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -36,7 +46,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
     InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
         BeforeEach {
-            $Script:ExternalVersion = '0.0'
+            $psPASSession.ExternalVersion = '0.0'
 
             Mock Invoke-PASRestMethod -MockWith {
                 [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
@@ -65,7 +75,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/API/UserGroups/123"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/API/UserGroups/123"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -86,9 +96,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             }
 
             It 'throws error if version requirement not met' {
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
                 { $InputObject | Set-PASGroup } | Should -Throw
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }

--- a/Tests/Set-PASLinkedAccount.Tests.ps1
+++ b/Tests/Set-PASLinkedAccount.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -36,7 +46,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
     InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
         BeforeEach {
-            $Script:ExternalVersion = '0.0'
+            $psPASSession.ExternalVersion = '0.0'
 
             Mock Invoke-PASRestMethod -MockWith {
             }
@@ -67,7 +77,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -eq "$($Script:BaseURI)/api/Accounts/12_3/LinkAccount"
+                    $URI -eq "$($Script:psPASSession.BaseURI)/api/Accounts/12_3/LinkAccount"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -88,9 +98,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             }
 
             It 'throws error if version requirement not met' {
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
                 { $InputObject | Set-PASLinkedAccount } | Should -Throw
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }

--- a/Tests/Set-PASOnboardingRule.Tests.ps1
+++ b/Tests/Set-PASOnboardingRule.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -78,7 +88,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Set-PASOnboardingRule
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/AutomaticOnboardingRules/123/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/AutomaticOnboardingRules/123/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -108,11 +118,11 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.2'
+				$psPASSession.ExternalVersion = '1.2'
 
 				{ $InputObj | Set-PASOnboardingRule } | Should -Throw
 
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Set-PASOpenIDConnectProvider.Tests.ps1
+++ b/Tests/Set-PASOpenIDConnectProvider.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -36,7 +46,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
 		BeforeEach {
-			$Script:ExternalVersion = '0.0'
+			$psPASSession.ExternalVersion = '0.0'
 
 			Mock Invoke-PASRestMethod -MockWith {
 				[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
@@ -70,7 +80,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Configuration/OIDC/Providers/idValue"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Configuration/OIDC/Providers/idValue"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -95,9 +105,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObject | Set-PASOpenIDConnectProvider } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Set-PASPTAEvent.Tests.ps1
+++ b/Tests/Set-PASPTAEvent.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -43,9 +53,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 					[PSCustomObject]@{'addsaferesult' = [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' } }
 				}
 
-				$Script:BaseURI = 'https://SomeURL/SomeApp'
-				$Script:ExternalVersion = '0.0'
-				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+				$Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+				$psPASSession.ExternalVersion = '0.0'
+				$psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 			}
 
@@ -59,7 +69,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				Set-PASPTAEvent -EventID 1234 -mStatus CLOSED
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -match "$($Script:BaseURI)/API/pta/API/Events/1234"
+					$URI -match "$($Script:psPASSession.BaseURI)/API/pta/API/Events/1234"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -82,9 +92,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Set-PASPTAEvent -EventID 1234 -mStatus CLOSED } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}
@@ -96,9 +106,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 					[PSCustomObject]@{'addsaferesult' = [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' } }
 				}
 
-				$Script:BaseURI = 'https://SomeURL/SomeApp'
-				$Script:ExternalVersion = '0.0'
-				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+				$Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+				$psPASSession.ExternalVersion = '0.0'
+				$psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 			}
 

--- a/Tests/Set-PASPTARemediation.Tests.ps1
+++ b/Tests/Set-PASPTARemediation.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -60,7 +70,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/pta/API/Settings/AutomaticRemediations/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/pta/API/Settings/AutomaticRemediations/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -91,9 +101,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Set-PASPTARemediation } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Set-PASPTARiskEvent.Tests.ps1
+++ b/Tests/Set-PASPTARiskEvent.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         }
 
         $Script:RequestBody = $null
-        $Script:BaseURI = 'https://SomeURL/SomeApp'
-        $Script:ExternalVersion = '0.0'
-        $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
     }
 
@@ -43,9 +53,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
                     [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
                 }
 
-                $Script:BaseURI = 'https://SomeURL/SomeApp'
-                $Script:ExternalVersion = '0.0'
-                $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                $Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+                $psPASSession.ExternalVersion = '0.0'
+                $psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
             }
 
@@ -59,7 +69,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
                 Set-PASPTARiskEvent -ID 1234 -Status CLOSED
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $URI -match "$($Script:BaseURI)/api/pta/API/Risks/RisksEvents/1234"
+                    $URI -match "$($Script:psPASSession.BaseURI)/api/pta/API/Risks/RisksEvents/1234"
 
                 } -Times 1 -Exactly -Scope It
 
@@ -82,9 +92,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             }
 
             It 'throws error if version requirement not met' {
-                $Script:ExternalVersion = '1.0'
+                $psPASSession.ExternalVersion = '1.0'
                 { Set-PASPTARiskEvent -ID 1234 -Status CLOSED } | Should -Throw
-                $Script:ExternalVersion = '0.0'
+                $psPASSession.ExternalVersion = '0.0'
             }
 
         }
@@ -96,9 +106,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
                     [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2'; 'Prop3' = 'Val2'; 'Prop4' = 'Val2'; 'Prop5' = 'Val2' }
                 }
 
-                $Script:BaseURI = 'https://SomeURL/SomeApp'
-                $Script:ExternalVersion = '0.0'
-                $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                $Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+                $psPASSession.ExternalVersion = '0.0'
+                $psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
             }
             It 'provides output' {

--- a/Tests/Set-PASPTARule.Tests.ps1
+++ b/Tests/Set-PASPTARule.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -92,7 +102,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/pta/API/Settings/RiskyActivity/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/pta/API/Settings/RiskyActivity/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -134,9 +144,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObj | Set-PASPTARule } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Set-PASPlatformPSMConfig.Tests.ps1
+++ b/Tests/Set-PASPlatformPSMConfig.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -54,7 +64,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Platforms/Targets/42/PrivilegedSessionManagement"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Platforms/Targets/42/PrivilegedSessionManagement"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -75,9 +85,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ Set-PASPlatformPSMConfig -ID 42 -PSMServerID SomePSMServer } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Set-PASSafe.Tests.ps1
+++ b/Tests/Set-PASSafe.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -77,7 +87,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Safes/SomeName"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Safes/SomeName"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -135,7 +145,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Safes/SomeName"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Safes/SomeName"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Set-PASSafeMember.Tests.ps1
+++ b/Tests/Set-PASSafeMember.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -98,7 +108,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Safes/SomeSafe/Members/SomeUser/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Safes/SomeSafe/Members/SomeUser/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -186,7 +196,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Safes/SomeSafe/Members/SomeUser/"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Safes/SomeSafe/Members/SomeUser/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -217,9 +227,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '12.1'
+				$psPASSession.ExternalVersion = '12.1'
 				{ $InputObj | Set-PASSafeMember } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Set-PASUser.Tests.ps1
+++ b/Tests/Set-PASUser.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -82,7 +92,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/WebServices/PIMServices.svc/Users/SomeUser"
+					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Users/SomeUser"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -134,7 +144,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/Users/1234"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Users/1234"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -159,10 +169,10 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 
 				{ $InputObj | Set-PASUser } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 
 			}
 

--- a/Tests/Set-PASUserPassword.Tests.ps1
+++ b/Tests/Set-PASUserPassword.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 

--- a/Tests/Skip-CertificateCheck.Tests.ps1
+++ b/Tests/Skip-CertificateCheck.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 

--- a/Tests/Start-PASAccountImportJob.Tests.ps1
+++ b/Tests/Start-PASAccountImportJob.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -66,7 +76,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				Start-PASAccountImportJob -Accounts $Accounts
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/bulkactions/accounts"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/bulkactions/accounts"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -108,10 +118,10 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '11.5'
+				$psPASSession.ExternalVersion = '11.5'
 
 				{ $InputObj | Start-PASAccountImportJob } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Stop-PASPSMSession.Tests.ps1
+++ b/Tests/Stop-PASPSMSession.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -74,7 +84,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/LiveSessions/SomeSessionID/Terminate"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/LiveSessions/SomeSessionID/Terminate"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -93,9 +103,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObj | Stop-PASPSMSession } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Suspend-PASPSMSession.Tests.ps1
+++ b/Tests/Suspend-PASPSMSession.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -75,7 +85,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/api/LiveSessions/SomeSessionID/Suspend"
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/LiveSessions/SomeSessionID/Suspend"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -94,9 +104,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 			It 'throws error if version requirement not met' {
-				$Script:ExternalVersion = '1.0'
+				$psPASSession.ExternalVersion = '1.0'
 				{ $InputObj | Suspend-PASPSMSession } | Should -Throw
-				$Script:ExternalVersion = '0.0'
+				$psPASSession.ExternalVersion = '0.0'
 			}
 
 		}

--- a/Tests/Test-PASPSMRecording.Tests.ps1
+++ b/Tests/Test-PASPSMRecording.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -62,7 +72,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Recordings/777_7/valid"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Recordings/777_7/valid"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Unblock-PASUser.Tests.ps1
+++ b/Tests/Unblock-PASUser.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -39,9 +49,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			BeforeEach {
 
-				$Script:BaseURI = 'https://SomeURL/SomeApp'
-				$Script:ExternalVersion = '0.0'
-				$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+				$Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+				$psPASSession.ExternalVersion = '0.0'
+				$psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
 				Mock Invoke-PASRestMethod -MockWith {
 					[PSCustomObject]@{'Detail1' = 'Detail'; 'Detail2' = 'Detail' }

--- a/Tests/Unlock-PASAccount.Tests.ps1
+++ b/Tests/Unlock-PASAccount.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -76,7 +86,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Accounts/22_2/CheckIn"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Accounts/22_2/CheckIn"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -88,7 +98,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:BaseURI)/API/Accounts/22_2/Unlock"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Accounts/22_2/Unlock"
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Use-PASSession.Tests.ps1
+++ b/Tests/Use-PASSession.Tests.ps1
@@ -20,9 +20,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 
 		$Script:RequestBody = $null
-		$Script:BaseURI = 'https://SomeURL/SomeApp'
-		$Script:ExternalVersion = '0.0'
-		$Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
 
 	}
 
@@ -30,6 +40,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 	AfterAll {
 
 		$Script:RequestBody = $null
+		$Script:psPASSession.ExternalVersion = [System.Version]'0.0'
 
 	}
 
@@ -47,14 +58,29 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 					BaseURI         = 'SomeURL'
 					ExternalVersion = '6.6'
 					WebSession      = $session
+					#NewProp         = "New Property"
 				}
-
+				Use-PASSession -Session $InputObject
 			}
 
-			It 'invokes set-variable the expected number of times' {
-				Mock Set-Variable -MockWith { }
-				Use-PASSession -Session $InputObject
-				Assert-MockCalled Set-Variable -Times 3 -Exactly -Scope It
+			It 'sets expected User' {
+				$psPASSession.User | Should -Be 'SomeUser'
+			}
+
+			It 'sets expected BaseURI' {
+				$psPASSession.BaseURI | Should -Be 'SomeURL'
+			}
+
+			It 'sets expected ExternalVersion' {
+				$psPASSession.ExternalVersion | Should -Be '6.6'
+			}
+
+			It 'sets expected WebSession' {
+				$psPASSession.WebSession.Headers['Test'] | Should -Be 'SomeValue'
+			}
+
+			It 'sets expected Other property' -Skip {
+
 			}
 
 		}

--- a/docs/collections/_commands/Add-PASGroupMember.md
+++ b/docs/collections/_commands/Add-PASGroupMember.md
@@ -65,7 +65,7 @@ Minimum required version 10.6
 ```yaml
 Type: Int32
 Parameter Sets: Gen2
-Aliases:
+Aliases: ID
 
 Required: True
 Position: Named

--- a/docs/collections/_commands/Remove-PASGroup.md
+++ b/docs/collections/_commands/Remove-PASGroup.md
@@ -15,7 +15,7 @@ Deletes a user group
 ## SYNTAX
 
 ```
-Remove-PASGroup [-GroupID] <Int32> [-WhatIf] [-Confirm] [<CommonParameters>]
+Remove-PASGroup -ID <Int32> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -34,21 +34,6 @@ Remove-PASGroup -GroupID 3
 Deletes vault group with ID of 3
 
 ## PARAMETERS
-
-### -GroupID
-The unique ID of the vault group to delete.
-
-```yaml
-Type: Int32
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 1
-Default value: 0
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
 
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
@@ -78,6 +63,21 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ID
+{{ Fill ID Description }}
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases: GroupID
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 

--- a/docs/collections/_commands/Set-PASGroup.md
+++ b/docs/collections/_commands/Set-PASGroup.md
@@ -15,7 +15,7 @@ Renames a Vault group
 ## SYNTAX
 
 ```
-Set-PASGroup [-GroupID] <Int32> [-GroupName] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+Set-PASGroup -ID <Int32> [-GroupName] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -35,21 +35,6 @@ PS C:\> Set-PASGroup -GroupID 420 -GroupName SomeName
 Renames group with id 420 to "SomeName"
 
 ## PARAMETERS
-
-### -GroupID
-The ID of the group to update
-
-```yaml
-Type: Int32
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 1
-Default value: 0
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
 
 ### -GroupName
 A new name for the group
@@ -94,6 +79,21 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ID
+{{ Fill ID Description }}
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases: GroupID
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 

--- a/docs/collections/_posts/2024-02-20-pspas-release-6-2.md
+++ b/docs/collections/_posts/2024-02-20-pspas-release-6-2.md
@@ -1,0 +1,64 @@
+---
+title: "psPAS Release 6.2"
+date: 2024-02-20 00:00:00
+tags:
+  - Release Notes
+  - Invoke-PASRestMethod
+  - Get-PASSession
+  - Add-PASGroupMember
+  - Remove-PASGroup
+  - Set-PASGroup
+  - New-PASPSMSession
+  - New-PASSession
+---
+
+## **6.2.##**
+
+Introducing enhancements to psPAS session related data.
+
+Using the `Get-PASSession` command, users of the module can now get data on session start time, elapsed time since authentication as well as details of the last command run, the raw results returned from the api, as well as any detail of the last error which may have been received during the session.
+
+This update makes troubleshooting API commands and expected results much easier from both an end user and module support perspective.
+
+```powershell
+PS> Get-PASSession
+
+Name                           Value
+----                           -----
+BaseURI                        https://sometenant.privilegecloud.cyberark.cloud/PasswordVault
+User                           someuser@cyberark.cloud.1312
+ExternalVersion                14.0.0
+WebSession                     Microsoft.PowerShell.Commands.WebRequestSession
+StartTime                      20/02/2024 18:14:01
+ElapsedTime                    00:04:03
+LastCommand                    System.Management.Automation.InvocationInfo
+LastCommandTime                20/02/2024 18:18:03
+LastCommandResults             {"Users":[{"id":26,"username":"someuser@somedomain.com","source":"CyberArk","userType":"SomeType",...
+LastError                      {"ErrorCode":"PASWS041E","ErrorMessage":"You are not authorized to perform this action."}
+LastErrorTime                  20/02/2024 18:13:12
+```
+
+To realise this update, lots of module wide changes to all module commands have been required; while no change to the general operation of the psPAS module should be noticed - do raise an issue if something does not appear correct.
+
+### Added
+- N/A
+
+### Updated
+- `Get-PASSession`
+  - makes additional information available to users running the command
+    - authentication time
+    - session length
+    - last command and result data
+    - last error details
+- `New-PASPSMSession`
+  - RDP and PSMGW connections will be automatically opened when issuing  connection request.
+- `New-PASSession`
+  - Adds logic around getting the logged on user name for either self-hosted or privilege cloud deployments
+- PSM Session Data Formats
+  - Adds `Start` & `End` to standard table view output
+  - Formats `Start` & `End` as standard datetime instead of unixtime.
+
+### Fixed
+- `Add-PASGroupMember`,`Remove-PASGroup`,`Set-PASGroup`
+  - Standardises name of `ID` parameter.
+  - Adds `GroupID` alias to `ID` parameter.

--- a/psPAS/Functions/AccountACL/Add-PASAccountACL.ps1
+++ b/psPAS/Functions/AccountACL/Add-PASAccountACL.ps1
@@ -67,7 +67,7 @@ function Add-PASAccountACL {
 	PROCESS {
 
 		#URL for request
-		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Account/$($AccountAddress |
+		$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Account/$($AccountAddress |
 
             Get-EscapedString)|$($AccountUserName |
 
@@ -83,7 +83,7 @@ function Add-PASAccountACL {
 			ConvertTo-Json
 
 		#Send Request
-		$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/AccountACL/Get-PASAccountACL.ps1
+++ b/psPAS/Functions/AccountACL/Get-PASAccountACL.ps1
@@ -31,7 +31,7 @@ function Get-PASAccountACL {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Account/$($AccountAddress |
+		$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Account/$($AccountAddress |
 
             Get-EscapedString)|$($AccountUserName |
 
@@ -40,7 +40,7 @@ function Get-PASAccountACL {
                     Get-EscapedString)/PrivilegedCommands/"
 
 		#Send request to Web Service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession #DevSkim: ignore DS104456
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET #DevSkim: ignore DS104456
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/AccountACL/Remove-PASAccountACL.ps1
+++ b/psPAS/Functions/AccountACL/Remove-PASAccountACL.ps1
@@ -36,7 +36,7 @@ function Remove-PASAccountACL {
 	PROCESS {
 
 		#URL for request
-		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Account/$($AccountAddress |
+		$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Account/$($AccountAddress |
 
             Get-EscapedString)|$($AccountUserName |
 
@@ -51,7 +51,7 @@ function Remove-PASAccountACL {
 				"Delete Privileged Command '$Id'")) {
 
 			#Send Request to Web Service
-			Invoke-PASRestMethod -Uri $URI -Method DELETE -Body $Body -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method DELETE -Body $Body
 
 		}
 

--- a/psPAS/Functions/AccountGroups/Add-PASAccountGroupMember.ps1
+++ b/psPAS/Functions/AccountGroups/Add-PASAccountGroupMember.ps1
@@ -23,7 +23,7 @@ function Add-PASAccountGroupMember {
 	PROCESS {
 
 		#Create URL for Request
-		$URI = "$Script:BaseURI/API/AccountGroups/$($GroupID |
+		$URI = "$($psPASSession.BaseURI)/API/AccountGroups/$($GroupID |
 
             Get-EscapedString)/Members"
 
@@ -33,7 +33,7 @@ function Add-PASAccountGroupMember {
 			Get-PASParameter -ParametersToRemove GroupID | ConvertTo-Json
 
 		#send request to PAS web service
-		Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+		Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
 	}#process
 

--- a/psPAS/Functions/AccountGroups/Get-PASAccountGroup.ps1
+++ b/psPAS/Functions/AccountGroups/Get-PASAccountGroup.ps1
@@ -33,7 +33,7 @@ function Get-PASAccountGroup {
 
 				Assert-VersionRequirement -RequiredVersion 10.5 -MaximumVersion 12.3
 				#Create URL for Request
-				$URI = "$Script:BaseURI/API/Safes/$($Safe | Get-EscapedString)/AccountGroups"
+				$URI = "$($psPASSession.BaseURI)/API/Safes/$($Safe | Get-EscapedString)/AccountGroups"
 
 				break
 
@@ -43,7 +43,7 @@ function Get-PASAccountGroup {
 
 				Assert-VersionRequirement -RequiredVersion 9.10
 				#Create URL for Request
-				$URI = "$Script:BaseURI/API/AccountGroups?$($PSBoundParameters | Get-PASParameter | ConvertTo-QueryString)"
+				$URI = "$($psPASSession.BaseURI)/API/AccountGroups?$($PSBoundParameters | Get-PASParameter | ConvertTo-QueryString)"
 
 			}
 
@@ -51,7 +51,7 @@ function Get-PASAccountGroup {
 
 
 		#send request to PAS web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/AccountGroups/Get-PASAccountGroupMember.ps1
+++ b/psPAS/Functions/AccountGroups/Get-PASAccountGroupMember.ps1
@@ -16,10 +16,10 @@ function Get-PASAccountGroupMember {
 	PROCESS {
 
 		#Create URL for Request
-		$URI = "$Script:BaseURI/API/AccountGroups/$GroupID/Members"
+		$URI = "$($psPASSession.BaseURI)/API/AccountGroups/$GroupID/Members"
 
 		#send request to PAS web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/AccountGroups/New-PASAccountGroup.ps1
+++ b/psPAS/Functions/AccountGroups/New-PASAccountGroup.ps1
@@ -29,7 +29,7 @@ function New-PASAccountGroup {
 	PROCESS {
 
 		#Create URL for Request
-		$URI = "$Script:BaseURI/API/AccountGroups/"
+		$URI = "$($psPASSession.BaseURI)/API/AccountGroups/"
 
 		#Create body of request
 		$body = $PSBoundParameters | Get-PASParameter | ConvertTo-Json
@@ -37,7 +37,7 @@ function New-PASAccountGroup {
 		if ($PSCmdlet.ShouldProcess($GroupName, 'Define New Account Group')) {
 
 			#send request to PAS web service
-			Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
 		}
 

--- a/psPAS/Functions/AccountGroups/Remove-PASAccountGroupMember.ps1
+++ b/psPAS/Functions/AccountGroups/Remove-PASAccountGroupMember.ps1
@@ -22,12 +22,12 @@ function Remove-PASAccountGroupMember {
 	PROCESS {
 
 		#Create URL for Request
-		$URI = "$Script:BaseURI/API/AccountGroups/$GroupID/Members/$AccountID"
+		$URI = "$($psPASSession.BaseURI)/API/AccountGroups/$GroupID/Members/$AccountID"
 
 		if ($PSCmdlet.ShouldProcess($AccountID, "Delete Member from Account Group $($GroupID)")) {
 
 			#send request to PAS web service
-			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method DELETE
 
 		}
 

--- a/psPAS/Functions/Accounts/Add-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Add-PASAccount.ps1
@@ -238,7 +238,7 @@ function Add-PASAccount {
 				Assert-VersionRequirement -RequiredVersion 10.4
 
 				#Create URL for Request
-				$URI = "$Script:BaseURI/api/Accounts"
+				$URI = "$($psPASSession.BaseURI)/api/Accounts"
 
 				$Account = New-PASAccountObject @boundParameters
 
@@ -251,7 +251,7 @@ function Add-PASAccount {
 			'Gen1' {
 
 				#Create URL for Request
-				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Account"
+				$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Account"
 
 				#deal with Password SecureString
 				If ($PSBoundParameters.ContainsKey('password')) {
@@ -320,7 +320,7 @@ function Add-PASAccount {
 		}
 
 		#send request to PAS web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
 		if ($PSCmdlet.ParameterSetName -eq 'Gen2') {
 

--- a/psPAS/Functions/Accounts/Add-PASDiscoveredAccount.ps1
+++ b/psPAS/Functions/Accounts/Add-PASDiscoveredAccount.ps1
@@ -264,7 +264,7 @@ function Add-PASDiscoveredAccount {
 	PROCESS {
 
 		#Create URL for Request
-		$URI = "$Script:BaseURI/api/DiscoveredAccounts"
+		$URI = "$($psPASSession.BaseURI)/api/DiscoveredAccounts"
 
 		#Get all parameters that will be sent in the request
 		$boundParameters = $PSBoundParameters | Get-PASParameter
@@ -302,7 +302,7 @@ function Add-PASDiscoveredAccount {
 		$Body = $boundParameters | Get-PASParameter -ParametersToRemove $AccountProperties | ConvertTo-Json
 
 		#send request to PAS web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/Accounts/Add-PASPendingAccount.ps1
+++ b/psPAS/Functions/Accounts/Add-PASPendingAccount.ps1
@@ -146,7 +146,7 @@ function Add-PASPendingAccount {
 	PROCESS {
 
 		#Create URL for Request
-		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/PendingAccounts"
+		$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/PendingAccounts"
 
 		#Get all parameters that will be sent in the request
 		$boundParameters = $PSBoundParameters | Get-PASParameter
@@ -171,7 +171,7 @@ function Add-PASPendingAccount {
 		} | ConvertTo-Json
 
 		#send request to PAS web service
-		Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+		Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
 	}#process
 

--- a/psPAS/Functions/Accounts/Add-PASPersonalAdminAccount.ps1
+++ b/psPAS/Functions/Accounts/Add-PASPersonalAdminAccount.ps1
@@ -33,14 +33,14 @@ function Add-PASPersonalAdminAccount {
         Assert-VersionRequirement -RequiredVersion 12.6
 
         #Create URL for Request
-        $URI = "$Script:BaseURI/api/Accounts/PersonalAdminAccount"
+        $URI = "$($psPASSession.BaseURI)/api/Accounts/PersonalAdminAccount"
 
         $Account = New-PASAccountObject @boundParameters -PersonalAdminAccount
 
         $Body = $Account | ConvertTo-Json
 
         #send request to PAS web service
-        $result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+        $result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
         If ($null -ne $result) {
 

--- a/psPAS/Functions/Accounts/Clear-PASDiscoveredAccountList.ps1
+++ b/psPAS/Functions/Accounts/Clear-PASDiscoveredAccountList.ps1
@@ -11,11 +11,11 @@ function Clear-PASDiscoveredAccountList {
 
     PROCESS {
 
-        $URI = "$Script:BaseURI/api/DiscoveredAccounts"
+        $URI = "$($psPASSession.BaseURI)/api/DiscoveredAccounts"
 
         if ($PSCmdlet.ShouldProcess('Discovered/Pending Account List', 'Delete')) {
 
-            Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+            Invoke-PASRestMethod -Uri $URI -Method DELETE
 
         }
 

--- a/psPAS/Functions/Accounts/Clear-PASLinkedAccount.ps1
+++ b/psPAS/Functions/Accounts/Clear-PASLinkedAccount.ps1
@@ -26,12 +26,12 @@ Function Clear-PASLinkedAccount {
     PROCESS {
 
         #Create URL for Request
-        $URI = "$Script:BaseURI/api/Accounts/$AccountID/LinkAccount/$extraPasswordIndex"
+        $URI = "$($psPASSession.BaseURI)/api/Accounts/$AccountID/LinkAccount/$extraPasswordIndex"
 
         if ($PSCmdlet.ShouldProcess($AccountID, "Clear extraPass$extraPasswordIndex Linked Account")) {
 
             #Send request to web service
-            Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+            Invoke-PASRestMethod -Uri $URI -Method DELETE
 
         }
 

--- a/psPAS/Functions/Accounts/Get-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccount.ps1
@@ -139,7 +139,7 @@ function Get-PASAccount {
 				$typeName = 'psPAS.CyberArk.Vault.Account.V10'
 
 				#define base URL
-				$URI = "$Script:BaseURI/api/Accounts"
+				$URI = "$($psPASSession.BaseURI)/api/Accounts"
 
 			}
 
@@ -149,7 +149,7 @@ function Get-PASAccount {
 				$typeName = 'psPAS.CyberArk.Vault.Account'
 
 				#Create request URL
-				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Accounts"
+				$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Accounts"
 
 			}
 
@@ -187,7 +187,7 @@ function Get-PASAccount {
 		}
 
 		#Send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession -TimeoutSec $TimeoutSec
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET -TimeoutSec $TimeoutSec
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/Accounts/Get-PASAccountActivity.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccountActivity.ps1
@@ -38,7 +38,7 @@ function Get-PASAccountActivity {
 				#!Depreciated above 13.2
 				Assert-VersionRequirement -MaximumVersion 13.2
 				#URL for Request
-				$URI = "$Script:BaseURI/WebServices/PIMServices.svc"
+				$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc"
 
 				break
 
@@ -48,7 +48,7 @@ function Get-PASAccountActivity {
 
 				Assert-VersionRequirement -RequiredVersion 13.2
 				#URL for Request
-				$URI = "$Script:BaseURI/api"
+				$URI = "$($psPASSession.BaseURI)/api"
 
 			}
 
@@ -58,7 +58,7 @@ function Get-PASAccountActivity {
 		$URI = "$URI/Accounts/$($AccountID | Get-EscapedString)/Activities"
 
 		#Send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/Accounts/Get-PASAccountDetail.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccountDetail.ps1
@@ -19,10 +19,10 @@ function Get-PASAccountDetail {
     PROCESS {
 
         #define base URL
-        $URI = "$Script:BaseURI/api/ExtendedAccounts/$id/overview"
+        $URI = "$($psPASSession.BaseURI)/api/ExtendedAccounts/$id/overview"
 
         #Send request to web service
-        $result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+        $result = Invoke-PASRestMethod -Uri $URI -Method GET
 
         If ($null -ne $result) {
             $result

--- a/psPAS/Functions/Accounts/Get-PASAccountImportJob.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccountImportJob.ps1
@@ -19,7 +19,7 @@ Function Get-PASAccountImportJob {
 	Process {
 
 		#Create URL for Request
-		$URI = "$Script:BaseURI/api/bulkactions/accounts"
+		$URI = "$($psPASSession.BaseURI)/api/bulkactions/accounts"
 
 		If ($PSCmdlet.ParameterSetName -eq 'byID') {
 
@@ -28,7 +28,7 @@ Function Get-PASAccountImportJob {
 		}
 
 		#send request
-		$Result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$Result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $Result) {
 

--- a/psPAS/Functions/Accounts/Get-PASAccountPassword.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccountPassword.ps1
@@ -96,7 +96,7 @@ function Get-PASAccountPassword {
 				#For Version 10.1+
 				$Request = @{
 
-					'URI'    = "$Script:BaseURI/api/Accounts/$($AccountID | Get-EscapedString)/Password/Retrieve"
+					'URI'    = "$($psPASSession.BaseURI)/api/Accounts/$($AccountID | Get-EscapedString)/Password/Retrieve"
 
 					'Method' = 'POST'
 
@@ -114,7 +114,7 @@ function Get-PASAccountPassword {
 				#For Version 9.7+
 				$Request = @{
 
-					'URI'    = "$Script:BaseURI/WebServices/PIMServices.svc/Accounts/$($AccountID | Get-EscapedString)/Credentials"
+					'URI'    = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Accounts/$($AccountID | Get-EscapedString)/Credentials"
 
 					'Method' = 'GET'
 
@@ -127,7 +127,7 @@ function Get-PASAccountPassword {
 		}
 
 		#Add default Request parameters
-		$Request.Add('WebSession', $Script:WebSession)
+		$Request.Add('WebSession', $($psPASSession.WebSession))
 
 		#splat request to web service
 		$result = Invoke-PASRestMethod @Request

--- a/psPAS/Functions/Accounts/Get-PASAccountPasswordVersion.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccountPasswordVersion.ps1
@@ -27,7 +27,7 @@ function Get-PASAccountPasswordVersion {
     PROCESS {
 
         #Create URL for request
-        $URI = "$Script:BaseURI/api/Accounts/$AccountID/Secret/Versions"
+        $URI = "$($psPASSession.BaseURI)/api/Accounts/$AccountID/Secret/Versions"
 
         $boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove AccountID
 
@@ -42,7 +42,7 @@ function Get-PASAccountPasswordVersion {
         }
 
         #Send request to webservice
-        $result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+        $result = Invoke-PASRestMethod -Uri $URI -Method GET
 
         If ($null -ne $result) {
 

--- a/psPAS/Functions/Accounts/Get-PASAccountSSHKey.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccountSSHKey.ps1
@@ -60,13 +60,13 @@ Function Get-PASAccountSSHKey {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/Accounts/$($AccountID | Get-EscapedString)/Secret/Retrieve"
+		$URI = "$($psPASSession.BaseURI)/api/Accounts/$($AccountID | Get-EscapedString)/Secret/Retrieve"
 
 		#Create request body
 		$body = $PSBoundParameters | Get-PASParameter -ParametersToRemove AccountID | ConvertTo-Json
 
 		#send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/Accounts/Get-PASDiscoveredAccount.ps1
+++ b/psPAS/Functions/Accounts/Get-PASDiscoveredAccount.ps1
@@ -68,7 +68,7 @@ Function Get-PASDiscoveredAccount {
 	Process {
 
 		#Create URL for Request
-		$URI = "$Script:BaseURI/api/DiscoveredAccounts"
+		$URI = "$($psPASSession.BaseURI)/api/DiscoveredAccounts"
 
 		switch ($PSCmdlet.ParameterSetName) {
 
@@ -116,7 +116,7 @@ Function Get-PASDiscoveredAccount {
 		}
 
 		#Send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $Result) {
 

--- a/psPAS/Functions/Accounts/Get-PASLinkedAccount.ps1
+++ b/psPAS/Functions/Accounts/Get-PASLinkedAccount.ps1
@@ -21,10 +21,10 @@ Function Get-PASLinkedAccount {
     PROCESS {
 
         #Create URL for Request
-        $URI = "$Script:BaseURI/api/ExtendedAccounts/$id/LinkedAccounts"
+        $URI = "$($psPASSession.BaseURI)/api/ExtendedAccounts/$id/LinkedAccounts"
 
         #Send request to web service
-        $result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+        $result = Invoke-PASRestMethod -Uri $URI -Method GET
 
         If ($null -ne $result) {
 

--- a/psPAS/Functions/Accounts/Get-PASLinkedGroup.ps1
+++ b/psPAS/Functions/Accounts/Get-PASLinkedGroup.ps1
@@ -21,10 +21,10 @@ Function Get-PASLinkedGroup {
     PROCESS {
 
         #Create URL for Request
-        $URI = "$Script:BaseURI/api/ExtendedAccounts/$id/LinkedAccounts"
+        $URI = "$($psPASSession.BaseURI)/api/ExtendedAccounts/$id/LinkedAccounts"
 
         #Send request to web service
-        $result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+        $result = Invoke-PASRestMethod -Uri $URI -Method GET
 
         If ($null -ne $result) {
 

--- a/psPAS/Functions/Accounts/Invoke-PASCPMOperation.ps1
+++ b/psPAS/Functions/Accounts/Invoke-PASCPMOperation.ps1
@@ -112,7 +112,7 @@ function Invoke-PASCPMOperation {
 
 		#Create hashtable for splatting
 		$ThisRequest = @{ }
-		$ThisRequest['WebSession'] = $Script:WebSession
+		$ThisRequest['WebSession'] = $psPASSession.WebSession
 		$ThisRequest['Method'] = 'PUT'
 
 	}#Begin
@@ -147,7 +147,7 @@ function Invoke-PASCPMOperation {
 
 			{ $PSItem -match 'Credentials$' } {
 
-				$URI = "$Script:BaseURI/WebServices/PIMServices.svc"
+				$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc"
 				break
 
 			}
@@ -158,7 +158,7 @@ function Invoke-PASCPMOperation {
 				#At least version 9.10 required to verify/change/reconcile
 				Assert-VersionRequirement -RequiredVersion 9.10
 
-				$URI = "$Script:BaseURI/API"
+				$URI = "$($psPASSession.BaseURI)/API"
 
 				#verify/change/reconcile method
 				$ThisRequest['Method'] = 'POST'

--- a/psPAS/Functions/Accounts/New-PASAccountPassword.ps1
+++ b/psPAS/Functions/Accounts/New-PASAccountPassword.ps1
@@ -21,12 +21,12 @@ function New-PASAccountPassword {
     PROCESS {
 
         #Create URL for request
-        $URI = "$Script:BaseURI/api/Accounts/$AccountID/Secret/Generate"
+        $URI = "$($psPASSession.BaseURI)/api/Accounts/$AccountID/Secret/Generate"
 
         if ($PSCmdlet.ShouldProcess($AccountID, 'Generate New Password')) {
 
             #Send request to webservice
-            $result = Invoke-PASRestMethod -Uri $URI -Method POST -WebSession $Script:WebSession
+            $result = Invoke-PASRestMethod -Uri $URI -Method POST
 
             if ($null -ne $result) {
 

--- a/psPAS/Functions/Accounts/Publish-PASDiscoveredAccount.ps1
+++ b/psPAS/Functions/Accounts/Publish-PASDiscoveredAccount.ps1
@@ -42,7 +42,7 @@ function Publish-PASDiscoveredAccount {
 
     PROCESS {
 
-        $URI = "$Script:BaseURI/api/DiscoveredAccounts/$id/Onboard"
+        $URI = "$($psPASSession.BaseURI)/api/DiscoveredAccounts/$id/Onboard"
 
         #Get all parameters that will be sent in the request
         $boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove id
@@ -59,7 +59,7 @@ function Publish-PASDiscoveredAccount {
 
         if ($PSCmdlet.ShouldProcess($id, 'Onboard Discovered Account')) {
 
-            Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+            Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
         }
 

--- a/psPAS/Functions/Accounts/Remove-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Remove-PASAccount.ps1
@@ -32,7 +32,7 @@ function Remove-PASAccount {
 			'Gen1' {
 
 				#Create URL for request (earlier than 10.4)
-				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Accounts/$AccountID"
+				$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Accounts/$AccountID"
 				break
 
 			}
@@ -40,7 +40,7 @@ function Remove-PASAccount {
 			default {
 
 				#Create URL for request (Version 10.4 onwards)
-				$URI = "$Script:BaseURI/api/Accounts/$AccountID"
+				$URI = "$($psPASSession.BaseURI)/api/Accounts/$AccountID"
 
 			}
 
@@ -49,7 +49,7 @@ function Remove-PASAccount {
 		if ($PSCmdlet.ShouldProcess($AccountID, 'Delete Account')) {
 
 			#Send request to webservice
-			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method DELETE
 
 		}
 

--- a/psPAS/Functions/Accounts/Request-PASJustInTimeAccess.ps1
+++ b/psPAS/Functions/Accounts/Request-PASJustInTimeAccess.ps1
@@ -19,10 +19,10 @@ function Request-PASJustInTimeAccess {
 	PROCESS {
 
 		#Create URL for request (Version 10.4 onwards)
-		$URI = "$Script:BaseURI/api/Accounts/$AccountID/grantAdministrativeAccess"
+		$URI = "$($psPASSession.BaseURI)/api/Accounts/$AccountID/grantAdministrativeAccess"
 
 		#Send request to webservice
-		Invoke-PASRestMethod -Uri $URI -Method POST -WebSession $Script:WebSession
+		Invoke-PASRestMethod -Uri $URI -Method POST
 
 	}#process
 

--- a/psPAS/Functions/Accounts/Revoke-PASJustInTimeAccess.ps1
+++ b/psPAS/Functions/Accounts/Revoke-PASJustInTimeAccess.ps1
@@ -19,10 +19,10 @@ function Revoke-PASJustInTimeAccess {
     PROCESS {
 
         #Create URL for request
-        $URI = "$Script:BaseURI/api/Accounts/$AccountID/RevokeAdministrativeAccess"
+        $URI = "$($psPASSession.BaseURI)/api/Accounts/$AccountID/RevokeAdministrativeAccess"
 
         #Send request to webservice
-        Invoke-PASRestMethod -Uri $URI -Method POST -WebSession $Script:WebSession
+        Invoke-PASRestMethod -Uri $URI -Method POST
 
     }#process
 

--- a/psPAS/Functions/Accounts/Set-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Set-PASAccount.ps1
@@ -140,7 +140,7 @@ function Set-PASAccount {
 				Assert-VersionRequirement -RequiredVersion 10.4
 
 				#Create URL for Request
-				$URI = "$Script:BaseURI/api/Accounts/$AccountID"
+				$URI = "$($psPASSession.BaseURI)/api/Accounts/$AccountID"
 
 				#Define method for request
 				$Method = 'PATCH'
@@ -163,7 +163,7 @@ function Set-PASAccount {
 			'Gen1' {
 
 				#Create URL for Request
-				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Accounts/$AccountID"
+				$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Accounts/$AccountID"
 
 				#Define method for request
 				$Method = 'PUT'
@@ -238,7 +238,7 @@ function Set-PASAccount {
 		if ($PSCmdlet.ShouldProcess($AccountID, 'Update Account Properties')) {
 
 			#send request to PAS web service
-			$Result = Invoke-PASRestMethod -Uri $URI -Method $Method -Body $Body -WebSession $Script:WebSession
+			$Result = Invoke-PASRestMethod -Uri $URI -Method $Method -Body $Body
 
 			If ($null -ne $result) {
 

--- a/psPAS/Functions/Accounts/Set-PASLinkedAccount.ps1
+++ b/psPAS/Functions/Accounts/Set-PASLinkedAccount.ps1
@@ -46,7 +46,7 @@ Function Set-PASLinkedAccount {
 	PROCESS {
 
 		#Create URL for Request
-		$URI = "$Script:BaseURI/api/Accounts/$AccountID/LinkAccount"
+		$URI = "$($psPASSession.BaseURI)/api/Accounts/$AccountID/LinkAccount"
 
 		#Get Parameters to include in request
 		$body = $PSBoundParameters | Get-PASParameter -ParametersToRemove AccountID | ConvertTo-Json
@@ -54,7 +54,7 @@ Function Set-PASLinkedAccount {
 		if ($PSCmdlet.ShouldProcess($AccountID, 'Set Linked Account')) {
 
 			#Send request to web service
-			Invoke-PASRestMethod -Uri $URI -Method POST -Body $body -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method POST -Body $body
 
 		}
 

--- a/psPAS/Functions/Accounts/Start-PASAccountImportJob.ps1
+++ b/psPAS/Functions/Accounts/Start-PASAccountImportJob.ps1
@@ -20,7 +20,7 @@ Function Start-PASAccountImportJob {
 		Assert-VersionRequirement -RequiredVersion 11.6
 
 		#Create URL for Request
-		$URI = "$Script:BaseURI/api/bulkactions/accounts"
+		$URI = "$($psPASSession.BaseURI)/api/bulkactions/accounts"
 
 	}
 
@@ -35,7 +35,7 @@ Function Start-PASAccountImportJob {
 		if ($PSCmdlet.ShouldProcess("List of $($accountsList.count) account(s)", 'Start Bulk Account Import Job')) {
 
 			#send request
-			$Result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+			$Result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
 			If ($null -ne $Result) {
 

--- a/psPAS/Functions/Accounts/Unlock-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Unlock-PASAccount.ps1
@@ -36,7 +36,7 @@ function Unlock-PASAccount {
 			'CheckIn' {
 
 				#Create URL for request
-				$URI = "$Script:BaseURI/API/Accounts/$AccountID/CheckIn"
+				$URI = "$($psPASSession.BaseURI)/API/Accounts/$AccountID/CheckIn"
 				break
 
 			}
@@ -47,7 +47,7 @@ function Unlock-PASAccount {
 				Assert-VersionRequirement -RequiredVersion 11.6
 
 				#Create URL for request
-				$URI = "$Script:BaseURI/API/Accounts/$AccountID/Unlock"
+				$URI = "$($psPASSession.BaseURI)/API/Accounts/$AccountID/Unlock"
 				break
 
 			}
@@ -58,7 +58,7 @@ function Unlock-PASAccount {
 		if ($PSCmdlet.ShouldProcess($AccountID, "$($PSCmdlet.ParameterSetName) Account")) {
 
 			#send request to web service
-			Invoke-PASRestMethod -Uri $URI -Method POST -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method POST
 
 		}
 

--- a/psPAS/Functions/Applications/Add-PASApplication.ps1
+++ b/psPAS/Functions/Applications/Add-PASApplication.ps1
@@ -83,7 +83,7 @@ function Add-PASApplication {
 	PROCESS {
 
 		#WebService URL
-		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Applications"
+		$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Applications"
 
 		#Get request parameters
 		$boundParameters = $PSBoundParameters | Get-PASParameter
@@ -106,7 +106,7 @@ function Add-PASApplication {
 		} | ConvertTo-Json
 
 		#Send Request
-		Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+		Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
 	}#process
 

--- a/psPAS/Functions/Applications/Add-PASApplicationAuthenticationMethod.ps1
+++ b/psPAS/Functions/Applications/Add-PASApplicationAuthenticationMethod.ps1
@@ -127,7 +127,7 @@ function Add-PASApplicationAuthenticationMethod {
 
     PROCESS {
 
-        $URI = "$Script:BaseURI/WebServices/PIMServices.svc/Applications/$($AppID | Get-EscapedString)/Authentications/"
+        $URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Applications/$($AppID | Get-EscapedString)/Authentications/"
 
         $boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove AppID
 
@@ -149,7 +149,7 @@ function Add-PASApplicationAuthenticationMethod {
 
         } | ConvertTo-Json
 
-        Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+        Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
     }#process
 

--- a/psPAS/Functions/Applications/Get-PASApplication.ps1
+++ b/psPAS/Functions/Applications/Get-PASApplication.ps1
@@ -43,7 +43,7 @@ function Get-PASApplication {
 	PROCESS {
 
 		#Base URL for Request
-		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Applications"
+		$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Applications"
 
 		#If AppID specified
 		If ($($PSCmdlet.ParameterSetName) -eq 'byAppID') {
@@ -72,7 +72,7 @@ function Get-PASApplication {
 		}
 
 		#Send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/Applications/Get-PASApplicationAuthenticationMethod.ps1
+++ b/psPAS/Functions/Applications/Get-PASApplicationAuthenticationMethod.ps1
@@ -13,11 +13,11 @@ function Get-PASApplicationAuthenticationMethod {
 
 	PROCESS {
 
-		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Applications/$($AppID |
+		$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Applications/$($AppID |
 
             Get-EscapedString)/Authentications/"
 
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/Applications/Remove-PASApplication.ps1
+++ b/psPAS/Functions/Applications/Remove-PASApplication.ps1
@@ -15,12 +15,12 @@ function Remove-PASApplication {
 	PROCESS {
 
 		#Request URL
-		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Applications/$($AppID | Get-EscapedString)/"
+		$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Applications/$($AppID | Get-EscapedString)/"
 
 		if ($PSCmdlet.ShouldProcess($AppID, 'Delete Application')) {
 
 			#Send Request
-			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method DELETE
 
 		}
 

--- a/psPAS/Functions/Applications/Remove-PASApplicationAuthenticationMethod.ps1
+++ b/psPAS/Functions/Applications/Remove-PASApplicationAuthenticationMethod.ps1
@@ -22,14 +22,14 @@ function Remove-PASApplicationAuthenticationMethod {
 	PROCESS {
 
 		#request URL
-		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Applications/$($AppID |
+		$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Applications/$($AppID |
 
             Get-EscapedString)/Authentications/$($AuthID | Get-EscapedString)"
 
 		if ($PSCmdlet.ShouldProcess($AppID, "Delete Authentication Method '$AuthID'")) {
 
 			#Send Request
-			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method DELETE
 
 		}
 

--- a/psPAS/Functions/Authentication/Add-PASAuthenticationMethod.ps1
+++ b/psPAS/Functions/Authentication/Add-PASAuthenticationMethod.ps1
@@ -74,13 +74,13 @@ Function Add-PASAuthenticationMethod {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/Configuration/AuthenticationMethods"
+		$URI = "$($psPASSession.BaseURI)/api/Configuration/AuthenticationMethods"
 
 		#Request body
 		$Body = $PSBoundParameters | Get-PASParameter | ConvertTo-Json
 
 		#send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
 
 		If ($null -ne $result) {

--- a/psPAS/Functions/Authentication/Add-PASOpenIDConnectProvider.ps1
+++ b/psPAS/Functions/Authentication/Add-PASOpenIDConnectProvider.ps1
@@ -99,7 +99,7 @@ Function Add-PASOpenIDConnectProvider {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/Configuration/OIDC/Providers"
+		$URI = "$($psPASSession.BaseURI)/api/Configuration/OIDC/Providers"
 
 		#Get request parameters
 		$boundParameters = $PSBoundParameters | Get-PASParameter
@@ -116,7 +116,7 @@ Function Add-PASOpenIDConnectProvider {
 		$body = $boundParameters | ConvertTo-Json
 
 		#send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $body -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $body
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/Authentication/Add-PASPublicSSHKey.ps1
+++ b/psPAS/Functions/Authentication/Add-PASPublicSSHKey.ps1
@@ -23,7 +23,7 @@ function Add-PASPublicSSHKey {
 	PROCESS {
 
 		#Create URL to endpoint for request
-		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName |
+		$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Users/$($UserName |
 
             Get-EscapedString)/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys/"
 
@@ -35,7 +35,7 @@ function Add-PASPublicSSHKey {
 		} | ConvertTo-Json
 
 		#send request to webservice
-		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/Authentication/Clear-PASPrivateSSHKey.ps1
+++ b/psPAS/Functions/Authentication/Clear-PASPrivateSSHKey.ps1
@@ -11,10 +11,10 @@ function Clear-PASPrivateSSHKey {
 
     PROCESS {
 
-        $URI = "$Script:BaseURI/api/Users/Secret/SSHKeys/ClearCache"
+        $URI = "$($psPASSession.BaseURI)/api/Users/Secret/SSHKeys/ClearCache"
 
         #send request to webservice
-        Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+        Invoke-PASRestMethod -Uri $URI -Method DELETE
 
     }#process
 

--- a/psPAS/Functions/Authentication/Close-PASSession.ps1
+++ b/psPAS/Functions/Authentication/Close-PASSession.ps1
@@ -38,28 +38,28 @@ function Close-PASSession {
 
 			'Gen1' {
 
-				$URI = "$Script:BaseURI/WebServices/auth/Cyberark/CyberArkAuthenticationService.svc/Logoff"
+				$URI = "$($psPASSession.BaseURI)/WebServices/auth/Cyberark/CyberArkAuthenticationService.svc/Logoff"
 				break
 
 			}
 
 			'saml' {
 
-				$URI = "$Script:BaseURI/WebServices/auth/SAML/SAMLAuthenticationService.svc/Logoff"
+				$URI = "$($psPASSession.BaseURI)/WebServices/auth/SAML/SAMLAuthenticationService.svc/Logoff"
 				break
 
 			}
 
 			'shared' {
 
-				$URI = "$Script:BaseURI/WebServices/auth/Shared/RestfulAuthenticationService.svc/Logoff"
+				$URI = "$($psPASSession.BaseURI)/WebServices/auth/Shared/RestfulAuthenticationService.svc/Logoff"
 				break
 
 			}
 
 			'Gen2' {
 
-				$URI = "$Script:BaseURI/API/Auth/Logoff"
+				$URI = "$($psPASSession.BaseURI)/API/Auth/Logoff"
 				break
 
 			}
@@ -71,19 +71,18 @@ function Close-PASSession {
 	PROCESS {
 
 		#Send Logoff Request
-		Invoke-PASRestMethod -Uri $URI -Method POST -WebSession $Script:WebSession | Out-Null
+		Invoke-PASRestMethod -Uri $URI -Method POST | Out-Null
 
 	}#process
 
 	END {
 
 		#Set ExternalVersion to 0.0
-		[System.Version]$Version = '0.0'
-		Set-Variable -Name ExternalVersion -Value $Version -Scope Script -ErrorAction SilentlyContinue
+		$psPASSession.ExternalVersion = [System.Version]'0.0'
 
 		#Clear Module scope variables on logoff
-		Clear-Variable -Name BaseURI -Scope Script -ErrorAction SilentlyContinue
-		Clear-Variable -Name WebSession -Scope Script -ErrorAction SilentlyContinue
+		$psPASSession.BaseURI = $null
+		$psPASSession.WebSession = $null
 
 	}#end
 }

--- a/psPAS/Functions/Authentication/Close-PASSession.ps1
+++ b/psPAS/Functions/Authentication/Close-PASSession.ps1
@@ -83,6 +83,9 @@ function Close-PASSession {
 		#Clear Module scope variables on logoff
 		$psPASSession.BaseURI = $null
 		$psPASSession.WebSession = $null
+		$psPASSession.User = $null
+		$psPASSession.StartTime = $null
+
 
 	}#end
 }

--- a/psPAS/Functions/Authentication/Get-PASAuthenticationMethod.ps1
+++ b/psPAS/Functions/Authentication/Get-PASAuthenticationMethod.ps1
@@ -21,10 +21,10 @@ Function Get-PASAuthenticationMethod {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/Configuration/AuthenticationMethods/$($ID | Get-EscapedString)"
+		$URI = "$($psPASSession.BaseURI)/api/Configuration/AuthenticationMethods/$($ID | Get-EscapedString)"
 
 		#send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 
 		If ($null -ne $result) {

--- a/psPAS/Functions/Authentication/Get-PASOpenIDConnectProvider.ps1
+++ b/psPAS/Functions/Authentication/Get-PASOpenIDConnectProvider.ps1
@@ -21,10 +21,10 @@ Function Get-PASOpenIDConnectProvider {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/Configuration/OIDC/Providers/$($id | Get-EscapedString)"
+		$URI = "$($psPASSession.BaseURI)/api/Configuration/OIDC/Providers/$($id | Get-EscapedString)"
 
 		#send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/Authentication/Get-PASPublicSSHKey.ps1
+++ b/psPAS/Functions/Authentication/Get-PASPublicSSHKey.ps1
@@ -16,12 +16,12 @@ function Get-PASPublicSSHKey {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName |
+		$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Users/$($UserName |
 
             Get-EscapedString)/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys/"
 
 		#Send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/Authentication/Get-PASSession.ps1
+++ b/psPAS/Functions/Authentication/Get-PASSession.ps1
@@ -7,10 +7,13 @@ function Get-PASSession {
 
 	PROCESS {
 
+		#Calculate the time elapsed since the start of the session and include in return data
 		if ($null -ne $psPASSession.StartTime) {
 			$psPASSession.ElapsedTime = '{0:HH:mm:ss}' -f ([datetime]$($(Get-Date) - $($psPASSession.StartTime)).Ticks)
-		}
-		$psPASSession
+		} else { $psPASSession.ElapsedTime = $null }
+
+		#Deep Copy the $psPASSession session object and return as psPAS Session type.
+		Get-SessionClone -InputObject $psPASSession | Add-ObjectDetail -typename psPAS.CyberArk.Vault.Session
 
 	}#process
 

--- a/psPAS/Functions/Authentication/Get-PASSession.ps1
+++ b/psPAS/Functions/Authentication/Get-PASSession.ps1
@@ -7,11 +7,10 @@ function Get-PASSession {
 
 	PROCESS {
 
-		[PSCustomObject]@{
-			BaseURI         = $Script:BaseURI
-			ExternalVersion = $Script:ExternalVersion
-			WebSession      = $Script:WebSession
-		} | Add-ObjectDetail -typename psPAS.CyberArk.Vault.Session
+		if ($null -ne $psPASSession.StartTime) {
+			$psPASSession.ElapsedTime = '{0:HH:mm:ss}' -f ([datetime]$($(Get-Date) - $($psPASSession.StartTime)).Ticks)
+		}
+		$psPASSession
 
 	}#process
 

--- a/psPAS/Functions/Authentication/New-PASPrivateSSHKey.ps1
+++ b/psPAS/Functions/Authentication/New-PASPrivateSSHKey.ps1
@@ -44,7 +44,7 @@ function New-PASPrivateSSHKey {
 
     PROCESS {
 
-        $URI = "$Script:BaseURI/api/Users"
+        $URI = "$($psPASSession.BaseURI)/api/Users"
 
         switch ($PSCmdlet.ParameterSetName) {
 
@@ -81,7 +81,7 @@ function New-PASPrivateSSHKey {
         if ($PSCmdlet.ShouldProcess($user, 'Generate Private SSH Key')) {
 
             #send request to webservice
-            $result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+            $result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
             If ($null -ne $result) {
 

--- a/psPAS/Functions/Authentication/New-PASSession.ps1
+++ b/psPAS/Functions/Authentication/New-PASSession.ps1
@@ -812,10 +812,25 @@ function New-PASSession {
 					Try {
 
 						#Get Authenticated User.
-						$psPASSession.User = Get-PASLoggedOnUser -ErrorAction Stop |
-							Select-Object -ExpandProperty UserName
+						$User = Get-PASLoggedOnUser -ErrorAction Stop
 
-					} Catch { $psPASSession.User = $null }
+					} Catch {
+
+						if ($PSBoundParameters.ContainsKey('Credential')) {
+							$User = $Credential
+						} else {
+							$User = $null
+						}
+
+					} Finally {
+
+						if ($null -ne $User) {
+							$Username = $User | Select-Object -ExpandProperty UserName
+						} else { $Username = $User }
+
+						$psPASSession.User = $Username
+
+					}
 
 				}
 

--- a/psPAS/Functions/Authentication/Remove-PASAuthenticationMethod.ps1
+++ b/psPAS/Functions/Authentication/Remove-PASAuthenticationMethod.ps1
@@ -20,12 +20,12 @@ Function Remove-PASAuthenticationMethod {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/Configuration/AuthenticationMethods/$($id | Get-EscapedString)"
+		$URI = "$($psPASSession.BaseURI)/api/Configuration/AuthenticationMethods/$($id | Get-EscapedString)"
 
 		if ($PSCmdlet.ShouldProcess($id, 'Delete Authentication Method')) {
 
 			#send request to web service
-			$result = Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+			$result = Invoke-PASRestMethod -Uri $URI -Method DELETE
 
 			If ($null -ne $result) {
 

--- a/psPAS/Functions/Authentication/Remove-PASOpenIDConnectProvider.ps1
+++ b/psPAS/Functions/Authentication/Remove-PASOpenIDConnectProvider.ps1
@@ -21,12 +21,12 @@ Function Remove-PASOpenIDConnectProvider {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/Configuration/OIDC/Providers/$($id | Get-EscapedString)"
+		$URI = "$($psPASSession.BaseURI)/api/Configuration/OIDC/Providers/$($id | Get-EscapedString)"
 
 		if ($PSCmdlet.ShouldProcess($id, 'Delete OIDC Provider')) {
 
 			#Send request to web service
-			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method DELETE
 
 		}
 

--- a/psPAS/Functions/Authentication/Remove-PASPrivateSSHKey.ps1
+++ b/psPAS/Functions/Authentication/Remove-PASPrivateSSHKey.ps1
@@ -18,7 +18,7 @@ function Remove-PASPrivateSSHKey {
 
     PROCESS {
 
-        $URI = "$Script:BaseURI/api/Users"
+        $URI = "$($psPASSession.BaseURI)/api/Users"
 
         If ($PSBoundParameters.ContainsKey('UserID')) {
 
@@ -37,7 +37,7 @@ function Remove-PASPrivateSSHKey {
         if ($PSCmdlet.ShouldProcess($user, 'Delete Private SSH Key')) {
 
             #send request to webservice
-            Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+            Invoke-PASRestMethod -Uri $URI -Method DELETE
 
         }
 

--- a/psPAS/Functions/Authentication/Remove-PASPublicSSHKey.ps1
+++ b/psPAS/Functions/Authentication/Remove-PASPublicSSHKey.ps1
@@ -22,14 +22,14 @@ function Remove-PASPublicSSHKey {
 	PROCESS {
 
 		#Create URL string for request
-		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName |
+		$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Users/$($UserName |
 
             Get-EscapedString)/AuthenticationMethods/SSHKeyAuthentication/AuthorizedKeys/$KeyID/"
 
 		if ($PSCmdlet.ShouldProcess($KeyID, 'Delete Public SSH Key')) {
 
 			#Send Request to web service
-			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method DELETE
 
 		}
 

--- a/psPAS/Functions/Authentication/Set-PASAuthenticationMethod.ps1
+++ b/psPAS/Functions/Authentication/Set-PASAuthenticationMethod.ps1
@@ -74,7 +74,7 @@ Function Set-PASAuthenticationMethod {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/Configuration/AuthenticationMethods/$($ID | Get-EscapedString)"
+		$URI = "$($psPASSession.BaseURI)/api/Configuration/AuthenticationMethods/$($ID | Get-EscapedString)"
 
 		#Request body
 		$Body = $PSBoundParameters | Get-PASParameter -ParametersToRemove ID | ConvertTo-Json
@@ -82,7 +82,7 @@ Function Set-PASAuthenticationMethod {
 		if ($PSCmdlet.ShouldProcess($ID, 'Update Authentication Method')) {
 
 			#send request to web service
-			$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body -WebSession $Script:WebSession
+			$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body
 
 		}
 

--- a/psPAS/Functions/Authentication/Set-PASOpenIDConnectProvider.ps1
+++ b/psPAS/Functions/Authentication/Set-PASOpenIDConnectProvider.ps1
@@ -99,7 +99,7 @@ Function Set-PASOpenIDConnectProvider {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/Configuration/OIDC/Providers/$($id | Get-EscapedString)"
+		$URI = "$($psPASSession.BaseURI)/api/Configuration/OIDC/Providers/$($id | Get-EscapedString)"
 
 		#Get request parameters
 		$boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove id
@@ -118,7 +118,7 @@ Function Set-PASOpenIDConnectProvider {
 		if ($PSCmdlet.ShouldProcess($id, 'Update OIDC Provider')) {
 
 			#send request to web service
-			$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $body -WebSession $Script:WebSession
+			$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $body
 
 			If ($null -ne $result) {
 

--- a/psPAS/Functions/Authentication/Use-PASSession.ps1
+++ b/psPAS/Functions/Authentication/Use-PASSession.ps1
@@ -14,9 +14,7 @@ function Use-PASSession {
 
 	PROCESS {
 
-		Set-Variable -Name BaseURI -Value $Session.BaseURI -Scope Script
-		Set-Variable -Name ExternalVersion -Value $Session.ExternalVersion -Scope Script
-		Set-Variable -Name WebSession -Value $Session.WebSession -Scope Script
+		New-Variable -Name psPASSession -Value $Session -Scope Script -Force
 
 	}#process
 

--- a/psPAS/Functions/Connections/Get-PASConnectionComponent.ps1
+++ b/psPAS/Functions/Connections/Get-PASConnectionComponent.ps1
@@ -13,10 +13,10 @@ Function Get-PASConnectionComponent {
 
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/API/PSM/Connectors"
+		$URI = "$($psPASSession.BaseURI)/API/PSM/Connectors"
 
 		#send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		if ($null -ne $result.PSMConnectors) {
 

--- a/psPAS/Functions/Connections/Get-PASPSMServer.ps1
+++ b/psPAS/Functions/Connections/Get-PASPSMServer.ps1
@@ -13,10 +13,10 @@ Function Get-PASPSMServer {
 
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/API/PSM/Servers"
+		$URI = "$($psPASSession.BaseURI)/API/PSM/Servers"
 
 		#send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		if ($null -ne $result.PSMServers) {
 

--- a/psPAS/Functions/Connections/Import-PASConnectionComponent.ps1
+++ b/psPAS/Functions/Connections/Import-PASConnectionComponent.ps1
@@ -19,7 +19,7 @@ function Import-PASConnectionComponent {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/API/ConnectionComponents/Import"
+		$URI = "$($psPASSession.BaseURI)/API/ConnectionComponents/Import"
 
 		#Convert File to byte array
 		$FileBytes = $ImportFile | Get-ByteArray
@@ -30,7 +30,7 @@ function Import-PASConnectionComponent {
 		if ($PSCmdlet.ShouldProcess($ImportFile, 'Imports Connection Component')) {
 
 			#send request to web service
-			Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession -Debug:$false
+			Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -Debug:$false
 
 		}
 

--- a/psPAS/Functions/Connections/New-PASPSMSession.ps1
+++ b/psPAS/Functions/Connections/New-PASPSMSession.ps1
@@ -298,13 +298,23 @@ function New-PASPSMSession {
 
 			If (($result | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name) -contains 'PSMGWRequest') {
 
-				#Return PSM GW URL Details
-				$result
+				$Path = [System.IO.Path]::GetTempPath()
+				$FileName = "$((Get-PASSession).LastCommandResults.Headers['X-Correlation-ID']).html"
+				$OutputPath = Join-Path $Path $FileName
+
+				#POST PSMGWRequest Details to HTML5 GW via html form
+				$htmlParams = @{
+					Title = 'PSMGWRequest'
+					Body  = '<form action="' + $result.PSMGWURL + '" method="POST"><input name="PSMGWRequest" type="hidden" value="' + $result.PSMGWRequest + '"></form><script>document.forms[0].submit()</script>'
+				}
+
+				ConvertTo-Html @htmlParams | Out-File $OutputPath
+				Get-Item -Path $OutputPath | Invoke-Item
 
 			} Else {
 
-				#Save the RDP file to disk
-				Out-PASFile -InputObject $result -Path $Path
+				#Save the RDP file to disk and automatically open it to spawn the RDP conenction to PSM
+				Out-PASFile -InputObject $result -Path $Path | Invoke-Item
 
 			}
 

--- a/psPAS/Functions/Connections/New-PASPSMSession.ps1
+++ b/psPAS/Functions/Connections/New-PASPSMSession.ps1
@@ -212,7 +212,7 @@ function New-PASPSMSession {
 				Assert-VersionRequirement -RequiredVersion 9.10
 
 				#Create URL for Request
-				$URI = "$Script:BaseURI/API/Accounts/$($AccountID)/PSMConnect"
+				$URI = "$($psPASSession.BaseURI)/API/Accounts/$($AccountID)/PSMConnect"
 
 				#Create body of request
 				$body = $boundParameters | ConvertTo-Json
@@ -227,7 +227,7 @@ function New-PASPSMSession {
 				Assert-VersionRequirement -RequiredVersion 10.5
 
 				#Create URL for Request
-				$URI = "$Script:BaseURI/API/Accounts/AdHocConnect"
+				$URI = "$($psPASSession.BaseURI)/API/Accounts/AdHocConnect"
 
 				#Include decoded password in request
 				$boundParameters['secret'] = $(ConvertTo-InsecureString -SecureString $secret)
@@ -262,7 +262,7 @@ function New-PASPSMSession {
 
 		}
 
-		$ThisSession = $Script:WebSession
+		$ThisSession = $psPASSession.WebSession
 
 		#if a connection method is specified
 		If ($PSBoundParameters.ContainsKey('ConnectionMethod')) {

--- a/psPAS/Functions/EventSecurity/Add-PASPTAExcludedTarget.ps1
+++ b/psPAS/Functions/EventSecurity/Add-PASPTAExcludedTarget.ps1
@@ -16,7 +16,7 @@ Function Add-PASPTAExcludedTarget {
     PROCESS {
 
         #Create request URL
-        $URI = "$Script:BaseURI/api/pta/API/Administration/properties/CidrExclusionList"
+        $URI = "$($psPASSession.BaseURI)/api/pta/API/Administration/properties/CidrExclusionList"
 
         #Create body of request
         $Body = $PSBoundParameters | Get-PASParameter | ConvertTo-Json
@@ -24,7 +24,7 @@ Function Add-PASPTAExcludedTarget {
         if ($PSCmdlet.ShouldProcess($cidr, 'Add PTA Excluded Monitored Target')) {
 
             #send request to web service
-            Invoke-PASRestMethod -Uri $URI -Method PATCH -Body $Body -WebSession $Script:WebSession
+            Invoke-PASRestMethod -Uri $URI -Method PATCH -Body $Body
 
         }
 

--- a/psPAS/Functions/EventSecurity/Add-PASPTAGlobalCatalog.ps1
+++ b/psPAS/Functions/EventSecurity/Add-PASPTAGlobalCatalog.ps1
@@ -49,7 +49,7 @@ Function Add-PASPTAGlobalCatalog {
     PROCESS {
 
         #Create URL for Request
-        $URI = "$Script:BaseURI/API/pta/API/Administration/GCConnectivity"
+        $URI = "$($psPASSession.BaseURI)/API/pta/API/Administration/GCConnectivity"
 
         #Get Parameters for request body
         $boundParameters = $PSBoundParameters | Get-PASParameter
@@ -68,7 +68,7 @@ Function Add-PASPTAGlobalCatalog {
         $body = $boundParameters | Get-PASParameter -ParametersToKeep ldap_certificate, properties | ConvertTo-Json
 
         #send request to PAS web service
-        $result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+        $result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
         If ($null -ne $result) {
 

--- a/psPAS/Functions/EventSecurity/Add-PASPTAIncludedTarget.ps1
+++ b/psPAS/Functions/EventSecurity/Add-PASPTAIncludedTarget.ps1
@@ -16,7 +16,7 @@ Function Add-PASPTAIncludedTarget {
     PROCESS {
 
         #Create request URL
-        $URI = "$Script:BaseURI/api/pta/API/Administration/properties/CidrInclusionList"
+        $URI = "$($psPASSession.BaseURI)/api/pta/API/Administration/properties/CidrInclusionList"
 
         #Create body of request
         $Body = $PSBoundParameters | Get-PASParameter | ConvertTo-Json
@@ -24,7 +24,7 @@ Function Add-PASPTAIncludedTarget {
         if ($PSCmdlet.ShouldProcess($cidr, 'Add PTA Included Monitored Target')) {
 
             #send request to web service
-            Invoke-PASRestMethod -Uri $URI -Method PATCH -Body $Body -WebSession $Script:WebSession
+            Invoke-PASRestMethod -Uri $URI -Method PATCH -Body $Body
 
         }
 

--- a/psPAS/Functions/EventSecurity/Add-PASPTAPrivilegedGroup.ps1
+++ b/psPAS/Functions/EventSecurity/Add-PASPTAPrivilegedGroup.ps1
@@ -22,7 +22,7 @@ Function Add-PASPTAPrivilegedGroup {
     PROCESS {
 
         #Create request URL
-        $URI = "$Script:BaseURI/API/pta/API/configuration/properties/PrivilegedDomainGroupsList"
+        $URI = "$($psPASSession.BaseURI)/API/pta/API/configuration/properties/PrivilegedDomainGroupsList"
 
         #Create body of request
         $Body = $PSBoundParameters | Get-PASParameter | ConvertTo-Json
@@ -30,7 +30,7 @@ Function Add-PASPTAPrivilegedGroup {
         if ($PSCmdlet.ShouldProcess($group, 'Add PTA Privileged Domain Group Configuration')) {
 
             #send request to web service
-            Invoke-PASRestMethod -Uri $URI -Method PATCH -Body $Body -WebSession $Script:WebSession
+            Invoke-PASRestMethod -Uri $URI -Method PATCH -Body $Body
 
         }
 

--- a/psPAS/Functions/EventSecurity/Add-PASPTAPrivilegedUser.ps1
+++ b/psPAS/Functions/EventSecurity/Add-PASPTAPrivilegedUser.ps1
@@ -23,7 +23,7 @@ Function Add-PASPTAPrivilegedUser {
     PROCESS {
 
         #Create request URL
-        $URI = "$Script:BaseURI/API/pta/API/configuration/properties/PrivilegedUsersList"
+        $URI = "$($psPASSession.BaseURI)/API/pta/API/configuration/properties/PrivilegedUsersList"
 
         #Create body of request
         $Body = $PSBoundParameters | Get-PASParameter | ConvertTo-Json
@@ -31,7 +31,7 @@ Function Add-PASPTAPrivilegedUser {
         if ($PSCmdlet.ShouldProcess($user, 'Add PTA Privileged User Configuration')) {
 
             #send request to web service
-            Invoke-PASRestMethod -Uri $URI -Method PATCH -Body $Body -WebSession $Script:WebSession
+            Invoke-PASRestMethod -Uri $URI -Method PATCH -Body $Body
 
         }
 

--- a/psPAS/Functions/EventSecurity/Add-PASPTARule.ps1
+++ b/psPAS/Functions/EventSecurity/Add-PASPTARule.ps1
@@ -84,7 +84,7 @@ Function Add-PASPTARule {
 		$boundParameters = $PSBoundParameters | Get-PASParameter
 
 		#Create URL for Request
-		$URI = "$Script:BaseURI/API/pta/API/Settings/RiskyActivity/"
+		$URI = "$($psPASSession.BaseURI)/API/pta/API/Settings/RiskyActivity/"
 
 		switch ($PSBoundParameters.keys) {
 
@@ -125,7 +125,7 @@ Function Add-PASPTARule {
 		$Body = $boundParameters | Get-PASParameter -ParametersToRemove $scopeParams | ConvertTo-Json -Depth 3
 
 		#send request to PAS web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/EventSecurity/Get-PASPTAEvent.ps1
+++ b/psPAS/Functions/EventSecurity/Get-PASPTAEvent.ps1
@@ -50,12 +50,12 @@ Function Get-PASPTAEvent {
 	PROCESS {
 
 		#Create request URL
-		$URI = "$Script:BaseURI/API/pta/API/Events/"
+		$URI = "$($psPASSession.BaseURI)/API/pta/API/Events/"
 
 		#Get Parameters to include in request
 		$boundParameters = $PSBoundParameters | Get-PASParameter
 
-		$ThisSession = $Script:WebSession
+		$ThisSession = $psPASSession.WebSession
 
 		switch ($PSCmdlet.ParameterSetName) {
 

--- a/psPAS/Functions/EventSecurity/Get-PASPTAExcludedTarget.ps1
+++ b/psPAS/Functions/EventSecurity/Get-PASPTAExcludedTarget.ps1
@@ -10,10 +10,10 @@ Function Get-PASPTAExcludedTarget {
     PROCESS {
 
         #Create request URL
-        $URI = "$Script:BaseURI/API/pta/API/administration"
+        $URI = "$($psPASSession.BaseURI)/API/pta/API/administration"
 
         #Send request to web service
-        $result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+        $result = Invoke-PASRestMethod -Uri $URI -Method GET
 
         If ($null -ne $result) {
 

--- a/psPAS/Functions/EventSecurity/Get-PASPTAGlobalCatalog.ps1
+++ b/psPAS/Functions/EventSecurity/Get-PASPTAGlobalCatalog.ps1
@@ -10,10 +10,10 @@ Function Get-PASPTAGlobalCatalog {
     PROCESS {
 
         #Create request URL
-        $URI = "$Script:BaseURI/API/pta/API/Administration/GCConnectivity"
+        $URI = "$($psPASSession.BaseURI)/API/pta/API/Administration/GCConnectivity"
 
         #Send request to web service
-        $result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+        $result = Invoke-PASRestMethod -Uri $URI -Method GET
 
         If ($null -ne $result) {
 

--- a/psPAS/Functions/EventSecurity/Get-PASPTAIncludedTarget.ps1
+++ b/psPAS/Functions/EventSecurity/Get-PASPTAIncludedTarget.ps1
@@ -10,10 +10,10 @@ Function Get-PASPTAIncludedTarget {
     PROCESS {
 
         #Create request URL
-        $URI = "$Script:BaseURI/API/pta/API/administration"
+        $URI = "$($psPASSession.BaseURI)/API/pta/API/administration"
 
         #Send request to web service
-        $result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+        $result = Invoke-PASRestMethod -Uri $URI -Method GET
 
         If ($null -ne $result) {
 

--- a/psPAS/Functions/EventSecurity/Get-PASPTAPrivilegedGroup.ps1
+++ b/psPAS/Functions/EventSecurity/Get-PASPTAPrivilegedGroup.ps1
@@ -10,10 +10,10 @@ Function Get-PASPTAPrivilegedGroup {
     PROCESS {
 
         #Create request URL
-        $URI = "$Script:BaseURI/API/pta/API/configuration"
+        $URI = "$($psPASSession.BaseURI)/API/pta/API/configuration"
 
         #Send request to web service
-        $result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+        $result = Invoke-PASRestMethod -Uri $URI -Method GET
 
         If ($null -ne $result) {
 

--- a/psPAS/Functions/EventSecurity/Get-PASPTAPrivilegedUser.ps1
+++ b/psPAS/Functions/EventSecurity/Get-PASPTAPrivilegedUser.ps1
@@ -21,10 +21,10 @@ Function Get-PASPTAPrivilegedUser {
             $ReturnValue = $ValueType
         }
         #Create request URL
-        $URI = "$Script:BaseURI/API/pta/API/configuration"
+        $URI = "$($psPASSession.BaseURI)/API/pta/API/configuration"
 
         #Send request to web service
-        $result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+        $result = Invoke-PASRestMethod -Uri $URI -Method GET
 
         If ($null -ne $result) {
 

--- a/psPAS/Functions/EventSecurity/Get-PASPTARemediation.ps1
+++ b/psPAS/Functions/EventSecurity/Get-PASPTARemediation.ps1
@@ -10,10 +10,10 @@ Function Get-PASPTARemediation {
 	PROCESS {
 
 		#Create request URL
-		$URI = "$Script:BaseURI/API/pta/API/Settings"
+		$URI = "$($psPASSession.BaseURI)/API/pta/API/Settings"
 
 		#Send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/EventSecurity/Get-PASPTARiskEvent.ps1
+++ b/psPAS/Functions/EventSecurity/Get-PASPTARiskEvent.ps1
@@ -79,7 +79,7 @@ Function Get-PASPTARiskEvent {
     PROCESS {
 
         #Create request URL
-        $URI = "$Script:BaseURI/API/pta/API/Risks/RisksEvents/"
+        $URI = "$($psPASSession.BaseURI)/API/pta/API/Risks/RisksEvents/"
 
         $filterParameters = $PSBoundParameters | Get-PASParameter -ParametersToKeep $Parameters
         $boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove @($Parameters + $TimeParameters)
@@ -143,7 +143,7 @@ Function Get-PASPTARiskEvent {
         }
 
         #Send request to web service
-        $result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+        $result = Invoke-PASRestMethod -Uri $URI -Method GET
 
         $Total = $result.totalEntities
 
@@ -173,7 +173,7 @@ Function Get-PASPTARiskEvent {
 
 
                 #Request nextLink. Add Risk Events to output collection.
-                $Null = $Events.AddRange((Invoke-PASRestMethod -Uri "$URI`?$nextLink" -Method GET -WebSession $Script:WebSession).entities)
+                $Null = $Events.AddRange((Invoke-PASRestMethod -Uri "$URI`?$nextLink" -Method GET).entities)
 
             }
 

--- a/psPAS/Functions/EventSecurity/Get-PASPTARiskSummary.ps1
+++ b/psPAS/Functions/EventSecurity/Get-PASPTARiskSummary.ps1
@@ -10,10 +10,10 @@ Function Get-PASPTARiskSummary {
     PROCESS {
 
         #Create request URL
-        $URI = "$Script:BaseURI/API/pta/API/Risks/Summary/"
+        $URI = "$($psPASSession.BaseURI)/API/pta/API/Risks/Summary/"
 
         #Send request to web service
-        $result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+        $result = Invoke-PASRestMethod -Uri $URI -Method GET
 
         If ($null -ne $result) {
 

--- a/psPAS/Functions/EventSecurity/Get-PASPTARule.ps1
+++ b/psPAS/Functions/EventSecurity/Get-PASPTARule.ps1
@@ -10,10 +10,10 @@ Function Get-PASPTARule {
 	PROCESS {
 
 		#Create request URL
-		$URI = "$Script:BaseURI/API/pta/API/Settings"
+		$URI = "$($psPASSession.BaseURI)/API/pta/API/Settings"
 
 		#Send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/EventSecurity/Remove-PASPTAExcludedTarget.ps1
+++ b/psPAS/Functions/EventSecurity/Remove-PASPTAExcludedTarget.ps1
@@ -16,12 +16,12 @@ Function Remove-PASPTAExcludedTarget {
     PROCESS {
 
         #Create request URL
-        $URI = "$Script:BaseURI/api/pta/API/Administration/properties/CidrExclusionList/$ID"
+        $URI = "$($psPASSession.BaseURI)/api/pta/API/Administration/properties/CidrExclusionList/$ID"
 
         if ($PSCmdlet.ShouldProcess($ID, 'Delete PTA Excluded Monitored Target')) {
 
             #send request to web service
-            Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+            Invoke-PASRestMethod -Uri $URI -Method DELETE
 
         }
 

--- a/psPAS/Functions/EventSecurity/Remove-PASPTAIncludedTarget.ps1
+++ b/psPAS/Functions/EventSecurity/Remove-PASPTAIncludedTarget.ps1
@@ -16,12 +16,12 @@ Function Remove-PASPTAIncludedTarget {
     PROCESS {
 
         #Create request URL
-        $URI = "$Script:BaseURI/api/pta/API/Administration/properties/CidrInclusionList/$ID"
+        $URI = "$($psPASSession.BaseURI)/api/pta/API/Administration/properties/CidrInclusionList/$ID"
 
         if ($PSCmdlet.ShouldProcess($ID, 'Delete PTA Included Monitored Target')) {
 
             #send request to web service
-            Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+            Invoke-PASRestMethod -Uri $URI -Method DELETE
 
         }
 

--- a/psPAS/Functions/EventSecurity/Remove-PASPTAPrivilegedGroup.ps1
+++ b/psPAS/Functions/EventSecurity/Remove-PASPTAPrivilegedGroup.ps1
@@ -16,12 +16,12 @@ Function Remove-PASPTAPrivilegedGroup {
     PROCESS {
 
         #Create request URL
-        $URI = "$Script:BaseURI/API/pta/API/configuration/properties/PrivilegedDomainGroupsList/$ID"
+        $URI = "$($psPASSession.BaseURI)/API/pta/API/configuration/properties/PrivilegedDomainGroupsList/$ID"
 
         if ($PSCmdlet.ShouldProcess($ID, 'Delete PTA Privileged Domain Group Configuration')) {
 
             #send request to web service
-            Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+            Invoke-PASRestMethod -Uri $URI -Method DELETE
 
         }
 

--- a/psPAS/Functions/EventSecurity/Remove-PASPTAPrivilegedUser.ps1
+++ b/psPAS/Functions/EventSecurity/Remove-PASPTAPrivilegedUser.ps1
@@ -16,12 +16,12 @@ Function Remove-PASPTAPrivilegedUser {
     PROCESS {
 
         #Create request URL
-        $URI = "$Script:BaseURI/API/pta/API/configuration/properties/PrivilegedUsersList/$ID"
+        $URI = "$($psPASSession.BaseURI)/API/pta/API/configuration/properties/PrivilegedUsersList/$ID"
 
         if ($PSCmdlet.ShouldProcess($ID, 'Delete PTA Privileged User Configuration')) {
 
             #send request to web service
-            Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+            Invoke-PASRestMethod -Uri $URI -Method DELETE
 
         }
 

--- a/psPAS/Functions/EventSecurity/Set-PASPTAEvent.ps1
+++ b/psPAS/Functions/EventSecurity/Set-PASPTAEvent.ps1
@@ -24,7 +24,7 @@ Function Set-PASPTAEvent {
 	PROCESS {
 
 		#Create request URL
-		$URI = "$Script:BaseURI/API/pta/API/Events/$EventID"
+		$URI = "$($psPASSession.BaseURI)/API/pta/API/Events/$EventID"
 
 		#Get Parameters to include in request
 		$Body = $PSBoundParameters | Get-PASParameter -ParametersToRemove EventID | ConvertTo-Json
@@ -32,7 +32,7 @@ Function Set-PASPTAEvent {
 		if ($PSCmdlet.ShouldProcess($EventID, 'Update Event Status')) {
 
 			#Send request to web service
-			$result = Invoke-PASRestMethod -Uri $URI -Method PATCH -Body $Body -WebSession $Script:WebSession
+			$result = Invoke-PASRestMethod -Uri $URI -Method PATCH -Body $Body
 
 		}
 

--- a/psPAS/Functions/EventSecurity/Set-PASPTARemediation.ps1
+++ b/psPAS/Functions/EventSecurity/Set-PASPTARemediation.ps1
@@ -40,7 +40,7 @@ Function Set-PASPTARemediation {
 		$boundParameters = $PSBoundParameters | Get-PASParameter
 
 		#Create URL for Request
-		$URI = "$Script:BaseURI/API/pta/API/Settings/AutomaticRemediations/"
+		$URI = "$($psPASSession.BaseURI)/API/pta/API/Settings/AutomaticRemediations/"
 
 
 		#Create body of request
@@ -49,7 +49,7 @@ Function Set-PASPTARemediation {
 		if ($PSCmdlet.ShouldProcess('PTA', 'Update Automatic Remediation Config')) {
 
 			#send request to PAS web service
-			Invoke-PASRestMethod -Uri $URI -Method PATCH -Body $Body -WebSession $Script:WebSession | Out-Null
+			Invoke-PASRestMethod -Uri $URI -Method PATCH -Body $Body | Out-Null
 
 		}
 

--- a/psPAS/Functions/EventSecurity/Set-PASPTARiskEvent.ps1
+++ b/psPAS/Functions/EventSecurity/Set-PASPTARiskEvent.ps1
@@ -52,7 +52,7 @@ Function Set-PASPTARiskEvent {
     PROCESS {
 
         #Create request URL
-        $URI = "$Script:BaseURI/api/pta/API/Risks/RisksEvents/$ID"
+        $URI = "$($psPASSession.BaseURI)/api/pta/API/Risks/RisksEvents/$ID"
 
         #Get Parameters to include in request
         $Body = $PSBoundParameters | Get-PASParameter -ParametersToRemove ID | ConvertTo-Json
@@ -60,7 +60,7 @@ Function Set-PASPTARiskEvent {
         if ($PSCmdlet.ShouldProcess($EventID, 'Update Event Status')) {
 
             #Send request to web service
-            $result = Invoke-PASRestMethod -Uri $URI -Method PATCH -Body $Body -WebSession $Script:WebSession
+            $result = Invoke-PASRestMethod -Uri $URI -Method PATCH -Body $Body
 
         }
 

--- a/psPAS/Functions/EventSecurity/Set-PASPTARule.ps1
+++ b/psPAS/Functions/EventSecurity/Set-PASPTARule.ps1
@@ -91,7 +91,7 @@ Function Set-PASPTARule {
 		$boundParameters = $PSBoundParameters | Get-PASParameter
 
 		#Create URL for Request
-		$URI = "$Script:BaseURI/API/pta/API/Settings/RiskyActivity/"
+		$URI = "$($psPASSession.BaseURI)/API/pta/API/Settings/RiskyActivity/"
 
 		switch ($PSBoundParameters.keys) {
 
@@ -134,7 +134,7 @@ Function Set-PASPTARule {
 		if ($PSCmdlet.ShouldProcess($id, 'Update Risky Activity Rule')) {
 
 			#send request to PAS web service
-			Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body
 
 		}
 

--- a/psPAS/Functions/General/Add-PASAllowedReferrer.ps1
+++ b/psPAS/Functions/General/Add-PASAllowedReferrer.ps1
@@ -24,13 +24,13 @@ Function Add-PASAllowedReferrer {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/Configuration/AccessRestriction/AllowedReferrers"
+		$URI = "$($psPASSession.BaseURI)/api/Configuration/AccessRestriction/AllowedReferrers"
 
 		#Create request body
 		$body = $PSBoundParameters | Get-PASParameter | ConvertTo-Json
 
 		#send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/General/Get-PASAllowedReferrer.ps1
+++ b/psPAS/Functions/General/Get-PASAllowedReferrer.ps1
@@ -12,10 +12,10 @@ Function Get-PASAllowedReferrer {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/Configuration/AccessRestriction/AllowedReferrers"
+		$URI = "$($psPASSession.BaseURI)/api/Configuration/AccessRestriction/AllowedReferrers"
 
 		#send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/LDAPDirectories/Add-PASDirectory.ps1
+++ b/psPAS/Functions/LDAPDirectories/Add-PASDirectory.ps1
@@ -113,7 +113,7 @@ function Add-PASDirectory {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/Configuration/LDAP/Directories"
+		$URI = "$($psPASSession.BaseURI)/api/Configuration/LDAP/Directories"
 
 		#Get request parameters
 		$boundParameters = $PSBoundParameters | Get-PASParameter
@@ -129,7 +129,7 @@ function Add-PASDirectory {
 		$body = $boundParameters | ConvertTo-Json
 
 		#send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/LDAPDirectories/Get-PASDirectory.ps1
+++ b/psPAS/Functions/LDAPDirectories/Get-PASDirectory.ps1
@@ -21,7 +21,7 @@ function Get-PASDirectory {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/Configuration/LDAP/Directories"
+		$URI = "$($psPASSession.BaseURI)/api/Configuration/LDAP/Directories"
 
 		switch ($PSCmdlet.ParameterSetName) {
 
@@ -49,7 +49,7 @@ function Get-PASDirectory {
 		}
 
 		#send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/LDAPDirectories/Get-PASDirectoryMapping.ps1
+++ b/psPAS/Functions/LDAPDirectories/Get-PASDirectoryMapping.ps1
@@ -31,7 +31,7 @@ function Get-PASDirectoryMapping {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/Configuration/LDAP/Directories/$DirectoryName/Mappings/"
+		$URI = "$($psPASSession.BaseURI)/api/Configuration/LDAP/Directories/$DirectoryName/Mappings/"
 
 		if ($PSCmdlet.ParameterSetName -eq 'Mapping') {
 
@@ -41,7 +41,7 @@ function Get-PASDirectoryMapping {
 		}
 
 		#send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/LDAPDirectories/New-PASDirectoryMapping.ps1
+++ b/psPAS/Functions/LDAPDirectories/New-PASDirectoryMapping.ps1
@@ -134,14 +134,14 @@ function New-PASDirectoryMapping {
 		}
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/Configuration/LDAP/Directories/$DirectoryName/Mappings/"
+		$URI = "$($psPASSession.BaseURI)/api/Configuration/LDAP/Directories/$DirectoryName/Mappings/"
 
 		$body = $boundParameters | ConvertTo-Json
 
 		if ($PSCmdlet.ShouldProcess($MappingName, 'Create Directory Mapping')) {
 
 			#send request to web service
-			$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+			$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
 			If ($null -ne $result) {
 

--- a/psPAS/Functions/LDAPDirectories/Remove-PASDirectory.ps1
+++ b/psPAS/Functions/LDAPDirectories/Remove-PASDirectory.ps1
@@ -18,12 +18,12 @@ function Remove-PASDirectory {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/Configuration/LDAP/Directories/$id/"
+		$URI = "$($psPASSession.BaseURI)/api/Configuration/LDAP/Directories/$id/"
 
 		if ($PSCmdlet.ShouldProcess($id, 'Delete Directory')) {
 
 			#send request to web service
-			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method DELETE
 
 		}
 

--- a/psPAS/Functions/LDAPDirectories/Remove-PASDirectoryMapping.ps1
+++ b/psPAS/Functions/LDAPDirectories/Remove-PASDirectoryMapping.ps1
@@ -22,12 +22,12 @@ function Remove-PASDirectoryMapping {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/Configuration/LDAP/Directories/$DirectoryName/Mappings/$MappingID/"
+		$URI = "$($psPASSession.BaseURI)/api/Configuration/LDAP/Directories/$DirectoryName/Mappings/$MappingID/"
 
 		if ($PSCmdlet.ShouldProcess($MappingID, 'Delete Directory Mapping')) {
 
 			#send request to web service
-			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method DELETE
 
 		}
 

--- a/psPAS/Functions/LDAPDirectories/Set-PASDirectoryMapping.ps1
+++ b/psPAS/Functions/LDAPDirectories/Set-PASDirectoryMapping.ps1
@@ -128,14 +128,14 @@ function Set-PASDirectoryMapping {
 		}
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/Configuration/LDAP/Directories/$DirectoryName/Mappings/$MappingID/"
+		$URI = "$($psPASSession.BaseURI)/api/Configuration/LDAP/Directories/$DirectoryName/Mappings/$MappingID/"
 
 		$body = $boundParameters | ConvertTo-Json
 
 		if ($PSCmdlet.ShouldProcess($MappingID, 'Update Directory Mapping')) {
 
 			#send request to web service
-			$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body -WebSession $Script:WebSession
+			$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body
 
 			If ($null -ne $result) {
 

--- a/psPAS/Functions/LDAPDirectories/Set-PASDirectoryMappingOrder.ps1
+++ b/psPAS/Functions/LDAPDirectories/Set-PASDirectoryMappingOrder.ps1
@@ -24,7 +24,7 @@ function Set-PASDirectoryMappingOrder {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/Configuration/LDAP/Directories/$DirectoryName/Mappings/Reorder/"
+		$URI = "$($psPASSession.BaseURI)/api/Configuration/LDAP/Directories/$DirectoryName/Mappings/Reorder/"
 
 		#Get request parameters
 		$body = $($PSBoundParameters | Get-PASParameter -ParametersToRemove DirectoryName) | ConvertTo-Json
@@ -32,7 +32,7 @@ function Set-PASDirectoryMappingOrder {
 		if ($PSCmdlet.ShouldProcess($DirectoryName, 'Update Directory Mapping Order')) {
 
 			#send request to web service
-			Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
 		}
 

--- a/psPAS/Functions/Monitoring/Connect-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Connect-PASPSMSession.ps1
@@ -24,9 +24,9 @@ function Connect-PASPSMSession {
 	PROCESS {
 
 		#Create URL for Request
-		$URI = "$($Script:BaseURI)/API/LiveSessions/$($SessionId | Get-EscapedString)/monitor"
+		$URI = "$($($psPASSession.BaseURI))/API/LiveSessions/$($SessionId | Get-EscapedString)/monitor"
 
-		$ThisSession = $Script:WebSession
+		$ThisSession = $psPASSession.WebSession
 
 		#if a connection method is specified
 		If ($PSBoundParameters.ContainsKey('ConnectionMethod')) {

--- a/psPAS/Functions/Monitoring/Export-PASPSMRecording.ps1
+++ b/psPAS/Functions/Monitoring/Export-PASPSMRecording.ps1
@@ -24,10 +24,10 @@ function Export-PASPSMRecording {
 	PROCESS {
 
 		#Create URL for Request
-		$URI = "$Script:BaseURI/API/Recordings/$($RecordingID | Get-EscapedString)/Play"
+		$URI = "$($psPASSession.BaseURI)/API/Recordings/$($RecordingID | Get-EscapedString)/Play"
 
 		#send request to PAS web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method POST -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method POST
 
 		#if we get a byte array
 		If ($null -ne $result) {

--- a/psPAS/Functions/Monitoring/Get-PASPSMRecording.ps1
+++ b/psPAS/Functions/Monitoring/Get-PASPSMRecording.ps1
@@ -73,7 +73,7 @@ function Get-PASPSMRecording {
 	PROCESS {
 
 		#Create URL for Request
-		$URI = "$Script:BaseURI/API/Recordings"
+		$URI = "$($psPASSession.BaseURI)/API/Recordings"
 
 		switch ($PSCmdlet.ParameterSetName) {
 
@@ -127,7 +127,7 @@ function Get-PASPSMRecording {
 		}
 
 		#send request to PAS web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		$Total = ($result.Recordings).Count
 
@@ -153,7 +153,7 @@ function Get-PASPSMRecording {
 
 				}
 
-				$result = (Invoke-PASRestMethod -Uri "$URI`?$nextLink" -Method GET -WebSession $Script:WebSession).Recordings
+				$result = (Invoke-PASRestMethod -Uri "$URI`?$nextLink" -Method GET).Recordings
 
 				$Total = $result.Count
 

--- a/psPAS/Functions/Monitoring/Get-PASPSMRecordingActivity.ps1
+++ b/psPAS/Functions/Monitoring/Get-PASPSMRecordingActivity.ps1
@@ -17,10 +17,10 @@ function Get-PASPSMRecordingActivity {
 	PROCESS {
 
 		#Create URL for Request
-		$URI = "$Script:BaseURI/API/Recordings/$($RecordingID | Get-EscapedString)/activities"
+		$URI = "$($psPASSession.BaseURI)/API/Recordings/$($RecordingID | Get-EscapedString)/activities"
 
 		#send request to PAS web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/Monitoring/Get-PASPSMRecordingProperty.ps1
+++ b/psPAS/Functions/Monitoring/Get-PASPSMRecordingProperty.ps1
@@ -17,10 +17,10 @@ function Get-PASPSMRecordingProperty {
 	PROCESS {
 
 		#Create URL for Request
-		$URI = "$Script:BaseURI/API/Recordings/$($RecordingID | Get-EscapedString)/properties"
+		$URI = "$($psPASSession.BaseURI)/API/Recordings/$($RecordingID | Get-EscapedString)/properties"
 
 		#send request to PAS web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/Monitoring/Get-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Get-PASPSMSession.ps1
@@ -73,7 +73,7 @@ function Get-PASPSMSession {
 	PROCESS {
 
 		#Create URL for Request
-		$URI = "$Script:BaseURI/API/LiveSessions"
+		$URI = "$($psPASSession.BaseURI)/API/LiveSessions"
 
 		switch ($PSCmdlet.ParameterSetName) {
 
@@ -109,6 +109,7 @@ function Get-PASPSMSession {
 					}
 
 				}
+
 				#Create Query String, escaped for inclusion in request URL
 				$queryString = $boundParameters | ConvertTo-QueryString
 
@@ -126,7 +127,7 @@ function Get-PASPSMSession {
 		}
 
 		#send request to PAS web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		$Total = ($result.LiveSessions).Count
 
@@ -152,7 +153,7 @@ function Get-PASPSMSession {
 
 				}
 
-				$result = (Invoke-PASRestMethod -Uri "$URI`?$nextLink" -Method GET -WebSession $Script:WebSession).LiveSessions
+				$result = (Invoke-PASRestMethod -Uri "$URI`?$nextLink" -Method GET).LiveSessions
 
 				$Total = $result.Count
 

--- a/psPAS/Functions/Monitoring/Get-PASPSMSessionActivity.ps1
+++ b/psPAS/Functions/Monitoring/Get-PASPSMSessionActivity.ps1
@@ -17,10 +17,10 @@ function Get-PASPSMSessionActivity {
 	PROCESS {
 
 		#Create URL for Request
-		$URI = "$Script:BaseURI/API/LiveSessions/$($LiveSessionId | Get-EscapedString)/activities"
+		$URI = "$($psPASSession.BaseURI)/API/LiveSessions/$($LiveSessionId | Get-EscapedString)/activities"
 
 		#send request to PAS web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/Monitoring/Get-PASPSMSessionProperty.ps1
+++ b/psPAS/Functions/Monitoring/Get-PASPSMSessionProperty.ps1
@@ -17,10 +17,10 @@ function Get-PASPSMSessionProperty {
 	PROCESS {
 
 		#Create URL for Request
-		$URI = "$Script:BaseURI/API/LiveSessions/$($liveSessionId | Get-EscapedString)/properties"
+		$URI = "$($psPASSession.BaseURI)/API/LiveSessions/$($liveSessionId | Get-EscapedString)/properties"
 
 		#send request to PAS web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/Monitoring/Resume-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Resume-PASPSMSession.ps1
@@ -18,12 +18,12 @@ function Resume-PASPSMSession {
 	PROCESS {
 
 		#Create URL for Request
-		$URI = "$Script:BaseURI/api/LiveSessions/$($LiveSessionId | Get-EscapedString)/Resume"
+		$URI = "$($psPASSession.BaseURI)/api/LiveSessions/$($LiveSessionId | Get-EscapedString)/Resume"
 
 		if ($PSCmdlet.ShouldProcess($LiveSessionId, 'Resume PSM Session')) {
 
 			#send request to PAS web service
-			Invoke-PASRestMethod -Uri $URI -Method POST -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method POST
 
 		}
 

--- a/psPAS/Functions/Monitoring/Stop-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Stop-PASPSMSession.ps1
@@ -18,12 +18,12 @@ function Stop-PASPSMSession {
 	PROCESS {
 
 		#Create URL for Request
-		$URI = "$Script:BaseURI/api/LiveSessions/$($LiveSessionId | Get-EscapedString)/Terminate"
+		$URI = "$($psPASSession.BaseURI)/api/LiveSessions/$($LiveSessionId | Get-EscapedString)/Terminate"
 
 		if ($PSCmdlet.ShouldProcess($LiveSessionId, 'Terminate PSM Session')) {
 
 			#send request to PAS web service
-			Invoke-PASRestMethod -Uri $URI -Method POST -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method POST
 
 		}
 

--- a/psPAS/Functions/Monitoring/Suspend-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Suspend-PASPSMSession.ps1
@@ -18,12 +18,12 @@ function Suspend-PASPSMSession {
 	PROCESS {
 
 		#Create URL for Request
-		$URI = "$Script:BaseURI/api/LiveSessions/$($LiveSessionId | Get-EscapedString)/Suspend"
+		$URI = "$($psPASSession.BaseURI)/api/LiveSessions/$($LiveSessionId | Get-EscapedString)/Suspend"
 
 		if ($PSCmdlet.ShouldProcess($LiveSessionId, 'Suspend PSM Session')) {
 
 			#send request to PAS web service
-			Invoke-PASRestMethod -Uri $URI -Method POST -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method POST
 
 		}
 

--- a/psPAS/Functions/Monitoring/Test-PASPSMRecording.ps1
+++ b/psPAS/Functions/Monitoring/Test-PASPSMRecording.ps1
@@ -16,10 +16,10 @@ function Test-PASPSMRecording {
 	PROCESS {
 
 		#Create URL for Request
-		$URI = "$Script:BaseURI/API/Recordings/$SessionID/valid"
+		$URI = "$($psPASSession.BaseURI)/API/Recordings/$SessionID/valid"
 
 		#send request to PAS web service
-		Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		Invoke-PASRestMethod -Uri $URI -Method GET
 
 	} #process
 

--- a/psPAS/Functions/OnboardingRules/Get-PASOnboardingRule.ps1
+++ b/psPAS/Functions/OnboardingRules/Get-PASOnboardingRule.ps1
@@ -18,7 +18,7 @@ function Get-PASOnboardingRule {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/AutomaticOnboardingRules"
+		$URI = "$($psPASSession.BaseURI)/api/AutomaticOnboardingRules"
 
 		If ($PSBoundParameters.ContainsKey('Names')) {
 
@@ -41,7 +41,7 @@ function Get-PASOnboardingRule {
 		}
 
 		#send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/OnboardingRules/New-PASOnboardingRule.ps1
+++ b/psPAS/Functions/OnboardingRules/New-PASOnboardingRule.ps1
@@ -121,7 +121,7 @@ function New-PASOnboardingRule {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/AutomaticOnboardingRules"
+		$URI = "$($psPASSession.BaseURI)/api/AutomaticOnboardingRules"
 
 		#create request body
 		$body = $PSBoundParameters | Get-PASParameter | ConvertTo-Json
@@ -148,7 +148,7 @@ function New-PASOnboardingRule {
 		if ($PSCmdlet.ShouldProcess($SafeName, "Add On-Boarding Rule Using '$PlatformID'")) {
 
 			#send request to web service
-			$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+			$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
 			If ($null -ne $result) {
 

--- a/psPAS/Functions/OnboardingRules/Remove-PASOnboardingRule.ps1
+++ b/psPAS/Functions/OnboardingRules/Remove-PASOnboardingRule.ps1
@@ -14,12 +14,12 @@ function Remove-PASOnboardingRule {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/AutomaticOnboardingRules/$($RuleID | Get-EscapedString)/"
+		$URI = "$($psPASSession.BaseURI)/api/AutomaticOnboardingRules/$($RuleID | Get-EscapedString)/"
 
 		if ($PSCmdlet.ShouldProcess($RuleID, 'Delete On-boarding Rule')) {
 
 			#Send request to web service
-			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method DELETE
 
 		}
 

--- a/psPAS/Functions/OnboardingRules/Set-PASOnboardingRule.ps1
+++ b/psPAS/Functions/OnboardingRules/Set-PASOnboardingRule.ps1
@@ -99,7 +99,7 @@ function Set-PASOnboardingRule {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/AutomaticOnboardingRules/$Id/"
+		$URI = "$($psPASSession.BaseURI)/api/AutomaticOnboardingRules/$Id/"
 
 		#create request body
 		$body = $PSBoundParameters | Get-PASParameter -ParametersToRemove Id | ConvertTo-Json
@@ -107,7 +107,7 @@ function Set-PASOnboardingRule {
 		if ($PSCmdlet.ShouldProcess($TargetPlatformId, "Update On-Boarding Rule $ID")) {
 
 			#send request to web service
-			$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body -WebSession $Script:WebSession
+			$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body
 
 			If ($null -ne $result) {
 

--- a/psPAS/Functions/Platforms/Copy-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Copy-PASPlatform.ps1
@@ -58,7 +58,7 @@ Function Copy-PASPlatform {
 	Process {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/API/Platforms/$($PSCmdLet.ParameterSetName)/$ID/duplicate"
+		$URI = "$($psPASSession.BaseURI)/API/Platforms/$($PSCmdLet.ParameterSetName)/$ID/duplicate"
 
 		#Get request parameters
 		$boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove ID, TargetPlatform,
@@ -69,7 +69,7 @@ Function Copy-PASPlatform {
 		if ($PSCmdlet.ShouldProcess($ID, "Duplicate $($PSCmdLet.ParameterSetName) Platform")) {
 
 			#send request
-			$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $body -WebSession $Script:WebSession
+			$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $body
 
 			If ($null -ne $result) {
 

--- a/psPAS/Functions/Platforms/Disable-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Disable-PASPlatform.ps1
@@ -42,12 +42,12 @@ Function Disable-PASPlatform {
 	Process {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/platforms/$($PSCmdLet.ParameterSetName)/$ID/deactivate"
+		$URI = "$($psPASSession.BaseURI)/api/platforms/$($PSCmdLet.ParameterSetName)/$ID/deactivate"
 
 		if ($PSCmdlet.ShouldProcess($ID, "Deactivate $($PSCmdLet.ParameterSetName) Platform")) {
 
 			#send request to web service
-			Invoke-PASRestMethod -Uri $URI -Method POST -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method POST
 
 		}
 

--- a/psPAS/Functions/Platforms/Enable-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Enable-PASPlatform.ps1
@@ -42,12 +42,12 @@ Function Enable-PASPlatform {
 	Process {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/platforms/$($PSCmdLet.ParameterSetName)/$ID/activate"
+		$URI = "$($psPASSession.BaseURI)/api/platforms/$($PSCmdLet.ParameterSetName)/$ID/activate"
 
 		if ($PSCmdlet.ShouldProcess($ID, "Activate $($PSCmdLet.ParameterSetName) Platform")) {
 
 			#send request to web service
-			Invoke-PASRestMethod -Uri $URI -Method POST -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method POST
 
 		}
 

--- a/psPAS/Functions/Platforms/Export-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Export-PASPlatform.ps1
@@ -23,12 +23,12 @@ function Export-PASPlatform {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/API/Platforms/$PlatformID/Export?platformID=$PlatformID"
+		$URI = "$($psPASSession.BaseURI)/API/Platforms/$PlatformID/Export?platformID=$PlatformID"
 
 		if ($PSCmdlet.ShouldProcess($PlatformID, 'Exports Platform Package')) {
 
 			#send request to web service
-			$result = Invoke-PASRestMethod -Uri $URI -Method POST -WebSession $Script:WebSession -Debug:$false
+			$result = Invoke-PASRestMethod -Uri $URI -Method POST -Debug:$false
 
 			#if we get a platform byte array
 			If ($null -ne $result) {

--- a/psPAS/Functions/Platforms/Get-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Get-PASPlatform.ps1
@@ -127,7 +127,7 @@ function Get-PASPlatform {
 				Assert-VersionRequirement -RequiredVersion 11.1
 
 				#Create request URL
-				$URI = "$Script:BaseURI/API/Platforms"
+				$URI = "$($psPASSession.BaseURI)/API/Platforms"
 
 				#Get Parameters to include in request
 				$boundParameters = $PSBoundParameters | Get-PASParameter
@@ -149,7 +149,7 @@ function Get-PASPlatform {
 				Assert-VersionRequirement -RequiredVersion 9.10
 
 				#Create request URL
-				$URI = "$Script:BaseURI/API/Platforms/$($PlatformID | Get-EscapedString)/"
+				$URI = "$($psPASSession.BaseURI)/API/Platforms/$($PlatformID | Get-EscapedString)/"
 
 				break
 
@@ -159,7 +159,7 @@ function Get-PASPlatform {
 
 				Assert-VersionRequirement -RequiredVersion 11.4
 
-				$URI = "$Script:BaseURI/API/Platforms/$($PSCmdlet.ParameterSetName)"
+				$URI = "$($psPASSession.BaseURI)/API/Platforms/$($PSCmdlet.ParameterSetName)"
 
 				#Parameter to include parameter value in url
 				$Parameters = [Collections.Generic.List[Object]]::New(@('Search'))
@@ -192,7 +192,7 @@ function Get-PASPlatform {
 
 				Assert-VersionRequirement -RequiredVersion 11.4
 
-				$URI = "$Script:BaseURI/API/Platforms/$($PSCmdlet.ParameterSetName)"
+				$URI = "$($psPASSession.BaseURI)/API/Platforms/$($PSCmdlet.ParameterSetName)"
 
 				break
 
@@ -201,7 +201,7 @@ function Get-PASPlatform {
 		}
 
 		#Send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/Platforms/Get-PASPlatformPSMConfig.ps1
+++ b/psPAS/Functions/Platforms/Get-PASPlatformPSMConfig.ps1
@@ -18,10 +18,10 @@ Function Get-PASPlatformPSMConfig {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/API/Platforms/Targets/$ID/PrivilegedSessionManagement"
+		$URI = "$($psPASSession.BaseURI)/API/Platforms/Targets/$ID/PrivilegedSessionManagement"
 
 		#send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/Platforms/Get-PASPlatformSafe.ps1
+++ b/psPAS/Functions/Platforms/Get-PASPlatformSafe.ps1
@@ -16,10 +16,10 @@ function Get-PASPlatformSafe {
 	PROCESS {
 
 		#Create request URL
-		$URI = "$Script:BaseURI/API/Platforms/$($PlatformID | Get-EscapedString)/Safes/"
+		$URI = "$($psPASSession.BaseURI)/API/Platforms/$($PlatformID | Get-EscapedString)/Safes/"
 
 		#Send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($result.count -gt 0) {
 

--- a/psPAS/Functions/Platforms/Get-PASPlatformSummary.ps1
+++ b/psPAS/Functions/Platforms/Get-PASPlatformSummary.ps1
@@ -10,10 +10,10 @@ function Get-PASPlatformSummary {
     PROCESS {
 
         #Create request URL
-        $URI = "$Script:BaseURI/API/Platforms/Targets/SystemTypes"
+        $URI = "$($psPASSession.BaseURI)/API/Platforms/Targets/SystemTypes"
 
         #Send request to web service
-        $result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+        $result = Invoke-PASRestMethod -Uri $URI -Method GET
 
         #$result
         If ($null -ne $result) {

--- a/psPAS/Functions/Platforms/Import-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Import-PASPlatform.ps1
@@ -19,7 +19,7 @@ function Import-PASPlatform {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/API/Platforms/Import"
+		$URI = "$($psPASSession.BaseURI)/API/Platforms/Import"
 
 		#Convert File to byte array
 		$FileBytes = $ImportFile | Get-ByteArray
@@ -29,7 +29,7 @@ function Import-PASPlatform {
 		if ($PSCmdlet.ShouldProcess($ImportFile, 'Imports Platform Package')) {
 
 			#send request to web service
-			Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession -Debug:$false
+			Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -Debug:$false
 
 		}
 

--- a/psPAS/Functions/Platforms/Remove-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Remove-PASPlatform.ps1
@@ -50,12 +50,12 @@ Function Remove-PASPlatform {
 	Process {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/API/Platforms/$($PSCmdLet.ParameterSetName)/$ID"
+		$URI = "$($psPASSession.BaseURI)/API/Platforms/$($PSCmdLet.ParameterSetName)/$ID"
 
 		if ($PSCmdlet.ShouldProcess($ID, "Delete $($PSCmdLet.ParameterSetName) Platform")) {
 
 			#send request to web service
-			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method DELETE
 
 		}
 

--- a/psPAS/Functions/Platforms/Set-PASPlatformPSMConfig.ps1
+++ b/psPAS/Functions/Platforms/Set-PASPlatformPSMConfig.ps1
@@ -30,7 +30,7 @@ Function Set-PASPlatformPSMConfig {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/API/Platforms/Targets/$ID/PrivilegedSessionManagement"
+		$URI = "$($psPASSession.BaseURI)/API/Platforms/Targets/$ID/PrivilegedSessionManagement"
 
 		#Request body
 		$Body = $PSBoundParameters | Get-PASParameter -ParametersToRemove ID | ConvertTo-Json
@@ -38,7 +38,7 @@ Function Set-PASPlatformPSMConfig {
 		if ($PSCmdlet.ShouldProcess($ID, 'Update Platform PSM Config')) {
 
 			#send request to web service
-			$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body -WebSession $Script:WebSession
+			$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body
 
 		}
 

--- a/psPAS/Functions/PolicyACL/Add-PASPolicyACL.ps1
+++ b/psPAS/Functions/PolicyACL/Add-PASPolicyACL.ps1
@@ -49,7 +49,7 @@ function Add-PASPolicyACL {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Policy/$($PolicyID |
+		$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Policy/$($PolicyID |
 
             Get-EscapedString)/PrivilegedCommands/"
 
@@ -61,7 +61,7 @@ function Add-PASPolicyACL {
 			ConvertTo-Json
 
 		#Send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/PolicyACL/Get-PASPolicyACL.ps1
+++ b/psPAS/Functions/PolicyACL/Get-PASPolicyACL.ps1
@@ -16,12 +16,12 @@ function Get-PASPolicyACL {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Policy/$($PolicyID |
+		$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Policy/$($PolicyID |
 
             Get-EscapedString)/PrivilegedCommands/"
 
 		#Send Request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/PolicyACL/Remove-PASPolicyACL.ps1
+++ b/psPAS/Functions/PolicyACL/Remove-PASPolicyACL.ps1
@@ -22,14 +22,14 @@ function Remove-PASPolicyACL {
 	PROCESS {
 
 		#Create base URL for request
-		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Policy/$($PolicyID |
+		$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Policy/$($PolicyID |
 
             Get-EscapedString)/PrivilegedCommands/$($Id | Get-EscapedString)/"
 
 		if ($PSCmdlet.ShouldProcess($PolicyID, "Delete Rule $Id")) {
 
 			#send request to web service
-			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method DELETE
 
 		}
 

--- a/psPAS/Functions/Requests/Approve-PASRequest.ps1
+++ b/psPAS/Functions/Requests/Approve-PASRequest.ps1
@@ -23,7 +23,7 @@ function Approve-PASRequest {
 	PROCESS {
 
 		#Create URL for Request
-		$URI = "$Script:BaseURI/API/IncomingRequests/$($RequestID)/Confirm"
+		$URI = "$($psPASSession.BaseURI)/API/IncomingRequests/$($RequestID)/Confirm"
 
 		#Create body of request
 		$body = $PSBoundParameters | Get-PASParameter -ParametersToRemove RequestId | ConvertTo-Json
@@ -31,7 +31,7 @@ function Approve-PASRequest {
 		if ($PSCmdlet.ShouldProcess($RequestId, 'Confirm Request for Account Access')) {
 
 			#send request to PAS web service
-			Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
 		}
 

--- a/psPAS/Functions/Requests/Deny-PASRequest.ps1
+++ b/psPAS/Functions/Requests/Deny-PASRequest.ps1
@@ -23,7 +23,7 @@ function Deny-PASRequest {
 	PROCESS {
 
 		#Create URL for Request
-		$URI = "$Script:BaseURI/API/IncomingRequests/$($RequestID)/Reject"
+		$URI = "$($psPASSession.BaseURI)/API/IncomingRequests/$($RequestID)/Reject"
 
 		#Create body of request
 		$body = $PSBoundParameters | Get-PASParameter -ParametersToRemove RequestId | ConvertTo-Json
@@ -31,7 +31,7 @@ function Deny-PASRequest {
 		if ($PSCmdlet.ShouldProcess($RequestId, 'Reject Request for Account Access')) {
 
 			#send request to PAS web service
-			Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
 		}
 

--- a/psPAS/Functions/Requests/Get-PASRequest.ps1
+++ b/psPAS/Functions/Requests/Get-PASRequest.ps1
@@ -53,14 +53,14 @@ function Get-PASRequest {
 
 				Assert-VersionRequirement -RequiredVersion 13.2
 
-				$URI = "$Script:BaseURI/API/$($PSCmdlet.ParameterSetName)/$id"
+				$URI = "$($psPASSession.BaseURI)/API/$($PSCmdlet.ParameterSetName)/$id"
 				break
 
 			}
 
 			'Requests' {
 
-				$URI = "$Script:BaseURI/API/$($RequestType)"
+				$URI = "$($psPASSession.BaseURI)/API/$($RequestType)"
 				break
 
 			}
@@ -78,7 +78,7 @@ function Get-PASRequest {
 		}
 
 		#send request to PAS web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/Requests/Get-PASRequestDetail.ps1
+++ b/psPAS/Functions/Requests/Get-PASRequestDetail.ps1
@@ -24,10 +24,10 @@ function Get-PASRequestDetail {
 	PROCESS {
 
 		#Create URL for Request
-		$URI = "$Script:BaseURI/API/$($RequestType)/$($RequestID)"
+		$URI = "$($psPASSession.BaseURI)/API/$($RequestType)/$($RequestID)"
 
 		#send request to PAS web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/Requests/New-PASRequest.ps1
+++ b/psPAS/Functions/Requests/New-PASRequest.ps1
@@ -290,7 +290,7 @@ function New-PASRequest {
 	PROCESS {
 
 		#Create URL for Request
-		$URI = "$Script:BaseURI/API/MyRequests"
+		$URI = "$($psPASSession.BaseURI)/API/MyRequests"
 
 		#Get all parameters that will be sent in the request
 		$boundParameters = $PSBoundParameters | Get-PASParameter
@@ -375,7 +375,7 @@ function New-PASRequest {
 		if ($PSCmdlet.ShouldProcess($Target, 'Request Account Access')) {
 
 			#send request to PAS web service
-			$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+			$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
 			If ($null -ne $result) {
 				switch ($PSCmdlet.ParameterSetName) {

--- a/psPAS/Functions/Requests/Remove-PASRequest.ps1
+++ b/psPAS/Functions/Requests/Remove-PASRequest.ps1
@@ -17,12 +17,12 @@ function Remove-PASRequest {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/API/MyRequests/$($RequestID)"
+		$URI = "$($psPASSession.BaseURI)/API/MyRequests/$($RequestID)"
 
 		if ($PSCmdlet.ShouldProcess($RequestID, 'Delete Request')) {
 
 			#Send request to web service
-			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method DELETE
 
 		}
 

--- a/psPAS/Functions/SafeMembers/Add-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Add-PASSafeMember.ps1
@@ -225,7 +225,7 @@ function Add-PASSafeMember {
 				Assert-VersionRequirement -MaximumVersion 12.3
 
 				#Create URL for request
-				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Safes/$($SafeName |
+				$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Safes/$($SafeName |
 				Get-EscapedString)/Members"
 
 				If ($PSBoundParameters.ContainsKey('MembershipExpirationDate')) {
@@ -258,7 +258,7 @@ function Add-PASSafeMember {
 				Assert-VersionRequirement -RequiredVersion 12.1
 
 				#Create URL for request
-				$URI = "$Script:BaseURI/api/Safes/$($SafeName | Get-EscapedString)/Members"
+				$URI = "$($psPASSession.BaseURI)/api/Safes/$($SafeName | Get-EscapedString)/Members"
 
 				If ($PSBoundParameters.ContainsKey('MemberType')) {
 
@@ -289,7 +289,7 @@ function Add-PASSafeMember {
 		}
 
 		#Send request to Web Service
-		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/SafeMembers/Get-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Get-PASSafeMember.ps1
@@ -129,7 +129,7 @@ function Get-PASSafeMember {
 			( { $PSItem -match '^Gen1-' } ) {
 
 				#Create URL for Gen1 API requests
-				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Safes/$($SafeName | Get-EscapedString)/Members"
+				$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Safes/$($SafeName | Get-EscapedString)/Members"
 
 			}
 
@@ -139,7 +139,7 @@ function Get-PASSafeMember {
 				Assert-VersionRequirement -RequiredVersion 12.0
 
 				#Create URL for Gen2 API requests
-				$URI = "$Script:BaseURI/api/Safes/$($SafeName | Get-EscapedString)/Members"
+				$URI = "$($psPASSession.BaseURI)/api/Safes/$($SafeName | Get-EscapedString)/Members"
 
 			}
 
@@ -224,7 +224,7 @@ function Get-PASSafeMember {
 		#Build Request Parameters
 		$Request['URI'] = $URI
 		$Request['Method'] = $Method
-		$Request['WebSession'] = $Script:WebSession
+		$Request['WebSession'] = $psPASSession.WebSession
 
 		#Send request to webservice
 		$result = Invoke-PASRestMethod @Request
@@ -310,7 +310,7 @@ function Get-PASSafeMember {
 
 
 										#Request nextLink. Add memberlist to output collection.
-										$Null = $Members.AddRange((Invoke-PASRestMethod -Uri "$URI`?$nextLink" -Method GET -WebSession $Script:WebSession -TimeoutSec $TimeoutSec).value)
+										$Null = $Members.AddRange((Invoke-PASRestMethod -Uri "$URI`?$nextLink" -Method GET -TimeoutSec $TimeoutSec).value)
 
 									}
 

--- a/psPAS/Functions/SafeMembers/Remove-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Remove-PASSafeMember.ps1
@@ -35,7 +35,7 @@ function Remove-PASSafeMember {
 			'Gen1' {
 
 				#Create URL for request
-				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Safes/$($SafeName |
+				$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Safes/$($SafeName |
 					Get-EscapedString)/Members/$($MemberName | Get-EscapedString)/"
 
 			}
@@ -45,7 +45,7 @@ function Remove-PASSafeMember {
 				Assert-VersionRequirement -RequiredVersion 12.2
 
 				#Create URL for request
-				$URI = "$Script:BaseURI/api/Safes/$($SafeName |
+				$URI = "$($psPASSession.BaseURI)/api/Safes/$($SafeName |
 					Get-EscapedString)/Members/$($MemberName | Get-EscapedString)/"
 
 			}
@@ -55,7 +55,7 @@ function Remove-PASSafeMember {
 		if ($PSCmdlet.ShouldProcess($SafeName, "Remove Safe Member '$MemberName'")) {
 
 			#Send Delete request to web service
-			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method DELETE
 
 		}
 

--- a/psPAS/Functions/SafeMembers/Set-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Set-PASSafeMember.ps1
@@ -211,7 +211,7 @@ function Set-PASSafeMember {
 				Assert-VersionRequirement -MaximumVersion 12.3
 
 				#Create URL for request
-				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Safes/$($SafeName |
+				$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Safes/$($SafeName |
 					Get-EscapedString)/Members/$($MemberName | Get-EscapedString)/"
 
 				If ($PSBoundParameters.ContainsKey('MembershipExpirationDate')) {
@@ -244,7 +244,7 @@ function Set-PASSafeMember {
 				Assert-VersionRequirement -RequiredVersion 12.2
 
 				#Create URL for request
-				$URI = "$Script:BaseURI/api/Safes/$($SafeName | Get-EscapedString)/Members/$($MemberName | Get-EscapedString)/"
+				$URI = "$($psPASSession.BaseURI)/api/Safes/$($SafeName | Get-EscapedString)/Members/$($MemberName | Get-EscapedString)/"
 
 				If ($PSBoundParameters.ContainsKey('MembershipExpirationDate')) {
 
@@ -271,7 +271,7 @@ function Set-PASSafeMember {
 		if ($PSCmdlet.ShouldProcess($SafeName, "Update Safe Permissions for '$MemberName'")) {
 
 			#Send request to webservice
-			$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body -WebSession $Script:WebSession
+			$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body
 
 			If ($null -ne $result) {
 

--- a/psPAS/Functions/Safes/Add-PASSafe.ps1
+++ b/psPAS/Functions/Safes/Add-PASSafe.ps1
@@ -98,7 +98,7 @@ function Add-PASSafe {
 			( { $PSItem -match '^Gen1-' } ) {
 
 				#Create URL for request
-				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Safes"
+				$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Safes"
 
 				#create request body
 				$body = @{
@@ -117,7 +117,7 @@ function Add-PASSafe {
 				Assert-VersionRequirement -RequiredVersion 12.0
 
 				#Create URL for request
-				$URI = "$Script:BaseURI/API/Safes"
+				$URI = "$($psPASSession.BaseURI)/API/Safes"
 
 				$typename = "$typename.Gen2"
 
@@ -130,7 +130,7 @@ function Add-PASSafe {
 		}
 
 		#send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/Safes/Find-PASSafe.ps1
+++ b/psPAS/Functions/Safes/Find-PASSafe.ps1
@@ -21,7 +21,7 @@ function Find-PASSafe {
 		Assert-VersionRequirement -RequiredVersion 10.1 -MaximumVersion 11.7
 
 		#Create base URL for request
-		$URI = "$Script:BaseURI/api/Safes"
+		$URI = "$($psPASSession.BaseURI)/api/Safes"
 		$SearchQuery = $null
 		$Limit = 25   #default if you call the API with no value
 
@@ -35,7 +35,7 @@ function Find-PASSafe {
 
 		}
 
-		$InitialResponse = Invoke-PASRestMethod -Uri "$URI`?limit=$Limit$SearchQuery" -Method GET -WebSession $Script:WebSession -TimeoutSec $TimeoutSec
+		$InitialResponse = Invoke-PASRestMethod -Uri "$URI`?limit=$Limit$SearchQuery" -Method GET -TimeoutSec $TimeoutSec
 
 		$Total = $InitialResponse.Total
 
@@ -45,7 +45,7 @@ function Find-PASSafe {
 
 			For ( $Offset = $Limit ; $Offset -lt $Total ; $Offset += $Limit ) {
 
-				$Null = $Safes.AddRange((Invoke-PASRestMethod -Uri "$URI`?limit=$Limit&OffSet=$Offset$searchQuery" -Method GET -WebSession $Script:WebSession -TimeoutSec $TimeoutSec).Safes)
+				$Null = $Safes.AddRange((Invoke-PASRestMethod -Uri "$URI`?limit=$Limit&OffSet=$Offset$searchQuery" -Method GET -TimeoutSec $TimeoutSec).Safes)
 
 			}
 

--- a/psPAS/Functions/Safes/Get-PASSafe.ps1
+++ b/psPAS/Functions/Safes/Get-PASSafe.ps1
@@ -141,7 +141,7 @@ function Get-PASSafe {
 				$returnProperty = 'value'
 
 				#define base URL
-				$URI = "$Script:BaseURI/API/Safes"
+				$URI = "$($psPASSession.BaseURI)/API/Safes"
 
 				If ($null -ne $queryString) {
 
@@ -162,7 +162,7 @@ function Get-PASSafe {
 				Assert-VersionRequirement -RequiredVersion 12.2
 
 				#define base URL
-				$URI = "$Script:BaseURI/API/Safes/$($SafeName | Get-EscapedString)"
+				$URI = "$($psPASSession.BaseURI)/API/Safes/$($SafeName | Get-EscapedString)"
 
 				$boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove SafeName
 
@@ -186,7 +186,7 @@ function Get-PASSafe {
 				Assert-VersionRequirement -MaximumVersion 12.3
 
 				#Create URL for Gen1 API requests
-				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Safes"
+				$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Safes"
 
 			}
 
@@ -227,7 +227,7 @@ function Get-PASSafe {
 		}
 
 		#send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession -TimeoutSec $TimeoutSec
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET -TimeoutSec $TimeoutSec
 
 		switch ($PSCmdlet.ParameterSetName) {
 
@@ -241,7 +241,7 @@ function Get-PASSafe {
 
 					For ( $Offset = $Limit ; $Offset -lt $Total ; $Offset += $Limit ) {
 
-						$Null = $Safes.AddRange((Invoke-PASRestMethod -Uri "$URI`?limit=$Limit&OffSet=$Offset$searchQuery" -Method GET -WebSession $Script:WebSession -TimeoutSec $TimeoutSec).Safes)
+						$Null = $Safes.AddRange((Invoke-PASRestMethod -Uri "$URI`?limit=$Limit&OffSet=$Offset$searchQuery" -Method GET -TimeoutSec $TimeoutSec).Safes)
 
 					}
 

--- a/psPAS/Functions/Safes/Remove-PASSafe.ps1
+++ b/psPAS/Functions/Safes/Remove-PASSafe.ps1
@@ -36,7 +36,7 @@ function Remove-PASSafe {
 				Assert-VersionRequirement -MaximumVersion 12.3
 
 				#Create URL for request
-				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Safes/$($SafeName |
+				$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Safes/$($SafeName |
 				Get-EscapedString)"
 
 				break
@@ -48,7 +48,7 @@ function Remove-PASSafe {
 				Assert-VersionRequirement -RequiredVersion 12.1
 
 				#Create URL for request
-				$URI = "$Script:BaseURI/api/Safes/$($SafeName | Get-EscapedString)"
+				$URI = "$($psPASSession.BaseURI)/api/Safes/$($SafeName | Get-EscapedString)"
 
 				break
 
@@ -59,7 +59,7 @@ function Remove-PASSafe {
 		if ($PSCmdlet.ShouldProcess($SafeName, 'Delete Safe')) {
 
 			#Send request to web service
-			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method DELETE
 
 		}
 

--- a/psPAS/Functions/Safes/Set-PASSafe.ps1
+++ b/psPAS/Functions/Safes/Set-PASSafe.ps1
@@ -115,7 +115,7 @@ function Set-PASSafe {
 				$typename = "$typename.Gen2"
 
 				#Create URL for Request
-				$URI = "$Script:BaseURI/api/Safes/$($SafeName | Get-EscapedString)"
+				$URI = "$($psPASSession.BaseURI)/api/Safes/$($SafeName | Get-EscapedString)"
 
 				#Create Request Body
 				$body = $BoundParameters | ConvertTo-Json
@@ -129,7 +129,7 @@ function Set-PASSafe {
 				Assert-VersionRequirement -MaximumVersion 12.3
 
 				#Create URL for Request
-				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Safes/$($SafeName | Get-EscapedString)"
+				$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Safes/$($SafeName | Get-EscapedString)"
 
 				#Create Request Body
 				$body = @{
@@ -147,7 +147,7 @@ function Set-PASSafe {
 		if ($PSCmdlet.ShouldProcess($SafeName, 'Update Safe Properties')) {
 
 			#Send request to web service
-			$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body -WebSession $Script:WebSession
+			$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body
 
 			If ($null -ne $result) {
 

--- a/psPAS/Functions/ServerWebServices/Get-PASSafeShareLogo.ps1
+++ b/psPAS/Functions/ServerWebServices/Get-PASSafeShareLogo.ps1
@@ -17,10 +17,10 @@ function Get-PASSafeShareLogo {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Logo?type=$ImageType"
+		$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Logo?type=$ImageType"
 
 		#send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 
 		If ($null -ne $result) {

--- a/psPAS/Functions/ServerWebServices/Get-PASServer.ps1
+++ b/psPAS/Functions/ServerWebServices/Get-PASServer.ps1
@@ -8,10 +8,10 @@ function Get-PASServer {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Server"
+		$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Server"
 
 		#send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/ServerWebServices/Get-PASServerWebService.ps1
+++ b/psPAS/Functions/ServerWebServices/Get-PASServerWebService.ps1
@@ -55,7 +55,7 @@ function Get-PASServerWebService {
 		}
 
 		#send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/SystemHealth/Get-PASComponentDetail.ps1
+++ b/psPAS/Functions/SystemHealth/Get-PASComponentDetail.ps1
@@ -25,10 +25,10 @@ Function Get-PASComponentDetail {
 		}
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/ComponentsMonitoringDetails/$ComponentID"
+		$URI = "$($psPASSession.BaseURI)/api/ComponentsMonitoringDetails/$ComponentID"
 
 		#send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/SystemHealth/Get-PASComponentSummary.ps1
+++ b/psPAS/Functions/SystemHealth/Get-PASComponentSummary.ps1
@@ -12,10 +12,10 @@ Function Get-PASComponentSummary {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/ComponentsMonitoringSummary"
+		$URI = "$($psPASSession.BaseURI)/api/ComponentsMonitoringSummary"
 
 		#send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/User/Add-PASGroupMember.ps1
+++ b/psPAS/Functions/User/Add-PASGroupMember.ps1
@@ -59,7 +59,7 @@ function Add-PASGroupMember {
 				Assert-VersionRequirement -MaximumVersion 12.3
 
 				#Create URL for request
-				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Groups/$($GroupName | Get-EscapedString)/Users/"
+				$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Groups/$($GroupName | Get-EscapedString)/Users/"
 
 				break
 
@@ -70,7 +70,7 @@ function Add-PASGroupMember {
 				Assert-VersionRequirement -RequiredVersion 10.6
 
 				#Create URL for request
-				$URI = "$Script:BaseURI/API/UserGroups/$groupId/Members"
+				$URI = "$($psPASSession.BaseURI)/API/UserGroups/$groupId/Members"
 
 				break
 
@@ -82,7 +82,7 @@ function Add-PASGroupMember {
 		$Body = $PSBoundParameters | Get-PASParameter -ParametersToRemove GroupName, groupId | ConvertTo-Json
 
 		#send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/User/Add-PASGroupMember.ps1
+++ b/psPAS/Functions/User/Add-PASGroupMember.ps1
@@ -7,6 +7,7 @@ function Add-PASGroupMember {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Gen2'
 		)]
+		[Alias('ID')]
 		[int]$groupId,
 
 		[parameter(

--- a/psPAS/Functions/User/Disable-PASUser.ps1
+++ b/psPAS/Functions/User/Disable-PASUser.ps1
@@ -18,12 +18,12 @@ function Disable-PASUser {
 
     PROCESS {
 
-        $URI = "$Script:BaseURI/API/Users/$id/disable/"
+        $URI = "$($psPASSession.BaseURI)/API/Users/$id/disable/"
 
         if ($PSCmdlet.ShouldProcess($id, 'Disable User')) {
 
             #send request to web service
-            Invoke-PASRestMethod -Uri $URI -Method POST -WebSession $Script:WebSession
+            Invoke-PASRestMethod -Uri $URI -Method POST
 
         }
 

--- a/psPAS/Functions/User/Enable-PASUser.ps1
+++ b/psPAS/Functions/User/Enable-PASUser.ps1
@@ -18,12 +18,12 @@ function Enable-PASUser {
 
     PROCESS {
 
-        $URI = "$Script:BaseURI/API/Users/$id/enable/"
+        $URI = "$($psPASSession.BaseURI)/API/Users/$id/enable/"
 
         if ($PSCmdlet.ShouldProcess($id, 'Enable User')) {
 
             #send request to web service
-            Invoke-PASRestMethod -Uri $URI -Method POST -WebSession $Script:WebSession
+            Invoke-PASRestMethod -Uri $URI -Method POST
 
         }
 

--- a/psPAS/Functions/User/Get-PASGroup.ps1
+++ b/psPAS/Functions/User/Get-PASGroup.ps1
@@ -62,7 +62,7 @@ function Get-PASGroup {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/API/UserGroups"
+		$URI = "$($psPASSession.BaseURI)/API/UserGroups"
 
 		#Get Parameters to include in request
 		$boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove $Parameters
@@ -129,7 +129,7 @@ function Get-PASGroup {
 		}
 
 		#send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/User/Get-PASLoggedOnUser.ps1
+++ b/psPAS/Functions/User/Get-PASLoggedOnUser.ps1
@@ -10,10 +10,10 @@ function Get-PASLoggedOnUser {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/WebServices/PIMServices.svc/User"
+		$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/User"
 
 		#send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/User/Get-PASUser.ps1
+++ b/psPAS/Functions/User/Get-PASUser.ps1
@@ -121,7 +121,7 @@ function Get-PASUser {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/Users"
+		$URI = "$($psPASSession.BaseURI)/api/Users"
 
 		switch ($PSCmdlet.ParameterSetName) {
 
@@ -186,7 +186,7 @@ function Get-PASUser {
 				Assert-VersionRequirement -MaximumVersion 12.3
 
 				#Create URL for request
-				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)"
+				$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)"
 
 				$TypeName = 'psPAS.CyberArk.Vault.User'
 
@@ -197,7 +197,7 @@ function Get-PASUser {
 		}
 
 		#send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		#Handle return
 		if ($PSCmdlet.ParameterSetName -match 'Gen2') {

--- a/psPAS/Functions/User/Get-PASUserLoginInfo.ps1
+++ b/psPAS/Functions/User/Get-PASUserLoginInfo.ps1
@@ -10,10 +10,10 @@ function Get-PASUserLoginInfo {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/LoginsInfo"
+		$URI = "$($psPASSession.BaseURI)/api/LoginsInfo"
 
 		#send request to web service
-		$result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
 
 		If ($null -ne $result) {
 

--- a/psPAS/Functions/User/Get-PASUserTypeInfo.ps1
+++ b/psPAS/Functions/User/Get-PASUserTypeInfo.ps1
@@ -10,10 +10,10 @@ function Get-PASUserTypeInfo {
     PROCESS {
 
         #Create URL for request
-        $URI = "$Script:BaseURI/API/UserTypes/"
+        $URI = "$($psPASSession.BaseURI)/API/UserTypes/"
 
         #send request to web service
-        $result = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession
+        $result = Invoke-PASRestMethod -Uri $URI -Method GET
 
         If ($null -ne $result) {
 

--- a/psPAS/Functions/User/New-PASGroup.ps1
+++ b/psPAS/Functions/User/New-PASGroup.ps1
@@ -28,7 +28,7 @@ function New-PASGroup {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/API/UserGroups"
+		$URI = "$($psPASSession.BaseURI)/API/UserGroups"
 
 		#Construct Request Body
 		$Body = $PSBoundParameters | Get-PASParameter | ConvertTo-Json
@@ -36,7 +36,7 @@ function New-PASGroup {
 		if ($PSCmdlet.ShouldProcess($groupName, 'Create Group')) {
 
 			#send request to web service
-			$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+			$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
 		}
 

--- a/psPAS/Functions/User/New-PASUser.ps1
+++ b/psPAS/Functions/User/New-PASUser.ps1
@@ -429,7 +429,7 @@ function New-PASUser {
 				}
 
 				#Create URL for request
-				$URI = "$Script:BaseURI/api/Users"
+				$URI = "$($psPASSession.BaseURI)/api/Users"
 
 				$boundParameters = $boundParameters | Format-PASUserObject
 
@@ -444,7 +444,7 @@ function New-PASUser {
 				Assert-VersionRequirement -MaximumVersion 12.3
 
 				#Create URL for request
-				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Users"
+				$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Users"
 
 				If ($PSBoundParameters.ContainsKey('ExpiryDate')) {
 
@@ -470,7 +470,7 @@ function New-PASUser {
 		if ($PSCmdlet.ShouldProcess($UserName, 'Create User')) {
 
 			#send request to web service
-			$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+			$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
 			If ($null -ne $result) {
 

--- a/psPAS/Functions/User/Remove-PASGroup.ps1
+++ b/psPAS/Functions/User/Remove-PASGroup.ps1
@@ -18,12 +18,12 @@ Function Remove-PASGroup {
 	Process {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/API/UserGroups/$GroupID"
+		$URI = "$($psPASSession.BaseURI)/API/UserGroups/$GroupID"
 
 		if ($PSCmdlet.ShouldProcess($GroupID, 'Delete Group')) {
 
 			#send request to web service
-			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method DELETE
 
 		}
 

--- a/psPAS/Functions/User/Remove-PASGroup.ps1
+++ b/psPAS/Functions/User/Remove-PASGroup.ps1
@@ -6,7 +6,8 @@ Function Remove-PASGroup {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[int]$GroupID
+		[Alias('GroupID')]
+		[int]$ID
 	)
 
 	BEGIN {
@@ -18,9 +19,9 @@ Function Remove-PASGroup {
 	Process {
 
 		#Create URL for request
-		$URI = "$($psPASSession.BaseURI)/API/UserGroups/$GroupID"
+		$URI = "$($psPASSession.BaseURI)/API/UserGroups/$ID"
 
-		if ($PSCmdlet.ShouldProcess($GroupID, 'Delete Group')) {
+		if ($PSCmdlet.ShouldProcess($ID, 'Delete Group')) {
 
 			#send request to web service
 			Invoke-PASRestMethod -Uri $URI -Method DELETE

--- a/psPAS/Functions/User/Remove-PASGroupMember.ps1
+++ b/psPAS/Functions/User/Remove-PASGroupMember.ps1
@@ -24,12 +24,12 @@ function Remove-PASGroupMember {
 	PROCESS {
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/API/UserGroups/$GroupID/members/$Member/"
+		$URI = "$($psPASSession.BaseURI)/API/UserGroups/$GroupID/members/$Member/"
 
 		if ($PSCmdlet.ShouldProcess($GroupID, "Remove Group Member $Member")) {
 
 			#send request to web service
-			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method DELETE
 
 		}
 

--- a/psPAS/Functions/User/Remove-PASUser.ps1
+++ b/psPAS/Functions/User/Remove-PASUser.ps1
@@ -34,7 +34,7 @@ function Remove-PASUser {
 
 			'Gen2' {
 
-				$URI = "$Script:BaseURI/api/Users/$id"
+				$URI = "$($psPASSession.BaseURI)/api/Users/$id"
 
 				$User = $id
 
@@ -47,7 +47,7 @@ function Remove-PASUser {
 				Assert-VersionRequirement -MaximumVersion 12.3
 
 				#Create URL for request
-				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)"
+				$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)"
 
 				$User = $UserName
 
@@ -60,7 +60,7 @@ function Remove-PASUser {
 		if ($PSCmdlet.ShouldProcess($User, 'Delete User')) {
 
 			#send request to web service
-			Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method DELETE
 
 		}
 

--- a/psPAS/Functions/User/Set-PASGroup.ps1
+++ b/psPAS/Functions/User/Set-PASGroup.ps1
@@ -24,7 +24,7 @@ Function Set-PASGroup {
     Process {
 
         #Create URL for request
-        $URI = "$Script:BaseURI/API/UserGroups/$GroupID"
+        $URI = "$($psPASSession.BaseURI)/API/UserGroups/$GroupID"
 
         #Get request parameters
         $boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove GroupID
@@ -35,7 +35,7 @@ Function Set-PASGroup {
         if ($PSCmdlet.ShouldProcess($GroupID, 'Update Group')) {
 
             #send request to web service
-            $result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body -WebSession $Script:WebSession
+            $result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body
 
         }
 

--- a/psPAS/Functions/User/Set-PASGroup.ps1
+++ b/psPAS/Functions/User/Set-PASGroup.ps1
@@ -6,7 +6,8 @@ Function Set-PASGroup {
             Mandatory = $true,
             ValueFromPipelinebyPropertyName = $true
         )]
-        [int]$GroupID,
+        [Alias('GroupID')]
+        [int]$ID,
 
         [parameter(
             Mandatory = $true,
@@ -24,15 +25,15 @@ Function Set-PASGroup {
     Process {
 
         #Create URL for request
-        $URI = "$($psPASSession.BaseURI)/API/UserGroups/$GroupID"
+        $URI = "$($psPASSession.BaseURI)/API/UserGroups/$ID"
 
         #Get request parameters
-        $boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove GroupID
+        $boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove ID
 
         #Construct Request Body
         $Body = $boundParameters | ConvertTo-Json
 
-        if ($PSCmdlet.ShouldProcess($GroupID, 'Update Group')) {
+        if ($PSCmdlet.ShouldProcess($ID, 'Update Group')) {
 
             #send request to web service
             $result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body

--- a/psPAS/Functions/User/Set-PASUser.ps1
+++ b/psPAS/Functions/User/Set-PASUser.ps1
@@ -442,7 +442,7 @@ function Set-PASUser {
 				}
 
 				#Create URL for request
-				$URI = "$Script:BaseURI/api/Users/$id"
+				$URI = "$($psPASSession.BaseURI)/api/Users/$id"
 
 				$boundParameters = $boundParameters | Format-PASUserObject
 
@@ -467,7 +467,7 @@ function Set-PASUser {
 				}
 
 				#Create URL for request
-				$URI = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)"
+				$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)"
 
 				$TypeName = 'psPAS.CyberArk.Vault.User'
 
@@ -493,7 +493,7 @@ function Set-PASUser {
 
 		if ($PSCmdlet.ShouldProcess($UserName, 'Update User Properties')) {
 			#send request to web service
-			$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body -WebSession $Script:WebSession
+			$result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body
 
 			If ($null -ne $result) {
 

--- a/psPAS/Functions/User/Set-PASUserPassword.ps1
+++ b/psPAS/Functions/User/Set-PASUserPassword.ps1
@@ -34,7 +34,7 @@ function Set-PASUserPassword {
 		$boundParameters['NewPassword'] = $Password
 
 		#Create URL for request
-		$URI = "$Script:BaseURI/api/Users/$id/ResetPassword"
+		$URI = "$($psPASSession.BaseURI)/api/Users/$id/ResetPassword"
 
 		#create request body
 		$body = $boundParameters | ConvertTo-Json
@@ -42,7 +42,7 @@ function Set-PASUserPassword {
 		if ($PSCmdlet.ShouldProcess($id, 'Reset Password')) {
 
 			#send request to web service
-			Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body -WebSession $Script:WebSession
+			Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 
 		}
 

--- a/psPAS/Functions/User/Unblock-PASUser.ps1
+++ b/psPAS/Functions/User/Unblock-PASUser.ps1
@@ -28,7 +28,7 @@ function Unblock-PASUser {
 
 	BEGIN {
 
-		$Request = @{'WebSession' = $Script:WebSession }
+		$Request = @{'WebSession' = $psPASSession.WebSession }
 
 	}#begin
 
@@ -41,7 +41,7 @@ function Unblock-PASUser {
 				Assert-VersionRequirement -RequiredVersion 10.10
 
 				#Create request
-				$Request['URI'] = "$Script:BaseURI/api/Users/$id/Activate"
+				$Request['URI'] = "$($psPASSession.BaseURI)/api/Users/$id/Activate"
 				$Request['Method'] = 'POST'
 
 				break
@@ -53,7 +53,7 @@ function Unblock-PASUser {
 				Assert-VersionRequirement -MaximumVersion 12.3
 
 				#Create request
-				$Request['URI'] = "$Script:BaseURI/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)"
+				$Request['URI'] = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Users/$($UserName | Get-EscapedString)"
 				$Request['Method'] = 'PUT'
 				$Request['Body'] = $PSBoundParameters | Get-PASParameter -ParametersToRemove UserName | ConvertTo-Json
 

--- a/psPAS/Private/Assert-VersionRequirement.ps1
+++ b/psPAS/Private/Assert-VersionRequirement.ps1
@@ -36,7 +36,7 @@ General notes
 			ValueFromPipelineByPropertyName = $true
 		)]
 		[System.Version]
-		$ExternalVersion = $Script:ExternalVersion,
+		$ExternalVersion = $psPASSession.ExternalVersion,
 
 		# The Required Software Version
 		[Parameter(

--- a/psPAS/Private/Get-NextLink.ps1
+++ b/psPAS/Private/Get-NextLink.ps1
@@ -62,7 +62,7 @@ Function Get-NextLink {
 
 			While ( $null -ne $NextLink ) {
 
-				$URI = "$Script:BaseURI/$NextLink"
+				$URI = "$($psPASSession.BaseURI)/$NextLink"
 
 				#*If there is a SavedFilter querystring, append it to the URL
 				If ($null -ne $queryString) {
@@ -72,7 +72,7 @@ Function Get-NextLink {
 
 				}
 
-				$NextResult = Invoke-PASRestMethod -Uri $URI -Method GET -WebSession $Script:WebSession -TimeoutSec $TimeoutSec
+				$NextResult = Invoke-PASRestMethod -Uri $URI -Method GET -TimeoutSec $TimeoutSec
 				$NextLink = $NextResult.nextLink
 				$null = $Result.AddRange(($NextResult.value))
 

--- a/psPAS/Private/Get-ParentFunction.ps1
+++ b/psPAS/Private/Get-ParentFunction.ps1
@@ -44,9 +44,15 @@ Function Get-ParentFunction {
 	)
 
 	Process {
+
+		#Get MyInvocation details from required scope
+		$CommandData = (Get-Variable MyInvocation -Scope $Scope).Value
 		[PSCustomObject]@{
-			FunctionName     = (Get-Variable MyInvocation -Scope $Scope).Value.MyCommand.Name
+			CommandData      = $CommandData
+			FunctionName     = $CommandData.MyCommand.Name
 			ParameterSetName = (Get-Variable PSCmdlet -Scope $Scope -ErrorAction SilentlyContinue).Value.ParameterSetName
 		}
+
 	}
+
 }

--- a/psPAS/Private/Get-SessionClone.ps1
+++ b/psPAS/Private/Get-SessionClone.ps1
@@ -38,11 +38,9 @@ function Get-SessionClone {
             }
             return $clone
         } else {
-            return [System.Management.Automation.PSSerializer]::Deserialize(
-                [System.Management.Automation.PSSerializer]::Serialize(
-                    $InputObject
-                )
-            )
+
+            return $InputObject
+
         }
     }
 }

--- a/psPAS/Private/Get-SessionClone.ps1
+++ b/psPAS/Private/Get-SessionClone.ps1
@@ -1,0 +1,48 @@
+function Get-SessionClone {
+    <#
+    .SYNOPSIS
+    Deep copy a hashtable
+
+    .DESCRIPTION
+    Deep copy a hashtable or ordered dictionary, and return an ordered dictionary
+
+    .PARAMETER InputObject
+    A hashtable or OrderedDictionary to clone
+
+    .EXAMPLE
+    Get-SessionClone -InputObject $Hashtable
+
+    Returns a new ordered hashtable, which is a deep copy of $Hashtable
+
+    .OUTPUTS
+    System.Collections.Specialized.OrderedDictionary
+    #>
+    [cmdletbinding()]
+    [OutputType('System.Collections.Specialized.OrderedDictionary')]
+    param(
+        [parameter(
+            Mandatory = $true,
+            ValueFromPipeline = $true
+        )]
+        $InputObject
+    )
+    process {
+        if (($InputObject -is [hashtable]) -or ($InputObject -is [System.Collections.Specialized.OrderedDictionary])) {
+            $clone = [ordered]@{}
+            foreach ($key in $InputObject.keys) {
+                if ($null -ne $InputObject[$key]) {
+                    $clone[$key] = Get-SessionClone $InputObject[$key]
+                } else {
+                    $clone[$key] = $null
+                }
+            }
+            return $clone
+        } else {
+            return [System.Management.Automation.PSSerializer]::Deserialize(
+                [System.Management.Automation.PSSerializer]::Serialize(
+                    $InputObject
+                )
+            )
+        }
+    }
+}

--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -9,7 +9,7 @@
 	queried and acted on.
 	All requests are sent with ContentType=application/json.
 	If the sessionVariable parameter is passed, the function will return the WebSession
-	object to the $Script:WebSession variable.
+	object to the $($psPASSession.WebSession) variable.
 
 	.PARAMETER Method
 	The method for the REST Method.
@@ -27,7 +27,7 @@
 	.PARAMETER SessionVariable
 	If passed, will be sent to invoke-webrequest which in turn will create a websession
 	variable using the string value as the name. This variable will only exist in the current scope
-	so will be set as the value of $Script:WebSession to be available in a modules scope.
+	so will be set as the value of $($psPASSession.WebSession) to be available in a modules scope.
 	Cannot be specified with WebSession
 
 	.PARAMETER WebSession
@@ -58,7 +58,7 @@
 	Skips certificate validation checks.
 
 	.EXAMPLE
-	Invoke-PASRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+	Invoke-PASRestMethod -Uri $URI -Method DELETE
 
 	Send request to web service
 	#>
@@ -121,6 +121,17 @@
 		if ( -not ($PSBoundParameters.ContainsKey('ContentType'))) {
 
 			$PSBoundParameters.Add('ContentType', 'application/json')
+
+		}
+
+		if (($PSCmdlet.ParameterSetName -ne 'SessionVariable') -and ($null -ne $psPASSession.WebSession)) {
+
+			#use the WebSession if it exists in the module scope, and alternate session or SessionVariable is not specified.
+			if ( -not ($PSBoundParameters.ContainsKey('WebSession'))) {
+
+				$PSBoundParameters.Add('WebSession', $psPASSession.WebSession)
+
+			}
 
 		}
 
@@ -217,7 +228,7 @@
 
 		} catch [System.UriFormatException] {
 
-			#Catch URI Format errors. Likely $Script:BaseURI is not set; New-PASSession should be run.
+			#Catch URI Format errors. Likely $($psPASSession.BaseURI) is not set; New-PASSession should be run.
 			$PSCmdlet.ThrowTerminatingError(
 
 				[System.Management.Automation.ErrorRecord]::new(
@@ -351,11 +362,16 @@
 
 		} finally {
 
+			#Add Command Data to $psPASSession module scope variable
+			$psPASSession.LastCommand = Get-ParentFunction | Select-Object -ExpandProperty CommandData
+			$psPASSession.LastCommandResults = $APIResponse
+			$psPASSession.LastCommandTime = Get-Date
+
 			#If Session Variable passed as argument
 			If ($PSCmdlet.ParameterSetName -eq 'SessionVariable') {
 
 				#Make the WebSession available in the module scope
-				Set-Variable -Name WebSession -Value $(Get-Variable $(Get-Variable sessionVariable).Value).Value -Scope Script
+				$psPASSession.WebSession = $(Get-Variable $(Get-Variable sessionVariable).Value).Value
 
 			}
 

--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -244,6 +244,9 @@
 
 		} catch {
 
+			$psPASSession.LastError = $PSItem
+			$psPASSession.LastErrorTime = Get-Date
+
 			#Privilege Cloud Shared Services Error Handling
 			If ($PSitem.TargetObject.RequestUri.Host -match 'cyberark.cloud') {
 

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -4758,7 +4758,7 @@ Add-PASDiscoveredAccount -UserName ServiceUser -Address 1.2.3.4 -discoveryDate (
     <command:syntax>
       <command:syntaxItem>
         <maml:name>Add-PASGroupMember</maml:name>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="ID">
           <maml:name>groupId</maml:name>
           <maml:description>
             <maml:para>The unique ID of the group to add the member to.</maml:para>
@@ -4841,7 +4841,7 @@ Add-PASDiscoveredAccount -UserName ServiceUser -Address 1.2.3.4 -discoveryDate (
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="ID">
         <maml:name>groupId</maml:name>
         <maml:description>
           <maml:para>The unique ID of the group to add the member to.</maml:para>
@@ -30396,18 +30396,6 @@ Publish-PASDiscoveredAccount -id 66_6 -PlatformID WinDomain -safeName SomeSafe -
     <command:syntax>
       <command:syntaxItem>
         <maml:name>Remove-PASGroup</maml:name>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
-          <maml:name>GroupID</maml:name>
-          <maml:description>
-            <maml:para>The unique ID of the vault group to delete.</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
-          <dev:type>
-            <maml:name>Int32</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>0</dev:defaultValue>
-        </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
           <maml:name>WhatIf</maml:name>
           <maml:description>
@@ -30430,21 +30418,21 @@ Publish-PASDiscoveredAccount -id 66_6 -PlatformID WinDomain -safeName SomeSafe -
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="GroupID">
+          <maml:name>ID</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ID Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
-        <maml:name>GroupID</maml:name>
-        <maml:description>
-          <maml:para>The unique ID of the vault group to delete.</maml:para>
-        </maml:description>
-        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
-        <dev:type>
-          <maml:name>Int32</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>0</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
         <maml:name>WhatIf</maml:name>
         <maml:description>
@@ -30468,6 +30456,18 @@ Publish-PASDiscoveredAccount -id 66_6 -PlatformID WinDomain -safeName SomeSafe -
           <maml:uri />
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="GroupID">
+        <maml:name>ID</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ID Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes />
@@ -34556,18 +34556,6 @@ Set-PASDirectoryMapping -DirectoryName $Directory -MappingAuthorizations AddUpda
     <command:syntax>
       <command:syntaxItem>
         <maml:name>Set-PASGroup</maml:name>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
-          <maml:name>GroupID</maml:name>
-          <maml:description>
-            <maml:para>The ID of the group to update</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
-          <dev:type>
-            <maml:name>Int32</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>0</dev:defaultValue>
-        </command:parameter>
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
           <maml:name>GroupName</maml:name>
           <maml:description>
@@ -34602,21 +34590,21 @@ Set-PASDirectoryMapping -DirectoryName $Directory -MappingAuthorizations AddUpda
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="GroupID">
+          <maml:name>ID</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ID Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
-        <maml:name>GroupID</maml:name>
-        <maml:description>
-          <maml:para>The ID of the group to update</maml:para>
-        </maml:description>
-        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
-        <dev:type>
-          <maml:name>Int32</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>0</dev:defaultValue>
-      </command:parameter>
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
         <maml:name>GroupName</maml:name>
         <maml:description>
@@ -34652,6 +34640,18 @@ Set-PASDirectoryMapping -DirectoryName $Directory -MappingAuthorizations AddUpda
           <maml:uri />
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="GroupID">
+        <maml:name>ID</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ID Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes />

--- a/psPAS/psPAS.psm1
+++ b/psPAS/psPAS.psm1
@@ -55,5 +55,17 @@ Get-ChildItem $PSScriptRoot\ -Recurse -Include '*.ps1' -Exclude '*.ps1xml' |
 
 	}
 
-[System.Version]$Version = '0.0'
-Set-Variable -Name ExternalVersion -Value $Version -Scope Script
+# Script scope session object for session data
+$psPASSession = [ordered]@{
+	BaseURI            = $null
+	User               = $null
+	ExternalVersion    = [System.Version]'0.0'
+	WebSession         = $null
+	StartTime          = $null
+	ElapsedTime        = $null
+	LastCommand        = $null
+	LastCommandTime    = $null
+	LastCommandResults = $null
+} | Add-ObjectDetail -typename psPAS.CyberArk.Vault.Session
+
+New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force

--- a/psPAS/psPAS.psm1
+++ b/psPAS/psPAS.psm1
@@ -66,6 +66,8 @@ $psPASSession = [ordered]@{
 	LastCommand        = $null
 	LastCommandTime    = $null
 	LastCommandResults = $null
+	LastError          = $null
+	LastErrorTime      = $null
 } | Add-ObjectDetail -typename psPAS.CyberArk.Vault.Session
 
 New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force

--- a/psPAS/xml/psPAS.CyberArk.Vault.PSM.Formats.ps1xml
+++ b/psPAS/xml/psPAS.CyberArk.Vault.PSM.Formats.ps1xml
@@ -15,6 +15,12 @@
 					<TableColumnHeader/>
 					<TableColumnHeader/>
 					<TableColumnHeader/>
+					<TableColumnHeader>
+						<Label>Start</Label>
+					</TableColumnHeader>
+					<TableColumnHeader>
+						<Label>End</Label>
+					</TableColumnHeader>
 				</TableHeaders>
 				<TableRowEntries>
 					<TableRowEntry>
@@ -36,6 +42,16 @@
 							</TableColumnItem>
 							<TableColumnItem>
 								<PropertyName>ConnectionComponentID</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<ScriptBlock>
+									(get-date 1/1/1970).addseconds($_.Start)
+								</ScriptBlock>
+							</TableColumnItem>
+							<TableColumnItem>
+								<ScriptBlock>
+									(get-date 1/1/1970).addseconds($_.End)
+								</ScriptBlock>
 							</TableColumnItem>
 						</TableColumnItems>
 					</TableRowEntry>
@@ -105,10 +121,12 @@
 								<PropertyName>FileName</PropertyName>
 							</ListItem>
 							<ListItem>
-								<PropertyName>Start</PropertyName>
+								<Label>Start</Label>
+								<ScriptBlock>(get-date 1/1/1970).addseconds($_.Start)</ScriptBlock>
 							</ListItem>
 							<ListItem>
-								<PropertyName>End</PropertyName>
+								<Label>End</Label>
+								<ScriptBlock>(get-date 1/1/1970).addseconds($_.End)</ScriptBlock>
 							</ListItem>
 							<ListItem>
 								<PropertyName>Duration</PropertyName>
@@ -242,10 +260,12 @@
 								<PropertyName>FileName</PropertyName>
 							</ListItem>
 							<ListItem>
-								<PropertyName>Start</PropertyName>
+								<Label>Start</Label>
+								<ScriptBlock>(get-date 1/1/1970).addseconds($_.Start)</ScriptBlock>
 							</ListItem>
 							<ListItem>
-								<PropertyName>End</PropertyName>
+								<Label>End</Label>
+								<ScriptBlock>(get-date 1/1/1970).addseconds($_.End)</ScriptBlock>
 							</ListItem>
 							<ListItem>
 								<PropertyName>Duration</PropertyName>
@@ -367,10 +387,12 @@
 								<PropertyName>FileName</PropertyName>
 							</ListItem>
 							<ListItem>
-								<PropertyName>Start</PropertyName>
+								<Label>Start</Label>
+								<ScriptBlock>(get-date 1/1/1970).addseconds($_.Start)</ScriptBlock>
 							</ListItem>
 							<ListItem>
-								<PropertyName>End</PropertyName>
+								<Label>End</Label>
+								<ScriptBlock>(get-date 1/1/1970).addseconds($_.End)</ScriptBlock>
 							</ListItem>
 							<ListItem>
 								<PropertyName>Duration</PropertyName>


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description

### Added
- N/A

### Updated
- `Get-PASSession`
  - makes additional information available to users running the command
    - authentication time
    - session length
    - last command and result data
    - last error details
- `New-PASPSMSession`
  - RDP and PSMGW connections will be automatically opened when issuing  connection request.
- `New-PASSession`
  - Adds logic around getting the logged on user name for either self-hosted or privilege cloud deployments
- PSM Session Data Formats
  - Adds `Start` & `End` to standard table view output
  - Formats `Start` & `End` as standard datetime instead of unixtime.

### Fixed
- `Add-PASGroupMember`,`Remove-PASGroup`,`Set-PASGroup`
  - Standardises name of `ID` parameter.
  - Adds `GroupID` alias to `ID` parameter.

Fixes #512 

## Type of change
<!--
Please select all relevant options:
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [ ] Documentation update (psPAS website or command help content)
- [X] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [X] Pester test(s) updated
- [X] Pester test(s) passing

**Test Configuration**:
- PowerShell version: 7.4
- CyberArk PAS version: 14.0
- OS Version: Win 11

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [X] My code follows the style guidelines of this project
- [X] I have followed the contributing guidelines.
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new test failures or errors
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [X] I have linked a related issue