### PR TITLE
Add some CyberArk 15.2 feature support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 
 ### Added
 
+- `Resume-PASCPMAutoManagement`
+  - Self-Hosted (15.2+) command to resume CPM auto management for an account
+- `Stop-PASCPMTask`
+  - Self-Hosted (15.2+) command to cancel a pending CPM task for an account
+- `New-PASPlatformSecret`
+  - Self-Hosted (15.2+) command to generate a secret for a platform
 - `Get-PASDiscoveryRuleSet`
   - Privilege Cloud only command to show configured discovery rule sets
 - `New-PASDiscoveryRuleSet`
@@ -24,6 +30,11 @@
 
 ### Updated
 
+- `Set-PASSafe`
+  - Adds `Quota` parameter to set the safe size quota (Self-Hosted 15.2+)
+  - Allows a `NumberOfVersionsRetention` value of `0`
+- `Get-PASVRMServiceStatus`, `Start-PASVRMService`, `Stop-PASVRMService`, `Restart-PASVRMService`
+  - Adds `ENE` as a supported `serviceName` value (requires 15.2+)
 - `Add-PASDependentAccount`
   - Adds logic to work against ISPSS endpoints which use different URL paths to Self-Hosted
 - `Get-PASDependentAccount`

--- a/Tests/Get-PASVRMServiceStatus.Tests.ps1
+++ b/Tests/Get-PASVRMServiceStatus.Tests.ps1
@@ -115,6 +115,18 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$psPASSession.ExternalVersion = '0.0'
 			}
 
+			It 'accepts ENE as a serviceName value' {
+				$psPASSession.ExternalVersion = '15.2'
+				{ Get-PASVRMServiceStatus -serviceName ENE -serverAddress '192.168.1.1' -servicePassword $SecurePassword } | Should -Not -Throw
+				$psPASSession.ExternalVersion = '0.0'
+			}
+
+			It 'throws for ENE serviceName if 15.2 version requirement not met' {
+				$psPASSession.ExternalVersion = '15.1'
+				{ Get-PASVRMServiceStatus -serviceName ENE -serverAddress '192.168.1.1' -servicePassword $SecurePassword } | Should -Throw
+				$psPASSession.ExternalVersion = '0.0'
+			}
+
 		}
 
 		Context 'Output' {

--- a/Tests/New-PASPlatformSecret.Tests.ps1
+++ b/Tests/New-PASPlatformSecret.Tests.ps1
@@ -36,7 +36,6 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	}
 
-
 	AfterAll {
 
 		$Script:RequestBody = $null
@@ -45,33 +44,34 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach {
-			Mock Invoke-PASRestMethod -MockWith { }
-
-			$SecurePassword = ConvertTo-SecureString -String 'P@ssw0rd' -AsPlainText -Force
-
-			$response = Start-PASVRMService -serviceName DR -serverAddress '192.168.1.1' -servicePassword $SecurePassword -Confirm:$false
-
-		}
-
-
 		Context 'Mandatory Parameters' {
 
-			$Parameters = @{Parameter = 'serviceName' }, @{Parameter = 'serverAddress' }, @{Parameter = 'servicePassword' }
+			$Parameters = @{Parameter = 'Platformid' }
 
 			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
-				(Get-Command Start-PASVRMService).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
+				(Get-Command New-PASPlatformSecret).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-
-
 		Context 'Input' {
+
+			BeforeEach {
+
+				Mock Invoke-PASRestMethod -MockWith { }
+
+				$InputObj = [pscustomobject]@{
+					'id' = 'SomeID'
+				}
+
+				$psPASSession.ExternalVersion = '0.0'
+				$response = $InputObj | New-PASPlatformSecret
+
+			}
 
 			It 'sends request' {
 
@@ -83,7 +83,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:psPASSession.BaseURI)/API/VaultActions/SetServiceStatus/Start"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Platforms/SomeID/GenerateSecret/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -95,34 +95,33 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			}
 
-			It 'sends request with expected body' {
-
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-
-					$Script:RequestBody = $Body | ConvertFrom-Json
-
-					($Script:RequestBody.serviceName) -ne $null
-
-				} -Times 1 -Exactly -Scope It
-
-			}
-
 			It 'throws error if version requirement not met' {
 				$psPASSession.ExternalVersion = '1.0'
-				{ Start-PASVRMService -serviceName DR -serverAddress '192.168.1.1' -servicePassword $SecurePassword -Confirm:$false } | Should -Throw
+				{ $InputObj | New-PASPlatformSecret } | Should -Throw
 				$psPASSession.ExternalVersion = '0.0'
 			}
 
-			It 'accepts ENE as a serviceName value' {
-				$psPASSession.ExternalVersion = '15.2'
-				{ Start-PASVRMService -serviceName ENE -serverAddress '192.168.1.1' -servicePassword $SecurePassword -Confirm:$false } | Should -Not -Throw
+		}
+
+		Context 'Output' {
+
+			BeforeEach {
+
+				Mock Invoke-PASRestMethod -MockWith { }
+
+				$InputObj = [pscustomobject]@{
+					'id' = 'SomeID'
+				}
+
 				$psPASSession.ExternalVersion = '0.0'
+				$response = $InputObj | New-PASPlatformSecret
+
 			}
 
-			It 'throws for ENE serviceName if 15.2 version requirement not met' {
-				$psPASSession.ExternalVersion = '15.1'
-				{ Start-PASVRMService -serviceName ENE -serverAddress '192.168.1.1' -servicePassword $SecurePassword -Confirm:$false } | Should -Throw
-				$psPASSession.ExternalVersion = '0.0'
+			It 'provides no output' {
+
+				$response | Should -BeNullOrEmpty
+
 			}
 
 		}

--- a/Tests/Restart-PASVRMService.Tests.ps1
+++ b/Tests/Restart-PASVRMService.Tests.ps1
@@ -113,6 +113,18 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$psPASSession.ExternalVersion = '0.0'
 			}
 
+			It 'accepts ENE as a serviceName value' {
+				$psPASSession.ExternalVersion = '15.2'
+				{ Restart-PASVRMService -serviceName ENE -serverAddress '192.168.1.1' -servicePassword $SecurePassword -Confirm:$false } | Should -Not -Throw
+				$psPASSession.ExternalVersion = '0.0'
+			}
+
+			It 'throws for ENE serviceName if 15.2 version requirement not met' {
+				$psPASSession.ExternalVersion = '15.1'
+				{ Restart-PASVRMService -serviceName ENE -serverAddress '192.168.1.1' -servicePassword $SecurePassword -Confirm:$false } | Should -Throw
+				$psPASSession.ExternalVersion = '0.0'
+			}
+
 		}
 
 	}

--- a/Tests/Resume-PASCPMAutoManagement.Tests.ps1
+++ b/Tests/Resume-PASCPMAutoManagement.Tests.ps1
@@ -36,7 +36,6 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	}
 
