### PR TITLE
UPDATE Get-PASAccount

### DIFF
--- a/Tests/Get-PASAccount.Tests.ps1
+++ b/Tests/Get-PASAccount.Tests.ps1
@@ -21,15 +21,16 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 		$Script:RequestBody = $null
 		$psPASSession = [ordered]@{
-			BaseURI            = 'https://SomeURL/SomeApp'
-			User               = $null
-			ExternalVersion    = [System.Version]'0.0'
-			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
-			StartTime          = $null
-			ElapsedTime        = $null
-			LastCommand        = $null
-			LastCommandTime    = $null
-			LastCommandResults = $null
+			BaseURI                 = 'https://SomeURL/SomeApp'
+			User                    = $null
+			ExternalVersion         = [System.Version]'0.0'
+			WebSession              = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime               = $null
+			ElapsedTime             = $null
+			LastCommand             = $null
+			LastCommandTime         = $null
+			LastCommandResults      = $null
+			AccountSearchProperties = $null
 		}
 
 		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
@@ -217,13 +218,23 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 					[pscustomobject]@{PropertyName = 'customProperty' }
 				}
 
+				$psPASSession.AccountSearchProperties = $null
 				$psPASSession.ExternalVersion = '14.6'
 
 			}
 
 			AfterEach {
 
+				$psPASSession.AccountSearchProperties = $null
 				$psPASSession.ExternalVersion = '0.0'
+
+			}
+
+			It 'only calls Get-PASAccountSearchProperty once per invocation, despite dynamicparam and begin both needing it' {
+
+				Get-PASAccount -customProperty 'SomeValue'
+
+				Assert-MockCalled Get-PASAccountSearchProperty -Times 1 -Exactly -Scope It
 
 			}
 

