### PR TITLE
Issue 602

### DIFF
--- a/Tests/Add-PASAccount.Tests.ps1
+++ b/Tests/Add-PASAccount.Tests.ps1
@@ -175,7 +175,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					($Body | ConvertFrom-Json | Select-Object -ExpandProperty Account) -ne $null
+					([System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json | Select-Object -ExpandProperty Account) -ne $null
 
 				} -Times 1 -Exactly -Scope It
 
@@ -186,7 +186,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObj | Add-PASAccount
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-					($Body | ConvertFrom-Json | Select-Object -ExpandProperty Account | Get-Member -MemberType NoteProperty).length -eq 11
+					([System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json | Select-Object -ExpandProperty Account | Get-Member -MemberType NoteProperty).length -eq 11
 				} -Times 1 -Exactly -Scope It
 			}
 
@@ -195,7 +195,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					($Body | ConvertFrom-Json | Select-Object -ExpandProperty Account | Select-Object -ExpandProperty Properties).count -eq 10
+					([System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json | Select-Object -ExpandProperty Account | Select-Object -ExpandProperty Properties).count -eq 10
 
 				} -Times 1 -Exactly -Scope It
 			}
@@ -206,7 +206,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					($Body | ConvertFrom-Json) -ne $null
+					([System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json) -ne $null
 
 				} -Times 1 -Exactly -Scope It
 
@@ -217,7 +217,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$InputObjV10 | Add-PASAccount
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-					($Body | ConvertFrom-Json | Get-Member -MemberType NoteProperty).length -eq 7
+					([System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json | Get-Member -MemberType NoteProperty).length -eq 7
 				} -Times 1 -Exactly -Scope It
 
 			}
@@ -227,7 +227,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					($Body | ConvertFrom-Json | Select-Object -ExpandProperty remoteMachinesAccess | Get-Member -MemberType NoteProperty).length -eq 2
+					([System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json | Select-Object -ExpandProperty remoteMachinesAccess | Get-Member -MemberType NoteProperty).length -eq 2
 
 				} -Times 1 -Exactly -Scope It
 
@@ -239,7 +239,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					($Body | ConvertFrom-Json | Select-Object -ExpandProperty secretManagement | Get-Member -MemberType NoteProperty).length -eq 1
+					([System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json | Select-Object -ExpandProperty secretManagement | Get-Member -MemberType NoteProperty).length -eq 1
 
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/Add-PASDirectory.Tests.ps1
+++ b/Tests/Add-PASDirectory.Tests.ps1
@@ -92,7 +92,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$Script:RequestBody = $Body | ConvertFrom-Json
+					$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 					($Script:RequestBody) -ne $null
 

--- a/Tests/Add-PASOpenIDConnectProvider.Tests.ps1
+++ b/Tests/Add-PASOpenIDConnectProvider.Tests.ps1
@@ -95,7 +95,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-					$($Body | ConvertFrom-Json) -ne $null
+					$([System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json) -ne $null
 				} -Times 1 -Exactly -Scope It
 
 			}

--- a/Tests/Add-PASPTAGlobalCatalog.Tests.ps1
+++ b/Tests/Add-PASPTAGlobalCatalog.Tests.ps1
@@ -115,7 +115,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                    $Script:RequestBody = $Body | ConvertFrom-Json
+                    $Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 					($Script:RequestBody) -ne $null
 

--- a/Tests/Add-PASPersonalAdminAccount.Tests.ps1
+++ b/Tests/Add-PASPersonalAdminAccount.Tests.ps1
@@ -97,7 +97,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					($Body | ConvertFrom-Json) -ne $null
+					([System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json) -ne $null
 
                 } -Times 1 -Exactly -Scope It
 

--- a/Tests/Get-PASVRMDRSystemHealth.Tests.ps1
+++ b/Tests/Get-PASVRMDRSystemHealth.Tests.ps1
@@ -101,7 +101,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$Script:RequestBody = $Body | ConvertFrom-Json
+					$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 					($Script:RequestBody.DRAddress) -ne $null
 

--- a/Tests/Get-PASVRMServiceConfig.Tests.ps1
+++ b/Tests/Get-PASVRMServiceConfig.Tests.ps1
@@ -101,7 +101,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$Script:RequestBody = $Body | ConvertFrom-Json
+					$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 					($Script:RequestBody.serviceName) -ne $null
 

--- a/Tests/Get-PASVRMServiceConfigParameter.Tests.ps1
+++ b/Tests/Get-PASVRMServiceConfigParameter.Tests.ps1
@@ -101,7 +101,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$Script:RequestBody = $Body | ConvertFrom-Json
+					$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 					($Script:RequestBody.serviceName) -ne $null
 

--- a/Tests/Get-PASVRMServiceStatus.Tests.ps1
+++ b/Tests/Get-PASVRMServiceStatus.Tests.ps1
@@ -101,7 +101,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$Script:RequestBody = $Body | ConvertFrom-Json
+					$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 					($Script:RequestBody.serviceName) -ne $null
 

--- a/Tests/Invoke-PASRestMethod.Tests.ps1
+++ b/Tests/Invoke-PASRestMethod.Tests.ps1
@@ -201,6 +201,83 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 		}
 
