### PR TITLE
Add Remove-PASReportSchedule function and enhance Export-PASPlatform and Get-PASUser

### DIFF
--- a/Tests/Export-PASPlatform.Tests.ps1
+++ b/Tests/Export-PASPlatform.Tests.ps1
@@ -45,36 +45,33 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
-		BeforeEach {
-			Mock Invoke-PASRestMethod -MockWith {
-
-				New-Object Byte[] 512
-
-			}
-
-			Mock Out-PASFile -MockWith { }
-
-			$response = Export-PASPlatform -PlatformID SomePlatform -path "$env:Temp\testExport.zip"
-		}
-
 		Context 'Mandatory Parameters' {
 
-			$Parameters = @{Parameter = 'PlatformID' },
-			@{Parameter = 'path' }
+			$Parameters = @{Parameter = 'path' }
 
 			It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
 
 				param($Parameter)
 
-				(Get-Command Export-PASPlatform).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
+				(Get-Command Export-PASPlatform).Parameters["$Parameter"].Attributes.Mandatory | Select-Object -Unique | Should -Be $true
 
 			}
 
 		}
 
+		Context 'Input - PlatformID' {
 
+			BeforeEach {
+				Mock Invoke-PASRestMethod -MockWith {
 
-		Context 'Input' {
+					New-Object Byte[] 512
+
+				}
+
+				Mock Out-PASFile -MockWith { }
+
+				$response = Export-PASPlatform -PlatformID SomePlatform -path "$env:Temp\testExport.zip"
+			}
 
 			It 'throws if path is invalid' {
 				{ Export-PASPlatform -PlatformID SomePlatform -path A:\test.txt } | Should -Throw
@@ -105,6 +102,127 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			It 'throws error if version requirement not met' {
 				$psPASSession.ExternalVersion = '1.0'
 				{ Export-PASPlatform -PlatformID SomePlatform -path "$env:Temp\testExport.zip" } | Should -Throw
+				$psPASSession.ExternalVersion = '0.0'
+			}
+
+		}
+
+		Context 'Input - RotationalGroupID' {
+
+			BeforeEach {
+				Mock Invoke-PASRestMethod -MockWith {
+
+					New-Object Byte[] 512
+
+				}
+
+				Mock Out-PASFile -MockWith { }
+
+				$response = Export-PASPlatform -RotationalGroupID SomeGroup -path "$env:Temp\testExport.zip"
+			}
+
+			It 'sends request' {
+
+				Assert-MockCalled Invoke-PASRestMethod -Scope It -Times 1 -Exactly
+
+			}
+
+			It 'sends request to expected endpoint' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Platforms/RotationalGroups/SomeGroup/Export"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'uses expected method' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
+
+			}
+
+		}
+
+		Context 'Input - DependentID' {
+
+			BeforeEach {
+				Mock Invoke-PASRestMethod -MockWith {
+
+					New-Object Byte[] 512
+
+				}
+
+				Mock Out-PASFile -MockWith { }
+
+				$response = Export-PASPlatform -DependentID 1 -path "$env:Temp\testExport.zip"
+			}
+
+			It 'sends request' {
+
+				Assert-MockCalled Invoke-PASRestMethod -Scope It -Times 1 -Exactly
+
+			}
+
+			It 'sends request to expected endpoint' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Platforms/Dependents/1/Export"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'uses expected method' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
+
+			}
+
+		}
+
+		Context 'Input - GroupPlatformID' {
+
+			BeforeEach {
+				Mock Invoke-PASRestMethod -MockWith {
+
+					New-Object Byte[] 512
+
+				}
+
+				Mock Out-PASFile -MockWith { }
+
+				$psPASSession.ExternalVersion = '12.2'
+				$response = Export-PASPlatform -GroupPlatformID SomeGroupPlatform -path "$env:Temp\testExport.zip"
+			}
+
+			It 'sends request' {
+
+				Assert-MockCalled Invoke-PASRestMethod -Scope It -Times 1 -Exactly
+
+			}
+
+			It 'sends request to expected endpoint' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Platforms/Groups/SomeGroupPlatform/Export"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'uses expected method' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'throws error if version requirement not met' {
+				$psPASSession.ExternalVersion = '1.0'
+				{ Export-PASPlatform -GroupPlatformID SomeGroupPlatform -path "$env:Temp\testExport.zip" } | Should -Throw
 				$psPASSession.ExternalVersion = '0.0'
 			}
 

