### PR TITLE
Support SelfHosted environments in Clear-PASDependentLinkedAccount

### DIFF
--- a/README.md
+++ b/README.md
@@ -1042,7 +1042,7 @@ Click the below dropdown to view the current list of psPAS functions and their m
 | [`Stop-PASVRMService`][Stop-PASVRMService]                                                 | **15.0**             | Stops a Vault or DR service                                  |
 | [`Restart-PASVRMService`][Restart-PASVRMService]                                           | **15.0**             | Restarts a Vault or DR service                               |
 | [`Invoke-PASVRMFailover`][Invoke-PASVRMFailover]                                           | **15.0**             | Initiates DR failover to the DR site                         |
-| [`Clear-PASDependentLinkedAccount`][Clear-PASDependentLinkedAccount]                       | **P Cloud Only**     | Clears a linked account from a dependent account             |
+| [`Clear-PASDependentLinkedAccount`][Clear-PASDependentLinkedAccount]                       | **15.0**             | Clears a linked account from a dependent account             |
 | [`Set-PASDependentLinkedAccount`][Set-PASDependentLinkedAccount]                           | **15.0**             | Sets a linked account for a dependent account                |
 | [`Import-PASTicketingSystem`][Import-PASTicketingSystem]                                   | **P Cloud Only**     | Imports a ticketing system into Privilege Cloud              |
 | [`Export-PASTicketingSystemLog`][Export-PASTicketingSystemLog]                             | **P Cloud Only**     | Exports ticketing system logs from Privilege Cloud           |

--- a/Tests/Clear-PASDependentLinkedAccount.Tests.ps1
+++ b/Tests/Clear-PASDependentLinkedAccount.Tests.ps1
@@ -103,6 +103,29 @@ Describe $($PSCommandPath -replace '.Tests.ps1') {
 
         }
 
+        Context 'SelfHosted' {
+
+            BeforeEach {
+                $psPASSession.ExternalVersion = [System.Version]'15.0'
+
+                $InputObject = [PSCustomObject]@{
+                    AccountID          = '22_3'
+                    dependentAccountId = '22_4'
+                }
+
+                $response = $InputObject | Clear-PASDependentLinkedAccount
+            }
+
+            It 'sends request to expected SelfHosted endpoint' {
+
+                Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+                    $URI -eq "$($Script:psPASSession.BaseURI)/api/Accounts/22_3/dependentAccounts/22_4/Unlink"
+                } -Times 1 -Exactly -Scope It
+
+            }
+
+        }
+
     }
 
 }

--- a/docs/collections/_commands/Clear-PASDependentLinkedAccount.md
+++ b/docs/collections/_commands/Clear-PASDependentLinkedAccount.md
@@ -14,9 +14,16 @@ Clears a linked account from a dependent account
 
 ## SYNTAX
 
+### SaaS
 ```
 Clear-PASDependentLinkedAccount [-AccountID] <String> [-dependentAccountId] <String>
  [-extraPasswordIndex] <Int32> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### SelfHosted
+```
+Clear-PASDependentLinkedAccount [-AccountID] <String> [-dependentAccountId] <String>
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -25,13 +32,23 @@ Unlink an account from a dependent account
 
 ## EXAMPLES
 
-### Example 1
+### Example 1 - Privilege Cloud
 
 ```powershell
 PS C:\> Clear-PASDependentLinkedAccount -AccountID 32_1 -dependentAccountId 32_2 -extraPasswordIndex 1
 ```
 
 Clears linked account index 1 from dependent account 32_2
+
+### Example 2 - Self-Hosted
+
+```powershell
+PS C:\> Clear-PASDependentLinkedAccount -AccountID 32_1 -dependentAccountId 32_2
+```
+
+Clears the linked account from dependent account 32_2
+
+Requires Self-Hosted CyberArk PAS v15.2 or greater.
 
 ## PARAMETERS
 
@@ -41,7 +58,7 @@ The ID of the parent account for the linked account
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: SaaS, SelfHosted
 Aliases: id
 
 Required: True
@@ -57,7 +74,7 @@ The ID of the Dependent account for the Parent Account
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: SaaS, SelfHosted
 Aliases: dependentid
 
 Required: True
@@ -69,11 +86,12 @@ Accept wildcard characters: False
 
 ### -extraPasswordIndex
 