+		Context 'Body Handling' {
+
+			BeforeEach {
+
+				$Response = New-MockObject -Type Microsoft.PowerShell.Commands.WebResponseObject
+				$Response | Add-Member -MemberType NoteProperty -Name StatusCode -Value 200 -Force
+				$Response | Add-Member -MemberType NoteProperty -Name Headers -Value @{ 'Content-Type' = 'application/json; charset=utf-8' } -Force
+				$Response | Add-Member -MemberType NoteProperty -Name Content -Value (@{ 'prop1' = 'value1' } | ConvertTo-Json) -Force
+
+				Mock Invoke-WebRequest -MockWith {
+
+					return $Response
+
+				}
+
+				Mock Skip-CertificateCheck -MockWith { }
+
+				$WebSession = @{
+					'URI'        = 'https://CyberArk_URL'
+					'Method'     = 'POST'
+					'WebSession' = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+				}
+
+			}
+
+			It 'sends a String Body to Invoke-WebRequest as UTF8 bytes' {
+
+				Invoke-PASRestMethod @WebSession -Body 'something'
+
+				Assert-MockCalled 'Invoke-WebRequest' -Times 1 -Scope It -Exactly -ParameterFilter {
+
+					($Body -is [byte[]]) -and ([System.Text.Encoding]::UTF8.GetString($Body) -eq 'something')
+
+				}
+
+			}
+
+			It 'passes an already-Byte[] Body to Invoke-WebRequest unmodified' {
+
+				$Bytes = [System.Text.Encoding]::UTF8.GetBytes('{"password":"SomeSecret"}')
+
+				Invoke-PASRestMethod @WebSession -Body $Bytes
+
+				Assert-MockCalled 'Invoke-WebRequest' -Times 1 -Scope It -Exactly -ParameterFilter {
+
+					($Body -is [byte[]]) -and ([System.Text.Encoding]::UTF8.GetString($Body) -eq '{"password":"SomeSecret"}')
+
+				}
+
+			}
+
+			It 'writes a sanitised debug preview for a String Body containing a secret' {
+
+				$DebugPreference = 'Continue'
+				$DebugText = $(Invoke-PASRestMethod @WebSession -Body '{"password":"SomeSecret"}' 5>&1) | Out-String
+				$DebugPreference = 'SilentlyContinue'
+
+				$DebugText | Should -Match '\[Body\].*\*\*\*\*\*\*'
+				$DebugText | Should -Not -Match 'SomeSecret'
+
+			}
+
+			It 'writes a sanitised debug preview for a Byte[] Body containing a secret' {
+
+				$Bytes = [System.Text.Encoding]::UTF8.GetBytes('{"password":"SomeSecret"}')
+
+				$DebugPreference = 'Continue'
+				$DebugText = $(Invoke-PASRestMethod @WebSession -Body $Bytes 5>&1) | Out-String
+				$DebugPreference = 'SilentlyContinue'
+
+				$DebugText | Should -Match '\[Body\].*\*\*\*\*\*\*'
+				$DebugText | Should -Not -Match 'SomeSecret'
+
+			}
+
+		}
+
 		Context 'Error Handling' {
 
 			BeforeEach {

--- a/Tests/Invoke-PASVRMFailover.Tests.ps1
+++ b/Tests/Invoke-PASVRMFailover.Tests.ps1
@@ -99,7 +99,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$Script:RequestBody = $Body | ConvertFrom-Json
+					$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 					($Script:RequestBody.DRAddress) -ne $null
 

--- a/Tests/New-PASPSMSession.Tests.ps1
+++ b/Tests/New-PASPSMSession.Tests.ps1
@@ -128,7 +128,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$Script:RequestBody = $Body | ConvertFrom-Json
+					$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 					($Script:RequestBody) -ne $null
 
@@ -196,7 +196,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				$AdHocObj | New-PASPSMSession -ConnectionMethod RDP -PSMRemoteMachine 'SomeServer'
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-					$RequestBody = $Body | ConvertFrom-Json
+					$RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 					$RequestBody.PSMConnectPrerequisites.ConnectionComponent -eq 'SomeConnectionComponent'
 				} -Times 1 -Exactly -Scope It
 
@@ -206,7 +206,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				$AdHocObj | New-PASPSMSession -ConnectionMethod RDP -PSMRemoteMachine 'SomeServer'
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-					$RequestBody = $Body | ConvertFrom-Json
+					$RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 					$RequestBody.PSMConnectPrerequisites.ConnectionParams.PSMRemoteMachine.value -eq 'SomeServer'
 				} -Times 1 -Exactly -Scope It
 

--- a/Tests/New-PASPrivateSSHKey.Tests.ps1
+++ b/Tests/New-PASPrivateSSHKey.Tests.ps1
@@ -89,7 +89,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             It 'sends request with expected body' {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-                    $($Body | ConvertFrom-Json) -ne $null
+                    $([System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json) -ne $null
                 } -Times 1 -Exactly -Scope It
 
             }
@@ -141,7 +141,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             It 'sends request with expected body' {
 
                 Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-                    $($Body | ConvertFrom-Json) -ne $null
+                    $([System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json) -ne $null
                 } -Times 1 -Exactly -Scope It
 
             }

--- a/Tests/New-PASSession.Tests.ps1
+++ b/Tests/New-PASSession.Tests.ps1
@@ -118,7 +118,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$Credentials | New-PASSession -BaseURI 'https://P_URI' -PVWAAppName 'SomeApp' -newPassword $NewPass -UseClassicAPI
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$Script:RequestBody = $Body | ConvertFrom-Json
+					$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 					($Script:RequestBody) -ne $null
 
@@ -154,7 +154,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$Credentials | New-PASSession -BaseURI 'https://P_URI' -UseClassicAPI -useRadiusAuthentication $true -OTP 987654 -OTPMode Append
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$Script:RequestBody = $Body | ConvertFrom-Json
+					$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 					$Script:RequestBody.password -eq 'SomePassword,987654'
 
