### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,18 @@
 - `Get-PASPSMRecording`
   - Updated to return recordings from the last 24 hours by default when `FromTime` & `ToTime` parameters are not specified.
   - When specifying `ToTime` without `FromTime`, recordings from the 24 hours before `ToTime` are returned.
+- `Set-PASUser`
+  - Updated to send any existing user properties, which are not being specifically updated, with the request `Set-PASUser`.
+    - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the user object.
+    - This update allows single properties to be updated without having to specify all properties.
+  - Allows Empty argument for `unAuthorizedInterfaces` & `vaultAuthorization` parameters to enable set values to be cleared.
+  - Corrects ValidateSet for `unAuthorizedInterfaces` parameter.
+- `New-PASUser`
+  - In-line with update to `Set-PASUser`
+    - Allows Empty argument for `unAuthorizedInterfaces` & `vaultAuthorization` parameters.
+    - Corrects ValidateSet for `unAuthorizedInterfaces` parameter.
 
 ### Fixed
-- N/A
-
-## **6.1.62**
-
-### Added
 - N/A
 
 ## **6.2.68**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@
   - In-line with update to `Set-PASUser`
     - Allows Empty argument for `unAuthorizedInterfaces` & `vaultAuthorization` parameters.
     - Corrects ValidateSet for `unAuthorizedInterfaces` parameter.
+- `Get-PASComponentDetail`
+  - Adds assertion that command specifying `PTA` component  must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
 - `Add-PASAccountACL`
   - Adds assertion that command must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
 - `Get-PASAccountACL`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@
 - N/A
 
 ### Updated
+- N/A
+
+### Fixed
+- N/A
+
+## **6.3.77**
+
+### Added
+- N/A
+
+### Updated
 - `Get-PASPSMRecording`
   - In-line with PVWA default operation:
     - Changed the default limit for each page of results to 100, in-line with PVWA default values
@@ -24,7 +35,9 @@
   - Allows Empty argument for `unAuthorizedInterfaces` & `vaultAuthorization` parameters to enable set values to be cleared.
   - Corrects ValidateSet for `unAuthorizedInterfaces` parameter.
 - `Set-PASSafe`
-  - Updated to send any existing properties, which are not being specifically updated, with the request.
+  - Updated to query for, and send, any existing properties, which are not being specifically updated, with the request.
+    - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the object.
+    - This update allows single properties to be updated without having to specify all properties.
 - `Set-PASOpenIDConnectProvider`
   - Updated to query for, and send, any existing properties, which are not being specifically updated, with the request.
     - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the object.
@@ -53,10 +66,6 @@
     - This update allows single properties to be updated without having to specify all properties.
     - Number of mandatory parameters required to be specified has been reduced
 - `Set-PASSafeMember`
-  - Updated to query for, and send, any existing properties, which are not being specifically updated, with the request.
-    - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the object.
-    - This update allows single properties to be updated without having to specify all properties.
-- `Set-PASSafe`
   - Updated to query for, and send, any existing properties, which are not being specifically updated, with the request.
     - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the object.
     - This update allows single properties to be updated without having to specify all properties.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,30 @@
   - In-line with update to `Set-PASUser`
     - Allows Empty argument for `unAuthorizedInterfaces` & `vaultAuthorization` parameters.
     - Corrects ValidateSet for `unAuthorizedInterfaces` parameter.
+- `Add-PASAccountACL`
+  - Adds assertion that command must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
+- `Get-PASAccountACL`
+  - Adds assertion that command must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
+- `Remove-PASAccountACL`
+  - Adds assertion that command must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
+- `Invoke-PASCPMOperation`
+  - Adds assertion that Gen1 verify task must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
+- `Set-PASAccount`
+  - Adds assertion that Gen1 task must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
+- `Close-PASSession`
+  - Adds assertion that Shared Authentication logoff request is executed against a self hosted implementation as invocation against privilege cloud is not supported.
+- `New-PASSession`
+  - Adds assertion that Shared Authentication logon request is executed against a self hosted implementation as invocation against privilege cloud is not supported.
+- `Add-PASPolicyACL`
+  - Adds assertion that command must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
+- `Get-PASPolicyACL`
+  - Adds assertion that command must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
+- `Remove-PASPolicyACL`
+  - Adds assertion that command must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
+- `Remove-PASSafeMember`
+  - Adds assertion that command using Gen1 parameters must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
+- `Assert-VersionRequirement`
+  - Updates helper function to provide ability to assert if command is being run against self-hosted or privilege cloud implementation.
 
 ### Fixed
 - N/A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,48 @@
   - When specifying `ToTime` without `FromTime`, recordings from the 48 hours before `ToTime` are returned.
     - This avoids potential for unintentionally long running queries which return details of many recording from the vault.
 - `Set-PASUser`
-  - Updated to send any existing user properties, which are not being specifically updated, with the request `Set-PASUser`.
+  - Updated to query for, and send, any existing user properties, which are not being specifically updated, with the request.
     - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the user object.
     - This update allows single properties to be updated without having to specify all properties.
   - Allows Empty argument for `unAuthorizedInterfaces` & `vaultAuthorization` parameters to enable set values to be cleared.
   - Corrects ValidateSet for `unAuthorizedInterfaces` parameter.
 - `Set-PASSafe`
   - Updated to send any existing properties, which are not being specifically updated, with the request.
+- `Set-PASOpenIDConnectProvider`
+  - Updated to query for, and send, any existing properties, which are not being specifically updated, with the request.
+    - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the object.
+    - This update allows single properties to be updated without having to specify all properties.
+    - Number of mandatory parameters required to be specified has been reduced
+- `Set-PASPTARule`
+  - Updated to query for, and send, any existing properties, which are not being specifically updated, with the request.
+    - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the object.
+    - This update allows single properties to be updated without having to specify all properties.
+    - Number of mandatory parameters required to be specified has been reduced
+- `Set-PASDirectoryMapping`
+  - Updated to query for, and send, any existing properties, which are not being specifically updated, with the request.
+    - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the object.
+    - This update allows single properties to be updated without having to specify all properties.
+    - Number of mandatory parameters required to be specified has been reduced
+- `New-PASOnboardingRule`
+  - Reordered parameters to simplify tab completion options
+- `Set-PASOnboardingRule`
+  - Updated to query for, and send, any existing properties, which are not being specifically updated, with the request.
+    - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the object.
+    - This update allows single properties to be updated without having to specify all properties.
+    - Number of mandatory parameters required to be specified has been reduced
+- `Set-PASPlatformPSMConfig`
+  - Updated to query for, and send, any existing properties, which are not being specifically updated, with the request.
+    - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the object.
+    - This update allows single properties to be updated without having to specify all properties.
+    - Number of mandatory parameters required to be specified has been reduced
+- `Set-PASSafeMember`
+  - Updated to query for, and send, any existing properties, which are not being specifically updated, with the request.
+    - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the object.
+    - This update allows single properties to be updated without having to specify all properties.
+- `Set-PASSafe`
+  - Updated to query for, and send, any existing properties, which are not being specifically updated, with the request.
+    - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the object.
+    - This update allows single properties to be updated without having to specify all properties.
 - `New-PASUser`
   - In-line with update to `Set-PASUser`
     - Allows Empty argument for `unAuthorizedInterfaces` & `vaultAuthorization` parameters.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
     - This update allows single properties to be updated without having to specify all properties.
   - Allows Empty argument for `unAuthorizedInterfaces` & `vaultAuthorization` parameters to enable set values to be cleared.
   - Corrects ValidateSet for `unAuthorizedInterfaces` parameter.
+- `Set-PASSafe`
+  - Updated to send any existing properties, which are not being specifically updated, with the request.
 - `New-PASUser`
   - In-line with update to `Set-PASUser`
     - Allows Empty argument for `unAuthorizedInterfaces` & `vaultAuthorization` parameters.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,11 @@
 
 ### Updated
 - `Get-PASPSMRecording`
-  - Updated to return recordings from the last 24 hours by default when `FromTime` & `ToTime` parameters are not specified.
-  - When specifying `ToTime` without `FromTime`, recordings from the 24 hours before `ToTime` are returned.
+  - In-line with PVWA default operation:
+    - Changed the default limit for each page of results to 100, in-line with PVWA default values
+    - Updated to return recordings from the last 48 hours by default when `FromTime` & `ToTime` parameters are not specified.
+  - When specifying `ToTime` without `FromTime`, recordings from the 48 hours before `ToTime` are returned.
+    - This avoids potential for unintentionally long running queries which return details of many recording from the vault.
 - `Set-PASUser`
   - Updated to send any existing user properties, which are not being specifically updated, with the request `Set-PASUser`.
     - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the user object.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@
 - N/A
 
 ### Updated
-- N/A
+- `Get-PASPSMRecording`
+  - Updated to return recordings from the last 24 hours by default when `FromTime` & `ToTime` parameters are not specified.
+  - When specifying `ToTime` without `FromTime`, recordings from the 24 hours before `ToTime` are returned.
 
 ### Fixed
 - N/A

--- a/README.md
+++ b/README.md
@@ -1300,7 +1300,7 @@ for the unofficial API documentation, general API wizardry & knowledge sharing.
 
 **Jesse McWilliams**
 ([JesseMcWilliamss](https://github.com/JesseMcWilliams))
-For the infomration needed to add PKIPN authentication into `New-PASSession`
+For the information needed to add PKIPN authentication into `New-PASSession`
 
 **Wojciech Ossowski**
 ([Qrelis](https://github.com/Qrelis))

--- a/Tests/Format-PutRequestObject.Tests.ps1
+++ b/Tests/Format-PutRequestObject.Tests.ps1
@@ -48,22 +48,32 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
         Context	'General Tests' {
             BeforeEach {
 
-                $object = [PSCustomObject]@{
-
-                    Prop1 = 'testvalue1'
-                    Nest1 = [PSCustomObject]@{nestedproperty1 = 'nested value1' }
-                    Prop2 = 'testvalue2'
-                    Nest2 = [PSCustomObject]@{nestedproperty2 = 'nested value2' }
-                    Nest3 = [PSCustomObject]@{nestedproperty3 = 'nested value3' }
-
+                $InputObject = [pscustomobject]@{'prop1' = 'value1' ; 'prop2' = 'value2' ; 'prop9' = 'value9' }
+                $BoundParameters = @{
+                    'prop3' = 'value 3'
+                    'prop4' = 'value 4'
                 }
-
-                $ReturnData = $object | Get-PASUserPropertyObject
+                Format-PutRequestObject -InputObject $InputObject -boundParameters $BoundParameters -ParametersToRemove prop1, prop2
             }
 
-            It 'returns a expected number of properties' {
+            AfterEach {
+                $BoundParameters = $null
+            }
+            It 'sets expected number of keys for BoundParameters' {
 
-                $ReturnData.Length | Should -Be 5
+                ($BoundParameters.Keys).Count | Should -Be 3
+
+            }
+
+            It 'sets expected expected value for prop9' {
+
+                $BoundParameters['prop9'] | Should -Be 'value9'
+
+            }
+
+            It 'sets expected expected value for prop1' {
+
+                $BoundParameters['prop1'] | Should -BeNullOrEmpty
 
             }
 

--- a/Tests/Get-PASPSMRecording.Tests.ps1
+++ b/Tests/Get-PASPSMRecording.Tests.ps1
@@ -124,7 +124,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				#311212800 1674345600
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -match 'FromTime=1674259200'
+					$URI -match 'FromTime=1674172800'
 
 				} -Times 1 -Exactly -Scope It
 
@@ -217,12 +217,12 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				Mock Invoke-PASRestMethod -MockWith {
 					If ($script:iteration -le 4) {
 						[PSCustomObject]@{
-							'Recordings'      = @(1..25)
+							'Recordings'      = @(1..100)
 							$script:iteration = $script:iteration++
 						}
 					} else {
 						[PSCustomObject]@{
-							'Recordings' = @(1..24)
+							'Recordings' = @(1..99)
 						}
 					}
 				}

--- a/Tests/Get-PASPSMRecording.Tests.ps1
+++ b/Tests/Get-PASPSMRecording.Tests.ps1
@@ -73,7 +73,25 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Get-PASPSMRecording
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:psPASSession.BaseURI)/API/Recordings?Limit=9"
+					$URI -match "$($Script:psPASSession.BaseURI)/API/Recordings?"
+
+				} -Times 1 -Exactly -Scope It
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -match 'Limit=9'
+
+				} -Times 1 -Exactly -Scope It
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -match 'ToTime=\d{10}'
+
+				} -Times 1 -Exactly -Scope It
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -match 'FromTime=\d{10}'
 
 				} -Times 1 -Exactly -Scope It
 
@@ -84,7 +102,29 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				#311212800 1674345600
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:psPASSession.BaseURI)/API/Recordings?ToTime=1674345600"
+					$URI -match 'ToTime=1674345600'
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'uses expected default ToTime value when ToTime not specified' {
+				Get-PASPSMRecording
+				#311212800 1674345600
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -match 'ToTime=\d{10}'
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'uses expected default FromTime value when FromTime not specified' {
+				Get-PASPSMRecording -ToTime (Get-Date -Year 2023 -Day 22 -Month 1 -Hour 0 -Minute 0 -Second 0 -Millisecond 0)
+				#311212800 1674345600
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -match 'FromTime=1674259200'
 
 				} -Times 1 -Exactly -Scope It
 
@@ -94,7 +134,8 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				Get-PASPSMRecording -FromTime (Get-Date -Year 1979 -Month 11 -Day 12 -Hour 0 -Minute 0 -Second 0 -Millisecond 0)
 				#311212800 1674345600
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-					$URI -eq "$($Script:psPASSession.BaseURI)/API/Recordings?fromTime=311212800"
+
+					$URI -match 'fromTime=311212800'
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Get-PASPropertyObject.Tests.ps1
+++ b/Tests/Get-PASPropertyObject.Tests.ps1
@@ -1,0 +1,72 @@
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
+
+    BeforeAll {
+        #Get Current Directory
+        $Here = Split-Path -Parent $PSCommandPath
+
+        #Assume ModuleName from Repository Root folder
+        $ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+        #Resolve Path to Module Directory
+        $ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+        #Define Path to Module Manifest
+        $ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+        if ( -not (Get-Module -Name $ModuleName -All)) {
+
+            Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+        }
+
+        $Script:RequestBody = $null
+        $psPASSession = [ordered]@{
+            BaseURI            = 'https://SomeURL/SomeApp'
+            User               = $null
+            ExternalVersion    = [System.Version]'0.0'
+            WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+            StartTime          = $null
+            ElapsedTime        = $null
+            LastCommand        = $null
+            LastCommandTime    = $null
+            LastCommandResults = $null
+        }
+
+        New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
+
+    }
+
+
+    AfterAll {
+
+        $Script:RequestBody = $null
+
+    }
+
+    InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+        Context	'General Tests' {
+            BeforeEach {
+
+                $object = [PSCustomObject]@{
+
+                    Prop1 = 'testvalue1'
+                    Nest1 = [PSCustomObject]@{nestedproperty1 = 'nested value1' }
+                    Prop2 = 'testvalue2'
+                    Nest2 = [PSCustomObject]@{nestedproperty2 = 'nested value2' }
+                    Nest3 = [PSCustomObject]@{nestedproperty3 = 'nested value3' }
+
+                }
+
+                $ReturnData = $object | Get-PASPropertyObject
+            }
+
+            It 'returns a expected number of properties' {
+
+                $ReturnData.Length | Should -Be 5
+
+            }
+
+        }
+    }
+}

--- a/Tests/Get-PASUserPropertyObject.Tests.ps1
+++ b/Tests/Get-PASUserPropertyObject.Tests.ps1
@@ -1,0 +1,72 @@
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
+
+    BeforeAll {
+        #Get Current Directory
+        $Here = Split-Path -Parent $PSCommandPath
+
+        #Assume ModuleName from Repository Root folder
+        $ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+        #Resolve Path to Module Directory
+        $ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+        #Define Path to Module Manifest
+        $ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+        if ( -not (Get-Module -Name $ModuleName -All)) {
+
+            Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+        }
+
+        $Script:RequestBody = $null
+        $psPASSession = [ordered]@{
+            BaseURI            = 'https://SomeURL/SomeApp'
+            User               = $null
+            ExternalVersion    = [System.Version]'0.0'
+            WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+            StartTime          = $null
+            ElapsedTime        = $null
+            LastCommand        = $null
+            LastCommandTime    = $null
+            LastCommandResults = $null
+        }
+
+        New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
+
+    }
+
+
+    AfterAll {
+
+        $Script:RequestBody = $null
+
+    }
+
+    InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+        Context	'General Tests' {
+            BeforeEach {
+
+                $object = [PSCustomObject]@{
+
+                    Prop1 = 'testvalue1'
+                    Nest1 = [PSCustomObject]@{nestedproperty1 = 'nested value1' }
+                    Prop2 = 'testvalue2'
+                    Nest2 = [PSCustomObject]@{nestedproperty2 = 'nested value2' }
+                    Nest3 = [PSCustomObject]@{nestedproperty3 = 'nested value3' }
+
+                }
+
+                $ReturnData = $object | Get-PASUserPropertyObject
+            }
+
+            It 'returns a expected number of properties' {
+
+                $ReturnData.Length | Should -Be 5
+
+            }
+
+        }
+    }
+}

--- a/Tests/Set-PASDirectoryMapping.Tests.ps1
+++ b/Tests/Set-PASDirectoryMapping.Tests.ps1
@@ -65,7 +65,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'sends request' {
 				$InputObj | Set-PASDirectoryMapping -MappingAuthorizations AddUpdateUsers ActivateUsers
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Scope It
 
 			}
 