-The index of the account to unlink from the dependent account
+The index of the account to unlink from the dependent account.
+Used for Privilege Cloud environments.
 
 ```yaml
 Type: Int32
-Parameter Sets: (All)
+Parameter Sets: SaaS
 Aliases:
 
 Required: True

--- a/psPAS/Functions/Accounts/Clear-PASDependentLinkedAccount.ps1
+++ b/psPAS/Functions/Accounts/Clear-PASDependentLinkedAccount.ps1
@@ -4,21 +4,34 @@ function Clear-PASDependentLinkedAccount {
     param(
         [parameter(
             Mandatory = $true,
-            ValueFromPipelinebyPropertyName = $true
+            ValueFromPipelinebyPropertyName = $true,
+            ParameterSetName = 'SelfHosted'
+        )]
+        [parameter(
+            Mandatory = $true,
+            ValueFromPipelinebyPropertyName = $true,
+            ParameterSetName = 'SaaS'
         )]
         [Alias('id')]
         [string]$AccountID,
 
         [parameter(
             Mandatory = $true,
-            ValueFromPipelinebyPropertyName = $true
+            ValueFromPipelinebyPropertyName = $true,
+            ParameterSetName = 'SelfHosted'
+        )]
+        [parameter(
+            Mandatory = $true,
+            ValueFromPipelinebyPropertyName = $true,
+            ParameterSetName = 'SaaS'
         )]
         [Alias('dependentid')]
         [string]$dependentAccountId,
 
         [parameter(
             Mandatory = $true,
-            ValueFromPipelinebyPropertyName = $true
+            ValueFromPipelinebyPropertyName = $true,
+            ParameterSetName = 'SaaS'
         )]
         [int]$extraPasswordIndex
 
@@ -26,16 +39,37 @@ function Clear-PASDependentLinkedAccount {
 
     begin {
 
-        Assert-VersionRequirement -PrivilegeCloud
-
     }#begin
 
     process {
 
-        #Create URL for Request
-        $URI = "$($psPASSession.BaseURI)/api/Accounts/$AccountID/account-dependents/$dependentAccountId/link-accounts/$extraPasswordIndex"
 
-        if ($PSCmdlet.ShouldProcess($dependentAccountId, "Clear extraPass$extraPasswordIndex Linked Account")) {
+        switch ($PSCmdlet.ParameterSetName) {
+
+            'SaaS' {
+
+                Assert-VersionRequirement -PrivilegeCloud
+
+                #Create URL for Request
+                $URI = "$($psPASSession.BaseURI)/api/Accounts/$AccountID/account-dependents/$dependentAccountId/link-accounts/$extraPasswordIndex"
+
+            }
+
+            'SelfHosted' {
+
+                #Self-Hosted parameter name, requires 15.0
+                Assert-VersionRequirement -SelfHosted
+                Assert-VersionRequirement -RequiredVersion 15.0
+
+                #Create URL for Request
+                $URI = "$($psPASSession.BaseURI)/api/Accounts/$AccountID/dependentAccounts/$dependentAccountId/Unlink"
+
+            }
+
+        }
+
+
+        if ($PSCmdlet.ShouldProcess($dependentAccountId, "Clear Linked Account")) {
 
             #Send request to web service
             Invoke-PASRestMethod -Uri $URI -Method DELETE

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -10522,7 +10522,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
           <maml:name>extraPasswordIndex</maml:name>
           <maml:description>
-            <maml:para>The index of the account to unlink from the dependent account</maml:para>
+            <maml:para>The index of the account to unlink from the dependent account. Used for Privilege Cloud environments.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
@@ -10530,6 +10530,55 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
             <maml:uri />
           </dev:type>
           <dev:defaultValue>0</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Clear-PASDependentLinkedAccount</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="id">
+          <maml:name>AccountID</maml:name>
+          <maml:description>
+            <maml:para>The ID of the parent account for the linked account</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="dependentid">
+          <maml:name>dependentAccountId</maml:name>
+          <maml:description>
+            <maml:para>The ID of the Dependent account for the Parent Account</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
           <maml:name>WhatIf</maml:name>
@@ -10583,7 +10632,7 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="3" aliases="none">
         <maml:name>extraPasswordIndex</maml:name>
         <maml:description>
-          <maml:para>The index of the account to unlink from the dependent account</maml:para>
+          <maml:para>The index of the account to unlink from the dependent account. Used for Privilege Cloud environments.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
@@ -10626,10 +10675,18 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
     </maml:alertSet>
     <command:examples>
       <command:example>
-        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <maml:title>----------------- Example 1 - Privilege Cloud -----------------</maml:title>
         <dev:code>PS C:\&gt; Clear-PASDependentLinkedAccount -AccountID 32_1 -dependentAccountId 32_2 -extraPasswordIndex 1</dev:code>
         <dev:remarks>
           <maml:para>Clears linked account index 1 from dependent account 32_2</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>------------------- Example 2 - Self-Hosted -------------------</maml:title>
+        <dev:code>PS C:\&gt; Clear-PASDependentLinkedAccount -AccountID 32_1 -dependentAccountId 32_2</dev:code>
+        <dev:remarks>
+          <maml:para>Clears the linked account from dependent account 32_2</maml:para>
+          <maml:para>Requires Self-Hosted CyberArk PAS v15.2 or greater.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
<!--
Please include a summary of the change and which issue is fixed & relevant motivation and context.
Put `Fixes #XXX` in your comment to link the issue that your PR fixes.
-->

This pull request updates the `Clear-PASDependentLinkedAccount` function to support both Privilege Cloud (SaaS) and Self-Hosted CyberArk PAS environments. 

* Added a new 'SelfHosted' parameter set to `Clear-PASDependentLinkedAccount`, allowing the function to work with Self-Hosted CyberArk PAS v15.0+.

## Type of change
<!--
Please select all relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [x] Documentation update (psPAS website or command help content)
- [ ] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [x] Pester test(s) updated
- [ ] Pester test(s) passing

**Test Configuration**:
- PowerShell version: 7
- CyberArk PAS version: 15.2
- OS Version: Windows Server 2025

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [x] My code follows the style guidelines of this project
- [x] I have followed the contributing guidelines.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new test failures or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [ ] I have linked a related issue