### PR TITLE
Enhance Set-PASDependentLinkedAccount for SelfHosted environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1043,7 +1043,7 @@ Click the below dropdown to view the current list of psPAS functions and their m
 | [`Restart-PASVRMService`][Restart-PASVRMService]                                           | **15.0**             | Restarts a Vault or DR service                               |
 | [`Invoke-PASVRMFailover`][Invoke-PASVRMFailover]                                           | **15.0**             | Initiates DR failover to the DR site                         |
 | [`Clear-PASDependentLinkedAccount`][Clear-PASDependentLinkedAccount]                       | **P Cloud Only**     | Clears a linked account from a dependent account             |
-| [`Set-PASDependentLinkedAccount`][Set-PASDependentLinkedAccount]                           | **P Cloud Only**     | Sets a linked account for a dependent account                |
+| [`Set-PASDependentLinkedAccount`][Set-PASDependentLinkedAccount]                           | **15.0**             | Sets a linked account for a dependent account                |
 | [`Import-PASTicketingSystem`][Import-PASTicketingSystem]                                   | **P Cloud Only**     | Imports a ticketing system into Privilege Cloud              |
 | [`Export-PASTicketingSystemLog`][Export-PASTicketingSystemLog]                             | **P Cloud Only**     | Exports ticketing system logs from Privilege Cloud           |
 

--- a/Tests/Set-PASDependentLinkedAccount.Tests.ps1
+++ b/Tests/Set-PASDependentLinkedAccount.Tests.ps1
@@ -112,6 +112,40 @@ Describe $($PSCommandPath -replace '.Tests.ps1') {
 
         }
 
+        Context 'SelfHosted' {
+
+            BeforeEach {
+                $psPASSession.ExternalVersion = [System.Version]'15.0'
+
+                $InputObject = [PSCustomObject]@{
+                    AccountID          = '22_3'
+                    dependentAccountId = '22_4'
+                    extraPasswordIndex = 1
+                    safe               = 'PSM'
+                    name               = 'PSMAdmin_WIN-4P294L4IT10'
+                }
+
+                $response = $InputObject | Set-PASDependentLinkedAccount
+            }
+
+            It 'sends request to expected SelfHosted endpoint' {
+
+                Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+                    $URI -eq "$($Script:psPASSession.BaseURI)/api/Accounts/22_3/dependentAccounts/22_4/Link"
+                } -Times 1 -Exactly -Scope It
+
+            }
+
+            It 'sends request with default folder value' {
+
+                Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+                    ($Body | ConvertFrom-Json).folder -eq 'Root'
+                } -Times 1 -Exactly -Scope It
+
+            }
+
+        }
+
     }
 
 }

--- a/docs/collections/_commands/Set-PASDependentLinkedAccount.md
+++ b/docs/collections/_commands/Set-PASDependentLinkedAccount.md
@@ -14,9 +14,17 @@ Sets a Linked Account for a Dependent Account
 
 ## SYNTAX
 
