### PR TITLE
Add ArgumentCompleter for path parameter in Set-PASAccount function

### DIFF
--- a/Tests/Set-PASAccount.Tests.ps1
+++ b/Tests/Set-PASAccount.Tests.ps1
@@ -64,6 +64,65 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 		}
 
+		Context 'path ArgumentCompleter' {
+
+			It 'provides ArgumentCompleter for path parameter' {
+
+				(Get-Command Set-PASAccount).Parameters['path'].Attributes |
+				Where-Object { $_ -is [System.Management.Automation.ArgumentCompleterAttribute] } |
+				Should -Not -BeNullOrEmpty
+
+			}
+
+			It 'returns account property paths from Get-PASAccount' {
+
+				Mock Get-PASAccount -MockWith {
+					[pscustomobject]@{
+						name = 'TestName'
+						secretManagement = [pscustomobject]@{
+							automaticManagementEnabled = $true
+						}
+					}
+				}
+
+				$Completer = (Get-Command Set-PASAccount).Parameters['path'].Attributes |
+				Where-Object { $_ -is [System.Management.Automation.ArgumentCompleterAttribute] } |
+				Select-Object -ExpandProperty ScriptBlock
+
+				$Result = & $Completer -commandName 'Set-PASAccount' -parameterName 'path' -wordToComplete '' -commandAst $null -fakeBoundParameters @{ AccountID = '22_3' }
+
+				$Result.CompletionText | Should -Contain '/name'
+				$Result.CompletionText | Should -Contain '/secretManagement/automaticManagementEnabled'
+
+			}
+
+			It 'resolves AccountID from a preceding Get-PASAccount command in a pipeline' {
+
+				Mock Get-PASAccount -MockWith {
+					[pscustomobject]@{
+						address = 'server.domain.com'
+					}
+				}
+
+				$Completer = (Get-Command Set-PASAccount).Parameters['path'].Attributes |
+				Where-Object { $_ -is [System.Management.Automation.ArgumentCompleterAttribute] } |
+				Select-Object -ExpandProperty ScriptBlock
+
+				$CommandAst = [System.Management.Automation.Language.Parser]::ParseInput(
+					'Get-PASAccount -id 22_3 | Set-PASAccount -path',
+					[ref]$null,
+					[ref]$null
+				).EndBlock.Statements[0].PipelineElements |
+				Where-Object { $_.GetCommandName() -eq 'Set-PASAccount' }
+
+				$Result = & $Completer -commandName 'Set-PASAccount' -parameterName 'path' -wordToComplete '' -commandAst $CommandAst -fakeBoundParameters @{}
+
+				$Result.CompletionText | Should -Contain '/address'
+
+			}
+
+		}
+
 		Context 'v10 API' {
 
 			BeforeEach {

--- a/psPAS/Functions/Accounts/Set-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Set-PASAccount.ps1
@@ -25,6 +25,79 @@ function Set-PASAccount {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Gen2SingleOp'
 		)]
+		[ArgumentCompleter({
+				#TO-DO: Consider excluding paths that are read-only, e.g. /id
+
+				#Standard ArgumentCompleter parameters, populated by the completion engine on tab.
+				param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+
+				#Avoid PSScriptAnalyzer PSReviewUnusedParameter rule on standard ArgumentCompleter parameters.
+				$null = $commandName, $parameterName
+
+				#Resolve AccountID: supplied directly, or from a preceding 'Get-PASAccount -id <value>' pipeline command.
+				#e.g. Set-PASAccount -AccountID 22_3 -op replace -path <tab>
+				$AccountID = $fakeBoundParameters['AccountID']
+
+				if (-not $AccountID) {
+
+					#e.g. Get-PASAccount -id 22_3 | Set-PASAccount -path <tab>
+					#Find the first Get-PASAccount command in the pipeline being typed & get its command elements.
+					$Elements = ($commandAst.Parent.PipelineElements |
+							Where-Object { ($_ -is [System.Management.Automation.Language.CommandAst]) -and ($_.GetCommandName() -eq 'Get-PASAccount') } |
+							Select-Object -First 1).CommandElements
+
+					#Take the constant value following the -id / -AccountID parameter.
+					for ($i = 1; $i -lt $Elements.Count; $i++) {
+
+						#Element must be a literal value preceded by the -id / -AccountID parameter name.
+						#StringConstantExpressionAst inherits from ConstantExpressionAst, so quoted, bareword & numeric values are all covered.
+						if (($Elements[$i - 1] -is [System.Management.Automation.Language.CommandParameterAst]) -and
+							($Elements[$i - 1].ParameterName -in 'id', 'AccountID') -and
+							($Elements[$i] -is [System.Management.Automation.Language.ConstantExpressionAst])) {
+
+							$AccountID = $Elements[$i].Value
+							break
+
+						}
+
+					}
+
+				}
+
+				#Nothing to complete without a resolved AccountID.
+				if (-not $AccountID) { return }
+
+				#Get the account object; no completions if retrieval fails (e.g. no session, unknown ID).
+				try { $Account = Get-PASAccount -id $AccountID -ErrorAction Stop } catch { return }
+
+				#Recursively emit '/parent/child' paths for every property on the account object.
+				function Get-PASAccountPropertyPath($Object, [string]$Prefix = '') {
+
+					foreach ($Property in $Object.PSObject.Properties) {
+
+						#Only NoteProperties hold account data (recursion ends on values with none, e.g. strings).
+						if ($Property.MemberType -eq 'NoteProperty') {
+
+							#Output the JSON Patch style path for this property.
+							$Path = "$Prefix/$($Property.Name)"
+							$Path
+
+							#Descend into nested objects, e.g. /platformAccountProperties/port
+							if ($null -ne $Property.Value) { Get-PASAccountPropertyPath $Property.Value $Path }
+
+						}
+
+					}
+
+				}
+
+				#Offer sorted paths matching any partial input as the completion results.
+				Get-PASAccountPropertyPath $Account |
+				Sort-Object -Unique |
+				Where-Object { $_ -like "$wordToComplete*" } |
+				ForEach-Object { [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_) }
+
+			})]
 		[string]$path,
 
 		[parameter(


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
<!--
Please include a summary of the change and which issue is fixed & relevant motivation and context.
Put `Fixes #XXX` in your comment to link the issue that your PR fixes.
-->

This pull request enhances the `Set-PASAccount` PowerShell function by adding an `ArgumentCompleter` to the `path` parameter, enabling tab completion of account property paths.

* Added an `[ArgumentCompleter]` to the `path` parameter in `Set-PASAccount`, which dynamically generates JSON Patch-style property paths for the specified account, supporting both direct and pipeline-supplied `AccountID`.

Only tested on self hosted and 15.2! But the same API exists for SaaS so should be fine. 
If the account id provided does not exists or user do not have list access, then no errors will happen. It will work like before. 

## Type of change
<!--
Please select all relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [ ] Documentation update (psPAS website or command help content)
- [ ] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [x] Pester test(s) updated
- [ ] Pester test(s) passing

**Test Configuration**:
- PowerShell version: 7
- CyberArk PAS version: 15.2
- OS Version: Windows server 2025

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [x] My code follows the style guidelines of this project
- [x] I have followed the contributing guidelines.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new test failures or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [ ] I have linked a related issue