### PR TITLE
Refactor account management request method assignment

### DIFF
--- a/psPAS/Functions/Accounts/Clear-PASLinkedAccount.ps1
+++ b/psPAS/Functions/Accounts/Clear-PASLinkedAccount.ps1
@@ -34,13 +34,13 @@ function Clear-PASLinkedAccount {
             $BulkConfirmation = $true
         }
 
-        $Request = @{
-            Method = 'DELETE'
-        }
-
     }#begin
 
     process {
+
+        $Request = @{
+            Method = 'DELETE'
+        }
 
         if ($BulkConfirmation) {
 

--- a/psPAS/Functions/Accounts/Resume-PASCPMAutoManagement.ps1
+++ b/psPAS/Functions/Accounts/Resume-PASCPMAutoManagement.ps1
@@ -24,13 +24,13 @@ function Resume-PASCPMAutoManagement {
             $BulkConfirmation = $true
         }
 
-        $Request = @{
-            Method = 'POST'
-        }
-
     }#begin
 
     process {
+
+        $Request = @{
+            Method = 'POST'
+        }
 
         if ($BulkConfirmation) {
 

--- a/psPAS/Functions/Accounts/Resume-PASDependentAccount.ps1
+++ b/psPAS/Functions/Accounts/Resume-PASDependentAccount.ps1
@@ -35,13 +35,13 @@ function Resume-PASDependentAccount {
             $BulkConfirmation = $true
         }
 
-        $Request = @{
-            Method = 'POST'
-        }
-
     }#begin
 
     process {
+
+        $Request = @{
+            Method = 'POST'
+        }
 
         if ($BulkConfirmation) {
 

--- a/psPAS/Functions/Accounts/Set-PASLinkedAccount.ps1
+++ b/psPAS/Functions/Accounts/Set-PASLinkedAccount.ps1
@@ -55,13 +55,13 @@ function Set-PASLinkedAccount {
 			$BulkConfirmation = $true
 		}
 
-		$Request = @{
-			Method = 'POST'
-		}
-
 	}#begin
 
 	process {
+
+		$Request = @{
+			Method = 'POST'
+		}
 
 		if ($BulkConfirmation) {
 

--- a/psPAS/Functions/Accounts/Stop-PASCPMTask.ps1
+++ b/psPAS/Functions/Accounts/Stop-PASCPMTask.ps1
@@ -31,13 +31,13 @@ function Stop-PASCPMTask {
             $BulkConfirmation = $true
         }
 
-        $Request = @{
-            Method = 'POST'
-        }
-
     }#begin
 
     process {
+
+        $Request = @{
+            Method = 'POST'
+        }
 
         if ($PSBoundParameters.ContainsKey('dependentAccountid')) {
 

--- a/psPAS/Functions/Accounts/Sync-PASDependentAccount.ps1
+++ b/psPAS/Functions/Accounts/Sync-PASDependentAccount.ps1
@@ -35,13 +35,13 @@ function Sync-PASDependentAccount {
             $BulkConfirmation = $true
         }
 
-        $Request = @{
-            Method = 'POST'
-        }
-
     }#begin
 
     process {
+
+        $Request = @{
+            Method = 'POST'
+        }
 
         #Create URL for Request
         $URI = "$($psPASSession.BaseURI)/API/Accounts/$AccountID/dependentAccounts"

--- a/psPAS/Functions/Accounts/Unlock-PASAccount.ps1
+++ b/psPAS/Functions/Accounts/Unlock-PASAccount.ps1
@@ -41,13 +41,13 @@ function Unlock-PASAccount {
 			$BulkConfirmation = $true
 		}
 
-		$Request = @{
-			Method = 'POST'
-		}
-
 	}#begin
 
 	process {
+
+		$Request = @{
+			Method = 'POST'
+		}
 
 		switch ($PSCmdlet.ParameterSetName) {
 


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
<!--
Please include a summary of the change and which issue is fixed & relevant motivation and context.
Put `Fixes #XXX` in your comment to link the issue that your PR fixes.
-->

There is currently a bug were if we pipe a command like this:
"Get-PASAccount | Resume-PASCPMAutoManagement"
It produces these errors:
Exception calling "Add" with "2" argument(s): "Item has already been added. Key in dictionary: 'Uri'  Key being added: 'Uri'"

This is because the $request should be in the process, not the begin part.

* Moved the initialization of the `$Request` hashtable from the `begin` block to the `process` block in the following functions:
  - `Clear-PASLinkedAccount`
  - `Resume-PASCPMAutoManagement` 
  - `Resume-PASDependentAccount` 
  - `Set-PASLinkedAccount`
  - `Stop-PASCPMTask`
  - `Sync-PASDependentAccount`
  - `Unlock-PASAccount` 
## Type of change
<!--
Please select all relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [ ] Documentation update (psPAS website or command help content)
- [ ] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [ ] Pester test(s) updated
- [x] Pester test(s) passing

**Test Configuration**:
- PowerShell version: 7
- CyberArk PAS version: 15.2
- OS Version: Windows Server 2025

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [x] My code follows the style guidelines of this project
- [x] I have followed the contributing guidelines.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new test failures or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [ ] I have linked a related issue