--- a/Tests/Get-PASReportSchedule.Tests.ps1
+++ b/Tests/Get-PASReportSchedule.Tests.ps1
@@ -93,6 +93,59 @@ Describe $($PSCommandPath -replace '.Tests.ps1') {
 
         }
 
+        Context 'Input - ID' {
+
+            BeforeEach {
+                Mock Invoke-PASRestMethod -MockWith {
+                    [PSCustomObject]@{'tasks' = [PSCustomObject]@{'Prop1' = 'VAL1'; 'Prop2' = 'Val2'; 'Prop3' = 'Val3' } }
+                }
+
+                $InputObj = [pscustomobject]@{
+                    'id' = 'SomeTaskID'
+                }
+
+                $Script:psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+                $psPASSession.ExternalVersion = '0.0'
+                $psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+            }
+
+            It 'sends request' {
+                $InputObj | Get-PASReportSchedule
+                Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+
+            }
+
+            It 'sends request to expected endpoint' {
+                $InputObj | Get-PASReportSchedule
+                Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+                    $URI -eq "$($Script:psPASSession.BaseURI)/API/Tasks/SomeTaskID"
+
+                } -Times 1 -Exactly -Scope It
+
+            }
+
+            It 'uses expected method' {
+                $InputObj | Get-PASReportSchedule
+                Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
+
+            }
+
+            It 'escapes the id value in the URL' {
+                $InputObj = [pscustomobject]@{
+                    'id' = 'Some Task ID'
+                }
+                $InputObj | Get-PASReportSchedule
+                Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+                    $URI -eq "$($Script:psPASSession.BaseURI)/API/Tasks/Some%20Task%20ID"
+
+                } -Times 1 -Exactly -Scope It
+
+            }
+
+        }
+
         Context 'Output' {
             BeforeEach {
                 Mock Invoke-PASRestMethod -MockWith {

--- a/Tests/Get-PASUser.Tests.ps1
+++ b/Tests/Get-PASUser.Tests.ps1
@@ -151,6 +151,27 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$psPASSession.ExternalVersion = '0.0'
 			}
 
+			It 'sends request to expected endpoint - Safes' {
+
+				$psPASSession.ExternalVersion = '12.2'
+				Get-PASUser -id 123 -safes
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:psPASSession.BaseURI)/API/Users/123/safes"
+
+				} -Times 1 -Exactly -Scope It
+
+				$psPASSession.ExternalVersion = '0.0'
+
+			}
+
+			It 'throws error if version 12.2 requirement not met for Safes' {
+				$psPASSession.ExternalVersion = '1.0'
+				{ Get-PASUser -id 123 -safes } | Should -Throw
+				$psPASSession.ExternalVersion = '0.0'
+			}
+
 		}
 
 		Context 'Output' {
@@ -204,6 +225,20 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 				$response = $InputObjV10 | Get-PASUser
 				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.User.Extended
+
+			}
+
+			It 'outputs object with expected typename - Safes' {
+
+				Mock Invoke-PASRestMethod -MockWith { [PSCustomObject]@{'Safes' =
+						[PSCustomObject]@{'SafeName' = 'SomeSafe' }
+					}
+				}
+
+				$psPASSession.ExternalVersion = '12.2'
+				$response = Get-PASUser -id 123 -safes
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.User.Safe
+				$psPASSession.ExternalVersion = '0.0'
 
 			}
 