@@ -75,7 +75,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 					$URI -eq "$($Script:psPASSession.BaseURI)/api/Configuration/LDAP/Directories/SomeDirectory/Mappings/SomeMappingID/"
 
-				} -Times 1 -Exactly -Scope It
+				} -Times 1 -Scope It
 
 			}
 

--- a/Tests/Set-PASOnboardingRule.Tests.ps1
+++ b/Tests/Set-PASOnboardingRule.Tests.ps1
@@ -47,10 +47,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 		Context 'Mandatory Parameters' {
 
-			$Parameters = @{Parameter = 'Id' },
-			@{Parameter = 'TargetPlatformId' },
-			@{Parameter = 'TargetSafeName' },
-			@{Parameter = 'SystemTypeFilter' }
+			$Parameters = @{Parameter = 'Id' }
 
 			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
@@ -65,7 +62,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		Context 'Input' {
 
 			BeforeEach {
-
+				Mock Get-PASOnboardingRule -MockWith {}
 				Mock Invoke-PASRestMethod -MockWith { }
 
 				$InputObj = [pscustomobject]@{
@@ -80,7 +77,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'sends request' {
 				$InputObj | Set-PASOnboardingRule
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Scope It
 
 			}
 
@@ -104,7 +101,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Set-PASOnboardingRule
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 					($Body) -ne $null
-				} -Times 1 -Exactly -Scope It
+				} -Times 1 -Scope It
 
 			}
 
@@ -140,11 +137,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 						'Prop4' = 'Value4'
 					}
 
-
-
 				}
 
-
+				Mock Get-PASOnboardingRule -MockWith {}
 				$InputObj = [pscustomobject]@{
 					'SystemTypeFilter' = 'Windows'
 					'TargetSafeName'   = 'SomeSafe'
@@ -166,8 +161,6 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.OnboardingRule
 
 			}
-
-
 
 		}
 

--- a/Tests/Set-PASOpenIDConnectProvider.Tests.ps1
+++ b/Tests/Set-PASOpenIDConnectProvider.Tests.ps1
@@ -52,6 +52,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
 			}
 
+			Mock Get-PASOpenIDConnectProvider -MockWith {}
 			$clientSecret = $('SomeClientSecret' | ConvertTo-SecureString -AsPlainText -Force)
 
 			$InputObject = [PSCustomObject]@{
@@ -72,7 +73,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'sends request' {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Scope It
 
 			}
 
@@ -82,7 +83,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 					$URI -eq "$($Script:psPASSession.BaseURI)/api/Configuration/OIDC/Providers/idValue"
 
-				} -Times 1 -Exactly -Scope It
+				} -Times 1 -Scope It
 
 			}
 

--- a/Tests/Set-PASPTARule.Tests.ps1
+++ b/Tests/Set-PASPTARule.Tests.ps1
@@ -49,7 +49,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			Mock Invoke-PASRestMethod -MockWith {
 
 			}
-
+			Mock Get-PASPTARule -MockWith {}
 			$InputObj = [pscustomobject]@{
 				'id'             = 99
 				'category'       = 'KEYSTROKES'
@@ -70,13 +70,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 		}
 		Context 'Mandatory Parameters' {
 
-			$Parameters = @{Parameter = 'id' },
-			@{Parameter = 'category' },
-			@{Parameter = 'regex' },
-			@{Parameter = 'score' },
-			@{Parameter = 'description' },
-			@{Parameter = 'response' },
-			@{Parameter = 'active' }
+			$Parameters = @{Parameter = 'id' }
 
 			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
@@ -94,7 +88,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'sends request' {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Scope It
 
 			}
 
@@ -122,7 +116,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 					($Script:RequestBody) -ne $null
 
-				} -Times 1 -Exactly -Scope It
+				} -Times 1 -Scope It
 
 			}
 

--- a/Tests/Set-PASPlatformPSMConfig.Tests.ps1
+++ b/Tests/Set-PASPlatformPSMConfig.Tests.ps1
@@ -49,14 +49,16 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			Mock Invoke-PASRestMethod -MockWith {
 				[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
 			}
-
+			Mock Get-PASPlatformPSMConfig -MockWith {
+				[PSCustomObject]@{'PSMServerID' = 'SomePSMServer' }
+			}
 			$response = Set-PASPlatformPSMConfig -ID 42 -PSMServerID SomePSMServer
 		}
 		Context 'Input' {
 
 			It 'sends request' {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -Scope It
 
 			}
 
@@ -66,7 +68,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 					$URI -eq "$($Script:psPASSession.BaseURI)/API/Platforms/Targets/42/PrivilegedSessionManagement"
 
-				} -Times 1 -Exactly -Scope It
+				} -Scope It
 
 			}
 
@@ -79,8 +81,10 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-					$($Body | ConvertFrom-Json | Select-Object -ExpandProperty PSMServerID) -eq 'SomePSMServer'
-				} -Times 1 -Exactly -Scope It
+					If ($null -ne $Body) {
+						$($Body | ConvertFrom-Json | Select-Object -ExpandProperty PSMServerID) -eq 'SomePSMServer'
+					}
+				} -Scope It -Times 1
 
 			}
 

--- a/Tests/Set-PASSafe.Tests.ps1
+++ b/Tests/Set-PASSafe.Tests.ps1
@@ -72,7 +72,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 					'SafeName' = 'SomeName'
 
 				}
-
+				Mock Get-PASSafe -MockWith {}
 				$response = $InputObj | Set-PASSafe -NumberOfDaysRetention 1 -ManagingCPM SomeCPM -NewSafeName SomeNewName -UseGen1API
 
 			}
@@ -89,13 +89,13 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Safes/SomeName"
 
-				} -Times 1 -Exactly -Scope It
+				} -Times 1 -Scope It
 
 			}
 
 			It 'uses expected method' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PUT' } -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PUT' } -Times 1 -Scope It
 
 			}
 
@@ -155,7 +155,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'uses expected method' {
 
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PUT' } -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PUT' } -Times 1 -Scope It
 
 			}
 
@@ -167,7 +167,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 					$Script:RequestBody -ne $null
 
-				} -Times 1 -Exactly -Scope It
+				} -Times 1 -Scope It
 
 			}
 
@@ -228,7 +228,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 					'SafeName' = 'SomeName'
 
 				}
-
+				Mock Get-PASSafe -MockWith {}
 				$response = $InputObj | Set-PASSafe -NumberOfDaysRetention 1 -ManagingCPM SomeCPM -NewSafeName SomeNewName
 
 			}

--- a/Tests/Set-PASSafe.Tests.ps1
+++ b/Tests/Set-PASSafe.Tests.ps1
@@ -79,7 +79,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'sends request' {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -Scope It
 
 			}
 
@@ -107,7 +107,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 					($Script:RequestBody.safe) -ne $null
 
-				} -Times 1 -Exactly -Scope It
+				} -Scope It
 
 			}
 
@@ -125,7 +125,9 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				Mock Invoke-PASRestMethod -MockWith {
 					[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
 				}
-
+				Mock Get-PASSafe -MockWith {
+					[PSCustomObject]@{'UpdateSafeResult' = [PSCustomObject]@{'description' = 'Val1'; 'location' = 'Val2' } }
+				}
 				$InputObj = [pscustomobject]@{
 					'SafeName' = 'SomeName'
 
@@ -137,7 +139,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'sends request' {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -Scope It
 
 			}
 
@@ -171,7 +173,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'has a request body with expected number of properties' {
 
-				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 3
+				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 5
 
 			}
 

--- a/Tests/Set-PASSafeMember.Tests.ps1
+++ b/Tests/Set-PASSafeMember.Tests.ps1
@@ -156,6 +156,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			BeforeEach {
 				Mock Invoke-PASRestMethod -MockWith {}
+				Mock Get-PASSafeMember -MockWith {}
 
 				$InputObj = [pscustomobject]@{
 					'SafeName'                               = 'SomeSafe'
@@ -188,7 +189,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'sends request' {
 
-				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+				Assert-MockCalled Invoke-PASRestMethod -Scope It
 
 			}
 
@@ -198,7 +199,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 					$URI -eq "$($Script:psPASSession.BaseURI)/api/Safes/SomeSafe/Members/SomeUser/"
 
-				} -Times 1 -Exactly -Scope It
+				} -Scope It
 
 			}
 
@@ -216,7 +217,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 					($Script:RequestBody) -ne $null
 
-				} -Times 1 -Exactly -Scope It
+				} -Scope It
 
 			}
 
@@ -419,6 +420,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				}
 
+				Mock Get-PASSafeMember -MockWith {}
 				$response = $InputObj | Set-PASSafeMember -MembershipExpirationDate '12/31/18'
 
 			}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # version format
-version: 6.2.{build}
+version: 6.3.{build}
 
 environment:
   #GIT_TRACE: 1

