### PR TITLE
Issue 561

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,23 @@
 
 - N/A
 
+## [7.0.242]
+
+### Added
+
+- N/A
+
+### Updated
+
+- `Set-PASSafeMember`
+  - Updates `MembershipExpirationDate` parameter to be able to accept null as a value to remove expiration date value from a safe member
+    - Thanks (again) [jmk-foofus](https://github.com/jmk-foofus)!
+  - Adds logic to ensure expiration date values are not a negative integer
+
+### Fixed
+
+- N/A
+
 ## [7.0.232]
 
 ### Added

--- a/Tests/Set-PASSafeMember.Tests.ps1
+++ b/Tests/Set-PASSafeMember.Tests.ps1
@@ -1,4 +1,4 @@
-Describe $($PSCommandPath -Replace '.Tests.ps1') {
+Describe $($PSCommandPath -replace '.Tests.ps1') {
 
 	BeforeAll {
 		#Get Current Directory
@@ -224,6 +224,26 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			It 'has a request body with expected number of properties' {
 
 				($Script:RequestBody | Get-Member -MemberType NoteProperty).length | Should -Be 2
+
+			}
+
+			It 'sends null expiration date if negative value returned from get request' {
+
+				Mock Get-PASSafeMember -MockWith {
+					@{
+						'MembershipExpirationDate' = -12345
+					}
+				}
+
+				$InputObj | Set-PASSafeMember
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					($Script:RequestBody).MembershipExpirationDate -eq $null
+
+				} -Scope It
 
 			}
 

--- a/psPAS/Functions/SafeMembers/Set-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Set-PASSafeMember.ps1
@@ -490,6 +490,7 @@ function Set-PASSafeMember {
 				Assert-VersionRequirement -RequiredVersion 12.2
 
 				$safeMember = Get-PASSafeMember -SafeName $SafeName -MemberName $MemberName
+
 				if ($null -ne $safeMember) {
 					Format-PutRequestObject -InputObject $safeMember -boundParameters $BoundParameters -ParametersToRemove safeNumber, memberId,
 					UserName, safeName, isExpiredMembershipEnable, memberName, memberType, safeUrlId, memberType, isPredefinedUser
@@ -498,6 +499,7 @@ function Set-PASSafeMember {
 				#Create URL for request
 				$URI = "$($psPASSession.BaseURI)/api/Safes/$($SafeName | Get-EscapedString)/Members/$($MemberName | Get-EscapedString)/"
 
+				#Convert expiration date if it was passed as a parameter and passed value is not null
 				if (($PSBoundParameters.ContainsKey('MembershipExpirationDate')) -and ($null -ne $MembershipExpirationDate)) {
 
 					#Convert MembershipExpirationDate to string in Required format
@@ -505,6 +507,14 @@ function Set-PASSafeMember {
 
 					#Include date string in request
 					$boundParameters['MembershipExpirationDate'] = $Date
+
+				}
+
+				#Set expiration date in request body to null if negative value returned from existing safe member
+				#This ensures the update does not fail due to an out of range value
+				if ([int]$boundParameters['MembershipExpirationDate'] -lt 0) {
+
+					$boundParameters[('MembershipExpirationDate')] = $null
 
 				}
 


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
### Updated

- `Set-PASSafeMember`
  - Updates `MembershipExpirationDate` parameter to be able to accept null as a value to remove expiration date value from a safe member
    - Thanks (again) [jmk-foofus](https://github.com/jmk-foofus)!
  - Adds logic to ensure expiration date values are not a negative integer

Fixes #561 

## Type of change
<!--
Please select all relevant options:
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [ ] Documentation update (psPAS website or command help content)
- [ ] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [X] Pester test(s) updated
- [X] Pester test(s) passing

**Test Configuration**:
- PowerShell version:
- CyberArk PAS version:
- OS Version:

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [ ] My code follows the style guidelines of this project
- [ ] I have followed the contributing guidelines.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new test failures or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [X] I have linked a related issue