### PR TITLE
Add validation attributes for parameter lengths in functions

### DIFF
--- a/psPAS/Functions/AccountGroups/Add-PASAccountGroupMember.ps1
+++ b/psPAS/Functions/AccountGroups/Add-PASAccountGroupMember.ps1
@@ -13,6 +13,7 @@ function Add-PASAccountGroupMember {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[ValidateLength(1, 170)]
 		[string]$AccountID
 	)
 

--- a/psPAS/Functions/AccountGroups/New-PASAccountGroup.ps1
+++ b/psPAS/Functions/AccountGroups/New-PASAccountGroup.ps1
@@ -7,18 +7,21 @@ function New-PASAccountGroup {
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateNotNullOrEmpty()]
+		[ValidateLength(1, 170)]
 		[string]$GroupName,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[ValidateLength(1, 170)]
 		[string]$GroupPlatformID,
 
 		[parameter(
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[ValidateLength(1, 28)]
 		[string]$Safe
 	)
 

--- a/psPAS/Functions/Accounts/Get-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccount.ps1
@@ -15,6 +15,7 @@ function Get-PASAccount {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Gen2Query'
 		)]
+		[ValidateLength(1, 500)]
 		[string]$search,
 
 		[parameter(

--- a/psPAS/Functions/Accounts/Get-PASDependentAccount.ps1
+++ b/psPAS/Functions/Accounts/Get-PASDependentAccount.ps1
@@ -32,6 +32,7 @@ function Get-PASDependentAccount {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'SpecificAccount'
 		)]
+		[ValidateLength(1, 500)]
 		[string]$search,
 
 		[parameter(

--- a/psPAS/Functions/Accounts/Get-PASDiscoveredAccount.ps1
+++ b/psPAS/Functions/Accounts/Get-PASDiscoveredAccount.ps1
@@ -36,6 +36,7 @@ function Get-PASDiscoveredAccount {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'byQuery'
 		)]
+		[ValidateLength(1, 500)]
 		[string]$search,
 
 		[parameter(

--- a/psPAS/Functions/Accounts/Get-PASDiscoveredLocalAccount.ps1
+++ b/psPAS/Functions/Accounts/Get-PASDiscoveredLocalAccount.ps1
@@ -14,6 +14,7 @@ function Get-PASDiscoveredLocalAccount {
             ValueFromPipelinebyPropertyName = $true,
             ParameterSetName = 'byQuery'
         )]
+        [ValidateLength(1, 500)]
         [string]$search,
 
         [parameter(

--- a/psPAS/Functions/Accounts/Set-PASDependentLinkedAccount.ps1
+++ b/psPAS/Functions/Accounts/Set-PASDependentLinkedAccount.ps1
@@ -54,6 +54,7 @@ function Set-PASDependentLinkedAccount {
             ValueFromPipelinebyPropertyName = $true,
             ParameterSetName = 'SelfHosted'
         )]
+        [ValidateLength(1, 28)]
         [string]$safe,
 
         [parameter(

--- a/psPAS/Functions/Accounts/Set-PASLinkedAccount.ps1
+++ b/psPAS/Functions/Accounts/Set-PASLinkedAccount.ps1
@@ -14,6 +14,7 @@ function Set-PASLinkedAccount {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[ValidateLength(1, 28)]
 		[string[]]$safe,
 
 		[parameter(

--- a/psPAS/Functions/Authentication/Add-PASAuthenticationMethod.ps1
+++ b/psPAS/Functions/Authentication/Add-PASAuthenticationMethod.ps1
@@ -34,6 +34,7 @@ function Add-PASAuthenticationMethod {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[ValidateLength(1, 2000)]
 		[string]$logoffUrl,
 
 		[parameter(

--- a/psPAS/Functions/Authentication/Add-PASOpenIDConnectProvider.ps1
+++ b/psPAS/Functions/Authentication/Add-PASOpenIDConnectProvider.ps1
@@ -8,6 +8,7 @@ function Add-PASOpenIDConnectProvider {
 			ValueFromPipelinebyPropertyName = $true
 		)]
 		[ValidateLength(1, 50)]
+		[ValidatePattern('^[a-zA-Z0-9]+$')]
 		[ValidateNotNullOrEmpty()]
 		[string]$id,
 

--- a/psPAS/Functions/Authentication/Set-PASAuthenticationMethod.ps1
+++ b/psPAS/Functions/Authentication/Set-PASAuthenticationMethod.ps1
@@ -34,6 +34,7 @@ function Set-PASAuthenticationMethod {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[ValidateLength(1, 2000)]
 		[string]$logoffUrl,
 
 		[parameter(

--- a/psPAS/Functions/LDAPDirectories/Set-PASDirectoryMapping.ps1
+++ b/psPAS/Functions/LDAPDirectories/Set-PASDirectoryMapping.ps1
@@ -19,6 +19,7 @@ function Set-PASDirectoryMapping {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[ValidateLength(1, 28)]
 		[string]$MappingName,
 
 		[parameter(

--- a/psPAS/Functions/Monitoring/Get-PASPSMRecording.ps1
+++ b/psPAS/Functions/Monitoring/Get-PASPSMRecording.ps1
@@ -35,6 +35,7 @@ function Get-PASPSMRecording {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'byQuery'
 		)]
+		[ValidateLength(1, 500)]
 		[string]$Search,
 
 		[parameter(

--- a/psPAS/Functions/Monitoring/Get-PASPSMSession.ps1
+++ b/psPAS/Functions/Monitoring/Get-PASPSMSession.ps1
@@ -35,6 +35,7 @@ function Get-PASPSMSession {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'byQuery'
 		)]
+		[ValidateLength(1, 500)]
 		[string]$Search,
 
 		[parameter(

--- a/psPAS/Functions/Platforms/Get-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Get-PASPlatform.ps1
@@ -29,6 +29,7 @@ function Get-PASPlatform {
             ValueFromPipelinebyPropertyName = $true,
             ParameterSetName = 'dependents'
         )]
+        [ValidateLength(1, 500)]
         [string]$Search,
 
         [parameter(

--- a/psPAS/Functions/Reports/Get-PASReport.ps1
+++ b/psPAS/Functions/Reports/Get-PASReport.ps1
@@ -13,6 +13,7 @@ function Get-PASReport {
             Mandatory = $false,
             ValueFromPipelinebyPropertyName = $true
         )]
+        [ValidateLength(1, 500)]
         [string]$search,
 
         [parameter(

--- a/psPAS/Functions/Reports/Get-PASReportTask.ps1
+++ b/psPAS/Functions/Reports/Get-PASReportTask.ps1
@@ -14,6 +14,7 @@ function Get-PASReportTask {
             ValueFromPipelinebyPropertyName = $true,
             ParameterSetName = 'byQuery'
         )]
+        [ValidateLength(1, 500)]
         [string]$search,
 
         [parameter(

--- a/psPAS/Functions/Reports/New-PASReportTask.ps1
+++ b/psPAS/Functions/Reports/New-PASReportTask.ps1
@@ -12,7 +12,7 @@ function New-PASReportTask {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
-		[AllowEmptyString()]
+		[ValidateSet('Report')]
 		[string]$type,
 
 		[parameter(
@@ -28,6 +28,7 @@ function New-PASReportTask {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[ValidateLength(1, 256)]
 		[string]$name,
 
 		[parameter(

--- a/psPAS/Functions/Reports/Set-PASReportTask.ps1
+++ b/psPAS/Functions/Reports/Set-PASReportTask.ps1
@@ -12,6 +12,7 @@ function Set-PASReportTask {
             Mandatory = $false,
             ValueFromPipelinebyPropertyName = $true
         )]
+        [ValidateLength(1, 256)]
         [string]$name,
 
         [parameter(

--- a/psPAS/Functions/SafeMembers/Get-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Get-PASSafeMember.ps1
@@ -57,6 +57,7 @@ function Get-PASSafeMember {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Gen2-MemberFilter'
 		)]
+		[ValidateLength(1, 500)]
 		[string]$search,
 
 		[parameter(

--- a/psPAS/Functions/Safes/Find-PASSafe.ps1
+++ b/psPAS/Functions/Safes/Find-PASSafe.ps1
@@ -6,6 +6,7 @@ function Find-PASSafe {
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $false
 		)]
+		[ValidateLength(1, 500)]
 		[string]$search,
 
 		[parameter(

--- a/psPAS/Functions/Safes/Get-PASSafe.ps1
+++ b/psPAS/Functions/Safes/Get-PASSafe.ps1
@@ -8,6 +8,7 @@ function Get-PASSafe {
 			ParameterSetName = 'Gen2'
 		)]
 		[ValidateNotNullOrEmpty()]
+		[ValidateLength(1, 500)]
 		[string]$search,
 
 		[parameter(

--- a/psPAS/Functions/User/Get-PASGroup.ps1
+++ b/psPAS/Functions/User/Get-PASGroup.ps1
@@ -36,6 +36,7 @@ function Get-PASGroup {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'groupType'
 		)]
+		[ValidateLength(1, 500)]
 		[string]$search,
 
 		[parameter(

--- a/psPAS/Functions/User/Get-PASUser.ps1
+++ b/psPAS/Functions/User/Get-PASUser.ps1
@@ -25,6 +25,7 @@ function Get-PASUser {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Gen2-ExtendedDetails'
 		)]
+		[ValidateLength(1, 500)]
 		[string]$Search,
 
 		[parameter(

--- a/psPAS/Functions/User/New-PASGroup.ps1
+++ b/psPAS/Functions/User/New-PASGroup.ps1
@@ -6,18 +6,21 @@ function New-PASGroup {
 			Mandatory = $true,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[ValidateLength(1, 128)]
 		[string]$groupName,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[ValidateLength(1, 100)]
 		[string]$description,
 
 		[parameter(
 			Mandatory = $false,
 			ValueFromPipelinebyPropertyName = $true
 		)]
+		[ValidateLength(1, 128)]
 		[string]$location
 	)
 

--- a/psPAS/Functions/User/New-PASUser.ps1
+++ b/psPAS/Functions/User/New-PASUser.ps1
@@ -130,6 +130,7 @@ function New-PASUser {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Gen2'
 		)]
+		[ValidateLength(1, 511)]
 		[string]$distinguishedName,
 
 		[parameter(
@@ -198,6 +199,7 @@ function New-PASUser {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Gen1'
 		)]
+		[ValidateLength(1, 128)]
 		[string]$Location,
 
 		[parameter(

--- a/psPAS/Functions/User/Set-PASGroup.ps1
+++ b/psPAS/Functions/User/Set-PASGroup.ps1
@@ -13,6 +13,7 @@ function Set-PASGroup {
             Mandatory = $true,
             ValueFromPipelinebyPropertyName = $true
         )]
+        [ValidateLength(1, 128)]
         [string]$GroupName
     )
 

--- a/psPAS/Functions/User/Set-PASUser.ps1
+++ b/psPAS/Functions/User/Set-PASUser.ps1
@@ -145,6 +145,7 @@ function Set-PASUser {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Gen2'
 		)]
+		[ValidateLength(1, 511)]
 		[string]$distinguishedName,
 
 		[parameter(
@@ -193,6 +194,7 @@ function Set-PASUser {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Gen1'
 		)]
+		[ValidateLength(1, 128)]
 		[string]$Location,
 
 		[parameter(


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
<!--
Please include a summary of the change and which issue is fixed & relevant motivation and context.
Put `Fixes #XXX` in your comment to link the issue that your PR fixes.
-->
**Input Length Validation Enhancements:**
* Added `ValidateLength` (as according to the swagger, with some smaller adjustments to were it make sense, such as min lenght and safe name lenght) constraints to various parameters
* Added `ValidatePattern` to the `id` parameter in `Add-PASOpenIDConnectProvider` to restrict the value to alphanumeric characters only.
* Changed the `type` parameter in `New-PASReportTask` to use `ValidateSet('Report')`, ensuring only the value `'Report'` is accepted, as according to offical documentation from cyberark https://docs.cyberark.com/pam-self-hosted/15.2/en/content/webservices/create-task.htm

## Type of change
<!--
Please select all relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [ ] Documentation update (psPAS website or command help content)
- [ ] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [ ] Pester test(s) updated
- [x] Pester test(s) passing

**Test Configuration**:
- PowerShell version: 7
- CyberArk PAS version: 15.2
- OS Version: Windows Server 2025

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [x] My code follows the style guidelines of this project
- [x] I have followed the contributing guidelines.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new test failures or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [ ] I have linked a related issue