--- a/Tests/Get-PASAccountSearchPropertyCache.Tests.ps1
+++ b/Tests/Get-PASAccountSearchPropertyCache.Tests.ps1
@@ -1,0 +1,112 @@
+Describe $($PSCommandPath -replace '.Tests.ps1') {
+
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
+
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+		if ( -not (Get-Module -Name $ModuleName -All)) {
+
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+		}
+
+		$psPASSession = [ordered]@{
+			BaseURI                 = 'https://SomeURL/SomeApp'
+			User                    = $null
+			ExternalVersion         = [System.Version]'14.4'
+			WebSession              = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime               = $null
+			ElapsedTime             = $null
+			LastCommand             = $null
+			LastCommandTime         = $null
+			LastCommandResults      = $null
+			AccountSearchProperties = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+		BeforeEach {
+
+			$psPASSession.AccountSearchProperties = $null
+			$psPASSession.BaseURI = 'https://SomeURL/SomeApp'
+			$psPASSession.ExternalVersion = [System.Version]'14.4'
+
+			Mock Get-PASAccountSearchProperty -MockWith {
+				[pscustomobject]@{ PropertyName = 'safeName' }
+			}
+
+		}
+
+		Context 'Cache Population' {
+
+			It 'calls Get-PASAccountSearchProperty when no cache exists' {
+
+				Get-PASAccountSearchPropertyCache
+
+				Assert-MockCalled Get-PASAccountSearchProperty -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'returns the properties from Get-PASAccountSearchProperty' {
+
+				$response = Get-PASAccountSearchPropertyCache
+
+				$response.PropertyName | Should -Be 'safeName'
+
+			}
+
+		}
+
+		Context 'Cache Reuse' {
+
+			It 'does not call Get-PASAccountSearchProperty again for a repeat call against the same session' {
+
+				Get-PASAccountSearchPropertyCache
+				Get-PASAccountSearchPropertyCache
+
+				Assert-MockCalled Get-PASAccountSearchProperty -Times 1 -Exactly
+
+			}
+
+		}
+
+		Context 'Cache Invalidation' {
+
+			It 'calls Get-PASAccountSearchProperty again if BaseURI has changed' {
+
+				Get-PASAccountSearchPropertyCache
+				$psPASSession.BaseURI = 'https://SomeOtherURL/SomeApp'
+				Get-PASAccountSearchPropertyCache
+
+				Assert-MockCalled Get-PASAccountSearchProperty -Times 2 -Exactly
+
+			}
+
+			It 'calls Get-PASAccountSearchProperty again if ExternalVersion has changed' {
+
+				Get-PASAccountSearchPropertyCache
+				$psPASSession.ExternalVersion = [System.Version]'14.6'
+				Get-PASAccountSearchPropertyCache
+
+				Assert-MockCalled Get-PASAccountSearchProperty -Times 2 -Exactly
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/Invoke-PASRestMethod.Tests.ps1
+++ b/Tests/Invoke-PASRestMethod.Tests.ps1
@@ -201,6 +201,61 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 		}
 
+		Context 'LastCommand Recording' {
+
+			BeforeEach {
+
+				$Response = New-MockObject -Type Microsoft.PowerShell.Commands.WebResponseObject
+				$Response | Add-Member -MemberType NoteProperty -Name StatusCode -Value 200 -Force
+				$Response | Add-Member -MemberType NoteProperty -Name Headers -Value @{ 'Content-Type' = 'application/json; charset=utf-8' } -Force
+				$Response | Add-Member -MemberType NoteProperty -Name Content -Value (@{ 'prop1' = 'value1' } | ConvertTo-Json) -Force
+
+				Mock Invoke-WebRequest -MockWith {
+
+					return $Response
+
+				}
+
+				$psPASSession.LastCommand = $null
+				$psPASSession.LastCommandResults = $null
+
+				$WebSession = @{
+					'URI'        = 'https://CyberArk_URL'
+					'Method'     = 'GET'
+					'WebSession' = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+				}
+
+			}
+
+			It 'records LastCommand and LastCommandResults for a normal invocation' {
+
+				Mock Get-ParentFunction -MockWith {
+					[PSCustomObject]@{ FunctionName = 'Get-PASAccount'; CommandData = 'SomeCommandData' }
+				}
+
+				Invoke-PASRestMethod @WebSession
+
+				$psPASSession.LastCommand | Should -Be 'SomeCommandData'
+				$psPASSession.LastCommandResults | Should -Not -Be $null
+				$psPASSession.LastCommandResults | Should -Be $Response
+
+			}
+
+			It 'does not record LastCommand or LastCommandResults when invoked via Get-PASAccountSearchProperty' {
+
+				Mock Get-ParentFunction -MockWith {
+					[PSCustomObject]@{ FunctionName = 'Get-PASAccountSearchProperty'; CommandData = 'SomeCommandData' }
+				}
+
+				Invoke-PASRestMethod @WebSession
+
+				$psPASSession.LastCommand | Should -BeNullOrEmpty
+				$psPASSession.LastCommandResults | Should -BeNullOrEmpty
+
+			}
+
+		}
+
 		Context 'Body Handling' {
 
 			BeforeEach {

--- a/psPAS/Functions/Accounts/Get-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Get-PASAccount.ps1
@@ -105,8 +105,8 @@ function Get-PASAccount {
 		if ($PSCmdlet.ParameterSetName -eq 'Gen2Query' -and
 			$script:psPASSession.ExternalVersion -ge [version]'14.4' -and [string]::IsNullOrEmpty($psPASSession.ApiURI)) {
 
-			# Get available search properties from the API
-			$SearchProperties = Get-PASAccountSearchProperty
+			# Get available search properties from the API (cached against the session)
+			$SearchProperties = Get-PASAccountSearchPropertyCache
 			$paramDictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
 
 			# List of existing static parameters to avoid duplicates
@@ -140,7 +140,7 @@ function Get-PASAccount {
 
 		# Add dynamic search properties to the filter parameters list for Gen2 14.4+ and Self Hosted (no ApiURI)
 		if ($PSCmdlet.ParameterSetName -match 'Gen2' -and $psPASSession.ExternalVersion -ge [version]'14.4' -and [string]::IsNullOrEmpty($psPASSession.ApiURI)) {
-			$SearchProperties = Get-PASAccountSearchProperty
+			$SearchProperties = Get-PASAccountSearchPropertyCache
 			# Build lookup for validation of supported operators
 			$SearchPropertyLookup = @{}
 			foreach ($property in $SearchProperties) {

--- a/psPAS/Private/Get-PASAccountSearchPropertyCache.ps1
+++ b/psPAS/Private/Get-PASAccountSearchPropertyCache.ps1
@@ -1,0 +1,42 @@
+function Get-PASAccountSearchPropertyCache {
+	<#
+	.SYNOPSIS
+	Returns Account search properties for the current session, caching the result to avoid repeat API calls
+
+	.DESCRIPTION
+	Get-PASAccount calls this from both its dynamicparam and begin blocks, and dynamicparam blocks can also be
+	evaluated by PowerShell outside of an actual invocation (tab-completion, IntelliSense) - each of those would
+	otherwise trigger a live call to the AdvancedSearchProperties endpoint via Get-PASAccountSearchProperty.
+
+	The result is cached on $psPASSession, keyed by BaseURI and ExternalVersion, and is only refreshed if the
+	connection has changed since the cache was populated.
+
+	.EXAMPLE
+	Get-PASAccountSearchPropertyCache
+
+	Returns cached account search properties, populating the cache first if required.
+	#>
+	[CmdletBinding()]
+	param()
+
+	process {
+
+		$Cache = $script:psPASSession.AccountSearchProperties
+
+		if (($null -eq $Cache) -or
+			($Cache.BaseURI -ne $script:psPASSession.BaseURI) -or
+			($Cache.ExternalVersion -ne $script:psPASSession.ExternalVersion)) {
+
+			$script:psPASSession.AccountSearchProperties = [PSCustomObject]@{
+				BaseURI         = $script:psPASSession.BaseURI
+				ExternalVersion = $script:psPASSession.ExternalVersion
+				Properties      = Get-PASAccountSearchProperty
+			}
+
+		}
+
+		$script:psPASSession.AccountSearchProperties.Properties
+
+	}
+
+}

--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -1,12 +1,4 @@
-﻿# List functions here which call Invoke-PASRestMethod purely as an internal implementation detail (e.g. a public
-# function's dynamicparam/begin block looking up supporting data) rather than as a command a user directly
-# issued - calls made on their behalf should not overwrite $psPASSession.LastCommand/LastCommandResults.
-# Add further function names here as similar internal-helper patterns emerge.
-$script:LastCommandExclusions = @(
-	'Get-PASAccountSearchProperty'
-)
-
-function Invoke-PASRestMethod {
+﻿function Invoke-PASRestMethod {
 	<#
 	.SYNOPSIS
 	Wrapper for Invoke-WebRequest to call REST method via API
@@ -121,6 +113,14 @@ function Invoke-PASRestMethod {
 	)
 
 	begin {
+
+		#Functions which call Invoke-PASRestMethod purely as an internal implementation detail (e.g. a public
+		#function's dynamicparam/begin block looking up supporting data) rather than as a command a user directly
+		#issued - calls made on their behalf should not overwrite $psPASSession.LastCommand/LastCommandResults.
+		#Add further function names here as similar internal-helper patterns emerge.
+		$LastCommandExclusions = @(
+			'Get-PASAccountSearchProperty'
+		)
 
 		#Set defaults for all function calls
 		$ProgressPreference = 'SilentlyContinue'
@@ -420,7 +420,7 @@ function Invoke-PASRestMethod {
 			#Identify calling function
 			$ParentFunction = Get-ParentFunction
 
-			if ($ParentFunction.FunctionName -notin $script:LastCommandExclusions) {
+			if ($ParentFunction.FunctionName -notin $LastCommandExclusions) {
 
 				#Add Command Data to $psPASSession module scope variable
 				$psPASSession.LastCommand = $ParentFunction.CommandData

--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -1,4 +1,12 @@
-﻿function Invoke-PASRestMethod {
+﻿# List functions here which call Invoke-PASRestMethod purely as an internal implementation detail (e.g. a public
+# function's dynamicparam/begin block looking up supporting data) rather than as a command a user directly
+# issued - calls made on their behalf should not overwrite $psPASSession.LastCommand/LastCommandResults.
+# Add further function names here as similar internal-helper patterns emerge.
+$script:LastCommandExclusions = @(
+	'Get-PASAccountSearchProperty'
+)
+
+function Invoke-PASRestMethod {
 	<#
 	.SYNOPSIS
 	Wrapper for Invoke-WebRequest to call REST method via API
@@ -409,10 +417,17 @@
 
 		} finally {
 
-			#Add Command Data to $psPASSession module scope variable
-			$psPASSession.LastCommand = Get-ParentFunction | Select-Object -ExpandProperty CommandData
-			$psPASSession.LastCommandResults = $APIResponse
-			$psPASSession.LastCommandTime = Get-Date
+			#Identify calling function
+			$ParentFunction = Get-ParentFunction
+
+			if ($ParentFunction.FunctionName -notin $script:LastCommandExclusions) {
+
+				#Add Command Data to $psPASSession module scope variable
+				$psPASSession.LastCommand = $ParentFunction.CommandData
+				$psPASSession.LastCommandResults = $APIResponse
+				$psPASSession.LastCommandTime = Get-Date
+
+			}
 
 			#If Session Variable passed as argument
 			if ($PSCmdlet.ParameterSetName -eq 'SessionVariable') {

--- a/psPAS/psPAS.psm1
+++ b/psPAS/psPAS.psm1
@@ -57,18 +57,19 @@ Get-ChildItem $PSScriptRoot\ -Recurse -Include '*.ps1' -Exclude '*.ps1xml' |
 
 # Script scope session object for session data
 $psPASSession = [ordered]@{
-	BaseURI            = $null
-	ApiURI             = $null
-	User               = $null
-	ExternalVersion    = [System.Version]'0.0'
-	WebSession         = $null
-	StartTime          = $null
-	ElapsedTime        = $null
-	LastCommand        = $null
-	LastCommandTime    = $null
-	LastCommandResults = $null
-	LastError          = $null
-	LastErrorTime      = $null
+	BaseURI                 = $null
+	ApiURI                  = $null
+	User                    = $null
+	ExternalVersion         = [System.Version]'0.0'
+	WebSession              = $null
+	StartTime               = $null
+	ElapsedTime             = $null
+	LastCommand             = $null
+	LastCommandTime         = $null
+	LastCommandResults      = $null
+	LastError               = $null
+	LastErrorTime           = $null
+	AccountSearchProperties = $null
 } | Add-ObjectDetail -typename psPAS.CyberArk.Vault.Session
 
 New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
<!--
Please include a summary of the change and which issue is fixed & relevant motivation and context.
Put `Fixes #XXX` in your comment to link the issue that your PR fixes.
-->

Reads DynamicParameter values from a new cache instead to prevent calls to Get-PASAccountSearchProperty clobbering up the LastCommand and LastCommandResult in the Get-PASSession output

Fixes #

## Type of change
<!--
Please select all relevant options:
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [ ] Documentation update (psPAS website or command help content)
- [ ] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [X] Pester test(s) updated
- [X] Pester test(s) passing

**Test Configuration**:
- PowerShell version:
- CyberArk PAS version:
- OS Version:

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [X] My code follows the style guidelines of this project
- [X] I have followed the contributing guidelines.
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new test failures or errors
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [ ] I have linked a related issue