-
 	AfterAll {
 
 		$Script:RequestBody = $null
@@ -45,33 +44,34 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach {
-			Mock Invoke-PASRestMethod -MockWith { }
-
-			$SecurePassword = ConvertTo-SecureString -String 'P@ssw0rd' -AsPlainText -Force
-
-			$response = Start-PASVRMService -serviceName DR -serverAddress '192.168.1.1' -servicePassword $SecurePassword -Confirm:$false
-
-		}
-
-
 		Context 'Mandatory Parameters' {
 
-			$Parameters = @{Parameter = 'serviceName' }, @{Parameter = 'serverAddress' }, @{Parameter = 'servicePassword' }
+			$Parameters = @{Parameter = 'Accountid' }
 
 			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
-				(Get-Command Start-PASVRMService).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
+				(Get-Command Resume-PASCPMAutoManagement).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-
-
 		Context 'Input' {
+
+			BeforeEach {
+
+				Mock Invoke-PASRestMethod -MockWith { }
+
+				$InputObj = [pscustomobject]@{
+					'id' = 'SomeID'
+				}
+
+				$psPASSession.ExternalVersion = '0.0'
+				$response = $InputObj | Resume-PASCPMAutoManagement
+
+			}
 
 			It 'sends request' {
 
@@ -83,7 +83,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:psPASSession.BaseURI)/API/VaultActions/SetServiceStatus/Start"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Accounts/SomeID/Resume/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -95,34 +95,33 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			}
 
-			It 'sends request with expected body' {
-
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-
-					$Script:RequestBody = $Body | ConvertFrom-Json
-
-					($Script:RequestBody.serviceName) -ne $null
-
-				} -Times 1 -Exactly -Scope It
-
-			}
-
 			It 'throws error if version requirement not met' {
 				$psPASSession.ExternalVersion = '1.0'
-				{ Start-PASVRMService -serviceName DR -serverAddress '192.168.1.1' -servicePassword $SecurePassword -Confirm:$false } | Should -Throw
+				{ $InputObj | Resume-PASCPMAutoManagement } | Should -Throw
 				$psPASSession.ExternalVersion = '0.0'
 			}
 
-			It 'accepts ENE as a serviceName value' {
-				$psPASSession.ExternalVersion = '15.2'
-				{ Start-PASVRMService -serviceName ENE -serverAddress '192.168.1.1' -servicePassword $SecurePassword -Confirm:$false } | Should -Not -Throw
+		}
+
+		Context 'Output' {
+
+			BeforeEach {
+
+				Mock Invoke-PASRestMethod -MockWith { }
+
+				$InputObj = [pscustomobject]@{
+					'id' = 'SomeID'
+				}
+
 				$psPASSession.ExternalVersion = '0.0'
+				$response = $InputObj | Resume-PASCPMAutoManagement
+
 			}
 
-			It 'throws for ENE serviceName if 15.2 version requirement not met' {
-				$psPASSession.ExternalVersion = '15.1'
-				{ Start-PASVRMService -serviceName ENE -serverAddress '192.168.1.1' -servicePassword $SecurePassword -Confirm:$false } | Should -Throw
-				$psPASSession.ExternalVersion = '0.0'
+			It 'provides no output' {
+
+				$response | Should -BeNullOrEmpty
+
 			}
 
 		}

--- a/Tests/Set-PASSafe.Tests.ps1
+++ b/Tests/Set-PASSafe.Tests.ps1
@@ -61,64 +61,6 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 
 
-		Context 'Input-Gen1' {
-
-			BeforeEach {
-				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{'UpdateSafeResult' = [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' } }
-				}
-
-				$InputObj = [pscustomobject]@{
-					'SafeName' = 'SomeName'
-
-				}
-				Mock Get-PASSafe -MockWith {}
-				$response = $InputObj | Set-PASSafe -NumberOfDaysRetention 1 -ManagingCPM SomeCPM -NewSafeName SomeNewName -UseGen1API
-
-			}
-
-			It 'sends request' {
-
-				Assert-MockCalled Invoke-PASRestMethod -Scope It
-
-			}
-
-			It 'sends request to expected endpoint' {
-
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-
-					$URI -eq "$($Script:psPASSession.BaseURI)/WebServices/PIMServices.svc/Safes/SomeName"
-
-				} -Times 1 -Scope It
-
-			}
-
-			It 'uses expected method' {
-
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'PUT' } -Times 1 -Scope It
-
-			}
-
-			It 'sends request with expected body' {
-
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-
-					$Script:RequestBody = $Body | ConvertFrom-Json
-
-					($Script:RequestBody.safe) -ne $null
-
-				} -Scope It
-
-			}
-
-			It 'has a request body with expected number of properties' {
-
-				($Script:RequestBody.safe | Get-Member -MemberType NoteProperty).length | Should -Be 3
-
-			}
-
-		}
-
 		Context 'Input-Gen2' {
 
 			BeforeEach {
@@ -179,44 +121,6 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 		}
 
-		Context 'Output-Gen1' {
-
-			BeforeEach {
-				Mock Invoke-PASRestMethod -MockWith {
-					[PSCustomObject]@{'UpdateSafeResult' = [PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' } }
-				}
-
-				$InputObj = [pscustomobject]@{
-					'SafeName' = 'SomeName'
-
-				}
-
-				$response = $InputObj | Set-PASSafe -NumberOfDaysRetention 1 -ManagingCPM SomeCPM -NewSafeName SomeNewName -UseGen1API
-
-			}
-
-			It 'provides output' {
-
-				$response | Should -Not -BeNullOrEmpty
-
-			}
-
-			It 'has output with expected number of properties' {
-
-				($response | Get-Member -MemberType NoteProperty).length | Should -Be 2
-
-			}
-
-			It 'outputs object with expected typename' {
-
-				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Safe
-
-			}
-
-
-
-		}
-
 		Context 'Output-Gen2' {
 
 			BeforeEach {
@@ -252,6 +156,60 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			}
 
 
+
+		}
+
+		Context 'Quota' {
+
+			BeforeEach {
+				Mock Invoke-PASRestMethod -MockWith {
+					[PSCustomObject]@{'Prop1' = 'Val1'; 'Prop2' = 'Val2' }
+				}
+
+				$InputObj = [pscustomobject]@{
+					'SafeName' = 'SomeName'
+
+				}
+				Mock Get-PASSafe -MockWith {}
+
+				$psPASSession.ExternalVersion = '0.0'
+				$response = $InputObj | Set-PASSafe -Quota 500
+
+			}
+
+			It 'sends request to expected endpoint' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Safes/SomeName"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'sends request with expected Quota value in body' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$Script:RequestBody = $Body | ConvertFrom-Json
+
+					$Script:RequestBody.Quota -eq 500
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'accepts a NumberOfVersionsRetention value of 0' {
+
+				{ $InputObj | Set-PASSafe -NumberOfVersionsRetention 0 } | Should -Not -Throw
+
+			}
+
+			It 'throws if Quota specified and 15.2 version requirement not met' {
+				$psPASSession.ExternalVersion = '15.1'
+				{ $InputObj | Set-PASSafe -Quota 500 } | Should -Throw
+				$psPASSession.ExternalVersion = '0.0'
+			}
 
 		}
 

--- a/Tests/Stop-PASCPMTask.Tests.ps1
+++ b/Tests/Stop-PASCPMTask.Tests.ps1
@@ -36,7 +36,6 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	}
 
-
 	AfterAll {
 
 		$Script:RequestBody = $null
@@ -45,33 +44,34 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach {
-			Mock Invoke-PASRestMethod -MockWith { }
-
-			$SecurePassword = ConvertTo-SecureString -String 'P@ssw0rd' -AsPlainText -Force
-
-			$response = Start-PASVRMService -serviceName DR -serverAddress '192.168.1.1' -servicePassword $SecurePassword -Confirm:$false
-
-		}
-
-
 		Context 'Mandatory Parameters' {
 
-			$Parameters = @{Parameter = 'serviceName' }, @{Parameter = 'serverAddress' }, @{Parameter = 'servicePassword' }
+			$Parameters = @{Parameter = 'Accountid' }
 
 			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
-				(Get-Command Start-PASVRMService).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
+				(Get-Command Stop-PASCPMTask).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
 
 			}
 
 		}
 
-
-
 		Context 'Input' {
+
+			BeforeEach {
+
+				Mock Invoke-PASRestMethod -MockWith { }
+
+				$InputObj = [pscustomobject]@{
+					'id' = 'SomeID'
+				}
+
+				$psPASSession.ExternalVersion = '0.0'
+				$response = $InputObj | Stop-PASCPMTask
+
+			}
 
 			It 'sends request' {
 
@@ -83,7 +83,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$URI -eq "$($Script:psPASSession.BaseURI)/API/VaultActions/SetServiceStatus/Start"
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Accounts/SomeID/Cancel/"
 
 				} -Times 1 -Exactly -Scope It
 
@@ -95,34 +95,33 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			}
 
-			It 'sends request with expected body' {
-
-				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-
-					$Script:RequestBody = $Body | ConvertFrom-Json
-
-					($Script:RequestBody.serviceName) -ne $null
-
-				} -Times 1 -Exactly -Scope It
-
-			}
-
 			It 'throws error if version requirement not met' {
 				$psPASSession.ExternalVersion = '1.0'
-				{ Start-PASVRMService -serviceName DR -serverAddress '192.168.1.1' -servicePassword $SecurePassword -Confirm:$false } | Should -Throw
+				{ $InputObj | Stop-PASCPMTask } | Should -Throw
 				$psPASSession.ExternalVersion = '0.0'
 			}
 
-			It 'accepts ENE as a serviceName value' {
-				$psPASSession.ExternalVersion = '15.2'
-				{ Start-PASVRMService -serviceName ENE -serverAddress '192.168.1.1' -servicePassword $SecurePassword -Confirm:$false } | Should -Not -Throw
+		}
+
+		Context 'Output' {
+
+			BeforeEach {
+
+				Mock Invoke-PASRestMethod -MockWith { }
+
+				$InputObj = [pscustomobject]@{
+					'id' = 'SomeID'
+				}
+
 				$psPASSession.ExternalVersion = '0.0'
+				$response = $InputObj | Stop-PASCPMTask
+
 			}
 
-			It 'throws for ENE serviceName if 15.2 version requirement not met' {
-				$psPASSession.ExternalVersion = '15.1'
-				{ Start-PASVRMService -serviceName ENE -serverAddress '192.168.1.1' -servicePassword $SecurePassword -Confirm:$false } | Should -Throw
-				$psPASSession.ExternalVersion = '0.0'
+			It 'provides no output' {
+
+				$response | Should -BeNullOrEmpty
+
 			}
 
 		}

--- a/Tests/Stop-PASVRMService.Tests.ps1
+++ b/Tests/Stop-PASVRMService.Tests.ps1
@@ -113,6 +113,18 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$psPASSession.ExternalVersion = '0.0'
 			}
 
+			It 'accepts ENE as a serviceName value' {
+				$psPASSession.ExternalVersion = '15.2'
+				{ Stop-PASVRMService -serviceName ENE -serverAddress '192.168.1.1' -servicePassword $SecurePassword -Confirm:$false } | Should -Not -Throw
+				$psPASSession.ExternalVersion = '0.0'
+			}
+
+			It 'throws for ENE serviceName if 15.2 version requirement not met' {
+				$psPASSession.ExternalVersion = '15.1'
+				{ Stop-PASVRMService -serviceName ENE -serverAddress '192.168.1.1' -servicePassword $SecurePassword -Confirm:$false } | Should -Throw
+				$psPASSession.ExternalVersion = '0.0'
+			}
+
 		}
 
 	}

