### PR TITLE
Added support for Logical Operator to Get-PASAccount and combined PTA APIs to one function

### DIFF
--- a/psPAS/Functions/EventSecurity/Get-PASPTASecurityConfigurationCategory.ps1
+++ b/psPAS/Functions/EventSecurity/Get-PASPTASecurityConfigurationCategory.ps1
@@ -1,5 +1,24 @@
 # .ExternalHelp psPAS-help.xml
 Function Get-PASPTASecurityConfigurationCategory {
+    [CmdletBinding(SupportsShouldProcess = $false, DefaultParameterSetName = 'ListAllCategories')]
+    param(
+        [parameter(
+            Mandatory = $false,
+            ValueFromPipelinebyPropertyName = $false,
+            ParameterSetName = 'ListAllCategories'
+        )]
+        [switch]$ListAllCategories,
+        [parameter(
+            Mandatory = $false,
+            ValueFromPipelinebyPropertyName = $false,
+            ParameterSetName = 'categoryKey'
+        )]
+        [ValidateSet('ActiveDormantUser', 'PrivilegedUsersAndGroups', 'IrregularIpUser', 'SuspectedCredentialsTheft', 'InteractiveLogonWithServiceAccount',
+            'IrregularHoursUser', 'UnmanagedPrivilegedAccess', 'SuspiciousActivityInPSMSession', 'IrregularDaysUser', 'FailedVaultLogonAttempts',
+            'ExcessiveAccessUser', 'SuspiciousPasswordChange')]
+        [Alias('Category')]
+        [string]$categoryKey
+    )
 
     BEGIN {
         Assert-VersionRequirement -SelfHosted
@@ -8,22 +27,47 @@ Function Get-PASPTASecurityConfigurationCategory {
 
     PROCESS {
 
-        #Create request URL
-        $URI = "$($psPASSession.BaseURI)/API/pta/API/configuration/categories"
+        switch ($PSCmdlet.ParameterSetName) {
 
-        #send request to web service
-        $result = Invoke-PASRestMethod -Uri $URI -Method GET
+            'ListAllCategories' {
 
-        If ($null -ne $result) {
+                #Create request URL
+                $URI = "$($psPASSession.BaseURI)/API/pta/API/configuration/categories"
 
-            #Return Results as objects
-            $result | ForEach-Object {
-                [PSCustomObject]@{
-                    Category = $_
+                #send request to web service
+                $result = Invoke-PASRestMethod -Uri $URI -Method GET
+
+                If ($null -ne $result) {
+
+                    #Return Results as objects
+                    $result | ForEach-Object {
+                        [PSCustomObject]@{
+                            Category = $_
+                        }
+                    }
+
                 }
+
+            }
+
+            'categoryKey' {
+
+                #Create URL for Request
+                $URI = "$($psPASSession.BaseURI)/API/pta/API/configuration/categories/$categoryKey"
+
+                #send request to web service
+                $result = Invoke-PASRestMethod -Uri $URI -Method GET
+
+                If ($null -ne $result) {
+
+                    $result 
+
+                }
+
             }
 
         }
+
 
     }#process
 

--- a/psPAS/Private/ConvertTo-FilterString.ps1
+++ b/psPAS/Private/ConvertTo-FilterString.ps1
@@ -58,7 +58,13 @@ Encloses value of the key/value pair in quotes.
 			Mandatory = $false,
 			ValueFromPipeline = $false
 		)]
-		[switch]$QuoteValue
+		[switch]$QuoteValue,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipeline = $false
+		)]
+		[string]$LogicalOperator
 	)
 
 	Begin {
@@ -113,7 +119,12 @@ Encloses value of the key/value pair in quotes.
 
 				If ($FilterList.count -gt 0) {
 
-					@{'filter' = $FilterList -join ' AND ' }
+					# Only use LogicalOperator for API 14.6+, default to AND for older versions
+					if ($ExternalVersion -and $ExternalVersion -ge [version]'14.6') {
+						@{'filter' = $FilterList -join " $LogicalOperator " }
+					} else {
+						@{'filter' = $FilterList -join ' AND ' }
+					}
 
 				}
 			}


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
<!--
Please include a summary of the change and which issue is fixed & relevant motivation and context.
Put `Fixes #XXX` in your comment to link the issue that your PR fixes.
-->

* Added a `LogicalOperator` parameter (with values 'AND' or 'OR') to `Get-PASAccount`, allowing users to specify how multiple filter criteria are combined when querying accounts. This is only applied for API version 14.6 and above. [[1]]
* Updated `ConvertTo-FilterString` to accept the `LogicalOperator` parameter and use it to join filter conditions for API 14.6+, defaulting to 'AND' for older versions. 
* Updated `Get-PASPTASecurityConfigurationCategory` to support two parameter sets: listing all categories or retrieving a specific category by key. By default it will list all.
Reason for this is to reduce the amount of functions for basic APIs. 

## Type of change
<!--
Please select all relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [ ] Documentation update (psPAS website or command help content)
- [ ] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [x] Pester test(s) update required
- [ ] Pester test(s) updated
- [ ] Pester test(s) passing

**Test Configuration**:
- PowerShell version: 7
- CyberArk PAS version: 14.6
- OS Version: Windows Server 2022

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [x] My code follows the style guidelines of this project
- [x] I have followed the contributing guidelines.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new test failures or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [ ] I have linked a related issue