### PR TITLE
Fix pipeline request-state leak across iterations

### DIFF
--- a/psPAS/Functions/Accounts/Clear-PASDiscoveredAccount.ps1
+++ b/psPAS/Functions/Accounts/Clear-PASDiscoveredAccount.ps1
@@ -21,9 +21,7 @@ function Clear-PASDiscoveredAccount {
         if (Test-IsMultiValue -Value $boundInput) {
 
             $BulkConfirmation = $true
-            $Request = @{
-                Method = 'POST'
-            }
+
         }
 
     }#begin
@@ -31,6 +29,10 @@ function Clear-PASDiscoveredAccount {
     process {
 
         if ($BulkConfirmation) {
+
+            $Request = @{
+                Method = 'POST'
+            }
 
             #Create URL for Request
             $URI = "$($psPASSession.BaseURI)/api/DiscoveredAccounts/Delete/Bulk"

--- a/psPAS/Functions/Platforms/Import-PASPlatform.ps1
+++ b/psPAS/Functions/Platforms/Import-PASPlatform.ps1
@@ -51,6 +51,10 @@ function Import-PASPlatform {
 
 	begin {
 		Assert-VersionRequirement -RequiredVersion 10.2
+	}#begin
+
+	process {
+
 		$Request = @{}
 		$Request['Method'] = 'POST'
 		#Create URL for request
@@ -58,9 +62,6 @@ function Import-PASPlatform {
 
 		$MessageItem = $null
 		$MessageText = $null
-	}#begin
-
-	process {
 
 		switch ($PSCmdlet.ParameterSetName) {
 

--- a/psPAS/Functions/SafeMembers/Get-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Get-PASSafeMember.ps1
@@ -117,12 +117,12 @@ function Get-PASSafeMember {
 
 	begin {
 
-		$Request = @{ }
-		$Method = 'GET'
-
 	}#begin
 
 	process {
+
+		$Request = @{ }
+		$Method = 'GET'
 
 		switch ($PSCmdlet.ParameterSetName) {
 


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
<!--
Please include a summary of the change and which issue is fixed & relevant motivation and context.
Put `Fixes #XXX` in your comment to link the issue that your PR fixes.
-->
Same class of bug fixed in PR #652: $Request object was initialised once in begin{}, then only partially mutated per pipeline item in process{}. Branches that didn't set every key left values from a prior pipeline item (URI, Method, Body) leaking into the request sent for the next item.

- Get-PASSafeMember: $Request/$Method now built fresh each process{} iteration instead of once in begin{}.
- Import-PASPlatform: $Request now built fresh each process{} iteration instead of once in begin{}.
- Clear-PASDiscoveredAccount: $Request for the bulk-confirmation path now built inside process{} instead of begin{}.
Fixes #

## Type of change
<!--
Please select all relevant options:
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [ ] Documentation update (psPAS website or command help content)
- [ ] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [ ] Pester test(s) updated
- [X] Pester test(s) passing

**Test Configuration**:
- PowerShell version:
- CyberArk PAS version:
- OS Version:

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [X] My code follows the style guidelines of this project
- [X] I have followed the contributing guidelines.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new test failures or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [ ] I have linked a related issue