### PR TITLE
Fixes bug with LogicalOperator intruduced in V7 of psPAS and CyberARk 14.6

### DIFF
--- a/psPAS/Private/ConvertTo-FilterString.ps1
+++ b/psPAS/Private/ConvertTo-FilterString.ps1
@@ -64,7 +64,7 @@ Encloses value of the key/value pair in quotes.
 			Mandatory = $false,
 			ValueFromPipeline = $false
 		)]
-		[string]$LogicalOperator
+		[string]$LogicalOperator = 'AND'
 	)
 
 	begin {


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
<!--
Please include a summary of the change and which issue is fixed & relevant motivation and context.
Put `Fixes #XXX` in your comment to link the issue that your PR fixes.
-->

Fixes #608 

```powershell

Get-PASGroup -groupName Auditors -groupType Vault

id groupName groupType location members
-- --------- --------- -------- -------
9  Auditors  Vault     \        {}

```

NOTE! 
I have only tested this change on 15.0. 
I have not tested on 14.4 or lower. But those versions should not be impacted by this bug anyway and I expect this fix to not impact them either as its already defaulted to AND anyway.

## Type of change
<!--
Please select all relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [ ] Documentation update (psPAS website or command help content)
- [ ] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [x] Pester test(s) update required
- [ ] Pester test(s) updated
- [ ] Pester test(s) passing

**Test Configuration**:
- PowerShell version: 7
- CyberArk PAS version: 15.0
- OS Version: Windows Server 2022

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [x] My code follows the style guidelines of this project
- [ ] I have followed the contributing guidelines.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new test failures or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have opened & linked a related issue
- [x] I have linked a related issue