+### SaaS
 ```
 Set-PASDependentLinkedAccount [-accountId] <String> [-dependentAccountId] <String>
  [-extraPasswordAccountId] <String> [-extraPasswordIndex] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### SelfHosted
+```
+Set-PASDependentLinkedAccount [-accountId] <String> [-dependentAccountId] <String>
+ [-extraPasswordIndex] <String> [-safe] <String> [-name] <String> [[-folder] <String>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -25,13 +33,21 @@ Links an account to a dependent account
 
 ## EXAMPLES
 
-### Example 1
+### Example 1 - Privilege Cloud
 
 ```powershell
 PS C:\> Set-PASDependentLinkedAccount -accountId 12_3 -dependentAccountId 12_4 -extraPasswordAccountId 56_7 -extraPasswordIndex 1
 ```
 
 Links account with ID 56_7 to linked account index 1 for dependent account 12_4 with parent account 12_3
+
+### Example 2 - Self-Hosted
+
+```powershell
+PS C:\> Set-PASDependentLinkedAccount -accountId 22_3 -dependentAccountId 22_4 -extraPasswordIndex 1 -safe somesafe -name accountname
+```
+
+Links the account named accountname in the somesafe Safe to linked account index 1 (logon account) for dependent account 22_4 with parent account 22_3
 
 ## PARAMETERS
 
@@ -41,7 +57,7 @@ The ID of the parent account for the dependent account
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: SaaS, SelfHosted
 Aliases: id
 
 Required: True
@@ -57,7 +73,7 @@ The ID of the dependent account
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: SaaS, SelfHosted
 Aliases: dependentid
 
 Required: True
@@ -69,11 +85,12 @@ Accept wildcard characters: False
 
 ### -extraPasswordAccountId
 
-The ID of the account to link to the dependent account
+The ID of the account to link to the dependent account.
+Used for Privilege Cloud environments.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: SaaS
 Aliases:
 
 Required: True
@@ -89,12 +106,63 @@ The index to link the account to
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: SaaS, SelfHosted
 Aliases:
 
 Required: True
 Position: 4
 Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -safe
+
+The Safe containing the account to link to the dependent account.
+Used for Self-Hosted environments.
+
+```yaml
+Type: String
+Parameter Sets: SelfHosted
+Aliases:
+
+Required: True
+Position: 5
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -name
+
+The name of the account to link to the dependent account.
+Used for Self-Hosted environments.
+
+```yaml
+Type: String
+Parameter Sets: SelfHosted
+Aliases:
+
+Required: True
+Position: 6
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -folder
+
+The folder containing the account to link to the dependent account.
+Used for Self-Hosted environments. Defaults to Root.
+
+```yaml
+Type: String
+Parameter Sets: SelfHosted
+Aliases:
+
+Required: False
+Position: 7
+Default value: Root
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```

--- a/psPAS/Functions/Accounts/Set-PASDependentLinkedAccount.ps1
+++ b/psPAS/Functions/Accounts/Set-PASDependentLinkedAccount.ps1
@@ -5,51 +5,115 @@ function Set-PASDependentLinkedAccount {
     param(
         [parameter(
             Mandatory = $true,
-            ValueFromPipelinebyPropertyName = $true
+            ValueFromPipelinebyPropertyName = $true,
+            ParameterSetName = 'SelfHosted'
+        )]
+        [parameter(
+            Mandatory = $true,
+            ValueFromPipelinebyPropertyName = $true,
+            ParameterSetName = 'SaaS'
         )]
         [Alias('id')]
         [string]$accountId,
 
         [parameter(
             Mandatory = $true,
-            ValueFromPipelinebyPropertyName = $true
+            ValueFromPipelinebyPropertyName = $true,
+            ParameterSetName = 'SelfHosted'
+        )]
+        [parameter(
+            Mandatory = $true,
+            ValueFromPipelinebyPropertyName = $true,
+            ParameterSetName = 'SaaS'
         )]
         [Alias('dependentid')]
         [string]$dependentAccountId,
 
         [parameter(
             Mandatory = $true,
-            ValueFromPipelinebyPropertyName = $true
+            ValueFromPipelinebyPropertyName = $true,
+            ParameterSetName = 'SaaS'
         )]
         [string]$extraPasswordAccountId,
 
         [parameter(
             Mandatory = $true,
-            ValueFromPipelinebyPropertyName = $true
+            ValueFromPipelinebyPropertyName = $true,
+            ParameterSetName = 'SaaS'
+        )]
+        [parameter(
+            Mandatory = $true,
+            ValueFromPipelinebyPropertyName = $true,
+            ParameterSetName = 'SelfHosted'
         )]
         [ValidateSet('1', '2', '3')]
-        [string]$extraPasswordIndex
+        [string]$extraPasswordIndex,
+
+        [parameter(
+            Mandatory = $true,
+            ValueFromPipelinebyPropertyName = $true,
+            ParameterSetName = 'SelfHosted'
+        )]
+        [string]$safe,
+
+        [parameter(
+            Mandatory = $true,
+            ValueFromPipelinebyPropertyName = $true,
+            ParameterSetName = 'SelfHosted'
+        )]
+        [string]$name,
+
+        [parameter(
+            Mandatory = $false,
+            ValueFromPipelinebyPropertyName = $true,
+            ParameterSetName = 'SelfHosted'
+        )]
+        [string]$folder = "Root"
 
     )
 
     begin {
 
-        Assert-VersionRequirement -PrivilegeCloud
-
     }#begin
 
     process {
 
-        #Create URL for Request
-        $URI = "$($psPASSession.BaseURI)/api/Accounts/$AccountID/account-dependents/$dependentAccountId/link-accounts"
+        switch ($PSCmdlet.ParameterSetName) {
 
-        #Get Parameters to include in request
-        $boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove AccountID, dependentAccountId
+            'SaaS' {
 
-        # Rename the extraPasswordAccountId key to AccountID
-        $boundParameters.accountID = $boundParameters.extraPasswordAccountId
-        $boundParameters.Remove('extraPasswordAccountId')
+                Assert-VersionRequirement -PrivilegeCloud
 
+                #Create URL for Request
+                $URI = "$($psPASSession.BaseURI)/api/Accounts/$AccountID/account-dependents/$dependentAccountId/link-accounts"
+
+                #Get Parameters to include in request
+                $boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove AccountID, dependentAccountId
+
+                # Rename the extraPasswordAccountId key to AccountID
+                $boundParameters.accountID = $boundParameters.extraPasswordAccountId
+                $boundParameters.Remove('extraPasswordAccountId')
+
+            }
+
+            'SelfHosted' {
+
+                Assert-VersionRequirement -SelfHosted
+                Assert-VersionRequirement -RequiredVersion 15.0
+
+                #Create URL for Request
+                $URI = "$($psPASSession.BaseURI)/api/Accounts/$AccountID/dependentAccounts/$dependentAccountId/Link"
+
+                #Get Parameters to include in request
+                $boundParameters = $PSBoundParameters | Get-PASParameter -ParametersToRemove AccountID, dependentAccountId
+
+                #Ensure folder value is included in the request body
+                $boundParameters['folder'] = $folder
+
+            }
+
+        }
+        
         $body = $boundParameters | ConvertTo-Json
 
         if ($PSCmdlet.ShouldProcess($dependentAccountId, 'Set Linked Account')) {
@@ -58,9 +122,6 @@ function Set-PASDependentLinkedAccount {
             Invoke-PASRestMethod -Uri $URI -Method POST -Body $body
 
         }
-
-    }#process
-
+    }
     end { }#end
-
 }

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -44971,7 +44971,7 @@ Set-PASAccount -AccountID 29_3 -operations $actions</dev:code>
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
           <maml:name>extraPasswordAccountId</maml:name>
           <maml:description>
-            <maml:para>The ID of the account to link to the dependent account</maml:para>
+            <maml:para>The ID of the account to link to the dependent account. Used for Privilege Cloud environments.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -44991,6 +44991,103 @@ Set-PASAccount -AccountID 29_3 -operations $actions</dev:code>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Set-PASDependentLinkedAccount</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="id">
+          <maml:name>accountId</maml:name>
+          <maml:description>
+            <maml:para>The ID of the parent account for the dependent account</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="dependentid">
+          <maml:name>dependentAccountId</maml:name>
+          <maml:description>
+            <maml:para>The ID of the dependent account</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="4" aliases="none">
+          <maml:name>extraPasswordIndex</maml:name>
+          <maml:description>
+            <maml:para>The index to link the account to</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
+          <maml:name>safe</maml:name>
+          <maml:description>
+            <maml:para>The Safe containing the account to link to the dependent account. Used for Self-Hosted environments.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
+          <maml:name>name</maml:name>
+          <maml:description>
+            <maml:para>The name of the account to link to the dependent account. Used for Self-Hosted environments.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="7" aliases="none">
+          <maml:name>folder</maml:name>
+          <maml:description>
+            <maml:para>The folder containing the account to link to the dependent account. Used for Self-Hosted environments. Defaults to Root.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>Root</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
           <maml:name>WhatIf</maml:name>
@@ -45044,7 +45141,7 @@ Set-PASAccount -AccountID 29_3 -operations $actions</dev:code>
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
         <maml:name>extraPasswordAccountId</maml:name>
         <maml:description>
-          <maml:para>The ID of the account to link to the dependent account</maml:para>
+          <maml:para>The ID of the account to link to the dependent account. Used for Privilege Cloud environments.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -45064,6 +45161,42 @@ Set-PASAccount -AccountID 29_3 -operations $actions</dev:code>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="5" aliases="none">
+        <maml:name>safe</maml:name>
+        <maml:description>
+          <maml:para>The Safe containing the account to link to the dependent account. Used for Self-Hosted environments.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="6" aliases="none">
+        <maml:name>name</maml:name>
+        <maml:description>
+          <maml:para>The name of the account to link to the dependent account. Used for Self-Hosted environments.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="7" aliases="none">
+        <maml:name>folder</maml:name>
+        <maml:description>
+          <maml:para>The folder containing the account to link to the dependent account. Used for Self-Hosted environments. Defaults to Root.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>Root</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
         <maml:name>WhatIf</maml:name>
@@ -45099,10 +45232,17 @@ Set-PASAccount -AccountID 29_3 -operations $actions</dev:code>
     </maml:alertSet>
     <command:examples>
       <command:example>
-        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <maml:title>----------------- Example 1 - Privilege Cloud -----------------</maml:title>
         <dev:code>PS C:\&gt; Set-PASDependentLinkedAccount -accountId 12_3 -dependentAccountId 12_4 -extraPasswordAccountId 56_7 -extraPasswordIndex 1</dev:code>
         <dev:remarks>
           <maml:para>Links account with ID 56_7 to linked account index 1 for dependent account 12_4 with parent account 12_3</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>------------------- Example 2 - Self-Hosted -------------------</maml:title>
+        <dev:code>PS C:\&gt; Set-PASDependentLinkedAccount -accountId 22_3 -dependentAccountId 22_4 -extraPasswordIndex 1 -safe somesafe -name accountname</dev:code>
+        <dev:remarks>
+          <maml:para>Links the account named accountname in the somesafe Safe to linked account index 1 (logon account) for dependent account 22_4 with parent account 22_3</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
<!--
Please include a summary of the change and which issue is fixed & relevant motivation and context.
Put `Fixes #XXX` in your comment to link the issue that your PR fixes.
-->

This pull request adds support for Self-Hosted environments to the `Set-PASDependentLinkedAccount` function, allowing it to work both with Privilege Cloud (SaaS) and Self-Hosted (v15.0+) CyberArk deployments. The changes introduce new parameters for Self-Hosted usage, update documentation and help files, and add tests to ensure correct behavior.

## Type of change
<!--
Please select all relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [x] Documentation update (psPAS website or command help content)
- [ ] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [x] Pester test(s) updated
- [ ] Pester test(s) passing

**Test Configuration**:
- PowerShell version: 7
- CyberArk PAS version: 15.2
- OS Version: Windows Server 2025

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [x] My code follows the style guidelines of this project
- [x] I have followed the contributing guidelines.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new test failures or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [ ] I have linked a related issue