--- a/Tests/Remove-PASReportSchedule.Tests.ps1
+++ b/Tests/Remove-PASReportSchedule.Tests.ps1
@@ -1,0 +1,61 @@
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
+
+    BeforeAll {
+        $Here = Split-Path -Parent $PSCommandPath
+        $ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+        $ModulePath = Resolve-Path "$Here\..\$ModuleName"
+        $ManifestPath = Join-Path $ModulePath "$ModuleName.psd1"
+
+        if (-not (Get-Module -Name $ModuleName -All)) {
+            Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+        }
+
+        $psPASSession = [ordered]@{
+            BaseURI            = 'https://SomeURL/SomeApp'
+            User               = $null
+            ExternalVersion    = [System.Version]'0.0'
+            WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+            StartTime          = $null
+            ElapsedTime        = $null
+            LastCommand        = $null
+            LastCommandTime    = $null
+            LastCommandResults = $null
+        }
+
+        New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
+    }
+
+    InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf) {
+
+        BeforeEach {
+            $script:seenUri = $null
+            $script:seenMethod = $null
+            $script:seenBody = $null
+
+            Mock Assert-VersionRequirement {}
+
+            Mock Invoke-PASRestMethod {
+                $script:seenUri = $Uri
+                $script:seenMethod = $Method
+                $script:seenBody = $Body
+            }
+        }
+
+        Context 'Input' {
+            It 'sends request to expected endpoint' {
+                $null = Remove-PASReportSchedule -id 'SomeTaskId' -Confirm:$false
+                $script:seenUri | Should -Be "$($Script:psPASSession.BaseURI)/API/Tasks/SomeTaskId"
+            }
+
+            It 'uses expected method' {
+                $null = Remove-PASReportSchedule -id 'SomeTaskId' -Confirm:$false
+                $script:seenMethod | Should -Match 'DELETE'
+            }
+
+            It 'sends request with no body' {
+                $null = Remove-PASReportSchedule -id 'SomeTaskId' -Confirm:$false
+                $script:seenBody | Should -Be $null
+            }
+        }
+    }
+}

--- a/Tests/Stop-PASCPMTask.Tests.ps1
+++ b/Tests/Stop-PASCPMTask.Tests.ps1
@@ -103,6 +103,46 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 		}
 