--- a/docs/collections/_commands/Get-PASVRMServiceStatus.md
+++ b/docs/collections/_commands/Get-PASVRMServiceStatus.md
@@ -54,7 +54,9 @@ Accept wildcard characters: False
 
 ### -serviceName
 The name of the service to check status for.
-Supported services: Vault, DR
+Supported services: Vault, DR, ENE
+
+The ENE service requires CyberArk version 15.2 or higher.
 
 ```yaml
 Type: String
@@ -111,6 +113,21 @@ Required: True
 Position: 5
 Default value: None
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/collections/_commands/New-PASPlatformSecret.md
+++ b/docs/collections/_commands/New-PASPlatformSecret.md
@@ -1,0 +1,111 @@
+---
+external help file: psPAS-help.xml
+Module Name: psPAS
+online version: https://pspas.pspete.dev/commands/New-PASPlatformSecret
+schema: 2.0.0
+title: New-PASPlatformSecret
+---
+
+# New-PASPlatformSecret
+
+## SYNOPSIS
+Generates a secret for a platform.
+
+## SYNTAX
+
+```
+New-PASPlatformSecret [-Platformid] <String> [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+Generates a new secret for a specific platform.
+
+Requires CyberArk Self-Hosted version 15.2 or higher.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> New-PASPlatformSecret -Platformid SomePlatform
+```
+
+Generates a secret for the platform with id SomePlatform.
+
+## PARAMETERS
+
+### -Platformid
+The unique id of the platform to generate a secret for.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: id
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS
+
+[https://pspas.pspete.dev/commands/New-PASPlatformSecret](https://pspas.pspete.dev/commands/New-PASPlatformSecret)

--- a/docs/collections/_commands/Restart-PASVRMService.md
+++ b/docs/collections/_commands/Restart-PASVRMService.md
@@ -55,7 +55,9 @@ Accept wildcard characters: False
 
 ### -serviceName
 The name of the service to restart.
-Supported services: Vault, DR
+Supported services: Vault, DR, ENE
+
+The ENE service requires CyberArk version 15.2 or higher.
 
 ```yaml
 Type: String
@@ -146,7 +148,15 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -WhatIf
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/docs/collections/_commands/Resume-PASCPMAutoManagement.md
+++ b/docs/collections/_commands/Resume-PASCPMAutoManagement.md
@@ -1,0 +1,80 @@
+---
+external help file: psPAS-help.xml
+Module Name: psPAS
+online version: https://pspas.pspete.dev/commands/Resume-PASCPMAutoManagement
+schema: 2.0.0
+title: Resume-PASCPMAutoManagement
+---
+
+# Resume-PASCPMAutoManagement
+
+## SYNOPSIS
+Resumes CPM auto management for an account.
+
+## SYNTAX
+
+```
+Resume-PASCPMAutoManagement [-Accountid] <String> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Resumes automatic password management by the CPM for a specific account whose management was previously suspended.
+
+Requires CyberArk Self-Hosted version 15.2 or higher.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Resume-PASCPMAutoManagement -Accountid 123_4
+```
+
+Resumes CPM auto management for account with id 123_4.
+
+## PARAMETERS
+
+### -Accountid
+The unique id of the account to resume CPM auto management for.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: id
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS
+
+[https://pspas.pspete.dev/commands/Resume-PASCPMAutoManagement](https://pspas.pspete.dev/commands/Resume-PASCPMAutoManagement)

--- a/docs/collections/_commands/Set-PASSafe.md
+++ b/docs/collections/_commands/Set-PASSafe.md
@@ -17,29 +17,15 @@ Updates a safe in the Vault
 ### Gen2-NumberOfDaysRetention (Default)
 ```
 Set-PASSafe -SafeName <String> [-NewSafeName <String>] [-Description <String>] [-location <String>]
- [-OLACEnabled <Boolean>] [-ManagingCPM <String>] [-NumberOfDaysRetention <Int32>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-OLACEnabled <Boolean>] [-ManagingCPM <String>] [-NumberOfDaysRetention <Int32>] [-Quota <Int32>]
+ [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Gen2-NumberOfVersionsRetention
 ```
 Set-PASSafe -SafeName <String> [-NewSafeName <String>] [-Description <String>] [-location <String>]
- [-OLACEnabled <Boolean>] [-ManagingCPM <String>] [-NumberOfVersionsRetention <Int32>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
-```
-
-### Gen1-NumberOfVersionsRetention
-```
-Set-PASSafe -SafeName <String> [-NewSafeName <String>] [-Description <String>] [-OLACEnabled <Boolean>]
- [-ManagingCPM <String>] [-NumberOfVersionsRetention <Int32>] [-UseGen1API] [-WhatIf] [-Confirm]
- [<CommonParameters>]
-```
-
-### Gen1-NumberOfDaysRetention
-```
-Set-PASSafe -SafeName <String> [-NewSafeName <String>] [-Description <String>] [-OLACEnabled <Boolean>]
- [-ManagingCPM <String>] [-NumberOfDaysRetention <Int32>] [-UseGen1API] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-OLACEnabled <Boolean>] [-ManagingCPM <String>] [-NumberOfVersionsRetention <Int32>] [-Quota <Int32>]
+ [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -59,10 +45,12 @@ Minimum required version 12.2
 
 ### EXAMPLE 2
 ```
-Set-PASSafe -SafeName SAFE -Description "New-Description" -NumberOfDaysRetention 10 -UseGen1API
+Set-PASSafe -SafeName SAFE -Quota 500
 ```
 
-Updates description and number of days retention on SAFE using Gen1 API
+Updates the size quota (in MB) of SAFE
+
+Minimum required version 15.2 (Self-Hosted)
 
 ## PARAMETERS
 
@@ -158,7 +146,7 @@ Specify either this parameter or NumberOfDaysRetention.
 
 ```yaml
 Type: Int32
-Parameter Sets: Gen2-NumberOfVersionsRetention, Gen1-NumberOfVersionsRetention
+Parameter Sets: Gen2-NumberOfVersionsRetention
 Aliases:
 
 Required: False
@@ -177,7 +165,7 @@ Specify either this parameter or NumberOfVersionsRetention
 
 ```yaml
 Type: Int32
-Parameter Sets: Gen2-NumberOfDaysRetention, Gen1-NumberOfDaysRetention
+Parameter Sets: Gen2-NumberOfDaysRetention
 Aliases:
 
 Required: False
@@ -225,7 +213,7 @@ Minimum required version 12.2
 
 ```yaml
 Type: String
-Parameter Sets: Gen2-NumberOfDaysRetention, Gen2-NumberOfVersionsRetention
+Parameter Sets: (All)
 Aliases:
 
 Required: False
@@ -235,17 +223,32 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -UseGen1API
-Specify to force usage the Gen1 API endpoint.
-
-Should be specified for versions earlier than 12.2
+### -ProgressAction
+{{ Fill ProgressAction Description }}
 
 ```yaml
-Type: SwitchParameter
-Parameter Sets: Gen1-NumberOfVersionsRetention, Gen1-NumberOfDaysRetention
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Quota
+The size quota, in MB, allocated to the safe.
+
+Requires CyberArk Self-Hosted version 15.2 or higher.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)

--- a/docs/collections/_commands/Start-PASVRMService.md
+++ b/docs/collections/_commands/Start-PASVRMService.md
@@ -55,7 +55,9 @@ Accept wildcard characters: False
 
 ### -serviceName
 The name of the service to start.
-Supported services: Vault, DR
+Supported services: Vault, DR, ENE
+
+The ENE service requires CyberArk version 15.2 or higher.
 
 ```yaml
 Type: String
@@ -146,7 +148,15 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -WhatIf
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/docs/collections/_commands/Stop-PASCPMTask.md
+++ b/docs/collections/_commands/Stop-PASCPMTask.md
@@ -1,0 +1,111 @@
+---
+external help file: psPAS-help.xml
+Module Name: psPAS
+online version: https://pspas.pspete.dev/commands/Stop-PASCPMTask
+schema: 2.0.0
+title: Stop-PASCPMTask
+---
+
+# Stop-PASCPMTask
+
+## SYNOPSIS
+Cancels a pending CPM task for an account.
+
+## SYNTAX
+
+```
+Stop-PASCPMTask [-Accountid] <String> [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+Cancels an in-progress or pending CPM operation (such as a change, verify or reconcile task) for a specific account.
+
+Requires CyberArk Self-Hosted version 15.2 or higher.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Stop-PASCPMTask -Accountid 123_4
+```
+
+Cancels the pending CPM task for account with id 123_4.
+
+## PARAMETERS
+
+### -Accountid
+The unique id of the account to cancel the pending CPM task for.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: id
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS
+
+[https://pspas.pspete.dev/commands/Stop-PASCPMTask](https://pspas.pspete.dev/commands/Stop-PASCPMTask)

--- a/docs/collections/_commands/Stop-PASVRMService.md
+++ b/docs/collections/_commands/Stop-PASVRMService.md
@@ -55,7 +55,9 @@ Accept wildcard characters: False
 
 ### -serviceName
 The name of the service to stop.
-Supported services: Vault, DR
+Supported services: Vault, DR, ENE
+
+The ENE service requires CyberArk version 15.2 or higher.
 
 ```yaml
 Type: String
@@ -146,7 +148,15 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -WhatIf
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/docs/collections/_pages/commands.md
+++ b/docs/collections/_pages/commands.md
@@ -75,6 +75,8 @@ A psPAS command may not appear in the below list due to it not being explicitly 
 [Change credentials, set next password][Change credentials, set next password]              | [Invoke-PASCPMOperation][Invoke-PASCPMOperation]
 [Change credentials in Vault][Change credentials in Vault]                                  | [Invoke-PASCPMOperation][Invoke-PASCPMOperation]
 [Reconcile credentials][Reconcile credentials]                                              | [Invoke-PASCPMOperation][Invoke-PASCPMOperation]
+[Resume CPM auto management][Resume CPM auto management]                                     | [Resume-PASCPMAutoManagement][Resume-PASCPMAutoManagement]
+[Cancel CPM task][Cancel CPM task]                                                           | [Stop-PASCPMTask][Stop-PASCPMTask]
 [Get directories][Get directories]                                                          | [Get-PASDirectory][Get-PASDirectory]
 [Get directory details][Get directory details]                                              | [Get-PASDirectory][Get-PASDirectory]
 [Create directory][Create directory]                                                        | [Add-PASDirectory][Add-PASDirectory]
@@ -125,6 +127,7 @@ A psPAS command may not appear in the below list due to it not being explicitly 
 [Get session management policy of platform][Get session management policy of platform]      | [Get-PASPlatformPSMConfig][Get-PASPlatformPSMConfig]
 [Update session management policy of platform][Update session management policy of platform]| [Set-PASPlatformPSMConfig][Set-PASPlatformPSMConfig]
 [Get safes by platform ID][Get safes by platform ID]                                        | [Get-PASPlatformSafe][Get-PASPlatformSafe]
+[Generate platform secret][Generate platform secret]                                        | [New-PASPlatformSecret][New-PASPlatformSecret]
 [Get OPM rules][Get OPM rules]                                                              | [Get-PASPolicyACL][Get-PASPolicyACL]
 [Add OPM policy][Add OPM policy]                                                            | [Add-PASPolicyACL][Add-PASPolicyACL]
 [Delete OPM policy][Delete OPM policy]                                                      | [Remove-PASPolicyACL][Remove-PASPolicyACL]
@@ -416,6 +419,9 @@ A psPAS command may not appear in the below list due to it not being explicitly 
 [Remove-PASDirectory]:/commands/Remove-PASDirectory
 [Find-PASSafe]:/commands/Find-PASSafe
 [Invoke-PASCPMOperation]:/commands/Invoke-PASCPMOperation
+[Resume-PASCPMAutoManagement]:/commands/Resume-PASCPMAutoManagement
+[Stop-PASCPMTask]:/commands/Stop-PASCPMTask
+[New-PASPlatformSecret]:/commands/New-PASPlatformSecret
 [Set-PASDirectoryMappingOrder]:/commands/Set-PASDirectoryMappingOrder
 [Set-PASUserPassword]:/commands/Set-PASUserPassword
 [Disable-PASCPMAutoManagement]:/commands/Disable-PASCPMAutoManagement
@@ -673,6 +679,9 @@ A psPAS command may not appear in the below list due to it not being explicitly 
 [Change credentials, set next password]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/SetNextPassword.htm
 [Change credentials in Vault]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/ChangeCredentialsInVault.htm
 [Reconcile credentials]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Reconcile-account.htm
+[Resume CPM auto management]:https://pspas.pspete.dev/commands/Resume-PASCPMAutoManagement
+[Cancel CPM task]:https://pspas.pspete.dev/commands/Stop-PASCPMTask
+[Generate platform secret]:https://pspas.pspete.dev/commands/New-PASPlatformSecret
 [Add discovered accounts - Gen 1]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Add%20Discovered%20Account%20v10.8.htm
 [Get discovered accounts]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Get-discovered-accounts.htm
 [Get discovered account details]:https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/Get-discovered-account-details.htm

--- a/psPAS/Functions/Accounts/Resume-PASCPMAutoManagement.ps1
+++ b/psPAS/Functions/Accounts/Resume-PASCPMAutoManagement.ps1
@@ -1,0 +1,29 @@
+# .ExternalHelp psPAS-help.xml
+function Resume-PASCPMAutoManagement {
+    [CmdletBinding()]
+    param(
+        [parameter(
+            Mandatory = $true,
+            ValueFromPipelinebyPropertyName = $true
+        )]
+        [Alias('id')]
+        [string]$Accountid
+    )
+
+    begin {
+        Assert-VersionRequirement -SelfHosted
+        Assert-VersionRequirement -RequiredVersion 15.2
+    }#begin
+
+    process {
+
+        #Create URL for request
+        $URI = "$($psPASSession.BaseURI)/API/Accounts/$Accountid/Resume/"
+
+        Invoke-PASRestMethod -Uri $URI -Method POST
+
+    }#process
+
+    end { }#end
+
+}

--- a/psPAS/Functions/Accounts/Stop-PASCPMTask.ps1
+++ b/psPAS/Functions/Accounts/Stop-PASCPMTask.ps1
@@ -1,0 +1,33 @@
+# .ExternalHelp psPAS-help.xml
+function Stop-PASCPMTask {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [parameter(
+            Mandatory = $true,
+            ValueFromPipelinebyPropertyName = $true
+        )]
+        [Alias('id')]
+        [string]$Accountid
+    )
+
+    begin {
+        Assert-VersionRequirement -SelfHosted
+        Assert-VersionRequirement -RequiredVersion 15.2
+    }#begin
+
+    process {
+
+        #Create URL for request
+        $URI = "$($psPASSession.BaseURI)/API/Accounts/$Accountid/Cancel/"
+
+        if ($PSCmdlet.ShouldProcess($Accountid, 'Cancel CPM Task')) {
+
+            Invoke-PASRestMethod -Uri $URI -Method POST
+
+        }
+
+    }#process
+
+    end { }#end
+
+}

--- a/psPAS/Functions/Platforms/New-PASPlatformSecret.ps1
+++ b/psPAS/Functions/Platforms/New-PASPlatformSecret.ps1
@@ -1,0 +1,33 @@
+# .ExternalHelp psPAS-help.xml
+function New-PASPlatformSecret {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [parameter(
+            Mandatory = $true,
+            ValueFromPipelinebyPropertyName = $true
+        )]
+        [Alias('id')]
+        [string]$Platformid
+    )
+
+    begin {
+        Assert-VersionRequirement -SelfHosted
+        Assert-VersionRequirement -RequiredVersion 15.2
+    }#begin
+
+    process {
+
+        #Create URL for request
+        $URI = "$($psPASSession.BaseURI)/API/Platforms/$Platformid/GenerateSecret/"
+
+        if ($PSCmdlet.ShouldProcess($Platformid, 'Generate Platform Secret')) {
+
+            Invoke-PASRestMethod -Uri $URI -Method POST
+
+        }
+
+    }#process
+
+    end { }#end
+
+}

--- a/psPAS/Functions/Safes/Set-PASSafe.ps1
+++ b/psPAS/Functions/Safes/Set-PASSafe.ps1
@@ -57,12 +57,7 @@ function Set-PASSafe {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Gen2-NumberOfVersionsRetention'
 		)]