--- a/docs/collections/_commands/Add-PASAccountACL.md
+++ b/docs/collections/_commands/Add-PASAccountACL.md
@@ -23,6 +23,8 @@ Add-PASAccountACL [-AccountPolicyId] <String> [-AccountAddress] <String> [-Accou
 ## DESCRIPTION
 Adds a new privileged command rule to an account.
 
+Not supported in Privilege Cloud
+
 ## EXAMPLES
 
 ### EXAMPLE 1

--- a/docs/collections/_commands/Add-PASPendingAccount.md
+++ b/docs/collections/_commands/Add-PASPendingAccount.md
@@ -30,7 +30,7 @@ as a pending account to the Accounts Feed.
 
 Users can identify privileged accounts and determine which are on-boarded to the vault.
 
-Depreciated from version 13.2
+Deprecated from version 13.2
 
 ## EXAMPLES
 

--- a/docs/collections/_commands/Add-PASPolicyACL.md
+++ b/docs/collections/_commands/Add-PASPolicyACL.md
@@ -22,6 +22,8 @@ Add-PASPolicyACL [-Command] <String> [-CommandGroup] <Boolean> [-PermissionType]
 ## DESCRIPTION
 Adds a new privileged command rule to a policy.
 
+Not supported in Privilege Cloud
+
 ## EXAMPLES
 
 ### EXAMPLE 1

--- a/docs/collections/_commands/Add-PASSafeMember.md
+++ b/docs/collections/_commands/Add-PASSafeMember.md
@@ -55,7 +55,7 @@ Unless otherwise specified, the default permissions applied to a safe member wil
 
 If these permissions should not be granted to the safe member, they must be explicitly set to `$false` in the request.
 
-Gen1 API is depreciated from version 12.3
+Gen1 API is deprecated from version 12.3
 
 ## EXAMPLES
 
@@ -477,7 +477,7 @@ Valid Values: 0, 1 or 2
 
 Get-PASSafeMember (Gen1) may not return details of this permission
 
-Depreciated from version 12.3
+Deprecated from version 12.3
 
 ```yaml
 Type: Int32
@@ -600,7 +600,7 @@ Force use of Gen1 API.
 
 Should be specified for versions earlier than 12.1
 
-Depreciated from version 12.3
+Deprecated from version 12.3
 
 ```yaml
 Type: SwitchParameter

--- a/docs/collections/_commands/Close-PASSession.md
+++ b/docs/collections/_commands/Close-PASSession.md
@@ -37,6 +37,8 @@ Close-PASSession [-SAMLAuthentication] [<CommonParameters>]
 ## DESCRIPTION
 Performs Logoff and removes the Vault session.
 
+Shared authentication is supported in Privilege Cloud
+
 ## EXAMPLES
 
 ### EXAMPLE 1

--- a/docs/collections/_commands/Find-PASSafe.md
+++ b/docs/collections/_commands/Find-PASSafe.md
@@ -10,7 +10,7 @@ title: Find-PASSafe
 # Find-PASSafe
 
 ## SYNOPSIS
-(Depreciated) Returns safe list from the vault.
+(Deprecated) Returns safe list from the vault.
 
 ## SYNTAX
 
@@ -21,7 +21,7 @@ Find-PASSafe [[-search] <String>] [[-TimeoutSec] <Int32>] [<CommonParameters>]
 ## DESCRIPTION
 Minimum required version 10.1
 
-Depreciated from 11.7
+Deprecated from 11.7
 
 Returns abbreviated details for all safes
 
@@ -83,7 +83,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ## NOTES
-Find-PASSafe is depreciated from 11.7
+Find-PASSafe is deprecated from 11.7
 
 Function was based on undocumented features available since V10
 

--- a/docs/collections/_commands/Get-PASAccountACL.md
+++ b/docs/collections/_commands/Get-PASAccountACL.md
@@ -22,6 +22,8 @@ Get-PASAccountACL [-AccountPolicyId] <String> [-AccountAddress] <String> [-Accou
 ## DESCRIPTION
 Gets list of all privileged commands associated with an account
 
+Not supported in Privilege Cloud
+
 ## EXAMPLES
 
 ### EXAMPLE 1

--- a/docs/collections/_commands/Get-PASAccountActivity.md
+++ b/docs/collections/_commands/Get-PASAccountActivity.md
@@ -63,7 +63,7 @@ Accept wildcard characters: False
 ### -UseGen1API
 Specify to force use of the Gen1 API
 
-Gen1 API is Depreciated from version 13.2
+Gen1 API is Deprecated from version 13.2
 
 ```yaml
 Type: SwitchParameter

--- a/docs/collections/_commands/Get-PASAccountGroup.md
+++ b/docs/collections/_commands/Get-PASAccountGroup.md
@@ -62,7 +62,7 @@ Accept wildcard characters: False
 ### -UseGen1API
 Specify to force usage the Gen1 API endpoint.
 
-This is based on the Get Account Groups By Safe API, introduced in PAS 10.5, depreciated in 12.6
+This is based on the Get Account Groups By Safe API, introduced in PAS 10.5, deprecated in 12.6
 
 ```yaml
 Type: SwitchParameter

--- a/docs/collections/_commands/Get-PASPSMRecording.md
+++ b/docs/collections/_commands/Get-PASPSMRecording.md
@@ -28,6 +28,9 @@ Get-PASPSMRecording [-RecordingID <String>] [<CommonParameters>]
 ## DESCRIPTION
 Returns the details of recordings of PSM, PSMP or OPM sessions.
 
+By default, recordings from the last 24 hours are returned.
+- When specifying `ToTime` without `FromTime`, recordings from the 24 hours before `ToTime` are returned.
+
 ## EXAMPLES
 
 ### EXAMPLE 1
@@ -35,7 +38,7 @@ Returns the details of recordings of PSM, PSMP or OPM sessions.
 Get-PASPSMRecording -Sort -FileName
 ```
 
-Lists all PSM recordings, sorted by descending filename.
+Lists PSM recordings from the last 24 hours, sorted by descending filename.
 
 ### EXAMPLE 2
 ```
@@ -166,6 +169,7 @@ Accept wildcard characters: False
 
 ### -ToTime
 Returns recordings from a specific date
+- When specifying `ToTime` without `FromTime`, recordings from the 24 hours prior to `ToTime` are returned.
 
 ```yaml
 Type: DateTime

--- a/docs/collections/_commands/Get-PASPSMRecording.md
+++ b/docs/collections/_commands/Get-PASPSMRecording.md
@@ -28,8 +28,8 @@ Get-PASPSMRecording [-RecordingID <String>] [<CommonParameters>]
 ## DESCRIPTION
 Returns the details of recordings of PSM, PSMP or OPM sessions.
 
-By default, recordings from the last 24 hours are returned.
-- When specifying `ToTime` without `FromTime`, recordings from the 24 hours before `ToTime` are returned.
+By default, recordings from the last 48 hours are returned.
+- When specifying `ToTime` without `FromTime`, recordings from the 48 hours before `ToTime` are returned.
 
 ## EXAMPLES
 
@@ -169,7 +169,7 @@ Accept wildcard characters: False
 
 ### -ToTime
 Returns recordings from a specific date
-- When specifying `ToTime` without `FromTime`, recordings from the 24 hours prior to `ToTime` are returned.
+- When specifying `ToTime` without `FromTime`, recordings from the 48 hours prior to `ToTime` are returned.
 
 ```yaml
 Type: DateTime

--- a/docs/collections/_commands/Get-PASPolicyACL.md
+++ b/docs/collections/_commands/Get-PASPolicyACL.md
@@ -21,6 +21,8 @@ Get-PASPolicyACL [-PolicyID] <String> [<CommonParameters>]
 ## DESCRIPTION
 Gets a list of the privileged commands (OPM Rules) associated with this policy
 
+Not supported in Privilege Cloud
+
 ## EXAMPLES
 
 ### EXAMPLE 1

--- a/docs/collections/_commands/Get-PASSafe.md
+++ b/docs/collections/_commands/Get-PASSafe.md
@@ -46,7 +46,7 @@ Gets safe by SafeName, by search query string, or, by default will return all sa
 - Minimum required version for default operation using Gen2 API is 12.0.
 - Minimum required version for operation using Gen2-byName ParameterSet is 12.2.
 - For PAS versions earlier than 12.0, the Gen1 API parameters must be used.
-- Gen1 API parameters are depreciated for versions higher than 12.3.
+- Gen1 API parameters are deprecated for versions higher than 12.3.
 
 ## EXAMPLES
 
@@ -84,7 +84,7 @@ Get-PASSafe -query SAFE1
 
 Returns details of safes matching query "Safe1" using Gen1 API.
 
-Depreciated from version 12.2
+Deprecated from version 12.2
 
 ### EXAMPLE 5
 ```
@@ -93,7 +93,7 @@ Get-PASSafe -FindAll -UseGen1API
 
 Returns details of all safes using Gen1 API.
 
-Depreciated from version 12.3
+Deprecated from version 12.3
 
 ### EXAMPLE 6
 ```
@@ -102,7 +102,7 @@ Get-PASSafe -SafeName SAFE1 -UseGen1API
 
 Returns details of "Safe1" using Gen1 API.
 
-Depreciated from version 12.3
+Deprecated from version 12.3
 
 ## PARAMETERS
 
@@ -183,7 +183,7 @@ Gen2 API operation requires minimum version 12.2
 
 When using Gen1 API in versions earlier than 12.0, must be specified with the `-UseGen1API` parameter.
 
-Gen1 operation depreciated from version 12.3
+Gen1 operation deprecated from version 12.3
 
 ```yaml
 Type: String
@@ -202,7 +202,7 @@ Query String for safe search in the vault using Gen1 API.
 
 Should be specified for versions earlier than 12.0
 
-Depreciated from version 12.3
+Deprecated from version 12.3
 
 ```yaml
 Type: String
@@ -221,7 +221,7 @@ Specify to find all safes using Gen1 API.
 
 Should be specified for versions earlier than 12.0
 
-Depreciated from version 12.3
+Deprecated from version 12.3
 
 ```yaml
 Type: SwitchParameter

--- a/docs/collections/_commands/Get-PASSafeMember.md
+++ b/docs/collections/_commands/Get-PASSafeMember.md
@@ -135,7 +135,7 @@ Get-PASSafeMember -SafeName Target_Safe -MemberName SomeUser -UseGen1API
 
 Lists all permissions for member SomeUser on Target_Safe using Gen1 API
 
-Depreciated from CyberArk Version 12.3
+Deprecated from CyberArk Version 12.3
 
 ## PARAMETERS
 
@@ -163,7 +163,7 @@ Operation against Gen2 API requires minimum version of 12.2
 - `-UseGen1API` parameter must be specified.
 - You cannot report on the permissions of the user authenticated to the API.
 - Reporting on the permissions of the Quota Owner is expected to fail.
-- Depreciated from CyberArk Version 12.3
+- Deprecated from CyberArk Version 12.3
 
 ```yaml
 Type: String

--- a/docs/collections/_commands/Get-PASSafeShareLogo.md
+++ b/docs/collections/_commands/Get-PASSafeShareLogo.md
@@ -21,7 +21,7 @@ Get-PASSafeShareLogo [-ImageType] <String> [<CommonParameters>]
 ## DESCRIPTION
 Gets configuration details of logo displayed in the SafeShare WebGUI
 
-Depreciated from version 13.2
+Deprecated from version 13.2
 
 ## EXAMPLES
 

--- a/docs/collections/_commands/Invoke-PASCPMOperation.md
+++ b/docs/collections/_commands/Invoke-PASCPMOperation.md
@@ -90,7 +90,7 @@ Invoke-PASCPMOperation -AccountID $ID -ChangeTask -ImmediateChangeByCPM Yes
 
 Marks an account for immediate change using the Gen1 API
 
-Depreciated from version 13.2
+Deprecated from version 13.2
 
 ### EXAMPLE 4
 ```
@@ -262,7 +262,7 @@ Yes/No value, dictating if the account will be scheduled for immediate change.
 
 Specify Yes to initiate a password change by CPM - Relevant for Gen1 API only.
 
-Depreciated from version 13.2
+Deprecated from version 13.2
 
 ```yaml
 Type: String

--- a/docs/collections/_commands/Invoke-PASCPMOperation.md
+++ b/docs/collections/_commands/Invoke-PASCPMOperation.md
@@ -67,6 +67,8 @@ CPM Change Options:
 
 Verify & Reconcile both require "Initiate CPM password management operations"
 
+Gen 1 Verify is not supported in Privilege Cloud
+
 ## EXAMPLES
 
 ### EXAMPLE 1
@@ -333,6 +335,8 @@ Accept wildcard characters: False
 Specify to force verification via Gen1 API.
 
 Should be specified for versions earlier than 10.1
+
+Gen 1 Verify is not supported in Privilege Cloud
 
 ```yaml
 Type: SwitchParameter

--- a/docs/collections/_commands/New-PASOnboardingRule.md
+++ b/docs/collections/_commands/New-PASOnboardingRule.md
@@ -24,7 +24,7 @@ New-PASOnboardingRule -TargetPlatformId <String> -TargetSafeName <String> [-IsAd
 
 ### Gen1
 ```
-New-PASOnboardingRule -DecisionPlatformId <String> -DecisionSafeName <String> [-IsAdminUIDFilter <String>]
+New-PASOnboardingRule -DecisionSafeName <String> -DecisionPlatformId <String> [-IsAdminUIDFilter <String>]
  [-MachineTypeFilter <String>] -SystemTypeFilter <String> [-UserNameFilter <String>] [-AddressFilter <String>]
  [-RuleName <String>] [-RuleDescription <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```

--- a/docs/collections/_commands/New-PASSession.md
+++ b/docs/collections/_commands/New-PASSession.md
@@ -113,6 +113,8 @@ Windows authentication requires at least CyberArk PAS version 10.4
 
 LDAP, RADIUS, SAML, and shared authentication all require a minimum CyberArk version of 9.7.
 
+Shared authentication is not supported in Privilege Cloud.
+
 Versions of CyberArk prior to 9.7: - only the CyberArk authentication mechanism is supported.
 
 - newPassword Parameter is not supported.

--- a/docs/collections/_commands/Remove-PASAccountACL.md
+++ b/docs/collections/_commands/Remove-PASAccountACL.md
@@ -22,6 +22,8 @@ Remove-PASAccountACL [-AccountPolicyId] <String> [-AccountAddress] <String> [-Ac
 ## DESCRIPTION
 Deletes privileged commands rule associated with account
 
+Not supported in Privilege Cloud
+
 ## EXAMPLES
 
 ### EXAMPLE 1

--- a/docs/collections/_commands/Remove-PASPolicyACL.md
+++ b/docs/collections/_commands/Remove-PASPolicyACL.md
@@ -21,6 +21,8 @@ Remove-PASPolicyACL [-PolicyID] <String> [-Id] <String> [-WhatIf] [-Confirm] [<C
 ## DESCRIPTION
 Deletes all privileged command rules associated with the policy
 
+Not supported in Privilege Cloud
+
 ## EXAMPLES
 
 ### EXAMPLE 1

--- a/docs/collections/_commands/Remove-PASSafeMember.md
+++ b/docs/collections/_commands/Remove-PASSafeMember.md
@@ -112,6 +112,8 @@ Specify to force usage the Gen1 API endpoint.
 
 Should be specified for versions earlier than 12.2
 
+Is not supported for Privilege Cloud
+
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)

--- a/docs/collections/_commands/Set-PASAccount.md
+++ b/docs/collections/_commands/Set-PASAccount.md
@@ -41,6 +41,7 @@ Default operation using the Gen2 API requires minimum version fo 10.4
 
 When using the Gen1 API:
 
+- It is not supported in Privilege Cloud
 - All of the account's property details MUST be passed to the function.
 - Any current properties of the account not sent as part of the request will be removed
 from the account.
@@ -102,6 +103,8 @@ Set-PASAccount -AccountID 21_3 -Folder Root -AccountName NewName `
 Will set the AccountName of account with AccountID of 21_3 to "NewName".
 
 **Any/All additional properties of the account which are not specified via parameters will be cleared**
+
+Not supported in Privilege Cloud
 
 ### EXAMPLE 6
 

--- a/docs/collections/_commands/Set-PASDirectoryMapping.md
+++ b/docs/collections/_commands/Set-PASDirectoryMapping.md
@@ -15,8 +15,8 @@ Updates an existing Directory Mapping for a directory
 ## SYNTAX
 
 ```
-Set-PASDirectoryMapping [-DirectoryName] <String> [-MappingID] <String> [-MappingName] <String>
- [-LDAPBranch] <String> [[-DomainGroups] <String[]>] [[-VaultGroups] <String[]>] [[-Location] <String>]
+Set-PASDirectoryMapping [-DirectoryName] <String> [-MappingID] <String> [[-MappingName] <String>]
+ [[-LDAPBranch] <String>] [[-DomainGroups] <String[]>] [[-VaultGroups] <String[]>] [[-Location] <String>]
  [[-LDAPQuery] <String>] [[-MappingAuthorizations] <Authorizations>] [[-UserActivityLogPeriod] <Int32>]
  [-UsedQuota <Int32>] [-AuthorizedInterfaces <String[]>] [-EnableENEWhenDisconnected <Boolean>] [-WhatIf]
  [-Confirm] [<CommonParameters>]
@@ -102,7 +102,7 @@ Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 3
 Default value: None
 Accept pipeline input: True (ByPropertyName)
@@ -117,7 +117,7 @@ Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 4
 Default value: None
 Accept pipeline input: True (ByPropertyName)

--- a/docs/collections/_commands/Set-PASOnboardingRule.md
+++ b/docs/collections/_commands/Set-PASOnboardingRule.md
@@ -15,8 +15,8 @@ Updates an automatic onboarding rule.
 ## SYNTAX
 
 ```
-Set-PASOnboardingRule [-Id] <Int32> [-TargetPlatformId] <String> [-TargetSafeName] <String>
- [[-IsAdminIDFilter] <Boolean>] [[-MachineTypeFilter] <String>] [-SystemTypeFilter] <String>
+Set-PASOnboardingRule [-Id] <Int32> [[-TargetPlatformId] <String>] [[-TargetSafeName] <String>]
+ [[-IsAdminIDFilter] <Boolean>] [[-MachineTypeFilter] <String>] [[-SystemTypeFilter] <String>]
  [[-UserNameFilter] <String>] [[-UserNameMethod] <String>] [[-AddressFilter] <String>]
  [[-AddressMethod] <String>] [[-AccountCategoryFilter] <String>] [[-RuleName] <String>]
  [[-RuleDescription] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
@@ -59,7 +59,7 @@ Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 2
 Default value: None
 Accept pipeline input: True (ByPropertyName)
@@ -74,7 +74,7 @@ Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 3
 Default value: None
 Accept pipeline input: True (ByPropertyName)
@@ -124,7 +124,7 @@ Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 6
 Default value: None
 Accept pipeline input: True (ByPropertyName)

--- a/docs/collections/_commands/Set-PASOpenIDConnectProvider.md
+++ b/docs/collections/_commands/Set-PASOpenIDConnectProvider.md
@@ -16,8 +16,8 @@ Updates an existing OIDC Identity Provider.
 
 ```
 Set-PASOpenIDConnectProvider -id <String> [-authenticationFlow <String>] [-authenticationEndpointUrl <String>]
- [-issuer <String>] [-description <String>] -discoveryEndpointUrl <String> [-jwkSet <String>]
- -clientId <String> [-clientSecret <SecureString>] -clientSecretMethod <String> [-userNameClaim <String>]
+ [-issuer <String>] [-description <String>] [-discoveryEndpointUrl <String>] [-jwkSet <String>]
+ [-clientId <String>] [-clientSecret <SecureString>] [-clientSecretMethod <String>] [-userNameClaim <String>]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -123,7 +123,7 @@ Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)
@@ -156,7 +156,7 @@ Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)
@@ -187,7 +187,7 @@ Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)

--- a/docs/collections/_commands/Set-PASPTARule.md
+++ b/docs/collections/_commands/Set-PASPTARule.md
@@ -15,9 +15,10 @@ Updates an existing Risky Activity rule to PTA
 ## SYNTAX
 
 ```
-Set-PASPTARule [-id] <String> [-category] <String> [-regex] <String> [-score] <Int32> [-description] <String>
- [-response] <String> [-active] <Boolean> [-vaultUsersMode <String>] [-vaultUsersList <String[]>]
- [-machinesMode <String>] [-machinesList <String[]>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Set-PASPTARule [-id] <String> [[-category] <String>] [[-regex] <String>] [[-score] <Int32>]
+ [[-description] <String>] [[-response] <String>] [[-active] <Boolean>] [-vaultUsersMode <String>]
+ [-vaultUsersList <String[]>] [-machinesMode <String>] [-machinesList <String[]>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -65,7 +66,7 @@ Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 2
 Default value: None
 Accept pipeline input: True (ByPropertyName)
@@ -82,7 +83,7 @@ Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 3
 Default value: None
 Accept pipeline input: True (ByPropertyName)
@@ -99,7 +100,7 @@ Type: Int32
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 4
 Default value: 0
 Accept pipeline input: True (ByPropertyName)
@@ -116,7 +117,7 @@ Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 5
 Default value: None
 Accept pipeline input: True (ByPropertyName)
@@ -133,7 +134,7 @@ Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 6
 Default value: None
 Accept pipeline input: True (ByPropertyName)
@@ -148,7 +149,7 @@ Type: Boolean
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 7
 Default value: False
 Accept pipeline input: True (ByPropertyName)

--- a/docs/collections/_commands/Set-PASPlatformPSMConfig.md
+++ b/docs/collections/_commands/Set-PASPlatformPSMConfig.md
@@ -15,7 +15,7 @@ Update target platform PSM Policy details.
 ## SYNTAX
 
 ```
-Set-PASPlatformPSMConfig [-ID] <Int32> [-PSMServerID] <String> [[-PSMConnectors] <PSObject[]>] [-WhatIf]
+Set-PASPlatformPSMConfig [-ID] <Int32> [[-PSMServerID] <String>] [[-PSMConnectors] <PSObject[]>] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
@@ -29,7 +29,7 @@ Allows Vault admins to update the PSM Policy Section of a target platform.
 $PSMConfig = Get-PASPlatformPSMConfig -ID 23
 
 $PSMConfig.PSMConnectors += (\[PSCustomObject\]@{"PSMConnectorID"="PSM-RDP";"Enabled"=$true})
-$PSMConfig | Set-PASPlatformPSMConfig -ID 23
+Set-PASPlatformPSMConfig -ID 23 -PSMConnectors $PSMConfig.PSMConnectors
 ```
 
 Adds PSM-RDP as an additional connection component configured on platform with id of 23
@@ -86,7 +86,7 @@ Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 2
 Default value: None
 Accept pipeline input: True (ByPropertyName)

--- a/docs/collections/_commands/Set-PASSafe.md
+++ b/docs/collections/_commands/Set-PASSafe.md
@@ -17,14 +17,14 @@ Updates a safe in the Vault
 ### Gen2-NumberOfDaysRetention (Default)
 ```
 Set-PASSafe -SafeName <String> [-NewSafeName <String>] [-Description <String>] [-location <String>]
- [-OLACEnabled <Boolean>] [-ManagingCPM <String>] -NumberOfDaysRetention <Int32> [-WhatIf] [-Confirm]
+ [-OLACEnabled <Boolean>] [-ManagingCPM <String>] [-NumberOfDaysRetention <Int32>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
 ### Gen2-NumberOfVersionsRetention
 ```
 Set-PASSafe -SafeName <String> [-NewSafeName <String>] [-Description <String>] [-location <String>]
- [-OLACEnabled <Boolean>] [-ManagingCPM <String>] -NumberOfVersionsRetention <Int32> [-WhatIf] [-Confirm]
+ [-OLACEnabled <Boolean>] [-ManagingCPM <String>] [-NumberOfVersionsRetention <Int32>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -169,19 +169,7 @@ Specify either this parameter or NumberOfDaysRetention.
 
 ```yaml
 Type: Int32
-Parameter Sets: Gen2-NumberOfVersionsRetention
-Aliases:
-
-Required: True
-Position: Named
-Default value: 0
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
-```yaml
-Type: Int32
-Parameter Sets: Gen1-NumberOfVersionsRetention
+Parameter Sets: Gen2-NumberOfVersionsRetention, Gen1-NumberOfVersionsRetention
 Aliases:
 
 Required: False
@@ -200,19 +188,7 @@ Specify either this parameter or NumberOfVersionsRetention
 
 ```yaml
 Type: Int32
-Parameter Sets: Gen2-NumberOfDaysRetention
-Aliases:
-
-Required: True
-Position: Named
-Default value: 0
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
-```yaml
-Type: Int32
-Parameter Sets: Gen1-NumberOfDaysRetention
+Parameter Sets: Gen2-NumberOfDaysRetention, Gen1-NumberOfDaysRetention
 Aliases:
 
 Required: False

--- a/docs/collections/_commands/Set-PASUser.md
+++ b/docs/collections/_commands/Set-PASUser.md
@@ -41,20 +41,51 @@ Set-PASUser -username <String> [-NewPassword <SecureString>] [-Email <String>]
 ## DESCRIPTION
 Updates an existing user in the vault.
 
-Appears to require all properties set on a user to be passed with the request.
-
-Not passing a value to an already set property will result in it being cleared.
-
 Default operation using the Gen2 API requires minimum version of 11.1
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 ```
+Set-PASUser -id 41 -username Bill -ExpiryDate (get-date).AddDays(5)
+```
+
+Sets ExpiryDate on Bill's vault user
+
+### EXAMPLE 2
+```
+Set-PASUser -id 41 -username Bill -unAuthorizedInterfaces PACLI,GUI
+```
+
+Sets unAuthorizedInterfaces on Bill's vault user
+
+### EXAMPLE 3
+```
+Set-PASUser -id 41 -username Bill -pagerNumber ""
+```
+
+Clears the pagerNumber property on Bill's vault user
+
+### EXAMPLE 4
+```
+Set-PASUser -id 41 -username Bill -unAuthorizedInterfaces @()
+```
+
+Clears the unAuthorizedInterfaces property on Bill's vault user
+
+### EXAMPLE 5
+```
 Set-PASUser -UserName Bill -Disabled $true
 ```
 
 Disables vault user Bill
+
+### EXAMPLE 6
+```
+Set-PASUser -id 41 -username Bill -ExpiryDate (get-date 1/1/1970)
+```
+
+Clear ExpiryDate on Bill's vault user
 
 ## PARAMETERS
 

--- a/docs/collections/_docs/10-compatibility.md
+++ b/docs/collections/_docs/10-compatibility.md
@@ -391,7 +391,7 @@ If version requirement criteria are not met, operations may be prevented.
 ### Get-PASAccountGroup
 
 - Version 10.5 introduced a new API endpoint, "Get Safe account groups".
-  - This API is depreciated from version 12.6.
+  - This API is deprecated from version 12.6.
   - The "Get Safe account groups" API endpoint can be used by specifying the `-UseGen1API` parameter.
 
 ### Add-PASAccount
@@ -498,7 +498,7 @@ If version requirement criteria are not met, operations may be prevented.
     - `GroupID`
     - `memberID`
 - The Gen1 API endpoint can be used by using the `GroupName` & `UserName` parameters.
-- Gen1 API depreciated from 12.3
+- Gen1 API deprecated from 12.3
 
 ### Get-PASUser
 
@@ -518,7 +518,7 @@ If version requirement criteria are not met, operations may be prevented.
 - Version 10.9 introduced a new API endpoint.
   - Supports:
     - Additional property parameters.
-- Gen1 API depreciated from 12.3
+- Gen1 API deprecated from 12.3
 - Version 13.2 introduced new parameters: `userActivityLogRetentionDays`, `loginFromHour` & `loginToHour`
 
 ### Unblock-PASUser
@@ -527,7 +527,7 @@ If version requirement criteria are not met, operations may be prevented.
   - Requires Parameters:
     - `userID`
 - The Gen1 API endpoint can be used by using the `userName` parameter.
-- Gen1 API depreciated from 12.3
+- Gen1 API deprecated from 12.3
 
 ### Get-PASDirectory
 
@@ -597,14 +597,14 @@ If version requirement criteria are not met, operations may be prevented.
 - Version 11.1 introduced a new API endpoint.
   - Supports:
     - Delete User by ID
-- Gen1 API depreciated from 12.3
+- Gen1 API deprecated from 12.3
 
 ### Set-PASUser
 
 - Version 11.1 introduced a new API endpoint.
   - Supports:
     - Additional parameters for updating users.
-- Gen1 API depreciated from 12.3
+- Gen1 API deprecated from 12.3
 - Version 13.2 introduced new parameters: `userActivityLogRetentionDays`, `loginFromHour` & `loginToHour`
 
 ### Get-PASPTAEvent

--- a/docs/collections/_posts/2020-07-14-pspas-release-4-1.md
+++ b/docs/collections/_posts/2020-07-14-pspas-release-4-1.md
@@ -55,7 +55,7 @@ tags:
   - `New-PASSession`
     - OTP can now be omitted entirely from used parameters in scenarios where the value is unknown.
     - Response from RADIUS now used as message for Read-Host prompt for OTP.
-    - Depreciated need for use of OTPMode parameter when a prompt for the OTP is required.
+    - Deprecated need for use of OTPMode parameter when a prompt for the OTP is required.
 
 - Other Fixes & Updates
   - Documentation updated.

--- a/docs/collections/_posts/2021-04-11-pspas-release-5-0.md
+++ b/docs/collections/_posts/2021-04-11-pspas-release-5-0.md
@@ -58,7 +58,7 @@ tags:
 - Updated Functions For CyberArk Version 12.0:
   - `Get-PASSafeMember`
     - Updated to use the new Gen2 API endpoint available from version 12.0
-    - `MemberName` Parameter depreciated past 12.2
+    - `MemberName` Parameter deprecated past 12.2
   - `Add-PASSafe`
     - Updated to use the new Gen2 API endpoint available from version 12.0
   - `Get-PASSafe`
@@ -80,5 +80,5 @@ tags:
     - Additional Gen2 Parameter available
 - Other
   - `Get-PASAccount`
-    - Removed depreciated Parameter `offset`
-    - Removed depreciated Parameter `limit`
+    - Removed deprecated Parameter `offset`
+    - Removed deprecated Parameter `limit`

--- a/docs/collections/_posts/2021-11-07-pspas-release-5-2.md
+++ b/docs/collections/_posts/2021-11-07-pspas-release-5-2.md
@@ -99,4 +99,4 @@ tags:
     - `GetDetails()`
       - New method using `Get-PASAccountDetail`
   - Alias Removal
-    - Removed alias values for previously depreciated command names
+    - Removed alias values for previously deprecated command names

--- a/docs/collections/_posts/2022-08-17-pspas-release-5-3.md
+++ b/docs/collections/_posts/2022-08-17-pspas-release-5-3.md
@@ -41,7 +41,7 @@ tags:
     - Added `id` parameter, supported from 12.6
     - Added `groupName` parameter, supported from 12.2.
   - `Get-PASAccountGroup`
-    - Depreciated use of "Get Safe account groups" API
+    - Deprecated use of "Get Safe account groups" API
     - Makes ParameterSet based on `Get account group by Safe` API the default.
   - Updates URL formatting to include a forward slash (/) to end of URL for functions which may include a dot (.) via provided parameter values.
   - Updated documentation and help text.

--- a/docs/collections/_posts/2023-09-06-pspas-release-6-0.md
+++ b/docs/collections/_posts/2023-09-06-pspas-release-6-0.md
@@ -57,15 +57,15 @@ tags:
 - `Set-PASSafe`
   - Allows `0` as valid value for parameter `NumberOfDaysRetention`
 - `Get-PASServerWebService`
-  - Depreciates Gen1 endpoint from 13.2. Adds Gen2 endpoint as default.
+  - Deprecates Gen1 endpoint from 13.2. Adds Gen2 endpoint as default.
 - `Get-PASSafeShareLogo`
-  - Depreciates command from 13.2.
+  - Deprecates command from 13.2.
 - `Invoke-PASCPMOperation`
-  - Depreciates Gen1 endpoint from 13.2.
+  - Deprecates Gen1 endpoint from 13.2.
 - `Get-PASAccountActivity`
-  - Depreciates command from 13.2.
+  - Deprecates command from 13.2.
 - `Add-PASPendingAccount`
-  - Depreciates command from 13.2.
+  - Deprecates command from 13.2.
 
 ### Fixed
 - `Get-PASAccount`

--- a/docs/collections/_posts/2024-03-21-pspas-release-6-3.md
+++ b/docs/collections/_posts/2024-03-21-pspas-release-6-3.md
@@ -1,0 +1,117 @@
+---
+title: "psPAS Release 6.3"
+date: 2024-03-21 00:00:00
+tags:
+  - Release Notes
+  - Get-PASPSMRecording
+  - Set-PASUser
+  - Set-PASSafe
+  - Set-PASOpenIDConnectProvider
+  - Set-PASPTARule
+  - Set-PASDirectoryMapping
+  - New-PASOnboardingRule
+  - Set-PASOnboardingRule
+  - Set-PASPlatformPSMConfig
+  - Set-PASSafeMember
+  - New-PASUser
+  - Get-PASComponentDetail
+  - Add-PASAccountACL
+  - Get-PASAccountACL
+  - Remove-PASAccountACL
+  - Invoke-PASCPMOperation
+  - Set-PASAccount
+  - Close-PASSession
+  - New-PASSession
+  - Add-PASPolicyACL
+  - Get-PASPolicyACL
+  - Remove-PASPolicyACL
+  - Remove-PASSafeMember
+  - Assert-VersionRequirement
+---
+
+## **6.3.77**
+
+### Added
+- N/A
+
+### Updated
+- `Get-PASPSMRecording`
+  - In-line with PVWA default operation:
+    - Changed the default limit for each page of results to 100, in-line with PVWA default values
+    - Updated to return recordings from the last 48 hours by default when `FromTime` & `ToTime` parameters are not specified.
+  - When specifying `ToTime` without `FromTime`, recordings from the 48 hours before `ToTime` are returned.
+    - This avoids potential for unintentionally long running queries which return details of many recording from the vault.
+- `Set-PASUser`
+  - Updated to query for, and send, any existing user properties, which are not being specifically updated, with the request.
+    - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the user object.
+    - This update allows single properties to be updated without having to specify all properties.
+  - Allows Empty argument for `unAuthorizedInterfaces` & `vaultAuthorization` parameters to enable set values to be cleared.
+  - Corrects ValidateSet for `unAuthorizedInterfaces` parameter.
+- `Set-PASSafe`
+  - Updated to query for, and send, any existing properties, which are not being specifically updated, with the request.
+    - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the object.
+    - This update allows single properties to be updated without having to specify all properties.
+- `Set-PASOpenIDConnectProvider`
+  - Updated to query for, and send, any existing properties, which are not being specifically updated, with the request.
+    - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the object.
+    - This update allows single properties to be updated without having to specify all properties.
+    - Number of mandatory parameters required to be specified has been reduced
+- `Set-PASPTARule`
+  - Updated to query for, and send, any existing properties, which are not being specifically updated, with the request.
+    - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the object.
+    - This update allows single properties to be updated without having to specify all properties.
+    - Number of mandatory parameters required to be specified has been reduced
+- `Set-PASDirectoryMapping`
+  - Updated to query for, and send, any existing properties, which are not being specifically updated, with the request.
+    - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the object.
+    - This update allows single properties to be updated without having to specify all properties.
+    - Number of mandatory parameters required to be specified has been reduced
+- `New-PASOnboardingRule`
+  - Reordered parameters to simplify tab completion options
+- `Set-PASOnboardingRule`
+  - Updated to query for, and send, any existing properties, which are not being specifically updated, with the request.
+    - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the object.
+    - This update allows single properties to be updated without having to specify all properties.
+    - Number of mandatory parameters required to be specified has been reduced
+- `Set-PASPlatformPSMConfig`
+  - Updated to query for, and send, any existing properties, which are not being specifically updated, with the request.
+    - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the object.
+    - This update allows single properties to be updated without having to specify all properties.
+    - Number of mandatory parameters required to be specified has been reduced
+- `Set-PASSafeMember`
+  - Updated to query for, and send, any existing properties, which are not being specifically updated, with the request.
+    - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the object.
+    - This update allows single properties to be updated without having to specify all properties.
+- `New-PASUser`
+  - In-line with update to `Set-PASUser`
+    - Allows Empty argument for `unAuthorizedInterfaces` & `vaultAuthorization` parameters.
+    - Corrects ValidateSet for `unAuthorizedInterfaces` parameter.
+- `Get-PASComponentDetail`
+  - Adds assertion that command specifying `PTA` component  must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
+- `Add-PASAccountACL`
+  - Adds assertion that command must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
+- `Get-PASAccountACL`
+  - Adds assertion that command must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
+- `Remove-PASAccountACL`
+  - Adds assertion that command must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
+- `Invoke-PASCPMOperation`
+  - Adds assertion that Gen1 verify task must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
+- `Set-PASAccount`
+  - Adds assertion that Gen1 task must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
+- `Close-PASSession`
+  - Adds assertion that Shared Authentication logoff request is executed against a self hosted implementation as invocation against privilege cloud is not supported.
+- `New-PASSession`
+  - Adds assertion that Shared Authentication logon request is executed against a self hosted implementation as invocation against privilege cloud is not supported.
+- `Add-PASPolicyACL`
+  - Adds assertion that command must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
+- `Get-PASPolicyACL`
+  - Adds assertion that command must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
+- `Remove-PASPolicyACL`
+  - Adds assertion that command must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
+- `Remove-PASSafeMember`
+  - Adds assertion that command using Gen1 parameters must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
+- `Assert-VersionRequirement`
+  - Updates helper function to provide ability to assert if command is being run against self-hosted or privilege cloud implementation.
+
+### Fixed
+- N/A

--- a/psPAS/Functions/AccountACL/Add-PASAccountACL.ps1
+++ b/psPAS/Functions/AccountACL/Add-PASAccountACL.ps1
@@ -62,7 +62,9 @@ function Add-PASAccountACL {
 
 	)
 
-	BEGIN { }#begin
+	BEGIN {
+		Assert-VersionRequirement -SelfHosted
+	}#begin
 
 	PROCESS {
 

--- a/psPAS/Functions/AccountACL/Get-PASAccountACL.ps1
+++ b/psPAS/Functions/AccountACL/Get-PASAccountACL.ps1
@@ -26,7 +26,9 @@ function Get-PASAccountACL {
 		[string]$AccountUserName
 	)
 
-	BEGIN { }#begin
+	BEGIN {
+		Assert-VersionRequirement -SelfHosted
+	}#begin
 
 	PROCESS {
 

--- a/psPAS/Functions/AccountACL/Remove-PASAccountACL.ps1
+++ b/psPAS/Functions/AccountACL/Remove-PASAccountACL.ps1
@@ -31,7 +31,9 @@ function Remove-PASAccountACL {
 		[string]$Id
 	)
 
-	BEGIN { }#begin
+	BEGIN {
+		Assert-VersionRequirement -SelfHosted
+	}#begin
 
 	PROCESS {
 

--- a/psPAS/Functions/Accounts/Add-PASPendingAccount.ps1
+++ b/psPAS/Functions/Accounts/Add-PASPendingAccount.ps1
@@ -139,7 +139,7 @@ function Add-PASPendingAccount {
 	)
 
 	BEGIN {
-		#!Depreciated above 13.2
+		#!Depracated above 13.2
 		Assert-VersionRequirement -MaximumVersion 13.2
 	}#begin
 

--- a/psPAS/Functions/Accounts/Get-PASAccountActivity.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccountActivity.ps1
@@ -35,7 +35,7 @@ function Get-PASAccountActivity {
 
 			'Gen1' {
 
-				#!Depreciated above 13.2
+				#!Depracated above 13.2
 				Assert-VersionRequirement -MaximumVersion 13.2
 				#URL for Request
 				$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc"

--- a/psPAS/Functions/Accounts/Invoke-PASCPMOperation.ps1
+++ b/psPAS/Functions/Accounts/Invoke-PASCPMOperation.ps1
@@ -127,7 +127,7 @@ function Invoke-PASCPMOperation {
 
 			'ChangeCredentials' {
 
-				#!Depreciated above 13.2
+				#!Depracated above 13.2
 				Assert-VersionRequirement -MaximumVersion 13.2
 
 				#add ImmediateChangeByCPM to header as key=value pair
@@ -139,6 +139,8 @@ function Invoke-PASCPMOperation {
 			}
 
 			'VerifyCredentials' {
+
+				Assert-VersionRequirement -SelfHosted
 
 				#Empty Body
 				$ThisRequest['Body'] = @{ } | ConvertTo-Json

--- a/psPAS/Functions/Accounts/Set-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Set-PASAccount.ps1
@@ -162,6 +162,8 @@ function Set-PASAccount {
 
 			'Gen1' {
 
+				Assert-VersionRequirement -SelfHosted
+
 				#Create URL for Request
 				$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Accounts/$AccountID"
 

--- a/psPAS/Functions/Authentication/Close-PASSession.ps1
+++ b/psPAS/Functions/Authentication/Close-PASSession.ps1
@@ -52,6 +52,8 @@ function Close-PASSession {
 
 			'shared' {
 
+				Assert-VersionRequirement -SelfHosted
+
 				$URI = "$($psPASSession.BaseURI)/WebServices/auth/Shared/RestfulAuthenticationService.svc/Logoff"
 				break
 

--- a/psPAS/Functions/Authentication/New-PASSession.ps1
+++ b/psPAS/Functions/Authentication/New-PASSession.ps1
@@ -493,6 +493,8 @@ function New-PASSession {
 
 			'shared' {
 
+				Assert-VersionRequirement -SelfHosted
+
 				$LogonRequest['Uri'] = "$Uri/WebServices/auth/Shared/RestfulAuthenticationService.svc/Logon"
 				break
 

--- a/psPAS/Functions/Authentication/Set-PASOpenIDConnectProvider.ps1
+++ b/psPAS/Functions/Authentication/Set-PASOpenIDConnectProvider.ps1
@@ -42,7 +42,7 @@ Function Set-PASOpenIDConnectProvider {
 		[string]$description,
 
 		[parameter(
-			Mandatory = $true,
+			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateNotNullOrEmpty()]
@@ -56,7 +56,7 @@ Function Set-PASOpenIDConnectProvider {
 		[string]$jwkSet,
 
 		[parameter(
-			Mandatory = $true,
+			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateLength(1, 100)]
@@ -71,7 +71,7 @@ Function Set-PASOpenIDConnectProvider {
 		[securestring]$clientSecret,
 
 		[parameter(
-			Mandatory = $true,
+			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateSet('Basic', 'Post')]
@@ -110,6 +110,11 @@ Function Set-PASOpenIDConnectProvider {
 			#Include decoded clientSecret in request
 			$boundParameters['clientSecret'] = $(ConvertTo-InsecureString -SecureString $clientSecret)
 
+		}
+
+		$OIDCProvider = Get-PASOpenIDConnectProvider -id $id
+		if ($null -ne $OIDCProvider) {
+			Format-PutRequestObject -InputObject $OIDCProvider -boundParameters $BoundParameters -ParametersToRemove id
 		}
 
 		#Create body of request

--- a/psPAS/Functions/LDAPDirectories/New-PASDirectoryMapping.ps1
+++ b/psPAS/Functions/LDAPDirectories/New-PASDirectoryMapping.ps1
@@ -68,8 +68,9 @@ function New-PASDirectoryMapping {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[AllowEmptyCollection()]
 		[ValidateSet('PIMSU', 'PSM', 'PSMP', 'PVWA', 'WINCLIENT', 'PTA', 'PACLI', 'NAPI', 'XAPI', 'HTTPGW',
-			'EVD', 'PIMSu', 'AIMApp', 'CPM', 'PVWAApp', 'PSMApp', 'AppPrv', 'AIMApp', 'PSMPApp', 'GUI')]
+			'EVD', 'CPM', 'PVWAApp', 'PSMApp', 'AppPrv', 'AIMApp', 'PSMPApp', 'GUI')]
 		[string[]]$AuthorizedInterfaces,
 
 		[parameter(

--- a/psPAS/Functions/LDAPDirectories/Set-PASDirectoryMapping.ps1
+++ b/psPAS/Functions/LDAPDirectories/Set-PASDirectoryMapping.ps1
@@ -74,8 +74,9 @@ function Set-PASDirectoryMapping {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[AllowEmptyCollection()]
 		[ValidateSet('PIMSU', 'PSM', 'PSMP', 'PVWA', 'WINCLIENT', 'PTA', 'PACLI', 'NAPI', 'XAPI', 'HTTPGW',
-			'EVD', 'PIMSu', 'AIMApp', 'CPM', 'PVWAApp', 'PSMApp', 'AppPrv', 'AIMApp', 'PSMPApp', 'GUI')]
+			'EVD', 'CPM', 'PVWAApp', 'PSMApp', 'AppPrv', 'AIMApp', 'PSMPApp', 'GUI')]
 		[string[]]$AuthorizedInterfaces,
 
 		[parameter(

--- a/psPAS/Functions/LDAPDirectories/Set-PASDirectoryMapping.ps1
+++ b/psPAS/Functions/LDAPDirectories/Set-PASDirectoryMapping.ps1
@@ -16,13 +16,13 @@ function Set-PASDirectoryMapping {
 		[string]$MappingID,
 
 		[parameter(
-			Mandatory = $true,
+			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[string]$MappingName,
 
 		[parameter(
-			Mandatory = $true,
+			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[string]$LDAPBranch,
@@ -130,6 +130,16 @@ function Set-PASDirectoryMapping {
 
 		#Create URL for request
 		$URI = "$($psPASSession.BaseURI)/api/Configuration/LDAP/Directories/$DirectoryName/Mappings/$MappingID/"
+
+		$DirectoryMapping = Get-PASDirectoryMapping -DirectoryName $DirectoryName -MappingID $MappingID
+		if ($null -ne $DirectoryMapping) {
+			Format-PutRequestObject -InputObject $DirectoryMapping -boundParameters $BoundParameters -ParametersToRemove MappingID, DirectoryMappingOrder,
+			LogonToHour, LogonFromHour, UserExpiration, DisableUser, UserType, AuthenticationMethod
+		}
+
+		$boundParameters['DomainGroups'] = $boundParameters['DomainGroups'] -as [array]
+		$boundParameters['AuthorizedInterfaces'] = $boundParameters['AuthorizedInterfaces'] -as [array]
+		$boundParameters['MappingAuthorizations'] = $boundParameters['MappingAuthorizations'] -as [array]
 
 		$body = $boundParameters | ConvertTo-Json
 

--- a/psPAS/Functions/Monitoring/Get-PASPSMRecording.ps1
+++ b/psPAS/Functions/Monitoring/Get-PASPSMRecording.ps1
@@ -87,27 +87,37 @@ function Get-PASPSMRecording {
 			}
 
 			'byQuery' {
+
 				#Get Parameters to include in request
 				$boundParameters = $PSBoundParameters | Get-PASParameter
 
-				switch ($PSBoundParameters) {
+				#If no arguments initialise boundparameters
+				if ($null -eq $boundparameters) {
+					$boundparameters = @{ }
+				}
 
-					{ $PSItem.ContainsKey('FromTime') } {
+				#* fetch last 24 hours by default.
+				#Set ToTime to provided value or now
+				If ($PSBoundParameters.ContainsKey('ToTime')) {
+					$boundParameters['ToTime'] = $ToTime
+				} Else {
+					#ToTime is now
+					$boundParameters['ToTime'] = Get-Date
+				}
 
-						$boundParameters['FromTime'] = $FromTime | ConvertTo-UnixTime
+				#Set FromTime to provided value or 24 hours before ToTime
+				If ($PSBoundParameters.ContainsKey('FromTime')) {
+					$boundParameters['FromTime'] = $FromTime | ConvertTo-UnixTime
+				} Else {
+					#If ToTime specified get previous 24 hours
+					$boundParameters['FromTime'] = (Get-Date $boundParameters['ToTime']).AddDays(-1) | ConvertTo-UnixTime
+				}
 
-					}
+				#Convert ToTime to UnixTime
+				$boundParameters['ToTime'] = $boundParameters['ToTime'] | ConvertTo-UnixTime
 
-					{ $PSItem.ContainsKey('ToTime') } {
-
-						$boundParameters['ToTime'] = $ToTime | ConvertTo-UnixTime
-
-					}
-
-					{ $PSBoundParameters.Keys -notcontains 'Limit' } {
-						$Limit = 25   #default if you call the API with no value
-					}
-
+				If ($PSBoundParameters.Keys -notcontains 'Limit') {
+					$Limit = 25   #default if you call the API with no value
 				}
 
 				#Create Query String, escaped for inclusion in request URL

--- a/psPAS/Functions/Monitoring/Get-PASPSMRecording.ps1
+++ b/psPAS/Functions/Monitoring/Get-PASPSMRecording.ps1
@@ -110,14 +110,14 @@ function Get-PASPSMRecording {
 					$boundParameters['FromTime'] = $FromTime | ConvertTo-UnixTime
 				} Else {
 					#If ToTime specified get previous 24 hours
-					$boundParameters['FromTime'] = (Get-Date $boundParameters['ToTime']).AddDays(-1) | ConvertTo-UnixTime
+					$boundParameters['FromTime'] = (Get-Date $boundParameters['ToTime']).AddDays(-2) | ConvertTo-UnixTime
 				}
 
 				#Convert ToTime to UnixTime
 				$boundParameters['ToTime'] = $boundParameters['ToTime'] | ConvertTo-UnixTime
 
 				If ($PSBoundParameters.Keys -notcontains 'Limit') {
-					$Limit = 25   #default if you call the API with no value
+					$Limit = 100   #default if you call the API with no value
 				}
 
 				#Create Query String, escaped for inclusion in request URL

--- a/psPAS/Functions/OnboardingRules/New-PASOnboardingRule.ps1
+++ b/psPAS/Functions/OnboardingRules/New-PASOnboardingRule.ps1
@@ -2,13 +2,6 @@
 function New-PASOnboardingRule {
 	[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'Gen2')]
 	param(
-		[parameter(
-			Mandatory = $true,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = 'Gen1'
-		)]
-		[ValidateLength(1, 99)]
-		[string]$DecisionPlatformId,
 
 		[parameter(
 			Mandatory = $true,
@@ -21,14 +14,6 @@ function New-PASOnboardingRule {
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = 'Gen1'
-		)]
-		[ValidateLength(1, 28)]
-		[string]$DecisionSafeName,
-
-		[parameter(
-			Mandatory = $true,
-			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Gen2'
 		)]
 		[ValidateLength(1, 28)]
@@ -37,17 +22,33 @@ function New-PASOnboardingRule {
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'Gen2'
+		)]
+		[boolean]$IsAdminIDFilter,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Gen1'
 		)]
-		[ValidateSet('Yes', 'No')]
-		[String]$IsAdminUIDFilter,
+		[ValidateLength(1, 28)]
+		[string]$DecisionSafeName,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'Gen1'
+		)]
+		[ValidateLength(1, 99)]
+		[string]$DecisionPlatformId,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = 'Gen2'
+			ParameterSetName = 'Gen1'
 		)]
-		[boolean]$IsAdminIDFilter,
+		[ValidateSet('Yes', 'No')]
+		[String]$IsAdminUIDFilter,
 
 		[parameter(
 			Mandatory = $false,

--- a/psPAS/Functions/OnboardingRules/Set-PASOnboardingRule.ps1
+++ b/psPAS/Functions/OnboardingRules/Set-PASOnboardingRule.ps1
@@ -9,14 +9,14 @@ function Set-PASOnboardingRule {
 		[int]$Id,
 
 		[parameter(
-			Mandatory = $true,
+			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateLength(1, 99)]
 		[string]$TargetPlatformId,
 
 		[parameter(
-			Mandatory = $true,
+			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateLength(1, 28)]
@@ -36,7 +36,7 @@ function Set-PASOnboardingRule {
 		[string]$MachineTypeFilter,
 
 		[parameter(
-			Mandatory = $true,
+			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateSet('Windows', 'Unix')]
@@ -101,8 +101,18 @@ function Set-PASOnboardingRule {
 		#Create URL for request
 		$URI = "$($psPASSession.BaseURI)/api/AutomaticOnboardingRules/$Id/"
 
+		#request parameters
+		$BoundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove Id
+
+		$OnboardingRule = Get-PASOnboardingRule | Where-Object { $PSItem.RuleId -eq $Id }
+		if ($null -ne $OnboardingRule) {
+			Format-PutRequestObject -InputObject $OnboardingRule -boundParameters $BoundParameters -ParametersToKeep SystemTypeFilter,
+			TargetPlatformId, TargetSafeName, AccountCategoryFilter, AddressFilter, AddressMethod, IsAdminIDFilter, MachineTypeFilter,
+			RuleDescription, RuleName, UserNameFilter, UserNameMethod
+		}
+
 		#create request body
-		$body = $PSBoundParameters | Get-PASParameter -ParametersToRemove Id | ConvertTo-Json
+		$body = $BoundParameters | ConvertTo-Json
 
 		if ($PSCmdlet.ShouldProcess($TargetPlatformId, "Update On-Boarding Rule $ID")) {
 

--- a/psPAS/Functions/Platforms/Set-PASPlatformPSMConfig.ps1
+++ b/psPAS/Functions/Platforms/Set-PASPlatformPSMConfig.ps1
@@ -9,15 +9,17 @@ Function Set-PASPlatformPSMConfig {
 		[int]$ID,
 
 		[parameter(
-			Mandatory = $true,
+			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[AllowEmptyString()]
 		[string]$PSMServerID,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[AllowEmptyCollection()]
 		[PSObject[]]$PSMConnectors
 	)
 
@@ -32,8 +34,15 @@ Function Set-PASPlatformPSMConfig {
 		#Create URL for request
 		$URI = "$($psPASSession.BaseURI)/API/Platforms/Targets/$ID/PrivilegedSessionManagement"
 
+		$BoundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove ID
+
+		$PlatformPSMConfig = Get-PASPlatformPSMConfig -ID $ID
+		if ($null -ne $PlatformPSMConfig) {
+			Format-PutRequestObject -InputObject $PlatformPSMConfig -boundParameters $BoundParameters -ParametersToKeep PSMServerID
+		}
+
 		#Request body
-		$Body = $PSBoundParameters | Get-PASParameter -ParametersToRemove ID | ConvertTo-Json
+		$Body = $BoundParameters | ConvertTo-Json
 
 		if ($PSCmdlet.ShouldProcess($ID, 'Update Platform PSM Config')) {
 

--- a/psPAS/Functions/PolicyACL/Add-PASPolicyACL.ps1
+++ b/psPAS/Functions/PolicyACL/Add-PASPolicyACL.ps1
@@ -44,7 +44,9 @@ function Add-PASPolicyACL {
 		[string]$UserName
 	)
 
-	BEGIN { }#begin
+	BEGIN {
+		Assert-VersionRequirement -SelfHosted
+	}#begin
 
 	PROCESS {
 

--- a/psPAS/Functions/PolicyACL/Get-PASPolicyACL.ps1
+++ b/psPAS/Functions/PolicyACL/Get-PASPolicyACL.ps1
@@ -11,7 +11,9 @@ function Get-PASPolicyACL {
 
 	)
 
-	BEGIN { }#begin
+	BEGIN {
+		Assert-VersionRequirement -SelfHosted
+	}#begin
 
 	PROCESS {
 

--- a/psPAS/Functions/PolicyACL/Remove-PASPolicyACL.ps1
+++ b/psPAS/Functions/PolicyACL/Remove-PASPolicyACL.ps1
@@ -17,7 +17,9 @@ function Remove-PASPolicyACL {
 
 	)
 
-	BEGIN { }#begin
+	BEGIN {
+		Assert-VersionRequirement -SelfHosted
+	}#begin
 
 	PROCESS {
 

--- a/psPAS/Functions/SafeMembers/Remove-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Remove-PASSafeMember.ps1
@@ -34,6 +34,8 @@ function Remove-PASSafeMember {
 
 			'Gen1' {
 
+				Assert-VersionRequirement -SelfHosted
+
 				#Create URL for request
 				$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Safes/$($SafeName |
 					Get-EscapedString)/Members/$($MemberName | Get-EscapedString)/"

--- a/psPAS/Functions/SafeMembers/Set-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Set-PASSafeMember.ps1
@@ -243,6 +243,12 @@ function Set-PASSafeMember {
 
 				Assert-VersionRequirement -RequiredVersion 12.2
 
+				$safeMember = Get-PASSafeMember -SafeName $SafeName -MemberName $MemberName
+				if ($null -ne $safeMember) {
+					Format-PutRequestObject -InputObject $safeMember -boundParameters $BoundParameters -ParametersToRemove safeNumber, memberId,
+					UserName, safeName, isExpiredMembershipEnable, memberName, memberType, safeUrlId, memberType, isPredefinedUser
+				}
+
 				#Create URL for request
 				$URI = "$($psPASSession.BaseURI)/api/Safes/$($SafeName | Get-EscapedString)/Members/$($MemberName | Get-EscapedString)/"
 

--- a/psPAS/Functions/Safes/Set-PASSafe.ps1
+++ b/psPAS/Functions/Safes/Set-PASSafe.ps1
@@ -53,7 +53,7 @@ function Set-PASSafe {
 		[string]$ManagingCPM,
 
 		[Parameter(
-			Mandatory = $true,
+			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Gen2-NumberOfVersionsRetention'
 		)]
@@ -66,7 +66,7 @@ function Set-PASSafe {
 		[int]$NumberOfVersionsRetention,
 
 		[Parameter(
-			Mandatory = $true,
+			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Gen2-NumberOfDaysRetention'
 		)]
@@ -100,10 +100,20 @@ function Set-PASSafe {
 
 		$BoundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove NewSafeName
 
-		if ($PSBoundParameters.ContainsKey('NewSafeName')) {
+		$SafeObject = Get-PASSafe -SafeName $SafeName
+		Format-PutRequestObject -InputObject $SafeObject -boundParameters $BoundParameters -ParametersToKeep ManagingCPM, location, Description,
+		NumberOfVersionsRetention, NumberOfDaysRetention
 
-			$BoundParameters['SafeName'] = $PSBoundParameters['NewSafeName']
-
+		switch ($PSBoundParameters.Keys) {
+			'NewSafeName' {
+				$BoundParameters['SafeName'] = $PSBoundParameters['NewSafeName']
+			}
+			'NumberOfDaysRetention' {
+				$BoundParameters.Remove('NumberOfVersionsRetention')
+			}
+			'NumberOfVersionsRetention' {
+				$BoundParameters.Remove('NumberOfDaysRetention')
+			}
 		}
 
 		switch ($PSCmdlet.ParameterSetName) {

--- a/psPAS/Functions/Safes/Set-PASSafe.ps1
+++ b/psPAS/Functions/Safes/Set-PASSafe.ps1
@@ -101,8 +101,10 @@ function Set-PASSafe {
 		$BoundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove NewSafeName
 
 		$SafeObject = Get-PASSafe -SafeName $SafeName
-		Format-PutRequestObject -InputObject $SafeObject -boundParameters $BoundParameters -ParametersToKeep ManagingCPM, location, Description,
-		NumberOfVersionsRetention, NumberOfDaysRetention
+		if ($null -ne $SafeObject) {
+			Format-PutRequestObject -InputObject $SafeObject -boundParameters $BoundParameters -ParametersToKeep ManagingCPM, location, Description,
+			NumberOfVersionsRetention, NumberOfDaysRetention
+		}
 
 		switch ($PSBoundParameters.Keys) {
 			'NewSafeName' {

--- a/psPAS/Functions/ServerWebServices/Get-PASSafeShareLogo.ps1
+++ b/psPAS/Functions/ServerWebServices/Get-PASSafeShareLogo.ps1
@@ -10,7 +10,7 @@ function Get-PASSafeShareLogo {
 	)
 
 	BEGIN {
-		#!Depreciated above 13.2
+		#!Depracated above 13.2
 		Assert-VersionRequirement -MaximumVersion 13.2
 	}#begin
 

--- a/psPAS/Functions/ServerWebServices/Get-PASServerWebService.ps1
+++ b/psPAS/Functions/ServerWebServices/Get-PASServerWebService.ps1
@@ -36,7 +36,7 @@ function Get-PASServerWebService {
 		switch ($PSBoundParameters.Keys) {
 
 			'UseGen1API' {
-				#!Depreciated above 13.2
+				#!Depracated above 13.2
 				Assert-VersionRequirement -MaximumVersion 13.2
 
 				#Create URL for request

--- a/psPAS/Functions/SystemHealth/Get-PASComponentDetail.ps1
+++ b/psPAS/Functions/SystemHealth/Get-PASComponentDetail.ps1
@@ -21,6 +21,7 @@ Function Get-PASComponentDetail {
 		if ($PSBoundParameters['ComponentID'] -eq 'PTA') {
 
 			Assert-VersionRequirement -RequiredVersion 12.0
+			Assert-VersionRequirement -SelfHosted
 
 		}
 

--- a/psPAS/Functions/User/New-PASUser.ps1
+++ b/psPAS/Functions/User/New-PASUser.ps1
@@ -39,8 +39,9 @@ function New-PASUser {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Gen2'
 		)]
+		[AllowEmptyCollection()]
 		[ValidateSet('PIMSU', 'PSM', 'PSMP', 'PVWA', 'WINCLIENT', 'PTA', 'PACLI', 'NAPI', 'XAPI', 'HTTPGW',
-			'EVD', 'PIMSu', 'AIMApp', 'CPM', 'PVWAApp', 'PSMApp', 'AppPrv', 'AIMApp', 'PSMPApp', 'GUI')]
+			'EVD', 'CPM', 'PVWAApp', 'PSMApp', 'AppPrv', 'AIMApp', 'PSMPApp', 'GUI')]
 		[string[]]$unAuthorizedInterfaces,
 
 		[parameter(
@@ -98,9 +99,9 @@ function New-PASUser {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Gen2'
 		)]
-		[ValidateSet('AddSafes', 'AuditUsers', 'AddUpdateUsers', 'ResetUsersPasswords', 'ActivateUsers',
-			'AddNetworkAreas', 'ManageDirectoryMapping', 'ManageServerFileCategories', 'BackupAllSafes',
-			'RestoreAllSafes')]
+		[ValidateSet('AddSafes', 'AuditUsers', 'AddUpdateUsers', 'ResetUsersPasswords', 'ActivateUsers', 'AddNetworkAreas',
+			'ManageDirectoryMapping', 'ManageServerFileCategories', 'BackupAllSafes', 'RestoreAllSafes')]
+		[AllowEmptyCollection()]
 		[string[]]$vaultAuthorization,
 
 		[parameter(

--- a/psPAS/Functions/User/Set-PASUser.ps1
+++ b/psPAS/Functions/User/Set-PASUser.ps1
@@ -445,8 +445,10 @@ function Set-PASUser {
 				$URI = "$($psPASSession.BaseURI)/api/Users/$id"
 
 				$UserObject = Get-PASUser -id $id
-				Format-PutRequestObject -InputObject $UserObject -boundParameters $BoundParameters -ParametersToRemove id, lastSuccessfulLoginDate,
-				source, componentUser, groupsMembership, authenticationMethod
+				if ($null -ne $UserObject) {
+					Format-PutRequestObject -InputObject $UserObject -boundParameters $BoundParameters -ParametersToRemove id, lastSuccessfulLoginDate,
+					source, componentUser, groupsMembership, authenticationMethod
+				}
 
 				$boundParameters = $boundParameters | Format-PASUserObject
 

--- a/psPAS/Functions/User/Set-PASUser.ps1
+++ b/psPAS/Functions/User/Set-PASUser.ps1
@@ -445,20 +445,8 @@ function Set-PASUser {
 				$URI = "$($psPASSession.BaseURI)/api/Users/$id"
 
 				$UserObject = Get-PASUser -id $id
-
-				$ExistingProperties = @{}
-				$UserObject | Get-PASUserPropertyObject | ForEach-Object {
-					$ExistingProperties[$($PSItem.Key)] = $($PSItem.Value)
-				}
-
-				$userParameters = $ExistingProperties | Get-PASParameter -ParametersToRemove id, lastSuccessfulLoginDate,
+				Format-PutRequestObject -InputObject $UserObject -boundParameters $BoundParameters -ParametersToRemove id, lastSuccessfulLoginDate,
 				source, componentUser, groupsMembership, authenticationMethod
-
-				$userParameters.Keys | ForEach-Object {
-					If (-not($boundParameters.ContainsKey($PSItem))) {
-						$boundParameters.Add($PSItem, $userParameters[$PSItem])
-					}
-				}
 
 				$boundParameters = $boundParameters | Format-PASUserObject
 

--- a/psPAS/Functions/User/Set-PASUser.ps1
+++ b/psPAS/Functions/User/Set-PASUser.ps1
@@ -301,7 +301,6 @@ function Set-PASUser {
 		[ValidateLength(0, 99)]
 		[string]$description,
 
-
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true,
@@ -446,7 +445,7 @@ function Set-PASUser {
 				$URI = "$($psPASSession.BaseURI)/api/Users/$id"
 
 				$UserObject = Get-PASUser -id $id
-				#$UserProperties = $UserObject | Get-PASUserPropertyObject
+
 				$ExistingProperties = @{}
 				$UserObject | Get-PASUserPropertyObject | ForEach-Object {
 					$ExistingProperties[$($PSItem.Key)] = $($PSItem.Value)

--- a/psPAS/Private/Assert-VersionRequirement.ps1
+++ b/psPAS/Private/Assert-VersionRequirement.ps1
@@ -1,19 +1,27 @@
 Function Assert-VersionRequirement {
 	<#
 .SYNOPSIS
-Affirms that a version satisfies a required level
+Affirms that a version requirments are satisfied
 
 .DESCRIPTION
-Throws an error if a provided version number odes not meet or exceed a required level.
+Throws an error if a provided version number does not meet or exceed a required level.
+
+Throws an error if an environment type does not apply for the current solution.
 
 .PARAMETER ExternalVersion
-A version number to comapre against the required version
+A version number to compare against the required version
 
 .PARAMETER RequiredVersion
 The version number the ExternalVersion Number must meet.
 
 .PARAMETER MaximumVersion
 The version number the ExternalVersion Number cannot exceed.
+
+.PARAMETER PrivilegeCloud
+Specify to assert that the command is being run against a Privilege Cloud Solution
+
+.PARAMETER SelfHosted
+Specify to assert that the command is being run against a Self-Hosted solution
 
 .EXAMPLE
 Assert-VersionRequirement -ExternalVersion 1.0 -RequiredVersion 2.0
@@ -28,12 +36,13 @@ Returns nothing as 1.0 exceeds 0.5
 .NOTES
 General notes
 #>
-	[CmdletBinding()]
+	[CmdletBinding(DefaultParameterSetName = 'CompareVersion')]
 	Param(
 		# The Current Software Version
 		[Parameter(
 			Mandatory = $false,
-			ValueFromPipelineByPropertyName = $true
+			ValueFromPipelineByPropertyName = $true,
+			ParameterSetName = 'CompareVersion'
 		)]
 		[System.Version]
 		$ExternalVersion = $psPASSession.ExternalVersion,
@@ -41,7 +50,8 @@ General notes
 		# The Required Software Version
 		[Parameter(
 			Mandatory = $false,
-			ValueFromPipelineByPropertyName = $true
+			ValueFromPipelineByPropertyName = $true,
+			ParameterSetName = 'CompareVersion'
 		)]
 		[System.Version]
 		$RequiredVersion,
@@ -49,10 +59,25 @@ General notes
 		# The Maximum Supported Software Version
 		[Parameter(
 			Mandatory = $false,
-			ValueFromPipelineByPropertyName = $true
+			ValueFromPipelineByPropertyName = $true,
+			ParameterSetName = 'CompareVersion'
 		)]
 		[System.Version]
-		$MaximumVersion
+		$MaximumVersion,
+
+		[Parameter(
+			Mandatory = $true,
+			ValueFromPipelineByPropertyName = $true,
+			ParameterSetName = 'PrivilegeCloud'
+		)]
+		[Switch]$PrivilegeCloud,
+
+		[Parameter(
+			Mandatory = $true,
+			ValueFromPipelineByPropertyName = $true,
+			ParameterSetName = 'SelfHosted'
+		)]
+		[Switch]$SelfHosted
 	)
 
 	Begin {
@@ -83,6 +108,30 @@ General notes
 				If (-not (Compare-MaximumVersion -Version $ExternalVersion -MaximumVersion $MaximumVersion)) {
 
 					Throw "CyberArk $ExternalVersion exceeds the maximum supported version of $MaximumVersion for $ParentFunction (using ParameterSet: $UsedParameterSet)"
+
+				}
+
+				Continue
+
+			}
+
+			'PrivilegeCloud' {
+
+				If (-not ($psPASSession.BaseUri -match 'cyberark.cloud')) {
+
+					Throw "$ParentFunction (using ParameterSet: $UsedParameterSet) is only applicable to Privilege Cloud Implementations"
+
+				}
+
+				Continue
+
+			}
+
+			'SelfHosted' {
+
+				If ($psPASSession.BaseUri -match 'cyberark.cloud') {
+
+					Throw "$ParentFunction (using ParameterSet: $UsedParameterSet) is only applicable for Self-Hosted Implementations"
 
 				}
 

--- a/psPAS/Private/Format-PutRequestObject.ps1
+++ b/psPAS/Private/Format-PutRequestObject.ps1
@@ -1,0 +1,93 @@
+Function Format-PutRequestObject {
+    <#
+    .SYNOPSIS
+    Give source object properties, and request parameters,
+    where a property is not presnt in a request, adds the current value from the source object.
+
+    .DESCRIPTION
+    Long description
+
+    .PARAMETER InputObject
+    The object representing current property values of an object to be updated
+
+    .PARAMETER boundParameters
+    The current request paramters for the update operation
+
+    .PARAMETER ParametersToRemove
+    Any parameter names from the input object which should not be included in the update request
+
+    .PARAMETER ParametersToKeep
+    Any parameter names from the input object which should be kept for the update request
+
+    .EXAMPLE
+    Format-PutRequestObject -InputObject $UserObject -boundParameters $BoundParameters -ParametersToRemove id
+
+    updates the bound paramter value with key/values not already included, but present in InputObject
+
+    .NOTES
+    Pete Maan 2024
+    #>
+    [CmdLetBinding(DefaultParameterSetName = 'Remove')]
+    Param (
+
+        [Parameter(
+            Mandatory = $True,
+            ValueFromPipelineByPropertyName = $True
+        )]
+        [psobject]$InputObject,
+
+        [Parameter(
+            Mandatory = $True,
+            ValueFromPipelineByPropertyName = $True
+        )]$boundParameters,
+
+        [parameter(
+            Mandatory = $false,
+            ValueFromPipelineByPropertyName = $True,
+            ParameterSetName = 'Remove'
+        )]
+        [string[]]$ParametersToRemove,
+
+        [parameter(
+            Mandatory = $false,
+            ValueFromPipelineByPropertyName = $True,
+            ParameterSetName = 'Keep'
+        )]
+        [string[]]$ParametersToKeep
+
+    )
+
+    Begin {
+        #initialise hashtable to hold exiting property values
+        $ExistingProperties = @{}
+    }
+
+    Process {
+
+        #ParametersToKeep or ParametersToRemove paramters to pass to Get-PASParameter
+        $PasParameters = $PSBoundParameters | Get-PASParameter -ParametersToKeep ParametersToKeep, ParametersToRemove
+
+        #Add properties of inputobject to ExistingProperties hashtable
+        $InputObject | Get-PASPropertyObject | ForEach-Object {
+            $ExistingProperties[$($PSItem.Key)] = $($PSItem.Value)
+        }
+
+        #Keep or remove any specified specific properties from the Input Object
+        #* Not all property values from an object can be sent in a PUT request
+        #* Keep or remove properties based on the input requirements for the PUT request.
+        $ExistingParameters = $ExistingProperties | Get-PASParameter @PasParameters
+
+        #If boundparameters does not include the existing propertyname, i.e. the property is not being udpated in the request:
+        # Add the existing property to boundparameters for inclusion in a PUT request
+        $ExistingParameters.Keys | ForEach-Object {
+            If (-not($boundParameters.ContainsKey($PSItem))) {
+                $boundParameters.Add($PSItem, $ExistingParameters[$PSItem])
+            }
+        }
+
+
+    }
+
+    End { }
+
+}

--- a/psPAS/Private/Get-PASPropertyObject.ps1
+++ b/psPAS/Private/Get-PASPropertyObject.ps1
@@ -1,14 +1,14 @@
-Function Get-PASUserPropertyObject {
+Function Get-PASPropertyObject {
     <#
     .SYNOPSIS
-    Designed to flatten objects returned from Get-PASUser
+    Designed to flatten objects returned from psPAS commands
 
     .DESCRIPTION
-    Get-PASUser output contains levels of nested properties, all with unique names.
+    psPAS output can contain multiple levels of nested properties.
 
     This function returns all property values as root level properties of the output object.
 
-    Facilitates sending existing property values as parametes for Set-PASUser
+    Facilitates sending existing property values as parametes for Set-PAS* commands.
 
     .PARAMETER InputObject
     The input object to flatten
@@ -21,7 +21,7 @@ Function Get-PASUserPropertyObject {
 
     }
 
-    $object | Get-PASUserPropertyObject
+    $object | Get-PASPropertyObject
 
     Name                           Value
     ----                           -----
@@ -48,32 +48,34 @@ Function Get-PASUserPropertyObject {
     }
     Process {
 
+        #Iterate each property
         $InputObject.psobject.Properties | ForEach-Object {
 
-
             If ($null -ne $PSItem.value) {
+
+                #save the property name
                 $property = $PSItem.name
+
                 switch ($PSItem) {
 
+                    #where property value is another (nested) object, recursivley call the function for the object
                     { ($PSItem.value.gettype() | Select-Object -ExpandProperty Name) -match 'PSCustomObject' } {
-                        $PSItem.value | Get-PASUserPropertyObject
+                        $PSItem.value | Get-PASPropertyObject
                     }
                     default {
+                        #add property name/value to hastable
                         $Properties.Add($Property, $PSItem.value)
                     }
 
                 }
             }
 
-
-
         }
-
-
 
     }
     End {
 
+        #output hashtable elements
         $Properties.GetEnumerator()
 
     }

--- a/psPAS/Private/Get-PASUserPropertyObject.ps1
+++ b/psPAS/Private/Get-PASUserPropertyObject.ps1
@@ -1,0 +1,80 @@
+Function Get-PASUserPropertyObject {
+    <#
+    .SYNOPSIS
+    Designed to flatten objects returned from Get-PASUser
+
+    .DESCRIPTION
+    Get-PASUser output contains levels of nested properties, all with unique names.
+
+    This function returns all property values as root level properties of the output object.
+
+    Facilitates sending existing property values as parametes for Set-PASUser
+
+    .PARAMETER InputObject
+    The input object to flatten
+
+    .EXAMPLE
+    $object = [PSCustomObject]@{
+
+    Prop = "testvalue"
+    Nest = [PSCustomObject]@{nestedproperty='nested value'}
+
+    }
+
+    $object | Get-PASUserPropertyObject
+
+    Name                           Value
+    ----                           -----
+    nestedproperty                 nested value
+    Prop                           testvalue
+
+    Outputs a flat object where nested property values are returned as top level properties of the output object
+
+    .NOTES
+    Pete Maan 2024
+    #>
+    [CmdLetBinding()]
+    Param (
+
+        [Parameter(
+            Mandatory = $True,
+            ValueFromPipeline = $True
+        )]
+        [psobject]$InputObject
+    )
+
+    Begin {
+        $Properties = @{}
+    }
+    Process {
+
+        $InputObject.psobject.Properties | ForEach-Object {
+
+
+            If ($null -ne $PSItem.value) {
+                $property = $PSItem.name
+                switch ($PSItem) {
+
+                    { ($PSItem.value.gettype() | Select-Object -ExpandProperty Name) -match 'PSCustomObject' } {
+                        $PSItem.value | Get-PASUserPropertyObject
+                    }
+                    default {
+                        $Properties.Add($Property, $PSItem.value)
+                    }
+
+                }
+            }
+
+
+
+        }
+
+
+
+    }
+    End {
+
+        $Properties.GetEnumerator()
+
+    }
+}

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -34001,7 +34001,7 @@ Set-PASAccount -AccountID 29_3 -operations $actions</dev:code>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
           <maml:name>MappingName</maml:name>
           <maml:description>
             <maml:para>The name of the PAS role that will be created.</maml:para>
@@ -34013,7 +34013,7 @@ Set-PASAccount -AccountID 29_3 -operations $actions</dev:code>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
           <maml:name>LDAPBranch</maml:name>
           <maml:description>
             <maml:para>The LDAP branch that will be used for external directory queries</maml:para>
@@ -34194,7 +34194,7 @@ Set-PASAccount -AccountID 29_3 -operations $actions</dev:code>
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
         <maml:name>MappingName</maml:name>
         <maml:description>
           <maml:para>The name of the PAS role that will be created.</maml:para>
@@ -34206,7 +34206,7 @@ Set-PASAccount -AccountID 29_3 -operations $actions</dev:code>
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
         <maml:name>LDAPBranch</maml:name>
         <maml:description>
           <maml:para>The LDAP branch that will be used for external directory queries</maml:para>
@@ -35001,7 +35001,7 @@ Set-PASDirectoryMapping -DirectoryName $Directory -MappingAuthorizations AddUpda
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
           <maml:name>TargetPlatformId</maml:name>
           <maml:description>
             <maml:para>The ID of the platform that will be associated to the on-boarded account.</maml:para>
@@ -35013,7 +35013,7 @@ Set-PASDirectoryMapping -DirectoryName $Directory -MappingAuthorizations AddUpda
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
           <maml:name>TargetSafeName</maml:name>
           <maml:description>
             <maml:para>The name of the Safe where the on-boarded account will be stored.</maml:para>
@@ -35051,7 +35051,7 @@ Set-PASDirectoryMapping -DirectoryName $Directory -MappingAuthorizations AddUpda
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
           <maml:name>SystemTypeFilter</maml:name>
           <maml:description>
             <maml:para>The System Type by which to filter.</maml:para>
@@ -35137,7 +35137,7 @@ Set-PASDirectoryMapping -DirectoryName $Directory -MappingAuthorizations AddUpda
         </dev:type>
         <dev:defaultValue>0</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
         <maml:name>TargetPlatformId</maml:name>
         <maml:description>
           <maml:para>The ID of the platform that will be associated to the on-boarded account.</maml:para>
@@ -35149,7 +35149,7 @@ Set-PASDirectoryMapping -DirectoryName $Directory -MappingAuthorizations AddUpda
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
         <maml:name>TargetSafeName</maml:name>
         <maml:description>
           <maml:para>The name of the Safe where the on-boarded account will be stored.</maml:para>
@@ -35187,7 +35187,7 @@ Set-PASDirectoryMapping -DirectoryName $Directory -MappingAuthorizations AddUpda
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
         <maml:name>SystemTypeFilter</maml:name>
         <maml:description>
           <maml:para>The System Type by which to filter.</maml:para>
@@ -35413,7 +35413,7 @@ Set-PASDirectoryMapping -DirectoryName $Directory -MappingAuthorizations AddUpda
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>discoveryEndpointUrl</maml:name>
           <maml:description>
             <maml:para>OIDC defines a discovery mechanism, called OpenID Connect Discovery, where an OIDC Identity provider publishes its metadata at a well-known URL.</maml:para>
@@ -35439,7 +35439,7 @@ Set-PASDirectoryMapping -DirectoryName $Directory -MappingAuthorizations AddUpda
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>clientId</maml:name>
           <maml:description>
             <maml:para>The unique identifier for the client application. This ID is created by the provider, and assigned to each client application upon registration.</maml:para>
@@ -35463,7 +35463,7 @@ Set-PASDirectoryMapping -DirectoryName $Directory -MappingAuthorizations AddUpda
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>clientSecretMethod</maml:name>
           <maml:description>
             <maml:para>The client authentication method for the client secret.</maml:para>
@@ -35572,7 +35572,7 @@ Set-PASDirectoryMapping -DirectoryName $Directory -MappingAuthorizations AddUpda
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>discoveryEndpointUrl</maml:name>
         <maml:description>
           <maml:para>OIDC defines a discovery mechanism, called OpenID Connect Discovery, where an OIDC Identity provider publishes its metadata at a well-known URL.</maml:para>
@@ -35598,7 +35598,7 @@ Set-PASDirectoryMapping -DirectoryName $Directory -MappingAuthorizations AddUpda
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>clientId</maml:name>
         <maml:description>
           <maml:para>The unique identifier for the client application. This ID is created by the provider, and assigned to each client application upon registration.</maml:para>
@@ -35622,7 +35622,7 @@ Set-PASDirectoryMapping -DirectoryName $Directory -MappingAuthorizations AddUpda
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>clientSecretMethod</maml:name>
         <maml:description>
           <maml:para>The client authentication method for the client secret.</maml:para>
@@ -35725,7 +35725,7 @@ Set-PASDirectoryMapping -DirectoryName $Directory -MappingAuthorizations AddUpda
           </dev:type>
           <dev:defaultValue>0</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
           <maml:name>PSMServerID</maml:name>
           <maml:description>
             <maml:para>PSM server ID linked to the platform</maml:para>
@@ -35786,7 +35786,7 @@ Set-PASDirectoryMapping -DirectoryName $Directory -MappingAuthorizations AddUpda
         </dev:type>
         <dev:defaultValue>0</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
         <maml:name>PSMServerID</maml:name>
         <maml:description>
           <maml:para>PSM server ID linked to the platform</maml:para>
@@ -35848,7 +35848,7 @@ Set-PASDirectoryMapping -DirectoryName $Directory -MappingAuthorizations AddUpda
         <dev:code>$PSMConfig = Get-PASPlatformPSMConfig -ID 23
 
 $PSMConfig.PSMConnectors += (\[PSCustomObject\]@{"PSMConnectorID"="PSM-RDP";"Enabled"=$true})
-$PSMConfig | Set-PASPlatformPSMConfig -ID 23</dev:code>
+Set-PASPlatformPSMConfig -ID 23 -PSMConnectors $PSMConfig.PSMConnectors</dev:code>
         <dev:remarks>
           <maml:para>Adds PSM-RDP as an additional connection component configured on platform with id of 23</maml:para>
         </dev:remarks>
@@ -36453,7 +36453,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
           <maml:name>category</maml:name>
           <maml:description>
             <maml:para>The Category of the risky activity - Valid values: SSH, WINDOWS, SCP, KEYSTROKES or SQL</maml:para>
@@ -36465,7 +36465,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
           <maml:name>regex</maml:name>
           <maml:description>
             <maml:para>Risky activity in regex form.</maml:para>
@@ -36478,7 +36478,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
           <maml:name>score</maml:name>
           <maml:description>
             <maml:para>Activity score.</maml:para>
@@ -36491,7 +36491,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>0</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
           <maml:name>description</maml:name>
           <maml:description>
             <maml:para>Activity description.</maml:para>
@@ -36504,7 +36504,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
           <maml:name>response</maml:name>
           <maml:description>
             <maml:para>Automatic response to be executed</maml:para>
@@ -36517,7 +36517,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="7" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="7" aliases="none">
           <maml:name>active</maml:name>
           <maml:description>
             <maml:para>Indicate if the rule should be active or disabled</maml:para>
@@ -36614,7 +36614,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
         <maml:name>category</maml:name>
         <maml:description>
           <maml:para>The Category of the risky activity - Valid values: SSH, WINDOWS, SCP, KEYSTROKES or SQL</maml:para>
@@ -36626,7 +36626,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
         <maml:name>regex</maml:name>
         <maml:description>
           <maml:para>Risky activity in regex form.</maml:para>
@@ -36639,7 +36639,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
         <maml:name>score</maml:name>
         <maml:description>
           <maml:para>Activity score.</maml:para>
@@ -36652,7 +36652,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>0</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
         <maml:name>description</maml:name>
         <maml:description>
           <maml:para>Activity description.</maml:para>
@@ -36665,7 +36665,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
         <maml:name>response</maml:name>
         <maml:description>
           <maml:para>Automatic response to be executed</maml:para>
@@ -36678,7 +36678,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="7" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="7" aliases="none">
         <maml:name>active</maml:name>
         <maml:description>
           <maml:para>Indicate if the rule should be active or disabled</maml:para>
@@ -36878,7 +36878,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>NumberOfVersionsRetention</maml:name>
           <maml:description>
             <maml:para>The number of retained versions of every password that is stored in the Safe. - Max value = 999 Specify either this parameter or NumberOfDaysRetention.</maml:para>
@@ -37109,7 +37109,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>NumberOfDaysRetention</maml:name>
           <maml:description>
             <maml:para>The number of days for which password versions are saved in the Safe.</maml:para>
@@ -37346,7 +37346,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>NumberOfVersionsRetention</maml:name>
         <maml:description>
           <maml:para>The number of retained versions of every password that is stored in the Safe. - Max value = 999 Specify either this parameter or NumberOfDaysRetention.</maml:para>
@@ -37358,7 +37358,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>0</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>NumberOfDaysRetention</maml:name>
         <maml:description>
           <maml:para>The number of days for which password versions are saved in the Safe.</maml:para>

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -15750,6 +15750,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
     </command:details>
     <maml:description>
       <maml:para>Returns the details of recordings of PSM, PSMP or OPM sessions.</maml:para>
+      <maml:para>By default, recordings from the last 24 hours are returned. - When specifying `ToTime` without `FromTime`, recordings from the 24 hours before `ToTime` are returned.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -15834,7 +15835,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>ToTime</maml:name>
           <maml:description>
-            <maml:para>Returns recordings from a specific date</maml:para>
+            <maml:para>Returns recordings from a specific date - When specifying `ToTime` without `FromTime`, recordings from the 24 hours prior to `ToTime` are returned.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">DateTime</command:parameterValue>
           <dev:type>
@@ -15935,7 +15936,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>ToTime</maml:name>
         <maml:description>
-          <maml:para>Returns recordings from a specific date</maml:para>
+          <maml:para>Returns recordings from a specific date - When specifying `ToTime` without `FromTime`, recordings from the 24 hours prior to `ToTime` are returned.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">DateTime</command:parameterValue>
         <dev:type>
@@ -15969,7 +15970,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
         <dev:code>Get-PASPSMRecording -Sort -FileName</dev:code>
         <dev:remarks>
-          <maml:para>Lists all PSM recordings, sorted by descending filename.</maml:para>
+          <maml:para>Lists PSM recordings from the last 24 hours, sorted by descending filename.</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -5288,7 +5288,7 @@ Add-PASDiscoveredAccount -UserName ServiceUser -Address 1.2.3.4 -discoveryDate (
     <maml:description>
       <maml:para>Enables an account or SSH key that is discovered by an external scanner to be added as a pending account to the Accounts Feed.</maml:para>
       <maml:para>Users can identify privileged accounts and determine which are on-boarded to the vault.</maml:para>
-      <maml:para>Depreciated from version 13.2</maml:para>
+      <maml:para>Deprecated from version 13.2</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -7866,7 +7866,7 @@ Add-PASDiscoveredAccount -UserName ServiceUser -Address 1.2.3.4 -discoveryDate (
       <maml:para>Default operation uses the Gen 2 API and requires version 12.1+ - Earlier versions must specify the `-UseGen1API` switch to force use of the Gen1 API. Note when using the Gen1 API:</maml:para>
       <maml:para>Unless otherwise specified, the default permissions applied to a safe member will include: - ListAccounts, RetrieveAccounts, UseAccounts, ViewAuditLog &amp; ViewSafeMembers.</maml:para>
       <maml:para>If these permissions should not be granted to the safe member, they must be explicitly set to `$false` in the request.</maml:para>
-      <maml:para>Gen1 API is depreciated from version 12.3</maml:para>
+      <maml:para>Gen1 API is deprecated from version 12.3</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -8136,7 +8136,7 @@ Add-PASDiscoveredAccount -UserName ServiceUser -Address 1.2.3.4 -discoveryDate (
             <maml:para>Integer value defining level assigned to RequestsAuthorizationLevel for safe member.</maml:para>
             <maml:para>Valid Values: 0, 1 or 2</maml:para>
             <maml:para>Get-PASSafeMember (Gen1) may not return details of this permission</maml:para>
-            <maml:para>Depreciated from version 12.3</maml:para>
+            <maml:para>Deprecated from version 12.3</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
@@ -8201,7 +8201,7 @@ Add-PASDiscoveredAccount -UserName ServiceUser -Address 1.2.3.4 -discoveryDate (
           <maml:description>
             <maml:para>Force use of Gen1 API.</maml:para>
             <maml:para>Should be specified for versions earlier than 12.1</maml:para>
-            <maml:para>Depreciated from version 12.3</maml:para>
+            <maml:para>Deprecated from version 12.3</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -8830,7 +8830,7 @@ Add-PASDiscoveredAccount -UserName ServiceUser -Address 1.2.3.4 -discoveryDate (
           <maml:para>Integer value defining level assigned to RequestsAuthorizationLevel for safe member.</maml:para>
           <maml:para>Valid Values: 0, 1 or 2</maml:para>
           <maml:para>Get-PASSafeMember (Gen1) may not return details of this permission</maml:para>
-          <maml:para>Depreciated from version 12.3</maml:para>
+          <maml:para>Deprecated from version 12.3</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
@@ -8921,7 +8921,7 @@ Add-PASDiscoveredAccount -UserName ServiceUser -Address 1.2.3.4 -discoveryDate (
         <maml:description>
           <maml:para>Force use of Gen1 API.</maml:para>
           <maml:para>Should be specified for versions earlier than 12.1</maml:para>
-          <maml:para>Depreciated from version 12.3</maml:para>
+          <maml:para>Deprecated from version 12.3</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -11527,12 +11527,12 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
       <command:verb>Find</command:verb>
       <command:noun>PASSafe</command:noun>
       <maml:description>
-        <maml:para>(Depreciated) Returns safe list from the vault.</maml:para>
+        <maml:para>(Deprecated) Returns safe list from the vault.</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
       <maml:para>Minimum required version 10.1</maml:para>
-      <maml:para>Depreciated from 11.7</maml:para>
+      <maml:para>Deprecated from 11.7</maml:para>
       <maml:para>Returns abbreviated details for all safes</maml:para>
     </maml:description>
     <command:syntax>
@@ -11596,7 +11596,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
     <command:returnValues />
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Find-PASSafe is depreciated from 11.7</maml:para>
+        <maml:para>Find-PASSafe is deprecated from 11.7</maml:para>
         <maml:para>Function was based on undocumented features available since V10</maml:para>
         <maml:para>It returns results faster than the Gen1 API (invoked with Get-PASSafe) but has a vastly different return object</maml:para>
         <maml:para>Now documented since version 12.0, this is the Gen2 API for Get-PASafe.</maml:para>
@@ -12220,7 +12220,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           <maml:name>UseGen1API</maml:name>
           <maml:description>
             <maml:para>Specify to force use of the Gen1 API</maml:para>
-            <maml:para>Gen1 API is Depreciated from version 13.2</maml:para>
+            <maml:para>Gen1 API is Deprecated from version 13.2</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -12247,7 +12247,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <maml:name>UseGen1API</maml:name>
         <maml:description>
           <maml:para>Specify to force use of the Gen1 API</maml:para>
-          <maml:para>Gen1 API is Depreciated from version 13.2</maml:para>
+          <maml:para>Gen1 API is Deprecated from version 13.2</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -12394,7 +12394,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           <maml:name>UseGen1API</maml:name>
           <maml:description>
             <maml:para>Specify to force usage the Gen1 API endpoint.</maml:para>
-            <maml:para>This is based on the Get Account Groups By Safe API, introduced in PAS 10.5, depreciated in 12.6</maml:para>
+            <maml:para>This is based on the Get Account Groups By Safe API, introduced in PAS 10.5, deprecated in 12.6</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -12421,7 +12421,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <maml:name>UseGen1API</maml:name>
         <maml:description>
           <maml:para>Specify to force usage the Gen1 API endpoint.</maml:para>
-          <maml:para>This is based on the Get Account Groups By Safe API, introduced in PAS 10.5, depreciated in 12.6</maml:para>
+          <maml:para>This is based on the Get Account Groups By Safe API, introduced in PAS 10.5, deprecated in 12.6</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -17768,7 +17768,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
       <maml:para>Gets safe by SafeName, by search query string, or, by default will return all safes. - Minimum required version for default operation using Gen2 API is 12.0.</maml:para>
       <maml:para>- Minimum required version for operation using Gen2-byName ParameterSet is 12.2.</maml:para>
       <maml:para>- For PAS versions earlier than 12.0, the Gen1 API parameters must be used.</maml:para>
-      <maml:para>- Gen1 API parameters are depreciated for versions higher than 12.3.</maml:para>
+      <maml:para>- Gen1 API parameters are deprecated for versions higher than 12.3.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -17862,7 +17862,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
             <maml:para>The name of a specific safe to get details of.</maml:para>
             <maml:para>Gen2 API operation requires minimum version 12.2</maml:para>
             <maml:para>When using Gen1 API in versions earlier than 12.0, must be specified with the `-UseGen1API` parameter.</maml:para>
-            <maml:para>Gen1 operation depreciated from version 12.3</maml:para>
+            <maml:para>Gen1 operation deprecated from version 12.3</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -17905,7 +17905,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
             <maml:para>The name of a specific safe to get details of.</maml:para>
             <maml:para>Gen2 API operation requires minimum version 12.2</maml:para>
             <maml:para>When using Gen1 API in versions earlier than 12.0, must be specified with the `-UseGen1API` parameter.</maml:para>
-            <maml:para>Gen1 operation depreciated from version 12.3</maml:para>
+            <maml:para>Gen1 operation deprecated from version 12.3</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -17946,7 +17946,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           <maml:description>
             <maml:para>Query String for safe search in the vault using Gen1 API.</maml:para>
             <maml:para>Should be specified for versions earlier than 12.0</maml:para>
-            <maml:para>Depreciated from version 12.3</maml:para>
+            <maml:para>Deprecated from version 12.3</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -17976,7 +17976,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           <maml:description>
             <maml:para>Specify to find all safes using Gen1 API.</maml:para>
             <maml:para>Should be specified for versions earlier than 12.0</maml:para>
-            <maml:para>Depreciated from version 12.3</maml:para>
+            <maml:para>Deprecated from version 12.3</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -18070,7 +18070,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           <maml:para>The name of a specific safe to get details of.</maml:para>
           <maml:para>Gen2 API operation requires minimum version 12.2</maml:para>
           <maml:para>When using Gen1 API in versions earlier than 12.0, must be specified with the `-UseGen1API` parameter.</maml:para>
-          <maml:para>Gen1 operation depreciated from version 12.3</maml:para>
+          <maml:para>Gen1 operation deprecated from version 12.3</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -18084,7 +18084,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <maml:description>
           <maml:para>Query String for safe search in the vault using Gen1 API.</maml:para>
           <maml:para>Should be specified for versions earlier than 12.0</maml:para>
-          <maml:para>Depreciated from version 12.3</maml:para>
+          <maml:para>Deprecated from version 12.3</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -18098,7 +18098,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <maml:description>
           <maml:para>Specify to find all safes using Gen1 API.</maml:para>
           <maml:para>Should be specified for versions earlier than 12.0</maml:para>
-          <maml:para>Depreciated from version 12.3</maml:para>
+          <maml:para>Deprecated from version 12.3</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -18182,7 +18182,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <dev:code>Get-PASSafe -query SAFE1</dev:code>
         <dev:remarks>
           <maml:para>Returns details of safes matching query "Safe1" using Gen1 API.</maml:para>
-          <maml:para>Depreciated from version 12.2</maml:para>
+          <maml:para>Deprecated from version 12.2</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
@@ -18190,7 +18190,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <dev:code>Get-PASSafe -FindAll -UseGen1API</dev:code>
         <dev:remarks>
           <maml:para>Returns details of all safes using Gen1 API.</maml:para>
-          <maml:para>Depreciated from version 12.3</maml:para>
+          <maml:para>Deprecated from version 12.3</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
@@ -18198,7 +18198,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <dev:code>Get-PASSafe -SafeName SAFE1 -UseGen1API</dev:code>
         <dev:remarks>
           <maml:para>Returns details of "Safe1" using Gen1 API.</maml:para>
-          <maml:para>Depreciated from version 12.3</maml:para>
+          <maml:para>Deprecated from version 12.3</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -18306,7 +18306,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
             <maml:para>Operation against Gen2 API requires minimum version of 12.2 NOTE for Gen1 Operation : An empty PUT request (update) is sent to retrieve full safe permissions for a user: - `-UseGen1API` parameter must be specified.</maml:para>
             <maml:para>- You cannot report on the permissions of the user authenticated to the API.</maml:para>
             <maml:para>- Reporting on the permissions of the Quota Owner is expected to fail.</maml:para>
-            <maml:para>- Depreciated from CyberArk Version 12.3</maml:para>
+            <maml:para>- Deprecated from CyberArk Version 12.3</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -18350,7 +18350,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
             <maml:para>Operation against Gen2 API requires minimum version of 12.2 NOTE for Gen1 Operation : An empty PUT request (update) is sent to retrieve full safe permissions for a user: - `-UseGen1API` parameter must be specified.</maml:para>
             <maml:para>- You cannot report on the permissions of the user authenticated to the API.</maml:para>
             <maml:para>- Reporting on the permissions of the Quota Owner is expected to fail.</maml:para>
-            <maml:para>- Depreciated from CyberArk Version 12.3</maml:para>
+            <maml:para>- Deprecated from CyberArk Version 12.3</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -18542,7 +18542,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           <maml:para>Operation against Gen2 API requires minimum version of 12.2 NOTE for Gen1 Operation : An empty PUT request (update) is sent to retrieve full safe permissions for a user: - `-UseGen1API` parameter must be specified.</maml:para>
           <maml:para>- You cannot report on the permissions of the user authenticated to the API.</maml:para>
           <maml:para>- Reporting on the permissions of the Quota Owner is expected to fail.</maml:para>
-          <maml:para>- Depreciated from CyberArk Version 12.3</maml:para>
+          <maml:para>- Deprecated from CyberArk Version 12.3</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -18692,7 +18692,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <dev:code>Get-PASSafeMember -SafeName Target_Safe -MemberName SomeUser -UseGen1API</dev:code>
         <dev:remarks>
           <maml:para>Lists all permissions for member SomeUser on Target_Safe using Gen1 API</maml:para>
-          <maml:para>Depreciated from CyberArk Version 12.3</maml:para>
+          <maml:para>Deprecated from CyberArk Version 12.3</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -18718,7 +18718,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
     </command:details>
     <maml:description>
       <maml:para>Gets configuration details of logo displayed in the SafeShare WebGUI</maml:para>
-      <maml:para>Depreciated from version 13.2</maml:para>
+      <maml:para>Deprecated from version 13.2</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -19980,7 +19980,7 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
           <maml:description>
             <maml:para>Yes/No value, dictating if the account will be scheduled for immediate change.</maml:para>
             <maml:para>Specify Yes to initiate a password change by CPM - Relevant for Gen1 API only.</maml:para>
-            <maml:para>Depreciated from version 13.2</maml:para>
+            <maml:para>Deprecated from version 13.2</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -20394,7 +20394,7 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
         <maml:description>
           <maml:para>Yes/No value, dictating if the account will be scheduled for immediate change.</maml:para>
           <maml:para>Specify Yes to initiate a password change by CPM - Relevant for Gen1 API only.</maml:para>
-          <maml:para>Depreciated from version 13.2</maml:para>
+          <maml:para>Deprecated from version 13.2</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -20483,7 +20483,7 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
         <dev:code>Invoke-PASCPMOperation -AccountID $ID -ChangeTask -ImmediateChangeByCPM Yes</dev:code>
         <dev:remarks>
           <maml:para>Marks an account for immediate change using the Gen1 API</maml:para>
-          <maml:para>Depreciated from version 13.2</maml:para>
+          <maml:para>Deprecated from version 13.2</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -798,6 +798,7 @@ Add-PASAccount -address domain -userName ThisUser -platformID UNIXVIASSHCERTIFIC
     </command:details>
     <maml:description>
       <maml:para>Adds a new privileged command rule to an account.</maml:para>
+      <maml:para>Not supported in Privilege Cloud</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -5989,6 +5990,7 @@ Add-PASDiscoveredAccount -UserName ServiceUser -Address 1.2.3.4 -discoveryDate (
     </command:details>
     <maml:description>
       <maml:para>Adds a new privileged command rule to a policy.</maml:para>
+      <maml:para>Not supported in Privilege Cloud</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -9455,6 +9457,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
     </command:details>
     <maml:description>
       <maml:para>Performs Logoff and removes the Vault session.</maml:para>
+      <maml:para>Shared authentication is supported in Privilege Cloud</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -12082,6 +12085,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
     </command:details>
     <maml:description>
       <maml:para>Gets list of all privileged commands associated with an account</maml:para>
+      <maml:para>Not supported in Privilege Cloud</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -15680,6 +15684,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
     </command:details>
     <maml:description>
       <maml:para>Gets a list of the privileged commands (OPM Rules) associated with this policy</maml:para>
+      <maml:para>Not supported in Privilege Cloud</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -19841,6 +19846,7 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
       <maml:para>Accounts Can be flagged for immediate verification, change or reconcile.</maml:para>
       <maml:para>CPM Change Options: - Flags a managed account credentials for an immediate CPM password change.   - The "Initiate CPM password management operations" permission is required. - Sets a password to use for an account's next CPM change.   - The "Initiate CPM password management operations" &amp; "Specify next password value" permission is required. - Updates the account's password only in the Vault (without affecting the credentials on the target device).   - The "Update password value" permission is required.</maml:para>
       <maml:para>Verify &amp; Reconcile both require "Initiate CPM password management operations"</maml:para>
+      <maml:para>Gen 1 Verify is not supported in Privilege Cloud</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -19943,6 +19949,7 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
           <maml:description>
             <maml:para>Specify to force verification via Gen1 API.</maml:para>
             <maml:para>Should be specified for versions earlier than 10.1</maml:para>
+            <maml:para>Gen 1 Verify is not supported in Privilege Cloud</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -20448,6 +20455,7 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
         <maml:description>
           <maml:para>Specify to force verification via Gen1 API.</maml:para>
           <maml:para>Should be specified for versions earlier than 10.1</maml:para>
+          <maml:para>Gen 1 Verify is not supported in Privilege Cloud</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -25141,6 +25149,7 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
       <maml:para>Use the -UseGen1API switch parameter to target the Gen1 API endpoint.</maml:para>
       <maml:para>Windows authentication requires at least CyberArk PAS version 10.4</maml:para>
       <maml:para>LDAP, RADIUS, SAML, and shared authentication all require a minimum CyberArk version of 9.7.</maml:para>
+      <maml:para>Shared authentication is not supported in Privilege Cloud.</maml:para>
       <maml:para>Versions of CyberArk prior to 9.7: - only the CyberArk authentication mechanism is supported.</maml:para>
       <maml:para>- newPassword Parameter is not supported.</maml:para>
       <maml:para>- useRadiusAuthentication Parameter is not supported.</maml:para>
@@ -29416,6 +29425,7 @@ Publish-PASDiscoveredAccount -id 66_6 -PlatformID WinDomain -safeName SomeSafe -
     </command:details>
     <maml:description>
       <maml:para>Deletes privileged commands rule associated with account</maml:para>
+      <maml:para>Not supported in Privilege Cloud</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -31234,6 +31244,7 @@ Publish-PASDiscoveredAccount -id 66_6 -PlatformID WinDomain -safeName SomeSafe -
     </command:details>
     <maml:description>
       <maml:para>Deletes all privileged command rules associated with the policy</maml:para>
+      <maml:para>Not supported in Privilege Cloud</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -32440,6 +32451,7 @@ Publish-PASDiscoveredAccount -id 66_6 -PlatformID WinDomain -safeName SomeSafe -
           <maml:description>
             <maml:para>Specify to force usage the Gen1 API endpoint.</maml:para>
             <maml:para>Should be specified for versions earlier than 12.2</maml:para>
+            <maml:para>Is not supported for Privilege Cloud</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -32503,6 +32515,7 @@ Publish-PASDiscoveredAccount -id 66_6 -PlatformID WinDomain -safeName SomeSafe -
         <maml:description>
           <maml:para>Specify to force usage the Gen1 API endpoint.</maml:para>
           <maml:para>Should be specified for versions earlier than 12.2</maml:para>
+          <maml:para>Is not supported for Privilege Cloud</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -32997,6 +33010,7 @@ Publish-PASDiscoveredAccount -id 66_6 -PlatformID WinDomain -safeName SomeSafe -
       <maml:para>Updates an existing accounts details.</maml:para>
       <maml:para>Default operation using the Gen2 API requires minimum version fo 10.4</maml:para>
       <maml:para>When using the Gen1 API:</maml:para>
+      <maml:para>- It is not supported in Privilege Cloud</maml:para>
       <maml:para>- All of the account's property details MUST be passed to the function.</maml:para>
       <maml:para>- Any current properties of the account not sent as part of the request will be removed</maml:para>
       <maml:para>from the account. - To change a property value not exposed via a named parameter, pass the property name and updated value to the function via the Properties parameter. - If changing the name or folder of a service account that has multiple dependencies (usages), the connection between it and its dependencies will be automatically maintained. - If changing the name or folder of an account that is linked to another account (whether logon, reconciliation or verification), the links will be automatically updated.</maml:para>
@@ -33590,7 +33604,7 @@ Set-PASAccount -AccountID 27_4 -operations $actions</dev:code>
         <dev:code>Set-PASAccount -AccountID 21_3 -Folder Root -AccountName NewName `
 -DeviceType Database -PlatformID Oracle -Address dbServer.domain.com -UserName DBUser</dev:code>
         <dev:remarks>
-          <maml:para>Will set the AccountName of account with AccountID of 21_3 to "NewName". Any/All additional properties of the account which are not specified via parameters will be cleared</maml:para>
+          <maml:para>Will set the AccountName of account with AccountID of 21_3 to "NewName". Any/All additional properties of the account which are not specified via parameters will be cleared Not supported in Privilege Cloud</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -38525,8 +38525,6 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
     </command:details>
     <maml:description>
       <maml:para>Updates an existing user in the vault.</maml:para>
-      <maml:para>Appears to require all properties set on a user to be passed with the request.</maml:para>
-      <maml:para>Not passing a value to an already set property will result in it being cleared.</maml:para>
       <maml:para>Default operation using the Gen2 API requires minimum version of 11.1</maml:para>
     </maml:description>
     <command:syntax>
@@ -39995,9 +39993,44 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
     <command:examples>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+        <dev:code>Set-PASUser -id 41 -username Bill -ExpiryDate (get-date).AddDays(5)</dev:code>
+        <dev:remarks>
+          <maml:para>Sets ExpiryDate on Bill's vault user</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
+        <dev:code>Set-PASUser -id 41 -username Bill -unAuthorizedInterfaces PACLI,GUI</dev:code>
+        <dev:remarks>
+          <maml:para>Sets unAuthorizedInterfaces on Bill's vault user</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 3 --------------------------</maml:title>
+        <dev:code>Set-PASUser -id 41 -username Bill -pagerNumber ""</dev:code>
+        <dev:remarks>
+          <maml:para>Clears the pagerNumber property on Bill's vault user</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 4 --------------------------</maml:title>
+        <dev:code>Set-PASUser -id 41 -username Bill -unAuthorizedInterfaces @()</dev:code>
+        <dev:remarks>
+          <maml:para>Clears the unAuthorizedInterfaces property on Bill's vault user</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 5 --------------------------</maml:title>
         <dev:code>Set-PASUser -UserName Bill -Disabled $true</dev:code>
         <dev:remarks>
           <maml:para>Disables vault user Bill</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 6 --------------------------</maml:title>
+        <dev:code>Set-PASUser -id 41 -username Bill -ExpiryDate (get-date 1/1/1970)</dev:code>
+        <dev:remarks>
+          <maml:para>Clear ExpiryDate on Bill's vault user</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -15750,7 +15750,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
     </command:details>
     <maml:description>
       <maml:para>Returns the details of recordings of PSM, PSMP or OPM sessions.</maml:para>
-      <maml:para>By default, recordings from the last 24 hours are returned. - When specifying `ToTime` without `FromTime`, recordings from the 24 hours before `ToTime` are returned.</maml:para>
+      <maml:para>By default, recordings from the last 48 hours are returned. - When specifying `ToTime` without `FromTime`, recordings from the 48 hours before `ToTime` are returned.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -15835,7 +15835,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>ToTime</maml:name>
           <maml:description>
-            <maml:para>Returns recordings from a specific date - When specifying `ToTime` without `FromTime`, recordings from the 24 hours prior to `ToTime` are returned.</maml:para>
+            <maml:para>Returns recordings from a specific date - When specifying `ToTime` without `FromTime`, recordings from the 48 hours prior to `ToTime` are returned.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">DateTime</command:parameterValue>
           <dev:type>
@@ -15936,7 +15936,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>ToTime</maml:name>
         <maml:description>
-          <maml:para>Returns recordings from a specific date - When specifying `ToTime` without `FromTime`, recordings from the 24 hours prior to `ToTime` are returned.</maml:para>
+          <maml:para>Returns recordings from a specific date - When specifying `ToTime` without `FromTime`, recordings from the 48 hours prior to `ToTime` are returned.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">DateTime</command:parameterValue>
         <dev:type>


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description

### Updated
- `Get-PASPSMRecording`
  - In-line with PVWA default operation:
    - Changed the default limit for each page of results to 100, in-line with PVWA default values
    - Updated to return recordings from the last 48 hours by default when `FromTime` & `ToTime` parameters are not specified.
  - When specifying `ToTime` without `FromTime`, recordings from the 48 hours before `ToTime` are returned.
    - This avoids potential for unintentionally long running queries which return details of many recording from the vault.
- `Set-PASUser`
  - Updated to query for, and send, any existing user properties, which are not being specifically updated, with the request.
    - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the user object.
    - This update allows single properties to be updated without having to specify all properties.
  - Allows Empty argument for `unAuthorizedInterfaces` & `vaultAuthorization` parameters to enable set values to be cleared.
  - Corrects ValidateSet for `unAuthorizedInterfaces` parameter.
- `Set-PASSafe`
  - Updated to query for, and send, any existing properties, which are not being specifically updated, with the request.
    - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the object.
    - This update allows single properties to be updated without having to specify all properties.
- `Set-PASOpenIDConnectProvider`
  - Updated to query for, and send, any existing properties, which are not being specifically updated, with the request.
    - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the object.
    - This update allows single properties to be updated without having to specify all properties.
    - Number of mandatory parameters required to be specified has been reduced
- `Set-PASPTARule`
  - Updated to query for, and send, any existing properties, which are not being specifically updated, with the request.
    - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the object.
    - This update allows single properties to be updated without having to specify all properties.
    - Number of mandatory parameters required to be specified has been reduced
- `Set-PASDirectoryMapping`
  - Updated to query for, and send, any existing properties, which are not being specifically updated, with the request.
    - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the object.
    - This update allows single properties to be updated without having to specify all properties.
    - Number of mandatory parameters required to be specified has been reduced
- `New-PASOnboardingRule`
  - Reordered parameters to simplify tab completion options
- `Set-PASOnboardingRule`
  - Updated to query for, and send, any existing properties, which are not being specifically updated, with the request.
    - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the object.
    - This update allows single properties to be updated without having to specify all properties.
    - Number of mandatory parameters required to be specified has been reduced
- `Set-PASPlatformPSMConfig`
  - Updated to query for, and send, any existing properties, which are not being specifically updated, with the request.
    - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the object.
    - This update allows single properties to be updated without having to specify all properties.
    - Number of mandatory parameters required to be specified has been reduced
- `Set-PASSafeMember`
  - Updated to query for, and send, any existing properties, which are not being specifically updated, with the request.
    - Previously, due to the PUT operation used by the API, any properties not specified in a request would be cleared on the object.
    - This update allows single properties to be updated without having to specify all properties.
- `New-PASUser`
  - In-line with update to `Set-PASUser`
    - Allows Empty argument for `unAuthorizedInterfaces` & `vaultAuthorization` parameters.
    - Corrects ValidateSet for `unAuthorizedInterfaces` parameter.
- `Get-PASComponentDetail`
  - Adds assertion that command specifying `PTA` component  must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
- `Add-PASAccountACL`
  - Adds assertion that command must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
- `Get-PASAccountACL`
  - Adds assertion that command must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
- `Remove-PASAccountACL`
  - Adds assertion that command must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
- `Invoke-PASCPMOperation`
  - Adds assertion that Gen1 verify task must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
- `Set-PASAccount`
  - Adds assertion that Gen1 task must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
- `Close-PASSession`
  - Adds assertion that Shared Authentication logoff request is executed against a self hosted implementation as invocation against privilege cloud is not supported.
- `New-PASSession`
  - Adds assertion that Shared Authentication logon request is executed against a self hosted implementation as invocation against privilege cloud is not supported.
- `Add-PASPolicyACL`
  - Adds assertion that command must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
- `Get-PASPolicyACL`
  - Adds assertion that command must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
- `Remove-PASPolicyACL`
  - Adds assertion that command must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
- `Remove-PASSafeMember`
  - Adds assertion that command using Gen1 parameters must be executed against a self hosted implementation as invocation against privilege cloud is not supported.
- `Assert-VersionRequirement`
  - Updates helper function to provide ability to assert if command is being run against self-hosted or privilege cloud implementation.

Closes #528

## Type of change
<!--
Please select all relevant options:
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [X] Documentation update (psPAS website or command help content)
- [X] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [X] Pester test(s) updated
- [X] Pester test(s) passing

**Test Configuration**:
- PowerShell version: 7
- CyberArk PAS version: 14
- OS Version: Win 11

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [X] My code follows the style guidelines of this project
- [X] I have followed the contributing guidelines.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new test failures or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [X] I have linked a related issue