+		Context 'Dependent Account Input' {
+
+			BeforeEach {
+				$psPASSession.ExternalVersion = '15.2'
+
+				Mock Invoke-PASRestMethod -MockWith { }
+
+				$InputObj = [pscustomobject]@{
+					'id'                  = 'SomeID'
+					'dependentAccountid'  = 'SomeDependentID'
+				}
+
+				$response = $InputObj | Stop-PASCPMTask
+
+			}
+
+			It 'sends request' {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'sends request to expected endpoint' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/Accounts/SomeID/DependentAccounts/SomeDependentID/Cancel"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'uses expected method' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'POST' } -Times 1 -Exactly -Scope It
+
+			}
+
+		}
+
 		Context 'Bulk Input' {
 
 			BeforeEach {

--- a/docs/collections/_commands/Export-PASPlatform.md
+++ b/docs/collections/_commands/Export-PASPlatform.md
@@ -14,8 +14,24 @@ Export a platform
 
 ## SYNTAX
 
+### PlatformID
 ```
 Export-PASPlatform [-PlatformID] <String> [-path] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### RotationalGroupID
+```
+Export-PASPlatform [-RotationalGroupID <String>] [-path] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### DependentID
+```
+Export-PASPlatform [-DependentID <String>] [-path] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### GroupPlatformID
+```
+Export-PASPlatform [-GroupPlatformID <String>] [-path] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -39,7 +55,7 @@ The name of the platform.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: PlatformID
 Aliases:
 
 Required: True
@@ -93,6 +109,51 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DependentID
+Exports a Dependent platform
+
+```yaml
+Type: String
+Parameter Sets: DependentID
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -GroupPlatformID
+Exports a Group platform
+
+```yaml
+Type: String
+Parameter Sets: GroupPlatformID
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -RotationalGroupID
+Exports a Rotational Group platform
+
+```yaml
+Type: String
+Parameter Sets: RotationalGroupID
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 

--- a/docs/collections/_commands/Get-PASReportSchedule.md
+++ b/docs/collections/_commands/Get-PASReportSchedule.md
@@ -14,7 +14,7 @@ Returns details of available report schedules
 ## SYNTAX
 
 ```
-Get-PASReportSchedule [<CommonParameters>]
+Get-PASReportSchedule [-id <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -30,6 +30,21 @@ PS C:\> Get-PASReportSchedule
 Returns all report schedules for the user
 
 ## PARAMETERS
+
+### -id
+When specified, returns a specific report schedule, otherwise returns all the user has access to. 
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
 
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).

--- a/docs/collections/_commands/Get-PASUser.md
+++ b/docs/collections/_commands/Get-PASUser.md
@@ -20,6 +20,11 @@ Get-PASUser [-Search <String>] [-UserType <String>] [-UserStatus <String>] [-sou
  [-ComponentUser <Boolean>] [-sort <String[]>] [-UserName <String>] [<CommonParameters>]
 ```
 
+### Safes
+```
+Get-PASUser -id <Int32> [-safes] [<CommonParameters>]
+```
+
 ### Gen2ID
 ```
 Get-PASUser -id <Int32> [<CommonParameters>]
@@ -105,7 +110,7 @@ Minimum required version 10.10
 
 ```yaml
 Type: Int32
-Parameter Sets: Gen2ID
+Parameter Sets: Safes, Gen2ID
 Aliases:
 
 Required: True
@@ -279,6 +284,21 @@ Parameter Sets: Gen2, Gen2-ExtendedDetails
 Aliases:
 
 Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -safes
+Returns all safes the user has access to, including permissions
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Safes
+Aliases:
+
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)

--- a/docs/collections/_commands/Remove-PASReportSchedule.md
+++ b/docs/collections/_commands/Remove-PASReportSchedule.md
@@ -1,0 +1,103 @@
+---
+external help file: psPAS-help.xml
+Module Name: psPAS
+online version: https://pspas.pspete.dev/commands/Remove-PASReportSchedule
+schema: 2.0.0
+---
+
+# Remove-PASReportSchedule
+
+## SYNOPSIS
+
+Removes a report schedule.
+
+## SYNTAX
+
+```
+Remove-PASReportSchedule [-id] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+Removes an existing report schedule by ID.
+
+This command requires CyberArk version 14.6 or later.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+Remove-PASReportSchedule -id 12345
+```
+
+Removes the report schedule with the specified ID.
+
+## PARAMETERS
+
+### -id
+
+The unique ID of the report schedule to remove.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+You can pipe objects with an `id` property to this command.
+
+## OUTPUTS
+
+### None
+
+## NOTES
+
+Minimum CyberArk version 14.6
+
+## RELATED LINKS
+
+[Remove-PASReportSchedule](https://pspas.pspete.dev/commands/Remove-PASReportSchedule)

--- a/docs/collections/_commands/Stop-PASCPMTask.md
+++ b/docs/collections/_commands/Stop-PASCPMTask.md
@@ -14,7 +14,8 @@ Cancels a pending CPM task for one or more accounts.
 ## SYNTAX
 
 ```
-Stop-PASCPMTask [-Accountid] <String[]> [-WhatIf] [-Confirm] [<CommonParameters>]
+Stop-PASCPMTask [-Accountid] <String[]> [-dependentAccountid <String>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -86,6 +87,21 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -dependentAccountid
+{{ Fill dependentAccountid Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 

--- a/psPAS/Functions/Accounts/Stop-PASCPMTask.ps1
+++ b/psPAS/Functions/Accounts/Stop-PASCPMTask.ps1
@@ -7,10 +7,17 @@ function Stop-PASCPMTask {
             ValueFromPipelinebyPropertyName = $true
         )]
         [Alias('id')]
-        [string[]]$Accountid
+        [string[]]$Accountid,
+
+        [parameter(
+            Mandatory = $false,
+            ValueFromPipelinebyPropertyName = $true
+        )]
+        [string]$dependentAccountid
     )
 
     begin {
+
         Assert-VersionRequirement -SelfHosted
         Assert-VersionRequirement -RequiredVersion 15.2
 
@@ -27,33 +34,42 @@ function Stop-PASCPMTask {
         $Request = @{
             Method = 'POST'
         }
+
     }#begin
 
     process {
 
-        if ($BulkConfirmation) {
+        if ($PSBoundParameters.ContainsKey('dependentAccountid')) {
 
-            #Create URL for Request
-            $URI = "$($psPASSession.BaseURI)/API/Accounts/Cancel/Bulk"
-
-            #Create body of request
-            $Body = @{'BulkItems' = [System.Collections.Generic.List[object]]::new() }
-            $AccountID | ForEach-Object {
-                $Body.BulkItems.Add(
-                    @{
-                        AccountID = $PSItem
-                    }
-                )
-            }
-            #Format body as JSON
-            $Body = $Body | ConvertTo-Json -Depth 3
-
-            $Request.Add('Body', $Body)
+            $URI = "$($psPASSession.BaseURI)/api/Accounts/$Accountid/DependentAccounts/$dependentAccountid/Cancel"
 
         } else {
 
-            #Create URL for request
-            $URI = "$($psPASSession.BaseURI)/API/Accounts/$Accountid/Cancel/"
+            if ($BulkConfirmation) {
+
+                #Create URL for Request
+                $URI = "$($psPASSession.BaseURI)/API/Accounts/Cancel/Bulk"
+
+                #Create body of request
+                $Body = @{'BulkItems' = [System.Collections.Generic.List[object]]::new() }
+                $AccountID | ForEach-Object {
+                    $Body.BulkItems.Add(
+                        @{
+                            AccountID = $PSItem
+                        }
+                    )
+                }
+                #Format body as JSON
+                $Body = $Body | ConvertTo-Json -Depth 3
+
+                $Request.Add('Body', $Body)
+
+            } else {
+
+                #Create URL for request
+                $URI = "$($psPASSession.BaseURI)/API/Accounts/$Accountid/Cancel/"
+
+            }
 
         }
 

--- a/psPAS/Functions/Platforms/Export-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Export-PASPlatform.ps1
@@ -4,13 +4,51 @@ function Export-PASPlatform {
 	param(
 		[parameter(
 			Mandatory = $true,
-			ValueFromPipelinebyPropertyName = $true
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'PlatformID'
 		)]
 		[string]$PlatformID,
 
 		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'RotationalGroupID'
+		)]
+		[string]$RotationalGroupID,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'DependentID'
+		)]
+		[int]$DependentID,
+
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'GroupPlatformID'
+		)]
+		[string]$GroupPlatformID,
+
+		[parameter(
 			Mandatory = $true,
-			ValueFromPipelinebyPropertyName = $true
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'PlatformID'
+		)]
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'RotationalGroupID'
+		)]
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'DependentID'
+		)]
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'GroupPlatformID'
 		)]
 		[ValidateScript( { Test-Path -Path $_ -IsValid })]
 		[string]$path
