### PR TITLE
Changed name to Set-PASPTASMTP from Add-PASPTASMTP

### DIFF
--- a/Tests/Add-PASPTASMTP.Tests.ps1
+++ b/Tests/Add-PASPTASMTP.Tests.ps1
@@ -1,1 +1,0 @@
-#TODO: Implement tests for Add-PASPTASMTP

--- a/Tests/Set-PASPTASMTP.Tests.ps1
+++ b/Tests/Set-PASPTASMTP.Tests.ps1
@@ -1,0 +1,1 @@
+#TODO: Implement tests for Set-PASPTASMTP

--- a/docs/collections/_commands/Set-PASPTASMTP.md
+++ b/docs/collections/_commands/Set-PASPTASMTP.md
@@ -1,14 +1,14 @@
 ---
 external help file: psPAS-help.xml
 Module Name: psPAS
-online version: https://pspas.pspete.dev/commands/Add-PASPTASMTP
+online version: https://pspas.pspete.dev/commands/Set-PASPTASMTP
 schema: 2.0.0
 ---
 
 # Add-PASPTASMTP
 
 ## SYNOPSIS
-Add an SMTP configuration to PTA
+Sets an SMTP configuration to PTA
 
 ## SYNTAX
 
@@ -166,4 +166,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[https://pspas.pspete.dev/commands/Add-PASPTASMTP](https://pspas.pspete.dev/commands/Add-PASPTASMTP)
+[https://pspas.pspete.dev/commands/Set-PASPTASMTP](https://pspas.pspete.dev/commands/Set-PASPTASMTP)

--- a/psPAS/Functions/PTAAdministration/Set-PASPTASMTP.ps1
+++ b/psPAS/Functions/PTAAdministration/Set-PASPTASMTP.ps1
@@ -1,5 +1,5 @@
 # .ExternalHelp psPAS-help.xml
-Function Add-PASPTASMTP {
+Function Set-PASPTASMTP {
     param(
         [parameter(
             Mandatory = $true,

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -290,7 +290,7 @@
 		'Set-PASTheme',
 		'Add-PASPTASyslog',
 		'Remove-PASPTASyslog',
-		'Add-PASPTASMTP'
+		'Set-PASPTASMTP'
 
 	)
 


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
<!--
Please include a summary of the change and which issue is fixed & relevant motivation and context.
Put `Fixes #XXX` in your comment to link the issue that your PR fixes.
-->

This pull request renames the `Add-PASPTASMTP` command to `Set-PASPTASMTP`
I don't believe there is a DELETE API for SMTP config. I think CyberArk wants you to send a update (put) if you want to make any changes to the SMTP config. This is also seen in PVWA as there is no Delete feature or disable, only update/set. 

## Type of change
<!--
Please select all relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that makes existing functionality work differently)
- [ ] Documentation update (psPAS website or command help content)
- [ ] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [x] Pester test(s) update required
- [ ] Pester test(s) updated
- [ ] Pester test(s) passing

**Test Configuration**:
- PowerShell version: 7
- CyberArk PAS version: 14.6
- OS Version: Windows Server 2022

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [x] My code follows the style guidelines of this project
- [x] I have followed the contributing guidelines.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new test failures or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [ ] I have linked a related issue