### PR TITLE
Update Set-PASUser documentation and function to allow login hour range from 0 to 24. Also added a missing vaultAuthorization

### DIFF
--- a/docs/collections/_commands/Set-PASUser.md
+++ b/docs/collections/_commands/Set-PASUser.md
@@ -934,7 +934,7 @@ Accept wildcard characters: False
 ### -loginToHour
 The end of the timeframe the user account is permitted to authenticate.
 
-Provide an hour of the day in 24-hour format (0-23)
+Provide an hour of the day in 24-hour format (0-24)
 
 Minimum required version 13.2
 

--- a/psPAS/Functions/LDAPDirectories/New-PASDirectoryMapping.ps1
+++ b/psPAS/Functions/LDAPDirectories/New-PASDirectoryMapping.ps1
@@ -84,7 +84,7 @@ function New-PASDirectoryMapping {
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[AllowEmptyCollection()]
-		[ValidateSet('SAML', 'PKI', 'FIDO', 'WINDOWS')]
+		[ValidateSet('SAML', 'PKI', 'PKIPN', 'FIDO', 'WINDOWS')]
 		[string[]]$allowedAuthenticationMethods
 
 	)

--- a/psPAS/Functions/LDAPDirectories/Set-PASDirectoryMapping.ps1
+++ b/psPAS/Functions/LDAPDirectories/Set-PASDirectoryMapping.ps1
@@ -90,7 +90,7 @@ function Set-PASDirectoryMapping {
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[AllowEmptyCollection()]
-		[ValidateSet('SAML', 'PKI', 'FIDO', 'WINDOWS')]
+		[ValidateSet('SAML', 'PKI', 'PKIPN', 'FIDO', 'WINDOWS')]
 		[string[]]$allowedAuthenticationMethods
 
 	)

--- a/psPAS/Functions/User/New-PASUser.ps1
+++ b/psPAS/Functions/User/New-PASUser.ps1
@@ -407,7 +407,7 @@ function New-PASUser {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Gen2'
 		)]
-		[ValidateSet('SAML', 'PKI', 'FIDO', 'WINDOWS')]
+		[ValidateSet('SAML', 'PKI', 'PKIPN', 'FIDO', 'WINDOWS')]
 		[AllowEmptyCollection()]
 		[string[]]$allowedAuthenticationMethods
 	)

--- a/psPAS/Functions/User/Set-PASUser.ps1
+++ b/psPAS/Functions/User/Set-PASUser.ps1
@@ -56,7 +56,7 @@ function Set-PASUser {
 		)]
 		[AllowEmptyCollection()]
 		[ValidateSet('PIMSU', 'PSM', 'PSMP', 'PVWA', 'WINCLIENT', 'PTA', 'PACLI', 'NAPI', 'XAPI', 'HTTPGW',
-			'EVD', 'CPM', 'PVWAApp', 'PSMApp', 'AppPrv', 'AIMApp', 'PSMPApp', 'GUI')]
+			'EVD', 'CPM', 'PVWAApp', 'PSMApp', 'AppPrv', 'AIMApp', 'PSMPApp', 'GUI', 'IBVSDK')]
 		[string[]]$unAuthorizedInterfaces,
 
 		[parameter(
@@ -177,7 +177,7 @@ function Set-PASUser {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Gen2'
 		)]
-		[ValidateRange(0, 23)]
+		[ValidateRange(0, 24)]
 		[int]$loginToHour,
 
 		[parameter(
@@ -420,7 +420,7 @@ function Set-PASUser {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Gen2'
 		)]
-		[ValidateSet('SAML', 'PKI', 'FIDO', 'WINDOWS')]
+		[ValidateSet('SAML', 'PKI', 'PKIPN', 'FIDO', 'WINDOWS')]
 		[AllowEmptyCollection()]
 		[string[]]$allowedAuthenticationMethods
 	)


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
<!--
Please include a summary of the change and which issue is fixed & relevant motivation and context.
Put `Fixes #XXX` in your comment to link the issue that your PR fixes.
-->


This pull request updates the `Set-PASUser` command and its documentation to fix a issue with `loginToHour` parameter and adds a missing authorized interface option. 
`Set-PASUser -id 22 -userActivityLogRetentionDays 7` does not work if the account is set to 24 as the function is limited to 23 hours (accounts can have 0-24, not 0-23).

* Expanded the valid range for the `loginToHour` parameter from `0-23` to `0-24` in both the code (`Set-PASUser.ps1`) and documentation (`Set-PASUser.md`) 

* Added `IBVSDK` to the list of values for the `unAuthorizedInterfaces` parameter in the `Set-PASUser` function.
Fixes #599

* Added `PKIPN` as a valid value to the `allowedAuthenticationMethods` parameter in the `New-PASDirectoryMapping`, `Set-PASDirectoryMapping`, `New-PASUser`, and `Set-PASUser` functions to support an additional authentication method

## Type of change
<!--
Please select all relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [x] Documentation update (psPAS website or command help content)
- [ ] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [ ] Pester test(s) updated
- [x] Pester test(s) passing

**Test Configuration**:
- PowerShell version: 7
- CyberArk PAS version: 14.6
- OS Version: Windows Server 2022

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [x] My code follows the style guidelines of this project
- [x] I have followed the contributing guidelines.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new test failures or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [ ] I have linked a related issue