@@ -22,8 +60,42 @@ function Export-PASPlatform {
 
 	process {
 
-		#Create URL for request
-		$URI = "$($psPASSession.BaseURI)/API/Platforms/$PlatformID/Export?platformID=$PlatformID"
+		switch ($PSCmdlet.ParameterSetName) {
+
+			'PlatformID' {
+
+				#Create URL for request
+				$URI = "$($psPASSession.BaseURI)/API/Platforms/$PlatformID/Export?platformID=$PlatformID"
+
+			}
+
+			'RotationalGroupID' {
+
+				#Create URL for request
+				$URI = "$($psPASSession.BaseURI)/api/Platforms/RotationalGroups/$RotationalGroupID/Export"
+
+			}
+
+			'DependentID' {
+
+				#Create URL for request
+				$URI = "$($psPASSession.BaseURI)/api/Platforms/Dependents/$DependentID/Export"
+
+			}
+
+			'GroupPlatformID' {
+
+				#Not sure when this API was added....
+				Assert-VersionRequirement -RequiredVersion 12.2
+
+				#Create URL for request
+				$URI = "$($psPASSession.BaseURI)/API/Platforms/Groups/$GroupPlatformID/Export"
+
+				break
+
+			}
+
+		}
 
 		if ($PSCmdlet.ShouldProcess($PlatformID, 'Exports Platform Package')) {
 

--- a/psPAS/Functions/Reports/Get-PASReportSchedule.ps1
+++ b/psPAS/Functions/Reports/Get-PASReportSchedule.ps1
@@ -1,7 +1,13 @@
 # .ExternalHelp psPAS-help.xml
 function Get-PASReportSchedule {
     [CmdletBinding()]
-    param( )
+    param( 
+        [parameter(
+            Mandatory = $false,
+            ValueFromPipelinebyPropertyName = $true
+        )]
+        [string]$id
+    )
 
     begin {
 
@@ -13,6 +19,12 @@ function Get-PASReportSchedule {
 
         #Create URL for Request
         $URI = "$($psPASSession.BaseURI)/API/Tasks"
+
+        if ($PSBoundParameters.ContainsKey('id')) {
+
+            $URI = "$URI/$($id | Get-EscapedString)"
+
+        }
 
         #Send request to web service
         $result = Invoke-PASRestMethod -Uri $URI -Method GET

--- a/psPAS/Functions/Reports/Remove-PASReportSchedule.ps1
+++ b/psPAS/Functions/Reports/Remove-PASReportSchedule.ps1
@@ -1,0 +1,33 @@
+# .ExternalHelp psPAS-help.xml
+function Remove-PASReportSchedule {
+    [CmdletBinding(SupportsShouldProcess)]
+    param( 
+        [parameter(
+            Mandatory = $true,
+            ValueFromPipelinebyPropertyName = $true
+        )]
+        [string]$id
+    )
+
+    begin {
+
+        Assert-VersionRequirement -RequiredVersion 14.6
+
+    }
+
+    process {
+
+        #Create URL for Request
+        $URI = "$($psPASSession.BaseURI)/API/Tasks/$($id | Get-EscapedString)"
+
+        if ($PSCmdlet.ShouldProcess($id, 'Remove Report Schedule')) {
+
+            Invoke-PASRestMethod -Uri $URI -Method DELETE
+
+        }
+
+    }
+
+    end {}
+
+}

--- a/psPAS/Functions/User/Get-PASUser.ps1
+++ b/psPAS/Functions/User/Get-PASUser.ps1
@@ -8,6 +8,11 @@ function Get-PASUser {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Gen2ID'
 		)]
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'Safes'
+		)]
 		[int]$id,
 
 		[parameter(
@@ -45,13 +50,14 @@ function Get-PASUser {
 					$Module = (Get-Command $commandName -ErrorAction Stop).Module
 					$UserTypes = & $Module { Get-PASUserType -ErrorAction Stop }
 
-				} catch { return }
+				}
+				catch { return }
 
 				$UserTypes.UserTypeName |
-					Where-Object { $_ -and ($_ -like "$wordToComplete*") } |
-					ForEach-Object { [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_) }
+				Where-Object { $_ -and ($_ -like "$wordToComplete*") } |
+				ForEach-Object { [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_) }
 
-		})]
+			})]
 		[string]$UserType,
 
 		[parameter(
@@ -91,6 +97,13 @@ function Get-PASUser {
 			ParameterSetName = 'Gen2-ExtendedDetails'
 		)]
 		[boolean]$ComponentUser,
+
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'Safes'
+		)]
+		[switch]$safes,
 
 		[parameter(
 			Mandatory = $false,
@@ -214,6 +227,20 @@ function Get-PASUser {
 
 			}
 
+			'Safes' {
+
+				#Not sure when this API was added....
+				Assert-VersionRequirement -RequiredVersion 12.2
+
+				#Create URL for request
+				$URI = "$($psPASSession.BaseURI)/API/Users/$id/safes"
+
+				$TypeName = 'psPAS.CyberArk.Vault.User.Safe'
+
+				break
+
+			}
+
 		}
 
 		#send request to web service
@@ -237,6 +264,13 @@ function Get-PASUser {
 				$result = $null
 
 			}
+
+		}
+
+		if ($PSCmdlet.ParameterSetName -eq 'Safes') {
+
+			#Safes endpoint returns object with Safes property
+			$result = $result.Safes
 
 		}
 

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -13078,6 +13078,153 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
       </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Export-PASPlatform</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
