### PR TITLE
Allow membershipExpirationDate value to be null.

### DIFF
--- a/psPAS/Functions/SafeMembers/Set-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Set-PASSafeMember.ps1
@@ -115,7 +115,7 @@ function Set-PASSafeMember {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Full'
 		)]
-		[datetime]$MembershipExpirationDate,
+		[Nullable[datetime]]$MembershipExpirationDate,
 
 		[parameter(
 			Mandatory = $false,
@@ -498,7 +498,7 @@ function Set-PASSafeMember {
 				#Create URL for request
 				$URI = "$($psPASSession.BaseURI)/api/Safes/$($SafeName | Get-EscapedString)/Members/$($MemberName | Get-EscapedString)/"
 
-				if ($PSBoundParameters.ContainsKey('MembershipExpirationDate')) {
+				if (($PSBoundParameters.ContainsKey('MembershipExpirationDate')) -and ($null -ne $MembershipExpirationDate)) {
 
 					#Convert MembershipExpirationDate to string in Required format
 					$Date = Get-Date $MembershipExpirationDate | ConvertTo-UnixTime


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description

I've encountered the same issue as #561. It appears that with at least 14.2, the membershipExpireDate parameter must be supplied on all safe member updates. The Set-PASSafeMember function works if we pass it a date value. However, if you don't actually want a date assigned, you need submit null. This pull request allows use of $null.

Fixes #561 

## Type of change
<!--
Please select all relevant options:
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [ ] Documentation update (psPAS website or command help content)
- [ ] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

Example of not providing parameter:
```
Set-PASSafeMember -SafeName TEST-EXPIRE -MemberName "testuser" -AddAccounts $true

Invoke-PASRestMethod : [400] There are some invalid parameters
ErrorCode=PASWS178E; ErrorMessage=Parameter [MembershipExpirationDate] must be between [0] and [2145830400]; ParameterName=MembershipExpirationDate
At line:551 char:14
+ ...      $result = Invoke-PASRestMethod -Uri $URI -Method PUT -Body $Body
+                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: ({"Details":[{"E...id parameters"}:ErrorRecord) [Invoke-PASRestMethod], Exception
    + FullyQualifiedErrorId : PASWS167E,Invoke-PASRestMethod
```

Example of providing null (or a non-date) with current psPAS:
```
Set-PASSafeMember -SafeName TEST-EXPIRE -MemberName "testuser" -AddAccounts $true -MembershipExpirationDate $null

Set-PASSafeMember : Cannot process argument transformation on parameter 'MembershipExpirationDate'. Cannot convert null to type "System.DateTime".
At line:1 char:117
+ ... "testuser" -AddAccounts $true -MembershipExpirationDate $null
+                                                                     ~~~~~
    + CategoryInfo          : InvalidData: (:) [Set-PASSafeMember], ParameterBindingArgumentTransformationException
    + FullyQualifiedErrorId : ParameterArgumentTransformationError,Set-PASSafeMember
```

- [ ] Pester test(s) update required
- [ ] Pester test(s) updated
- [ ] Pester test(s) passing

**Test Configuration**:
- PowerShell version:
- CyberArk PAS version:
- OS Version:

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [ ] My code follows the style guidelines of this project
- [ ] I have followed the contributing guidelines.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new test failures or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [ ] I have linked a related issue