-		[parameter(
-			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = 'Gen1-NumberOfVersionsRetention'
-		)]
-		[ValidateRange(1, 999)]
+		[ValidateRange(0, 999)]
 		[int]$NumberOfVersionsRetention,
 
 		[Parameter(
@@ -70,29 +65,20 @@ function Set-PASSafe {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Gen2-NumberOfDaysRetention'
 		)]
-		[parameter(
-			Mandatory = $false,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = 'Gen1-NumberOfDaysRetention'
-		)]
 		[ValidateRange(0, 3650)]
 		[int]$NumberOfDaysRetention,
 
-		[parameter(
-			Mandatory = $true,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = 'Gen1-NumberOfVersionsRetention'
+		[Parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
 		)]
-		[parameter(
-			Mandatory = $true,
-			ValueFromPipelinebyPropertyName = $true,
-			ParameterSetName = 'Gen1-NumberOfDaysRetention'
-		)]
-		[switch]$UseGen1API
-
+		[ValidateNotNullOrEmpty()]
+		[int]$Quota
 	)
 
-	begin { }#begin
+	begin {
+		Assert-VersionRequirement -RequiredVersion 12.2
+	}#begin
 
 	process {
 
@@ -103,7 +89,7 @@ function Set-PASSafe {
 		$SafeObject = Get-PASSafe -SafeName $SafeName
 		if ($null -ne $SafeObject) {
 			Format-PutRequestObject -InputObject $SafeObject -boundParameters $BoundParameters -ParametersToKeep ManagingCPM, location, Description,
-			NumberOfVersionsRetention, NumberOfDaysRetention
+			NumberOfVersionsRetention, NumberOfDaysRetention, Quota
 		}
 
 		switch ($PSBoundParameters.Keys) {
@@ -116,45 +102,30 @@ function Set-PASSafe {
 			'NumberOfVersionsRetention' {
 				$BoundParameters.Remove('NumberOfDaysRetention')
 			}
+			'Quota' {
+				Assert-VersionRequirement -SelfHosted
+				Assert-VersionRequirement -RequiredVersion 15.2
+				continue
+			}
 		}
 
-		switch ($PSCmdlet.ParameterSetName) {
 
-			( { $PSItem -match '^Gen2-' } ) {
+		$typename = "$typename.Gen2"
 
-				Assert-VersionRequirement -RequiredVersion 12.2
-
-				$typename = "$typename.Gen2"
-
-				#Create URL for Request
-				$URI = "$($psPASSession.BaseURI)/api/Safes/$($SafeName | Get-EscapedString)"
-
-				#Create Request Body
-				$body = $BoundParameters | ConvertTo-Json
-
-				break
-
+		# Convert quota values with an MB suffix to numeric values in the request body
+		if ($BoundParameters.ContainsKey('Quota')) {
+			$quotaValue = $BoundParameters['Quota']
+			if ($quotaValue -is [string]) {
+				$BoundParameters['Quota'] = [int]$Matches.value
 			}
-
-			( { $PSItem -match '^Gen1-' } ) {
-
-				Assert-VersionRequirement -MaximumVersion 12.3
-
-				#Create URL for Request
-				$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Safes/$($SafeName | Get-EscapedString)"
-
-				#Create Request Body
-				$body = @{
-
-					'safe' = $BoundParameters
-
-				} | ConvertTo-Json
-
-				break
-
-			}
-
 		}
+
+		#Create URL for Request
+		$URI = "$($psPASSession.BaseURI)/api/Safes/$($SafeName | Get-EscapedString)"
+
+		#Create Request Body
+		$body = $BoundParameters | ConvertTo-Json
+
 
 		if ($PSCmdlet.ShouldProcess($SafeName, 'Update Safe Properties')) {
 
@@ -163,25 +134,7 @@ function Set-PASSafe {
 
 			if ($null -ne $result) {
 
-				switch ($PSCmdlet.ParameterSetName) {
-
-					( { $PSItem -match '^Gen1-' } ) {
-
-						$return = $result.UpdateSafeResult
-
-						break
-
-					}
-
-					default {
-
-						$return = $result
-
-						break
-
-					}
-
-				}
+				$return = $result
 
 				$return | Add-ObjectDetail -typename $typename
 

--- a/psPAS/Functions/VaultRemoteManager/Get-PASVRMServiceStatus.ps1
+++ b/psPAS/Functions/VaultRemoteManager/Get-PASVRMServiceStatus.ps1
@@ -13,7 +13,7 @@ function Get-PASVRMServiceStatus {
             ValueFromPipelineByPropertyName = $true
         )]
         [ValidateNotNullOrEmpty()]
-        [ValidateSet('Vault', 'DR')]
+        [ValidateSet('Vault', 'DR', 'ENE')]
         [string]$serviceName,
 
         [parameter(
@@ -50,6 +50,10 @@ function Get-PASVRMServiceStatus {
         #Use the BaseURI from the session (New-PASSession) if not provided
         if (-not $PSBoundParameters.ContainsKey('BaseURI')) {
             $BaseURI = $psPASSession.BaseURI
+        }
+
+        if ($serviceName -eq 'ENE') {
+            Assert-VersionRequirement -RequiredVersion 15.2
         }
 
         #Create URL for request

--- a/psPAS/Functions/VaultRemoteManager/Restart-PASVRMService.ps1
+++ b/psPAS/Functions/VaultRemoteManager/Restart-PASVRMService.ps1
@@ -13,7 +13,7 @@ function Restart-PASVRMService {
             ValueFromPipelineByPropertyName = $true
         )]
         [ValidateNotNullOrEmpty()]
-        [ValidateSet('Vault', 'DR')]
+        [ValidateSet('Vault', 'DR', 'ENE')]
         [string]$serviceName,
 
         [parameter(
@@ -50,6 +50,10 @@ function Restart-PASVRMService {
         #Use the BaseURI from the session (New-PASSession) if not provided
         if (-not $PSBoundParameters.ContainsKey('BaseURI')) {
             $BaseURI = $psPASSession.BaseURI
+        }
+
+        if ($serviceName -eq 'ENE') {
+            Assert-VersionRequirement -RequiredVersion 15.2
         }
 
         #Create URL for request

--- a/psPAS/Functions/VaultRemoteManager/Start-PASVRMService.ps1
+++ b/psPAS/Functions/VaultRemoteManager/Start-PASVRMService.ps1
@@ -13,7 +13,7 @@ function Start-PASVRMService {
             ValueFromPipelineByPropertyName = $true
         )]
         [ValidateNotNullOrEmpty()]
-        [ValidateSet('Vault', 'DR')]
+        [ValidateSet('Vault', 'DR', 'ENE')]
         [string]$serviceName,
 
         [parameter(
@@ -50,6 +50,10 @@ function Start-PASVRMService {
         #Use the BaseURI from the session (New-PASSession) if not provided
         if (-not $PSBoundParameters.ContainsKey('BaseURI')) {
             $BaseURI = $psPASSession.BaseURI
+        }
+
+        if ($serviceName -eq 'ENE') {
+            Assert-VersionRequirement -RequiredVersion 15.2
         }
 
         #Create URL for request

--- a/psPAS/Functions/VaultRemoteManager/Stop-PASVRMService.ps1
+++ b/psPAS/Functions/VaultRemoteManager/Stop-PASVRMService.ps1
@@ -13,7 +13,7 @@ function Stop-PASVRMService {
             ValueFromPipelineByPropertyName = $true
         )]
         [ValidateNotNullOrEmpty()]
-        [ValidateSet('Vault', 'DR')]
+        [ValidateSet('Vault', 'DR', 'ENE')]
         [string]$serviceName,
 
         [parameter(
@@ -50,6 +50,10 @@ function Stop-PASVRMService {
         #Use the BaseURI from the session (New-PASSession) if not provided
         if (-not $PSBoundParameters.ContainsKey('BaseURI')) {
             $BaseURI = $psPASSession.BaseURI
+        }
+
+        if ($serviceName -eq 'ENE') {
+            Assert-VersionRequirement -RequiredVersion 15.2
         }
 
         #Create URL for request

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -23628,7 +23628,7 @@ PS C:\&gt; Get-PASVRMDRSystemHealth -DRAddress dr-vault.company.com -servicePass
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
           <maml:name>servicePassword</maml:name>
           <maml:description>
-            <maml:para>Seems like Administrator is the only allowed username? https://docs.cyberark.com/pam-self-hosted/15.0/en/content/pasimp/vault-remote-manager.htm#Configurationrequirements REST API docs however doesnt mention this so we leave it as a parameter with default value with the option to change it.</maml:para>
+            <maml:para>The PARAgent password as a SecureString</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
           <dev:type>
@@ -23703,7 +23703,7 @@ PS C:\&gt; Get-PASVRMDRSystemHealth -DRAddress dr-vault.company.com -servicePass
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
         <maml:name>servicePassword</maml:name>
         <maml:description>
-          <maml:para>Seems like Administrator is the only allowed username? https://docs.cyberark.com/pam-self-hosted/15.0/en/content/pasimp/vault-remote-manager.htm#Configurationrequirements REST API docs however doesnt mention this so we leave it as a parameter with default value with the option to change it.</maml:para>
+          <maml:para>The PARAgent password as a SecureString</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
         <dev:type>
@@ -23767,7 +23767,8 @@ PS C:\&gt; Get-PASVRMServiceConfigParameter -parameterName 'ReplicationInterval'
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
           <maml:name>serviceName</maml:name>
           <maml:description>
-            <maml:para>The name of the service to check status for. Supported services: Vault, DR</maml:para>
+            <maml:para>The name of the service to check status for. Supported services: Vault, DR, ENE</maml:para>
+            <maml:para>The ENE service requires CyberArk version 15.2 or higher.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -23812,6 +23813,18 @@ PS C:\&gt; Get-PASVRMServiceConfigParameter -parameterName 'ReplicationInterval'
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
@@ -23830,7 +23843,8 @@ PS C:\&gt; Get-PASVRMServiceConfigParameter -parameterName 'ReplicationInterval'
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
         <maml:name>serviceName</maml:name>
         <maml:description>
-          <maml:para>The name of the service to check status for. Supported services: Vault, DR</maml:para>
+          <maml:para>The name of the service to check status for. Supported services: Vault, DR, ENE</maml:para>
+          <maml:para>The ENE service requires CyberArk version 15.2 or higher.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -23871,6 +23885,18 @@ PS C:\&gt; Get-PASVRMServiceConfigParameter -parameterName 'ReplicationInterval'
         <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
         <dev:type>
           <maml:name>SecureString</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -25340,7 +25366,7 @@ PS C:\&gt; Get-PASVRMServiceStatus -serviceName Vault -serverAddress vault.compa
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
           <maml:name>servicePassword</maml:name>
           <maml:description>
-            <maml:para>Seems like Administrator is the only allowed username? https://docs.cyberark.com/pam-self-hosted/15.0/en/content/pasimp/vault-remote-manager.htm#Configurationrequirements REST API docs however doesnt mention this so we leave it as a parameter with default value with the option to change it.</maml:para>
+            <maml:para>The PARAgent password as a SecureString</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
           <dev:type>
@@ -25413,7 +25439,7 @@ PS C:\&gt; Get-PASVRMServiceStatus -serviceName Vault -serverAddress vault.compa
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
         <maml:name>servicePassword</maml:name>
         <maml:description>
-          <maml:para>Seems like Administrator is the only allowed username? https://docs.cyberark.com/pam-self-hosted/15.0/en/content/pasimp/vault-remote-manager.htm#Configurationrequirements REST API docs however doesnt mention this so we leave it as a parameter with default value with the option to change it.</maml:para>
+          <maml:para>The PARAgent password as a SecureString</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
         <dev:type>
@@ -27598,6 +27624,161 @@ PS C:\&gt; Invoke-PASVRMFailover -DRAddress dr-vault.company.com -servicePasswor
       <maml:navigationLink>
         <maml:linkText>https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/AddAutomaticOnboardingRule.htm</maml:linkText>
         <maml:uri>https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/WebServices/AddAutomaticOnboardingRule.htm</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>New-PASPlatformSecret</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>PASPlatformSecret</command:noun>
+      <maml:description>
+        <maml:para>Generates a secret for a platform.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Generates a new secret for a specific platform.</maml:para>
+      <maml:para>Requires CyberArk Self-Hosted version 15.2 or higher.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>New-PASPlatformSecret</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="id">
+          <maml:name>Platformid</maml:name>
+          <maml:description>
+            <maml:para>The unique id of the platform to generate a secret for.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="id">
+        <maml:name>Platformid</maml:name>
+        <maml:description>
+          <maml:para>The unique id of the platform to generate a secret for.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+        <maml:name>WhatIf</maml:name>
+        <maml:description>
+          <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; New-PASPlatformSecret -Platformid SomePlatform</dev:code>
+        <dev:remarks>
+          <maml:para>Generates a secret for the platform with id SomePlatform.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>https://pspas.pspete.dev/commands/New-PASPlatformSecret</maml:linkText>
+        <maml:uri>https://pspas.pspete.dev/commands/New-PASPlatformSecret</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -41576,7 +41757,8 @@ Publish-PASDiscoveredAccount -id 66_6 -PlatformID WinDomain -safeName SomeSafe -
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
           <maml:name>serviceName</maml:name>
           <maml:description>
-            <maml:para>The name of the service to restart. Supported services: Vault, DR</maml:para>
+            <maml:para>The name of the service to restart. Supported services: Vault, DR, ENE</maml:para>
+            <maml:para>The ENE service requires CyberArk version 15.2 or higher.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -41612,7 +41794,7 @@ Publish-PASDiscoveredAccount -id 66_6 -PlatformID WinDomain -safeName SomeSafe -
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
           <maml:name>servicePassword</maml:name>
           <maml:description>
-            <maml:para>Seems like Administrator is the only allowed username? https://docs.cyberark.com/pam-self-hosted/15.0/en/content/pasimp/vault-remote-manager.htm#Configurationrequirements REST API docs however doesnt mention this so we leave it as a parameter with default value with the option to change it.</maml:para>
+            <maml:para>The PARAgent password as a SecureString</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
           <dev:type>
@@ -41643,6 +41825,18 @@ Publish-PASDiscoveredAccount -id 66_6 -PlatformID WinDomain -safeName SomeSafe -
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
@@ -41661,7 +41855,8 @@ Publish-PASDiscoveredAccount -id 66_6 -PlatformID WinDomain -safeName SomeSafe -
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
         <maml:name>serviceName</maml:name>
         <maml:description>
-          <maml:para>The name of the service to restart. Supported services: Vault, DR</maml:para>
+          <maml:para>The name of the service to restart. Supported services: Vault, DR, ENE</maml:para>
+          <maml:para>The ENE service requires CyberArk version 15.2 or higher.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -41697,7 +41892,7 @@ Publish-PASDiscoveredAccount -id 66_6 -PlatformID WinDomain -safeName SomeSafe -
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
         <maml:name>servicePassword</maml:name>
         <maml:description>
-          <maml:para>Seems like Administrator is the only allowed username? https://docs.cyberark.com/pam-self-hosted/15.0/en/content/pasimp/vault-remote-manager.htm#Configurationrequirements REST API docs however doesnt mention this so we leave it as a parameter with default value with the option to change it.</maml:para>
+          <maml:para>The PARAgent password as a SecureString</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
         <dev:type>
@@ -41730,14 +41925,14 @@ Publish-PASDiscoveredAccount -id 66_6 -PlatformID WinDomain -safeName SomeSafe -
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="false" position="named" aliases="none">
-        <maml:name>WhatIf</maml:name>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
         <maml:description>
-          <maml:para>Position: Named Default value: None Accept pipeline input: False Accept wildcard characters: False ```</maml:para>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
         </maml:description>
-        <command:parameterValue required="true" variableLength="false"></command:parameterValue>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
         <dev:type>
-          <maml:name></maml:name>
+          <maml:name>ActionPreference</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -41764,6 +41959,115 @@ PS C:\&gt; Restart-PASVRMService -serviceName DR -serverAddress dr-vault.company
       <maml:navigationLink>
         <maml:linkText>Online Version:</maml:linkText>
         <maml:uri>https://pspas.pspete.dev/commands/Restart-PASVRMService</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Resume-PASCPMAutoManagement</command:name>
+      <command:verb>Resume</command:verb>
+      <command:noun>PASCPMAutoManagement</command:noun>
+      <maml:description>
+        <maml:para>Resumes CPM auto management for an account.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Resumes automatic password management by the CPM for a specific account whose management was previously suspended.</maml:para>
+      <maml:para>Requires CyberArk Self-Hosted version 15.2 or higher.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Resume-PASCPMAutoManagement</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="id">
+          <maml:name>Accountid</maml:name>
+          <maml:description>
+            <maml:para>The unique id of the account to resume CPM auto management for.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="id">
+        <maml:name>Accountid</maml:name>
+        <maml:description>
+          <maml:para>The unique id of the account to resume CPM auto management for.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; Resume-PASCPMAutoManagement -Accountid 123_4</dev:code>
+        <dev:remarks>
+          <maml:para>Resumes CPM auto management for account with id 123_4.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>https://pspas.pspete.dev/commands/Resume-PASCPMAutoManagement</maml:linkText>
+        <maml:uri>https://pspas.pspete.dev/commands/Resume-PASCPMAutoManagement</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -47358,120 +47662,30 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-      </command:syntaxItem>
-      <command:syntaxItem>
-        <maml:name>Set-PASSafe</maml:name>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
-          <maml:name>SafeName</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
           <maml:description>
-            <maml:para>The name of the safe to update. - Max Length 28 characters.</maml:para>
-            <maml:para>- Cannot start with a space.</maml:para>
-            <maml:para>- Cannot contain: '\','/',':','*','&lt;','&gt;','"','.' or '|'</maml:para>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
           <dev:type>
-            <maml:name>String</maml:name>
+            <maml:name>ActionPreference</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
-          <maml:name>NewSafeName</maml:name>
+          <maml:name>Quota</maml:name>
           <maml:description>
-            <maml:para>A name to rename the safe to - Max Length 28 characters.</maml:para>
-            <maml:para>- Cannot start with a space.</maml:para>
-            <maml:para>- Cannot contain: '\','/',':','*','&lt;','&gt;','"','.' or '|'</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
-          <maml:name>Description</maml:name>
-          <maml:description>
-            <maml:para>Updated Description for safe.</maml:para>
-            <maml:para>Max 100 characters.</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>OLACEnabled</maml:name>
-          <maml:description>
-            <maml:para>Boolean value, dictating whether or not to enable Object Level Access Control on the safe.</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
-          <dev:type>
-            <maml:name>Boolean</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
-          <maml:name>ManagingCPM</maml:name>
-          <maml:description>
-            <maml:para>The Name of the CPM user to manage the safe.</maml:para>
-            <maml:para>Specify "" to prevent CPM management.</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
-          <maml:name>NumberOfVersionsRetention</maml:name>
-          <maml:description>
-            <maml:para>The number of retained versions of every password that is stored in the Safe. - Max value = 999 Specify either this parameter or NumberOfDaysRetention.</maml:para>
+            <maml:para>The size quota, in MB, allocated to the safe.</maml:para>
+            <maml:para>Requires CyberArk Self-Hosted version 15.2 or higher.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
             <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
-          <dev:defaultValue>0</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
-          <maml:name>WhatIf</maml:name>
-          <maml:description>
-            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
-          </maml:description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
-          <maml:name>Confirm</maml:name>
-          <maml:description>
-            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
-          </maml:description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
-          <maml:name>UseGen1API</maml:name>
-          <maml:description>
-            <maml:para>Specify to force usage the Gen1 API endpoint.</maml:para>
-            <maml:para>Should be specified for versions earlier than 12.2</maml:para>
-          </maml:description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
+          <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
@@ -47592,123 +47806,30 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-      </command:syntaxItem>
-      <command:syntaxItem>
-        <maml:name>Set-PASSafe</maml:name>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
-          <maml:name>SafeName</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
           <maml:description>
-            <maml:para>The name of the safe to update. - Max Length 28 characters.</maml:para>
-            <maml:para>- Cannot start with a space.</maml:para>
-            <maml:para>- Cannot contain: '\','/',':','*','&lt;','&gt;','"','.' or '|'</maml:para>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
           <dev:type>
-            <maml:name>String</maml:name>
+            <maml:name>ActionPreference</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
-          <maml:name>NewSafeName</maml:name>
+          <maml:name>Quota</maml:name>
           <maml:description>
-            <maml:para>A name to rename the safe to - Max Length 28 characters.</maml:para>
-            <maml:para>- Cannot start with a space.</maml:para>
-            <maml:para>- Cannot contain: '\','/',':','*','&lt;','&gt;','"','.' or '|'</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
-          <maml:name>Description</maml:name>
-          <maml:description>
-            <maml:para>Updated Description for safe.</maml:para>
-            <maml:para>Max 100 characters.</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>OLACEnabled</maml:name>
-          <maml:description>
-            <maml:para>Boolean value, dictating whether or not to enable Object Level Access Control on the safe.</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">Boolean</command:parameterValue>
-          <dev:type>
-            <maml:name>Boolean</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
-          <maml:name>ManagingCPM</maml:name>
-          <maml:description>
-            <maml:para>The Name of the CPM user to manage the safe.</maml:para>
-            <maml:para>Specify "" to prevent CPM management.</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
-          <maml:name>NumberOfDaysRetention</maml:name>
-          <maml:description>
-            <maml:para>The number of days for which password versions are saved in the Safe.</maml:para>
-            <maml:para>- Minimum Value: 0</maml:para>
-            <maml:para>- Maximum Value: 3650</maml:para>
-            <maml:para>Specify either this parameter or NumberOfVersionsRetention</maml:para>
+            <maml:para>The size quota, in MB, allocated to the safe.</maml:para>
+            <maml:para>Requires CyberArk Self-Hosted version 15.2 or higher.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
             <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
-          <dev:defaultValue>0</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
-          <maml:name>WhatIf</maml:name>
-          <maml:description>
-            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
-          </maml:description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
-          <maml:name>Confirm</maml:name>
-          <maml:description>
-            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
-          </maml:description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
-          <maml:name>UseGen1API</maml:name>
-          <maml:description>
-            <maml:para>Specify to force usage the Gen1 API endpoint.</maml:para>
-            <maml:para>Should be specified for versions earlier than 12.2</maml:para>
-          </maml:description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
+          <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
       </command:syntaxItem>
     </command:syntax>
@@ -47843,18 +47964,30 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
-        <maml:name>UseGen1API</maml:name>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
         <maml:description>
-          <maml:para>Specify to force usage the Gen1 API endpoint.</maml:para>
-          <maml:para>Should be specified for versions earlier than 12.2</maml:para>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
         <dev:type>
-          <maml:name>SwitchParameter</maml:name>
+          <maml:name>ActionPreference</maml:name>
           <maml:uri />
         </dev:type>
-        <dev:defaultValue>False</dev:defaultValue>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>Quota</maml:name>
+        <maml:description>
+          <maml:para>The size quota, in MB, allocated to the safe.</maml:para>
+          <maml:para>Requires CyberArk Self-Hosted version 15.2 or higher.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes />
@@ -47875,9 +48008,10 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
       </command:example>
       <command:example>
         <maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
-        <dev:code>Set-PASSafe -SafeName SAFE -Description "New-Description" -NumberOfDaysRetention 10 -UseGen1API</dev:code>
+        <dev:code>Set-PASSafe -SafeName SAFE -Quota 500</dev:code>
         <dev:remarks>
-          <maml:para>Updates description and number of days retention on SAFE using Gen1 API</maml:para>
+          <maml:para>Updates the size quota (in MB) of SAFE</maml:para>
+          <maml:para>Minimum required version 15.2 (Self-Hosted)</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -51292,7 +51426,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
           <maml:name>loginToHour</maml:name>
           <maml:description>
             <maml:para>The end of the timeframe the user account is permitted to authenticate.</maml:para>
-            <maml:para>Provide an hour of the day in 24-hour format (0-23)</maml:para>
+            <maml:para>Provide an hour of the day in 24-hour format (0-24)</maml:para>
             <maml:para>Minimum required version 13.2</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
@@ -52146,7 +52280,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         <maml:name>loginToHour</maml:name>
         <maml:description>
           <maml:para>The end of the timeframe the user account is permitted to authenticate.</maml:para>
-          <maml:para>Provide an hour of the day in 24-hour format (0-23)</maml:para>
+          <maml:para>Provide an hour of the day in 24-hour format (0-24)</maml:para>
           <maml:para>Minimum required version 13.2</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
@@ -52467,7 +52601,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
           <maml:name>servicePassword</maml:name>
           <maml:description>
-            <maml:para>Seems like Administrator is the only allowed username? https://docs.cyberark.com/pam-self-hosted/15.0/en/content/pasimp/vault-remote-manager.htm#Configurationrequirements REST API docs however doesnt mention this so we leave it as a parameter with default value with the option to change it.</maml:para>
+            <maml:para>The PARAgent password as a SecureString</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
           <dev:type>
@@ -52564,7 +52698,7 @@ Set-PASPlatformPSMConfig -ID 52 -PSMServerID PSM-LoadBalancer-EMEA -PSMConnector
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
         <maml:name>servicePassword</maml:name>
         <maml:description>
-          <maml:para>Seems like Administrator is the only allowed username? https://docs.cyberark.com/pam-self-hosted/15.0/en/content/pasimp/vault-remote-manager.htm#Configurationrequirements REST API docs however doesnt mention this so we leave it as a parameter with default value with the option to change it.</maml:para>
+          <maml:para>The PARAgent password as a SecureString</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
         <dev:type>
@@ -52803,7 +52937,8 @@ Start-PASAccountImportJob -source "SomeSource" -accountsList $Accounts</dev:code
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
           <maml:name>serviceName</maml:name>
           <maml:description>
-            <maml:para>The name of the service to start. Supported services: Vault, DR</maml:para>
+            <maml:para>The name of the service to start. Supported services: Vault, DR, ENE</maml:para>
+            <maml:para>The ENE service requires CyberArk version 15.2 or higher.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -52839,7 +52974,7 @@ Start-PASAccountImportJob -source "SomeSource" -accountsList $Accounts</dev:code
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
           <maml:name>servicePassword</maml:name>
           <maml:description>
-            <maml:para>Seems like Administrator is the only allowed username? https://docs.cyberark.com/pam-self-hosted/15.0/en/content/pasimp/vault-remote-manager.htm#Configurationrequirements REST API docs however doesnt mention this so we leave it as a parameter with default value with the option to change it.</maml:para>
+            <maml:para>The PARAgent password as a SecureString</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
           <dev:type>
@@ -52870,6 +53005,18 @@ Start-PASAccountImportJob -source "SomeSource" -accountsList $Accounts</dev:code
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
@@ -52888,7 +53035,8 @@ Start-PASAccountImportJob -source "SomeSource" -accountsList $Accounts</dev:code
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
         <maml:name>serviceName</maml:name>
         <maml:description>
-          <maml:para>The name of the service to start. Supported services: Vault, DR</maml:para>
+          <maml:para>The name of the service to start. Supported services: Vault, DR, ENE</maml:para>
+          <maml:para>The ENE service requires CyberArk version 15.2 or higher.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -52924,7 +53072,7 @@ Start-PASAccountImportJob -source "SomeSource" -accountsList $Accounts</dev:code
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
         <maml:name>servicePassword</maml:name>
         <maml:description>
-          <maml:para>Seems like Administrator is the only allowed username? https://docs.cyberark.com/pam-self-hosted/15.0/en/content/pasimp/vault-remote-manager.htm#Configurationrequirements REST API docs however doesnt mention this so we leave it as a parameter with default value with the option to change it.</maml:para>
+          <maml:para>The PARAgent password as a SecureString</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
         <dev:type>
@@ -52957,14 +53105,14 @@ Start-PASAccountImportJob -source "SomeSource" -accountsList $Accounts</dev:code
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="false" position="named" aliases="none">
-        <maml:name>WhatIf</maml:name>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
         <maml:description>
-          <maml:para>Position: Named Default value: None Accept pipeline input: False Accept wildcard characters: False ```</maml:para>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
         </maml:description>
-        <command:parameterValue required="true" variableLength="false"></command:parameterValue>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
         <dev:type>
-          <maml:name></maml:name>
+          <maml:name>ActionPreference</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -52991,6 +53139,161 @@ PS C:\&gt; Start-PASVRMService -serviceName Vault -serverAddress vault.company.c
       <maml:navigationLink>
         <maml:linkText>Online Version:</maml:linkText>
         <maml:uri>https://pspas.pspete.dev/commands/Start-PASVRMService</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Stop-PASCPMTask</command:name>
+      <command:verb>Stop</command:verb>
+      <command:noun>PASCPMTask</command:noun>
+      <maml:description>
+        <maml:para>Cancels a pending CPM task for an account.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Cancels an in-progress or pending CPM operation (such as a change, verify or reconcile task) for a specific account.</maml:para>
+      <maml:para>Requires CyberArk Self-Hosted version 15.2 or higher.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Stop-PASCPMTask</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="id">
+          <maml:name>Accountid</maml:name>
+          <maml:description>
+            <maml:para>The unique id of the account to cancel the pending CPM task for.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="id">
+        <maml:name>Accountid</maml:name>
+        <maml:description>
+          <maml:para>The unique id of the account to cancel the pending CPM task for.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+        <maml:name>WhatIf</maml:name>
+        <maml:description>
+          <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; Stop-PASCPMTask -Accountid 123_4</dev:code>
+        <dev:remarks>
+          <maml:para>Cancels the pending CPM task for account with id 123_4.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>https://pspas.pspete.dev/commands/Stop-PASCPMTask</maml:linkText>
+        <maml:uri>https://pspas.pspete.dev/commands/Stop-PASCPMTask</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -53140,7 +53443,8 @@ PS C:\&gt; Start-PASVRMService -serviceName Vault -serverAddress vault.company.c
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
           <maml:name>serviceName</maml:name>
           <maml:description>
-            <maml:para>The name of the service to stop. Supported services: Vault, DR</maml:para>
+            <maml:para>The name of the service to stop. Supported services: Vault, DR, ENE</maml:para>
+            <maml:para>The ENE service requires CyberArk version 15.2 or higher.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -53207,6 +53511,18 @@ PS C:\&gt; Start-PASVRMService -serviceName Vault -serverAddress vault.company.c
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
@@ -53225,7 +53541,8 @@ PS C:\&gt; Start-PASVRMService -serviceName Vault -serverAddress vault.company.c
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
         <maml:name>serviceName</maml:name>
         <maml:description>
-          <maml:para>The name of the service to stop. Supported services: Vault, DR</maml:para>
+          <maml:para>The name of the service to stop. Supported services: Vault, DR, ENE</maml:para>
+          <maml:para>The ENE service requires CyberArk version 15.2 or higher.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -53294,14 +53611,14 @@ PS C:\&gt; Start-PASVRMService -serviceName Vault -serverAddress vault.company.c
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="false" position="named" aliases="none">
-        <maml:name>WhatIf</maml:name>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
         <maml:description>
-          <maml:para>Position: Named Default value: None Accept pipeline input: False Accept wildcard characters: False ```</maml:para>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
         </maml:description>
-        <command:parameterValue required="true" variableLength="false"></command:parameterValue>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
         <dev:type>
-          <maml:name></maml:name>
+          <maml:name>ActionPreference</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -304,7 +304,10 @@
 		'Get-PASVRMDRSystemHealth',
 		'Invoke-PASVRMFailover',
 		'Get-PASVRMServiceConfigParameter',
-		'Set-PASVRMServiceConfig'
+		'Set-PASVRMServiceConfig',
+		'New-PASPlatformSecret',
+		'Stop-PASCPMTask',
+		'Resume-PASCPMAutoManagement'
 
 	)
 


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
<!--
Please include a summary of the change and which issue is fixed & relevant motivation and context.
Put `Fixes #XXX` in your comment to link the issue that your PR fixes.
-->

Adds some Self-Hosted 15.2 commands and extends existing ones with tests and command documentation.
I have only tested these changes on a 15.2 environment!

Added:
- New-PASPlatformSecret: generate a secret for a platform
- Stop-PASCPMTask: cancel a pending CPM task for an account
- Resume-PASCPMAutoManagement: resume CPM auto management for an account

Updated:
- Set-PASSafe: add Quota parameter, allow NumberOfVersionsRetention value of 0
- Get/Start/Stop/Restart-PASVRMService: add ENE serviceName value

Got some help by AI to create the tests and documentation, for info. 

## Type of change
<!--
Please select all relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that makes existing functionality work differently)
- [x] Documentation update (psPAS website or command help content)
- [x] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [x] Pester test(s) update required
- [x] Pester test(s) updated
- [x] Pester test(s) passing

**Test Configuration**:
- PowerShell version: 7
- CyberArk PAS version: 15.2
- OS Version: Windows Server 2025

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [x] My code follows the style guidelines of this project
- [x] I have followed the contributing guidelines.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new test failures or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [ ] I have linked a related issue