+          <maml:name>path</maml:name>
+          <maml:description>
+            <maml:para>The path to export the platform configuration to. If the path includes a file name and extension, the platform is saved to that exact file; otherwise the path is treated as a destination folder.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>DependentID</maml:name>
+          <maml:description>
+            <maml:para>Exports a Dependent platform</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Export-PASPlatform</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
+          <maml:name>path</maml:name>
+          <maml:description>
+            <maml:para>The path to export the platform configuration to. If the path includes a file name and extension, the platform is saved to that exact file; otherwise the path is treated as a destination folder.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>GroupPlatformID</maml:name>
+          <maml:description>
+            <maml:para>Exports a Group platform</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Export-PASPlatform</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
+          <maml:name>path</maml:name>
+          <maml:description>
+            <maml:para>The path to export the platform configuration to. If the path includes a file name and extension, the platform is saved to that exact file; otherwise the path is treated as a destination folder.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>RotationalGroupID</maml:name>
+          <maml:description>
+            <maml:para>Exports a Rotational Group platform</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
     </command:syntax>
     <command:parameters>
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
@@ -13127,6 +13274,42 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
           <maml:uri />
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>DependentID</maml:name>
+        <maml:description>
+          <maml:para>Exports a Dependent platform</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>GroupPlatformID</maml:name>
+        <maml:description>
+          <maml:para>Exports a Group platform</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>RotationalGroupID</maml:name>
+        <maml:description>
+          <maml:para>Exports a Rotational Group platform</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes />
@@ -21134,9 +21317,34 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
     <command:syntax>
       <command:syntaxItem>
         <maml:name>Get-PASReportSchedule</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>id</maml:name>