@@ -166,7 +166,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$Credentials | New-PASSession -BaseURI 'https://P_URI' -type RADIUS -OTP 987654 -OTPMode Append
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$Script:RequestBody = $Body | ConvertFrom-Json
+					$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 					$Script:RequestBody.password -eq 'SomePassword,987654'
 
@@ -178,7 +178,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$Credentials | New-PASSession -BaseURI 'https://P_URI' -type RADIUS -OTP 987654 -OTPMode Challenge -RadiusChallenge Password
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$Script:RequestBody = $Body | ConvertFrom-Json
+					$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 					$Script:RequestBody.password -eq '987654'
 
@@ -190,7 +190,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$Credentials | New-PASSession -BaseURI 'https://P_URI' -type RADIUS -OTP 987654 -OTPMode Append -OTPDelimiter '#'
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$Script:RequestBody = $Body | ConvertFrom-Json
+					$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 					$Script:RequestBody.password -eq 'SomePassword#987654'
 
@@ -202,7 +202,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$Credentials | New-PASSession -BaseURI 'https://P_URI' -type RADIUS -OTP 987654 -OTPMode Append -OTPDelimiter $null
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$Script:RequestBody = $Body | ConvertFrom-Json
+					$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 					$Script:RequestBody.password -eq 'SomePassword987654'
 
@@ -214,7 +214,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$Credentials | New-PASSession -BaseURI 'https://P_URI' -type RADIUS -OTP 987654 -OTPMode Append -OTPDelimiter ''
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$Script:RequestBody = $Body | ConvertFrom-Json
+					$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 					$Script:RequestBody.password -eq 'SomePassword987654'
 
@@ -229,7 +229,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				New-PASSession -BaseURI 'https://P_URI' -type LDAP -Credential $Credentials -concurrentSession $true
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$Script:RequestBody = $Body | ConvertFrom-Json
+					$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 					$Script:RequestBody.concurrentSession -eq $true
 