+          <maml:description>
+            <maml:para>When specified, returns a specific report schedule, otherwise returns all the user has access to.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
-    <command:parameters />
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>id</maml:name>
+        <maml:description>
+          <maml:para>When specified, returns a specific report schedule, otherwise returns all the user has access to.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
     <command:inputTypes />
     <command:returnValues />
     <maml:alertSet>
@@ -22982,6 +23190,33 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
           </dev:type>
           <dev:defaultValue>0</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>safes</maml:name>
+          <maml:description>
+            <maml:para>Returns all safes the user has access to, including permissions</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Get-PASUser</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>id</maml:name>
+          <maml:description>
+            <maml:para>The numeric id of the user to return details of.</maml:para>
+            <maml:para>Minimum required version 10.10</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>0</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Get-PASUser</maml:name>
@@ -23351,6 +23586,18 @@ Invoke-RestMethod -Method GET -Uri "$session.BaseURI/SomePath" -WebSession $sess
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>safes</maml:name>
+        <maml:description>
+          <maml:para>Returns all safes the user has access to, including permissions</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes />
@@ -41093,6 +41340,137 @@ Publish-PASDiscoveredAccount -id 66_6 -PlatformID WinDomain -safeName SomeSafe -
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
+      <command:name>Remove-PASReportSchedule</command:name>
+      <command:verb>Remove</command:verb>
+      <command:noun>PASReportSchedule</command:noun>
+      <maml:description>
+        <maml:para>Removes a report schedule.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Removes an existing report schedule by ID.</maml:para>
+      <maml:para>This command requires CyberArk version 14.6 or later.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Remove-PASReportSchedule</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
+          <maml:name>id</maml:name>
+          <maml:description>
+            <maml:para>The unique ID of the report schedule to remove.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
+        <maml:name>id</maml:name>
+        <maml:description>
+          <maml:para>The unique ID of the report schedule to remove.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+        <maml:name>WhatIf</maml:name>
+        <maml:description>
+          <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para>You can pipe objects with an `id` property to this command.</maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Minimum CyberArk version 14.6</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>Remove-PASReportSchedule -id 12345</dev:code>
+        <dev:remarks>
+          <maml:para>Removes the report schedule with the specified ID.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>Remove-PASReportSchedule</maml:linkText>
+        <maml:uri>https://pspas.pspete.dev/commands/Remove-PASReportSchedule</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
       <command:name>Remove-PASRequest</command:name>
       <command:verb>Remove</command:verb>
       <command:noun>PASRequest</command:noun>
@@ -54666,6 +55044,18 @@ PS C:\&gt; Start-PASVRMService -serviceName Vault -serverAddress vault.company.c
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>dependentAccountid</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill dependentAccountid Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
@@ -54705,6 +55095,18 @@ PS C:\&gt; Start-PASVRMService -serviceName Vault -serverAddress vault.company.c
           <maml:uri />
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>dependentAccountid</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill dependentAccountid Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes>

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -265,6 +265,7 @@
 		'Get-PASReport',
 		'Get-PASReportSchedule',
 		'New-PASReportSchedule',
+		'Remove-PASReportSchedule',
 		'Export-PASReport',
 		'Remove-PASUserAllowedAuthenticationMethod',
 		'Add-PASUserAllowedAuthenticationMethod',


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
<!--
Please include a summary of the change and which issue is fixed & relevant motivation and context.
Put `Fixes #XXX` in your comment to link the issue that your PR fixes.
-->

* `Export-PASPlatform` now supports new parameters and endpoints, enabling export by `RotationalGroupID`, `DependentID`, and `GroupPlatformID`
* `Stop-PASCPMTask` adds support for stopping CPM tasks on dependent accounts via a new `dependentAccountid` parameter
* `Get-PASUser` supports a new `-safes` parameter set, allowing retrieval of safes for a user
* New cmdlet `Remove-PASReportSchedule` is added to allow deletion of report schedules by ID
* `Get-PASReportSchedule` now accepts an optional `id` parameter to fetch a specific report schedule

## Type of change
<!--
Please select all relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [ ] Documentation update (psPAS website or command help content)
- [ ] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [x] Pester test(s) updated
- [ ] Pester test(s) passing

**Test Configuration**:
- PowerShell version: 7
- CyberArk PAS version: 15.2
- OS Version: Windows Server 2025

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [x] My code follows the style guidelines of this project
- [x] I have followed the contributing guidelines.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new test failures or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [ ] I have linked a related issue