@@ -541,7 +541,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 					Assert-MockCalled Invoke-WebRequest -ParameterFilter {
 
-						$Script:RequestBody = $Body | ConvertFrom-Json
+						$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 						$Script:RequestBody.password -eq 'SomePassword'
 
@@ -549,7 +549,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 					Assert-MockCalled Invoke-WebRequest -ParameterFilter {
 
-						$Script:RequestBody = $Body | ConvertFrom-Json
+						$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 						$Script:RequestBody.password -eq '987654'
 
@@ -563,7 +563,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 					Assert-MockCalled Invoke-WebRequest -ParameterFilter {
 
-						$Script:RequestBody = $Body | ConvertFrom-Json
+						$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 						$Script:RequestBody.password -eq '987654'
 
@@ -571,7 +571,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 					Assert-MockCalled Invoke-WebRequest -ParameterFilter {
 
-						$Script:RequestBody = $Body | ConvertFrom-Json
+						$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 						$Script:RequestBody.password -eq 'SomePassword'
 

--- a/Tests/New-PASUser.Tests.ps1
+++ b/Tests/New-PASUser.Tests.ps1
@@ -114,7 +114,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$Script:RequestBody = $Body | ConvertFrom-Json
+					$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 					($Script:RequestBody) -ne $null
 
@@ -183,7 +183,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$Script:RequestBody = $Body | ConvertFrom-Json
+					$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 					($Script:RequestBody) -ne $null
 

--- a/Tests/Restart-PASVRMService.Tests.ps1
+++ b/Tests/Restart-PASVRMService.Tests.ps1
@@ -99,7 +99,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$Script:RequestBody = $Body | ConvertFrom-Json
+					$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 					($Script:RequestBody.serviceName) -ne $null
 

--- a/Tests/Set-PASOpenIDConnectProvider.Tests.ps1
+++ b/Tests/Set-PASOpenIDConnectProvider.Tests.ps1
@@ -96,7 +96,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			It 'sends request with expected body' {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
-					$($Body | ConvertFrom-Json) -ne $null
+					$([System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json) -ne $null
 				} -Times 1 -Exactly -Scope It
 
 			}

--- a/Tests/Set-PASUser.Tests.ps1
+++ b/Tests/Set-PASUser.Tests.ps1
@@ -179,7 +179,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$Script:RequestBody = $Body | ConvertFrom-Json
+					$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 					($Script:RequestBody) -ne $null
 
@@ -190,7 +190,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			It 'sends request with expected existing personal details' {
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$Script:RequestBody = $Body | ConvertFrom-Json
+					$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 					($Script:RequestBody).personalDetails.LastName -eq 'User'
 
@@ -198,7 +198,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$Script:RequestBody = $Body | ConvertFrom-Json
+					$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 					($Script:RequestBody).personalDetails.FirstName -eq 'Some'
 
@@ -208,7 +208,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			It 'sends request with expected existing internet details' {
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$Script:RequestBody = $Body | ConvertFrom-Json
+					$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 					($Script:RequestBody).internet.homepage -eq 'www.geocities.com'
 

--- a/Tests/Set-PASVRMServiceConfig.Tests.ps1
+++ b/Tests/Set-PASVRMServiceConfig.Tests.ps1
@@ -106,7 +106,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$Script:RequestBody = $Body | ConvertFrom-Json
+					$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 					($Script:RequestBody.parameters) -ne $null
 

--- a/Tests/Start-PASVRMService.Tests.ps1
+++ b/Tests/Start-PASVRMService.Tests.ps1
@@ -99,7 +99,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$Script:RequestBody = $Body | ConvertFrom-Json
+					$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 					($Script:RequestBody.serviceName) -ne $null
 

--- a/Tests/Stop-PASVRMService.Tests.ps1
+++ b/Tests/Stop-PASVRMService.Tests.ps1
@@ -99,7 +99,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-					$Script:RequestBody = $Body | ConvertFrom-Json
+					$Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
 					($Script:RequestBody.serviceName) -ne $null
 

--- a/psPAS/Functions/Accounts/Add-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Add-PASAccount.ps1
@@ -335,6 +335,10 @@ function Add-PASAccount {
 
 		}
 
+		#Send as raw UTF8 bytes rather than a String so ParameterBinding/module logging of this
+		#call records a non-revealing type name instead of the literal request content.
+		$Body = [System.Text.Encoding]::UTF8.GetBytes($Body)
+
 		#send request to PAS web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body
 

--- a/psPAS/Functions/Accounts/Add-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Add-PASAccount.ps1
@@ -267,14 +267,6 @@ function Add-PASAccount {
 				#Create URL for Request
 				$URI = "$($psPASSession.BaseURI)/WebServices/PIMServices.svc/Account"
 
-				#deal with Password SecureString
-				if ($PSBoundParameters.ContainsKey('password')) {
-
-					#Include decoded password in request
-					$boundParameters['password'] = $(ConvertTo-InsecureString -SecureString $password)
-
-				}
-
 				#Process for required formatting - fix V10 specific parameter names
 				$boundParameters.remove('SafeName')
 				$boundParameters.remove('userName')
@@ -318,11 +310,21 @@ function Add-PASAccount {
 				#Add "non-base" parameter hashtable as value of "properties" on boundparameters object
 				$boundParameters['properties'] = [Collections.Generic.List[Object]]@($properties.getenumerator() | ForEach-Object { $_ })
 
+				#account node does not contain non-base parameters
+				$AccountObject = $boundParameters | Get-PASParameter -ParametersToRemove $keysToRemove
+
+				#deal with Password SecureString
+				if ($PSBoundParameters.ContainsKey('password')) {
+
+					#Include decoded password in request
+					$AccountObject['password'] = $(ConvertTo-InsecureString -SecureString $password)
+
+				}
+
 				#Create body of request
 				$body = @{
 
-					#account node does not contain non-base parameters
-					'account' = $boundParameters | Get-PASParameter -ParametersToRemove $keysToRemove
+					'account' = $AccountObject
 
 					#ensure nodes at all required depths are included in the JSON object
 				} | ConvertTo-Json -Depth 4

--- a/psPAS/Functions/Accounts/Add-PASPersonalAdminAccount.ps1
+++ b/psPAS/Functions/Accounts/Add-PASPersonalAdminAccount.ps1
@@ -37,7 +37,9 @@ function Add-PASPersonalAdminAccount {
 
         $Account = New-PASAccountObject @boundParameters -PersonalAdminAccount
 
-        $Body = $Account | ConvertTo-Json
+        #Send as raw UTF8 bytes rather than a String so ParameterBinding/module logging of this
+        #call records a non-revealing type name instead of the literal request content.
+        $Body = [System.Text.Encoding]::UTF8.GetBytes($($Account | ConvertTo-Json))
 
         #send request to PAS web service
         $result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body

--- a/psPAS/Functions/Accounts/Invoke-PASCPMOperation.ps1
+++ b/psPAS/Functions/Accounts/Invoke-PASCPMOperation.ps1
@@ -134,7 +134,9 @@ function Invoke-PASCPMOperation {
 				$ThisRequest['WebSession'].Headers['ImmediateChangeByCPM'] = $ImmediateChangeByCPM
 
 				#create request body
-				$ThisRequest['Body'] = $boundParameters | ConvertTo-Json
+				#Send as raw UTF8 bytes rather than a String so ParameterBinding/module logging of this
+				#call records a non-revealing type name instead of the literal request content.
+				$ThisRequest['Body'] = [System.Text.Encoding]::UTF8.GetBytes($($boundParameters | ConvertTo-Json))
 
 			}
 
@@ -177,7 +179,9 @@ function Invoke-PASCPMOperation {
 				}
 
 				#create request body
-				$ThisRequest['Body'] = $boundParameters | ConvertTo-Json
+				#Send as raw UTF8 bytes rather than a String so ParameterBinding/module logging of this
+				#call records a non-revealing type name instead of the literal request content.
+				$ThisRequest['Body'] = [System.Text.Encoding]::UTF8.GetBytes($($boundParameters | ConvertTo-Json))
 
 			}
 

--- a/psPAS/Functions/Accounts/New-PASAccountObject.ps1
+++ b/psPAS/Functions/Accounts/New-PASAccountObject.ps1
@@ -179,14 +179,6 @@ function New-PASAccountObject {
 		#Get all parameters that will be sent in the request
 		$boundParameters = $PSBoundParameters | Get-PASParameter
 
-		#deal with "secret" SecureString
-		if ($PSBoundParameters.ContainsKey('secret')) {
-
-			#Include decoded password in request
-			$boundParameters['secret'] = $(ConvertTo-InsecureString -SecureString $secret)
-
-		}
-
 		switch ($PSCmdlet.ParameterSetName) {
 
 			'AccountObject' {
@@ -251,7 +243,17 @@ function New-PASAccountObject {
 
 		if ($PSCmdlet.ShouldProcess($userName, 'Create Account Object Definition')) {
 
-			$boundParameters | Get-PASParameter -ParametersToRemove @($remoteMachine + $SecretMgmt + 'PersonalAdminAccount' + 'DependentAccount')
+			$boundParameters = $boundParameters | Get-PASParameter -ParametersToRemove @($remoteMachine + $SecretMgmt + 'PersonalAdminAccount' + 'DependentAccount')
+
+			#deal with "secret" SecureString
+			if ($PSBoundParameters.ContainsKey('secret')) {
+
+				#Include decoded password in request
+				$boundParameters['secret'] = $(ConvertTo-InsecureString -SecureString $secret)
+
+			}
+
+			$boundParameters
 
 		}
 

--- a/psPAS/Functions/Accounts/Publish-PASDiscoveredAccount.ps1
+++ b/psPAS/Functions/Accounts/Publish-PASDiscoveredAccount.ps1
@@ -55,7 +55,9 @@ function Publish-PASDiscoveredAccount {
 
         }
 
-        $Body = $boundParameters | ConvertTo-Json
+        #Send as raw UTF8 bytes rather than a String so ParameterBinding/module logging of this
+        #call records a non-revealing type name instead of the literal request content.
+        $Body = [System.Text.Encoding]::UTF8.GetBytes($($boundParameters | ConvertTo-Json))
 
         if ($PSCmdlet.ShouldProcess($id, 'Onboard Discovered Account')) {
 

--- a/psPAS/Functions/Accounts/Publish-PASDiscoveredLocalAccount.ps1
+++ b/psPAS/Functions/Accounts/Publish-PASDiscoveredLocalAccount.ps1
@@ -84,7 +84,9 @@ function Publish-PASDiscoveredLocalAccount {
 
         }
 
-        $Body = $boundParameters | ConvertTo-Json
+        #Send as raw UTF8 bytes rather than a String so ParameterBinding/module logging of this
+        #call records a non-revealing type name instead of the literal request content.
+        $Body = [System.Text.Encoding]::UTF8.GetBytes($($boundParameters | ConvertTo-Json))
 
         if ($PSCmdlet.ShouldProcess($id, 'Onboard Discovered Local Account')) {
 

--- a/psPAS/Functions/Accounts/Publish-PASDiscoveredLocalAccount.ps1
+++ b/psPAS/Functions/Accounts/Publish-PASDiscoveredLocalAccount.ps1
@@ -55,14 +55,6 @@ function Publish-PASDiscoveredLocalAccount {
         #Get all parameters that will be sent in the request
         $boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove id
 
-        #deal with defaultPassword SecureString
-        if ($PSBoundParameters.ContainsKey('secret')) {
-
-            #Include decoded password in request
-            $boundParameters['secret'] = $(ConvertTo-InsecureString -SecureString $secret)
-
-        }
-
         $boundParameters.keys | Where-Object { $coreAttributes -contains $_ } | ForEach-Object {
 
             $coreAttributesProperties = @{ }
@@ -82,7 +74,17 @@ function Publish-PASDiscoveredLocalAccount {
 
         }
 
-        $Body = $boundParameters | Get-PASParameter -ParametersToRemove $coreAttributes | ConvertTo-Json
+        $boundParameters = $boundParameters | Get-PASParameter -ParametersToRemove $coreAttributes
+
+        #deal with secret SecureString
+        if ($PSBoundParameters.ContainsKey('secret')) {
+
+            #Include decoded password in request
+            $boundParameters['secret'] = $(ConvertTo-InsecureString -SecureString $secret)
+
+        }
+
+        $Body = $boundParameters | ConvertTo-Json
 
         if ($PSCmdlet.ShouldProcess($id, 'Onboard Discovered Local Account')) {
 

--- a/psPAS/Functions/Authentication/Add-PASOpenIDConnectProvider.ps1
+++ b/psPAS/Functions/Authentication/Add-PASOpenIDConnectProvider.ps1
@@ -113,7 +113,9 @@ function Add-PASOpenIDConnectProvider {
 		}
 
 		#Create body of request
-		$body = $boundParameters | ConvertTo-Json
+		#Send as raw UTF8 bytes rather than a String so ParameterBinding/module logging of this
+		#call records a non-revealing type name instead of the literal request content.
+		$body = [System.Text.Encoding]::UTF8.GetBytes($($boundParameters | ConvertTo-Json))
 
 		#send request to web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $body

--- a/psPAS/Functions/Authentication/New-PASPrivateSSHKey.ps1
+++ b/psPAS/Functions/Authentication/New-PASPrivateSSHKey.ps1
@@ -76,7 +76,9 @@ function New-PASPrivateSSHKey {
 
         }
 
-        $body = $boundParameters | ConvertTo-Json
+        #Send as raw UTF8 bytes rather than a String so ParameterBinding/module logging of this
+        #call records a non-revealing type name instead of the literal request content.
+        $body = [System.Text.Encoding]::UTF8.GetBytes($($boundParameters | ConvertTo-Json))
 
         if ($PSCmdlet.ShouldProcess($user, 'Generate Private SSH Key')) {
 

--- a/psPAS/Functions/Authentication/New-PASSession.ps1
+++ b/psPAS/Functions/Authentication/New-PASSession.ps1
@@ -636,7 +636,9 @@ function New-PASSession {
 				}
 
 				#Construct Request Body
-				$LogonRequest['Body'] = $boundParameters | ConvertTo-Json
+				#Send as raw UTF8 bytes rather than a String so ParameterBinding/module logging of this
+				#call records a non-revealing type name instead of the literal request content.
+				$LogonRequest['Body'] = [System.Text.Encoding]::UTF8.GetBytes($($boundParameters | ConvertTo-Json))
 
 				break
 

--- a/psPAS/Functions/Authentication/Set-PASOpenIDConnectProvider.ps1
+++ b/psPAS/Functions/Authentication/Set-PASOpenIDConnectProvider.ps1
@@ -118,7 +118,9 @@ function Set-PASOpenIDConnectProvider {
 		}
 
 		#Create body of request
-		$body = $boundParameters | ConvertTo-Json
+		#Send as raw UTF8 bytes rather than a String so ParameterBinding/module logging of this
+		#call records a non-revealing type name instead of the literal request content.
+		$body = [System.Text.Encoding]::UTF8.GetBytes($($boundParameters | ConvertTo-Json))
 
 		if ($PSCmdlet.ShouldProcess($id, 'Update OIDC Provider')) {
 

--- a/psPAS/Functions/Connections/New-PASPSMSession.ps1
+++ b/psPAS/Functions/Connections/New-PASPSMSession.ps1
@@ -229,9 +229,6 @@ function New-PASPSMSession {
 				#Create URL for Request
 				$URI = "$($psPASSession.BaseURI)/API/Accounts/AdHocConnect"
 
-				#Include decoded password in request
-				$boundParameters['secret'] = $(ConvertTo-InsecureString -SecureString $secret)
-
 				#Connection parameters are included under the PSMConnectPrerequisites property of the JSON body, for each one specified
 				$boundParameters.keys | Where-Object { $AdHocParameters -contains $PSItem } | ForEach-Object {
 
@@ -251,8 +248,13 @@ function New-PASPSMSession {
 					}
 				}
 
+				$boundParameters = $boundParameters | Get-PASParameter -ParametersToRemove $AdHocParameters
+
+				#Include decoded password in request
+				$boundParameters['secret'] = $(ConvertTo-InsecureString -SecureString $secret)
+
 				#Create body of request
-				$body = $boundParameters | Get-PASParameter -ParametersToRemove $AdHocParameters | ConvertTo-Json -Depth 4
+				$body = $boundParameters | ConvertTo-Json -Depth 4
 
 				$ShouldProcess = $userName
 
@@ -286,6 +288,10 @@ function New-PASPSMSession {
 			$ThisSession.Headers['Accept'] = $Accept
 
 		}
+
+		#Send as raw UTF8 bytes rather than a String so ParameterBinding/module logging of this
+		#call records a non-revealing type name instead of the literal request content.
+		$body = [System.Text.Encoding]::UTF8.GetBytes($body)
 
 		if ($PSCmdlet.ShouldProcess($ShouldProcess, 'New PSM Session')) {
 

--- a/psPAS/Functions/LDAPDirectories/Add-PASDirectory.ps1
+++ b/psPAS/Functions/LDAPDirectories/Add-PASDirectory.ps1
@@ -126,7 +126,9 @@ function Add-PASDirectory {
 
 		}
 
-		$body = $boundParameters | ConvertTo-Json
+		#Send as raw UTF8 bytes rather than a String so ParameterBinding/module logging of this
+		#call records a non-revealing type name instead of the literal request content.
+		$body = [System.Text.Encoding]::UTF8.GetBytes($($boundParameters | ConvertTo-Json))
 
 		#send request to web service
 		$result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body

--- a/psPAS/Functions/PTAAdministration/Add-PASPTAGlobalCatalog.ps1
+++ b/psPAS/Functions/PTAAdministration/Add-PASPTAGlobalCatalog.ps1
@@ -55,18 +55,22 @@ function Add-PASPTAGlobalCatalog {
         #Get Parameters for request body
         $boundParameters = $PSBoundParameters | Get-PASParameter
 
+        $boundParameters['properties'] = $($boundParameters | Get-PASParameter -ParametersToRemove ldap_certificate)
+
+        $AccountObject = $boundParameters | Get-PASParameter -ParametersToKeep ldap_certificate, properties
+
         #deal with Password SecureString
         if ($PSBoundParameters.ContainsKey('ldapPassword')) {
 
             #Include decoded password in request
-            $boundParameters['ldapPassword'] = $(ConvertTo-InsecureString -SecureString $ldapPassword)
+            $AccountObject['properties']['ldapPassword'] = $(ConvertTo-InsecureString -SecureString $ldapPassword)
 
         }
 
-        $boundParameters['properties'] = $($boundParameters | Get-PASParameter -ParametersToRemove ldap_certificate)
-
         #Create body of request
-        $body = $boundParameters | Get-PASParameter -ParametersToKeep ldap_certificate, properties | ConvertTo-Json
+        #Send as raw UTF8 bytes rather than a String so ParameterBinding/module logging of this
+        #call records a non-revealing type name instead of the literal request content.
+        $body = [System.Text.Encoding]::UTF8.GetBytes($($AccountObject | ConvertTo-Json))
 
         #send request to PAS web service
         $result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body

--- a/psPAS/Functions/User/New-PASUser.ps1
+++ b/psPAS/Functions/User/New-PASUser.ps1
@@ -419,13 +419,6 @@ function New-PASUser {
 		#Get request parameters
 		$boundParameters = $PSBoundParameters | Get-PASParameter
 
-		if ($PSBoundParameters.ContainsKey('InitialPassword')) {
-
-			#Include decoded password in request
-			$boundParameters['InitialPassword'] = $(ConvertTo-InsecureString -SecureString $InitialPassword)
-
-		}
-
 		switch ($PSCmdlet.ParameterSetName) {
 
 			'Gen2' {
@@ -477,6 +470,13 @@ function New-PASUser {
 				break
 
 			}
+
+		}
+
+		if ($PSBoundParameters.ContainsKey('InitialPassword')) {
+
+			#Include decoded password in request
+			$boundParameters['InitialPassword'] = $(ConvertTo-InsecureString -SecureString $InitialPassword)
 
 		}
 

--- a/psPAS/Functions/User/New-PASUser.ps1
+++ b/psPAS/Functions/User/New-PASUser.ps1
@@ -481,7 +481,9 @@ function New-PASUser {
 		}
 
 		#Construct Request Body
-		$body = $boundParameters | ConvertTo-Json -Depth 4
+		#Send as raw UTF8 bytes rather than a String so ParameterBinding/module logging of this
+		#call records a non-revealing type name instead of the literal request content.
+		$body = [System.Text.Encoding]::UTF8.GetBytes($($boundParameters | ConvertTo-Json -Depth 4))
 
 		if ($PSCmdlet.ShouldProcess($UserName, 'Create User')) {
 

--- a/psPAS/Functions/User/Set-PASUser.ps1
+++ b/psPAS/Functions/User/Set-PASUser.ps1
@@ -510,7 +510,9 @@ function Set-PASUser {
 		}
 
 		#Construct Request Body
-		$body = $boundParameters | ConvertTo-Json -Depth 4
+		#Send as raw UTF8 bytes rather than a String so ParameterBinding/module logging of this
+		#call records a non-revealing type name instead of the literal request content.
+		$body = [System.Text.Encoding]::UTF8.GetBytes($($boundParameters | ConvertTo-Json -Depth 4))
 
 		if ($PSCmdlet.ShouldProcess($UserName, 'Update User Properties')) {
 			#send request to web service

--- a/psPAS/Functions/User/Set-PASUserPassword.ps1
+++ b/psPAS/Functions/User/Set-PASUserPassword.ps1
@@ -37,7 +37,9 @@ function Set-PASUserPassword {
 		$URI = "$($psPASSession.BaseURI)/api/Users/$id/ResetPassword"
 
 		#create request body
-		$body = $boundParameters | ConvertTo-Json
+		#Send as raw UTF8 bytes rather than a String so ParameterBinding/module logging of this
+		#call records a non-revealing type name instead of the literal request content.
+		$body = [System.Text.Encoding]::UTF8.GetBytes($($boundParameters | ConvertTo-Json))
 
 		if ($PSCmdlet.ShouldProcess($id, 'Reset Password')) {
 

--- a/psPAS/Functions/VaultRemoteManager/Get-PASVRMDRSystemHealth.ps1
+++ b/psPAS/Functions/VaultRemoteManager/Get-PASVRMDRSystemHealth.ps1
@@ -64,7 +64,9 @@ function Get-PASVRMDRSystemHealth {
         }
 
         #Create body of request
-        $body = $boundParameters | ConvertTo-Json
+        #Send as raw UTF8 bytes rather than a String so ParameterBinding/module logging of this
+        #call records a non-revealing type name instead of the literal request content.
+        $body = [System.Text.Encoding]::UTF8.GetBytes($($boundParameters | ConvertTo-Json))
 
         #send request to web service
         $result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body

--- a/psPAS/Functions/VaultRemoteManager/Get-PASVRMServiceConfig.ps1
+++ b/psPAS/Functions/VaultRemoteManager/Get-PASVRMServiceConfig.ps1
@@ -72,7 +72,9 @@ function Get-PASVRMServiceConfig {
         }
 
         #Create body of request
-        $body = $boundParameters | ConvertTo-Json
+        #Send as raw UTF8 bytes rather than a String so ParameterBinding/module logging of this
+        #call records a non-revealing type name instead of the literal request content.
+        $body = [System.Text.Encoding]::UTF8.GetBytes($($boundParameters | ConvertTo-Json))
 
         #send request to web service
         $result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body

--- a/psPAS/Functions/VaultRemoteManager/Get-PASVRMServiceConfigParameter.ps1
+++ b/psPAS/Functions/VaultRemoteManager/Get-PASVRMServiceConfigParameter.ps1
@@ -99,7 +99,9 @@ function Get-PASVRMServiceConfigParameter {
         }
 
         #Create body of request
-        $body = $boundParameters | ConvertTo-Json
+        #Send as raw UTF8 bytes rather than a String so ParameterBinding/module logging of this
+        #call records a non-revealing type name instead of the literal request content.
+        $body = [System.Text.Encoding]::UTF8.GetBytes($($boundParameters | ConvertTo-Json))
 
         #send request to web service
         $result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body

--- a/psPAS/Functions/VaultRemoteManager/Get-PASVRMServiceStatus.ps1
+++ b/psPAS/Functions/VaultRemoteManager/Get-PASVRMServiceStatus.ps1
@@ -76,7 +76,9 @@ function Get-PASVRMServiceStatus {
         }
 
         #Create body of request
-        $body = $boundParameters | ConvertTo-Json
+        #Send as raw UTF8 bytes rather than a String so ParameterBinding/module logging of this
+        #call records a non-revealing type name instead of the literal request content.
+        $body = [System.Text.Encoding]::UTF8.GetBytes($($boundParameters | ConvertTo-Json))
 
         #send request to web service
         $result = Invoke-PASRestMethod -Uri $URI -Method POST -Body $Body

--- a/psPAS/Functions/VaultRemoteManager/Invoke-PASVRMFailover.ps1
+++ b/psPAS/Functions/VaultRemoteManager/Invoke-PASVRMFailover.ps1
@@ -64,7 +64,9 @@ function Invoke-PASVRMFailover {
         }
 
         #Create body of request
-        $body = $boundParameters | ConvertTo-Json
+        #Send as raw UTF8 bytes rather than a String so ParameterBinding/module logging of this
+        #call records a non-revealing type name instead of the literal request content.
+        $body = [System.Text.Encoding]::UTF8.GetBytes($($boundParameters | ConvertTo-Json))
 
         if ($PSCmdlet.ShouldProcess($DRAddress, 'Initiate DR Failover')) {
 

--- a/psPAS/Functions/VaultRemoteManager/Restart-PASVRMService.ps1
+++ b/psPAS/Functions/VaultRemoteManager/Restart-PASVRMService.ps1
@@ -75,7 +75,9 @@ function Restart-PASVRMService {
         }
 
         #Create body of request
-        $body = $boundParameters | ConvertTo-Json
+        #Send as raw UTF8 bytes rather than a String so ParameterBinding/module logging of this
+        #call records a non-revealing type name instead of the literal request content.
+        $body = [System.Text.Encoding]::UTF8.GetBytes($($boundParameters | ConvertTo-Json))
 
         if ($PSCmdlet.ShouldProcess("$serviceName on $serverAddress", 'Restart Service')) {
 

--- a/psPAS/Functions/VaultRemoteManager/Set-PASVRMServiceConfig.ps1
+++ b/psPAS/Functions/VaultRemoteManager/Set-PASVRMServiceConfig.ps1
@@ -106,7 +106,9 @@ function Set-PASVRMServiceConfig {
         }
 
         #Create body of request
-        $body = $boundParameters | ConvertTo-Json
+        #Send as raw UTF8 bytes rather than a String so ParameterBinding/module logging of this
+        #call records a non-revealing type name instead of the literal request content.
+        $body = [System.Text.Encoding]::UTF8.GetBytes($($boundParameters | ConvertTo-Json))
 
         if ($PSCmdlet.ShouldProcess("$serviceName on $serverAddress", 'Set Service Configuration')) {
 

--- a/psPAS/Functions/VaultRemoteManager/Start-PASVRMService.ps1
+++ b/psPAS/Functions/VaultRemoteManager/Start-PASVRMService.ps1
@@ -75,7 +75,9 @@ function Start-PASVRMService {
         }
 
         #Create body of request
-        $body = $boundParameters | ConvertTo-Json
+        #Send as raw UTF8 bytes rather than a String so ParameterBinding/module logging of this
+        #call records a non-revealing type name instead of the literal request content.
+        $body = [System.Text.Encoding]::UTF8.GetBytes($($boundParameters | ConvertTo-Json))
 
         if ($PSCmdlet.ShouldProcess("$serviceName on $serverAddress", 'Start Service')) {
 

--- a/psPAS/Functions/VaultRemoteManager/Stop-PASVRMService.ps1
+++ b/psPAS/Functions/VaultRemoteManager/Stop-PASVRMService.ps1
@@ -76,7 +76,9 @@ function Stop-PASVRMService {
         }
 
         #Create body of request
-        $body = $boundParameters | ConvertTo-Json
+        #Send as raw UTF8 bytes rather than a String so ParameterBinding/module logging of this
+        #call records a non-revealing type name instead of the literal request content.
+        $body = [System.Text.Encoding]::UTF8.GetBytes($($boundParameters | ConvertTo-Json))
 
         if ($PSCmdlet.ShouldProcess("$serviceName on $serverAddress", 'Stop Service')) {
 

--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -216,11 +216,25 @@
 			Write-Debug "[Uri] $URI"
 			Write-Debug "[Method] $Method"
 
-			if (($PSBoundParameters.ContainsKey('Body')) -and (($PSBoundParameters['Body']).GetType().Name -eq 'String')) {
+			if ($PSBoundParameters.ContainsKey('Body')) {
 
-				Write-Debug "[Body] $(Hide-SecretValue -InputValue $Body)"
+				switch (($Body).GetType().Name) {
+
+					'String' { Write-Debug "[Body] $(Hide-SecretValue -InputValue $Body)" }
+
+					'Byte[]' { Write-Debug "[Body] $(Hide-SecretValue -InputValue $([System.Text.Encoding]::UTF8.GetString($Body)))" }
+
+				}
 
 			}
+
+		}
+
+		#Send a String body as raw UTF8 bytes so ParameterBinding/module logging of the Invoke-WebRequest call
+		#records a non-revealing type name (System.Byte[]) instead of the literal request content.
+		if (($PSBoundParameters.ContainsKey('Body')) -and (($Body).GetType().Name -eq 'String')) {
+
+			$PSBoundParameters['Body'] = [System.Text.Encoding]::UTF8.GetBytes($Body)
 
 		}
 


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
<!--
Please include a summary of the change and which issue is fixed & relevant motivation and context.
Put `Fixes #XXX` in your comment to link the issue that your PR fixes.
-->

When Windows PowerShell Module Logging is enabled, it can record the full value of parameters passed to functions, including passwords, in the Windows Event Log. This module builds request bodies containing plaintext passwords/secrets and passes them around as strings, which made them visible in that logging.

- Reordered a few functions so secrets are decoded from SecureString only at the very last moment, instead of being decoded early and passed through extra helper functions (each extra pass was another place the plaintext could get logged).
- Every request body that contains a decoded secret is now sent as raw bytes instead of a plain string. A byte array doesn't reveal its contents when logged (it just shows up as System.Byte[]), so this closes off the logging exposure without changing what's actually sent to the CyberArk API.
- Applied this consistently across every function in the module that handles a password/secret (accounts, users, sessions, PSM connections, directories, OIDC providers, SSH keys, CPM operations, Vault Remote Manager).
- Debug output still shows a sanitized preview of the request body, same as before.
- No behavior or API changes, same requests, same responses, just less exposure in logs. 
- Full test suite passes, including new coverage for the byte-conversion and debug-preview behavior.

Fixes #602 

## Type of change
<!--
Please select all relevant options:
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [ ] Documentation update (psPAS website or command help content)
- [ ] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [X] Pester test(s) updated
- [X] Pester test(s) passing

**Test Configuration**:
- PowerShell version:
- CyberArk PAS version:
- OS Version:

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [X] My code follows the style guidelines of this project
- [X] I have followed the contributing guidelines.
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new test failures or errors
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [X] I have linked a related issue