### PR TITLE
Get Directory GUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@
 - Continued development to encompass any new documented features of the CyberArk API.
 - psPAS v9.0...
 
+### Added
+
+- `Get-PASDirectoryID`
+  - Resolves the directory ID value required by `Add-PASSafeMember -SearchIn` on Privilege Cloud, given a directory's friendly name - this value isn't otherwise exposed anywhere in the CyberArk UI
+  - Also works against a self-hosted Vault, returning the directory name itself as its ID, matching what self-hosted `-SearchIn` already expects
+  - `-Name` parameter supports tab completion
+
+### Updated
+
+- `Add-PASSafeMember`
+  - `-SearchIn` now supports tab completion via `Get-PASDirectoryID`: displays directory names in the completion list while inserting the required ID value
+  - Docs: added an example resolving `-SearchIn` via `Get-PASDirectoryID` for Privilege Cloud
+
+### Fixed
+
+- `New-PASSession`
+  - Fixes a double-slash appearing in request URIs (e.g. `.../cyberark.cloud//PasswordVault/...`) when authenticating via `-TenantSubdomain` - the Privilege Cloud/Identity URLs returned by Shared Services discovery weren't having a trailing slash stripped before being combined with the PVWA application name
+
 ## [8.0.11]
 
 ### Added

--- a/Tests/Add-PASSafeMember.Tests.ps1
+++ b/Tests/Add-PASSafeMember.Tests.ps1
@@ -609,8 +609,8 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 			It 'inserts the directory ID while displaying the directory Name' {
 
 				Mock Get-PASDirectoryID -MockWith {
-					[pscustomobject]@{Name = 'Active Directory: ad.cyberiam.com'; ID = '77dac292-a38e-76c4-9eaa-d25e196c428d' },
-					[pscustomobject]@{Name = 'Active Directory: cyberiam.tech'; ID = '37babddc-b4c3-4d01-8704-d59da59d2228' }
+					[pscustomobject]@{Name = 'Active Directory: ad.SomeDomain.com'; ID = '77dac292-a38e-76c4-9eaa-d25e196c428d' },
+					[pscustomobject]@{Name = 'Active Directory: SomeOtherDomain.com'; ID = '37babddc-b4c3-4d01-8704-d59da59d2228' }
 				}
 
 				$Completer = (Get-Command Add-PASSafeMember).Parameters['SearchIn'].Attributes |
@@ -620,7 +620,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 				$Result = & $Completer -commandName 'Add-PASSafeMember' -parameterName 'SearchIn' -wordToComplete 'Active Directory: ad' -commandAst $null -fakeBoundParameters @{}
 
 				$Result.CompletionText | Should -Be "'77dac292-a38e-76c4-9eaa-d25e196c428d'"
-				$Result.ListItemText | Should -Be 'Active Directory: ad.cyberiam.com'
+				$Result.ListItemText | Should -Be 'Active Directory: ad.SomeDomain.com'
 
 			}
 

--- a/Tests/Add-PASSafeMember.Tests.ps1
+++ b/Tests/Add-PASSafeMember.Tests.ps1
@@ -596,6 +596,48 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 		}
 
+		Context 'SearchIn ArgumentCompleter' {
+
+			It 'provides ArgumentCompleter for SearchIn parameter' {
+
+				(Get-Command Add-PASSafeMember).Parameters['SearchIn'].Attributes |
+				Where-Object { $_ -is [System.Management.Automation.ArgumentCompleterAttribute] } |
+				Should -Not -BeNullOrEmpty
+
+			}
+
+			It 'inserts the directory ID while displaying the directory Name' {
+
+				Mock Get-PASDirectoryID -MockWith {
+					[pscustomobject]@{Name = 'Active Directory: ad.cyberiam.com'; ID = '77dac292-a38e-76c4-9eaa-d25e196c428d' },
+					[pscustomobject]@{Name = 'Active Directory: cyberiam.tech'; ID = '37babddc-b4c3-4d01-8704-d59da59d2228' }
+				}
+
+				$Completer = (Get-Command Add-PASSafeMember).Parameters['SearchIn'].Attributes |
+				Where-Object { $_ -is [System.Management.Automation.ArgumentCompleterAttribute] } |
+				Select-Object -ExpandProperty ScriptBlock
+
+				$Result = & $Completer -commandName 'Add-PASSafeMember' -parameterName 'SearchIn' -wordToComplete 'Active Directory: ad' -commandAst $null -fakeBoundParameters @{}
+
+				$Result.CompletionText | Should -Be "'77dac292-a38e-76c4-9eaa-d25e196c428d'"
+				$Result.ListItemText | Should -Be 'Active Directory: ad.cyberiam.com'
+
+			}
+
+			It 'returns nothing if Get-PASDirectoryID throws' {
+
+				Mock Get-PASDirectoryID -MockWith { throw 'Some Error' }
+
+				$Completer = (Get-Command Add-PASSafeMember).Parameters['SearchIn'].Attributes |
+				Where-Object { $_ -is [System.Management.Automation.ArgumentCompleterAttribute] } |
+				Select-Object -ExpandProperty ScriptBlock
+
+				{ & $Completer -commandName 'Add-PASSafeMember' -parameterName 'SearchIn' -wordToComplete '' -commandAst $null -fakeBoundParameters @{} } | Should -Not -Throw
+
+			}
+
+		}
+
 	}
 
 }

--- a/Tests/Get-PASDirectoryID.Tests.ps1
+++ b/Tests/Get-PASDirectoryID.Tests.ps1
@@ -54,7 +54,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 					'IdentityMemberTypes'  = @('User', 'Group', 'Role')
 					'Directories'          = @(
 						[PSCustomObject]@{'Name' = 'Idira Cloud Directory'; 'ID' = '09B9A9B0-6CE8-465F-AB03-65766D33B05E' },
-						[PSCustomObject]@{'Name' = 'Active Directory: ad.cyberiam.com'; 'ID' = '77dac292-a38e-76c4-9eaa-d25e196c428d' }
+						[PSCustomObject]@{'Name' = 'Active Directory: ad.SomeDomain.com'; 'ID' = '77dac292-a38e-76c4-9eaa-d25e196c428d' }
 					)
 				}
 			}

--- a/Tests/Get-PASDirectoryID.Tests.ps1
+++ b/Tests/Get-PASDirectoryID.Tests.ps1
@@ -1,0 +1,157 @@
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
+
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
+
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+		if ( -not (Get-Module -Name $ModuleName -All)) {
+
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+		}
+
+		$Script:RequestBody = $null
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
+
+	}
+
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+		BeforeEach {
+
+			Mock Invoke-PASRestMethod -MockWith {
+				[PSCustomObject]@{
+					'IdentityUM'           = $true
+					'OnPremiseMemberTypes' = @('User', 'Group')
+					'IdentityMemberTypes'  = @('User', 'Group', 'Role')
+					'Directories'          = @(
+						[PSCustomObject]@{'Name' = 'Idira Cloud Directory'; 'ID' = '09B9A9B0-6CE8-465F-AB03-65766D33B05E' },
+						[PSCustomObject]@{'Name' = 'Active Directory: ad.cyberiam.com'; 'ID' = '77dac292-a38e-76c4-9eaa-d25e196c428d' }
+					)
+				}
+			}
+
+			$response = Get-PASDirectoryID
+
+		}
+
+		Context 'Input' {
+
+			It 'sends request' {
+
+				Assert-MockCalled Invoke-PASRestMethod -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'sends request to expected endpoint' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+					$URI -eq "$($Script:psPASSession.BaseURI)/api/settings/AddSafeMember"
+
+				} -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'uses expected method' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Method -match 'GET' } -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'sends request with no body' {
+
+				Assert-MockCalled Invoke-PASRestMethod -ParameterFilter { $Body -eq $null } -Times 1 -Exactly -Scope It
+
+			}
+
+		}
+
+		Context 'Output' {
+
+			It 'provides output' {
+
+				$response | Should -Not -BeNullOrEmpty
+
+			}
+
+			It 'returns all directories' {
+
+				$response.Count | Should -Be 2
+
+			}
+
+			It 'has output with expected number of properties' {
+
+				($response[0] | Get-Member -MemberType NoteProperty).length | Should -Be 2
+
+			}
+
+			It 'outputs object with expected typename' {
+
+				$response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be psPAS.CyberArk.Vault.Safe.Member.Directory
+
+			}
+
+			It 'filters returned directories by name' {
+
+				$response = Get-PASDirectoryID -Name 'Idira Cloud Directory'
+
+				$response.Count | Should -Be 1
+				$response.ID | Should -Be '09B9A9B0-6CE8-465F-AB03-65766D33B05E'
+
+			}
+
+			It 'returns the directory name as the ID for a self-hosted, AD-integrated Vault' {
+
+				Mock Invoke-PASRestMethod -MockWith {
+					[PSCustomObject]@{
+						'IdentityUM'           = $false
+						'OnPremiseMemberTypes' = @('User', 'Group')
+						'IdentityMemberTypes'  = @('User', 'Group', 'Role')
+						'Directories'          = @(
+							[PSCustomObject]@{'Name' = 'SomeDirectory'; 'ID' = 'SomeDirectory' }
+						)
+					}
+				}
+
+				$response = Get-PASDirectoryID
+
+				$response.Name | Should -Be 'SomeDirectory'
+				$response.ID | Should -Be 'SomeDirectory'
+
+			}
+
+		}
+
+	}
+
+}

--- a/Tests/New-PASSession.Tests.ps1
+++ b/Tests/New-PASSession.Tests.ps1
@@ -1153,6 +1153,22 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			}
 
+			It 'sets expected BaseURI with no double slash when discovery URL has a trailing slash' {
+
+				Mock Find-SharedServicesURL -MockWith {
+
+					[pscustomobject]@{
+						identity_user_portal = [pscustomobject]@{api = 'https://SomeSubDomain.id.cyberark.cloud/' }
+						pcloud               = [pscustomobject]@{api = 'https://SomeSubDomain.privilegecloud.cyberark.cloud/' }
+					}
+
+				}
+
+				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -ServiceUser
+				$Script:psPASSession.BaseURI | Should -Be 'https://SomeSubDomain.privilegecloud.cyberark.cloud/PasswordVault'
+
+			}
+
 			It 'sets expected authorization header' {
 
 				$Credentials | New-PASSession -TenantSubdomain SomeSubDomain -ServiceUser

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -313,6 +313,8 @@ commands:
         url: /commands/Add-PASDirectory
       - title: "Get-PASDirectory"
         url: /commands/Get-PASDirectory
+      - title: "Get-PASDirectoryID"
+        url: /commands/Get-PASDirectoryID
       - title: "Remove-PASDirectory"
         url: /commands/Remove-PASDirectory
       - title: "Get-PASDirectoryMapping"

--- a/docs/collections/_commands/Add-PASSafeMember.md
+++ b/docs/collections/_commands/Add-PASSafeMember.md
@@ -185,6 +185,22 @@ Add-PASSafeMember -SafeName NewSafe -MemberName User28 -SearchIn Vault -ConnectO
 
 Adds User28 to NewSafe with the predefined "Connect Only" role.
 
+### EXAMPLE 10
+```
+$DirectoryID = Get-PASDirectoryID -Name "Active Directory: ad.SomeDomain.com" | Select-Object -ExpandProperty ID
+
+Add-PASSafeMember -SafeName Windows_Domain_Safe -MemberName anADGroup -SearchIn $DirectoryID -MemberType Group `
+-UseAccounts $true -RetrieveAccounts $true -ListAccounts $true
+```
+
+Adds the AD Group *anADGroup* to *Windows_Domain_Safe* with Use, Retrieve & List permissions.
+
+On Privilege Cloud, SearchIn must be the directory ID rather than a directory name - Get-PASDirectoryID resolves
+this from the directory's friendly name. MemberType must always be specified alongside a Privilege Cloud SearchIn
+value.
+
+Minimum required version 12.6
+
 ## PARAMETERS
 
 ### -SafeName
@@ -229,6 +245,10 @@ rather than a directory name - see Get-PASDirectoryID.
 
 Supports tab completion: queries Get-PASDirectoryID and offers directory names in the completion list, while
 inserting the required ID value onto the command line.
+
+A plain Tab press cycles straight through the ID values with no names shown, since PSReadLine's default Tab
+behaviour only ever inserts the completion value. Press Ctrl+Space (PSReadLine's list/menu completion) instead
+to see the directory names alongside the values as you choose one - much easier to work with than the GUIDs.
 
 ```yaml
 Type: String

--- a/docs/collections/_commands/Add-PASSafeMember.md
+++ b/docs/collections/_commands/Add-PASSafeMember.md
@@ -224,6 +224,12 @@ The Vault or Domain, defined in the vault,
 
 in which to search for the member to add to the safe.
 
+On Privilege Cloud, this must be the ID of the directory as known to the underlying CyberArk Identity platform,
+rather than a directory name - see Get-PASDirectoryID.
+
+Supports tab completion: queries Get-PASDirectoryID and offers directory names in the completion list, while
+inserting the required ID value onto the command line.
+
 ```yaml
 Type: String
 Parameter Sets: (All)

--- a/docs/collections/_commands/Get-PASDirectoryID.md
+++ b/docs/collections/_commands/Get-PASDirectoryID.md
@@ -1,0 +1,85 @@
+---
+category: PSPAS
+external help file: psPAS-help.xml
+Module Name: psPAS
+online version: https://pspas.pspete.dev/commands/Get-PASDirectoryID
+schema: 2.0.0
+title: Get-PASDirectoryID
+---
+
+# Get-PASDirectoryID
+
+## SYNOPSIS
+Lists the directories available for use as the SearchIn value with Add-PASSafeMember
+
+## SYNTAX
+
+```
+Get-PASDirectoryID [[-Name] <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+In Privilege Cloud, directories are not directly integrated with Privilege Cloud, they are integrated with the
+underlying CyberArk Identity Platform.
+
+Because of this, the value required for the SearchIn parameter of Add-PASSafeMember is the GUID of the relevant
+directory as known to Identity, rather than a directory name, and this value is not otherwise exposed anywhere
+in the CyberArk UI.
+
+This function returns the directories available for use as the SearchIn value, resolving the required GUID for a
+given directory name.
+
+This also works against a self-hosted Vault - there, the same request instead returns the SearchIn value already
+expected by Add-PASSafeMember on self-hosted (the mapped directory's own name), rather than a GUID.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Get-PASDirectoryID
+```
+
+Returns all directories available for use as the SearchIn value with Add-PASSafeMember
+
+### EXAMPLE 2
+```
+Get-PASDirectoryID -Name "Active Directory: SomeDomain.com"
+```
+
+Returns the directory matching the specified name
+
+## PARAMETERS
+
+### -Name
+The name of a directory to return the details of.
+
+Accepts wildcards.
+
+Supports tab completion, which will query the available directories and offer their names as suggestions.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: DomainName
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[https://pspas.pspete.dev/commands/Get-PASDirectoryID](https://pspas.pspete.dev/commands/Get-PASDirectoryID)
+
+[https://community.cyberark.com/s/article/PCloud-Adding-AD-Group-as-Safe-Member-via-Rest-API](https://community.cyberark.com/s/article/PCloud-Adding-AD-Group-as-Safe-Member-via-Rest-API)

--- a/docs/collections/_docs/10-compatibility.md
+++ b/docs/collections/_docs/10-compatibility.md
@@ -107,6 +107,7 @@ If version requirement criteria are not met, operations may be prevented.
 | [`Set-PASUser`][Set-PASUser]                                                               | **9.7** ([Notes](#set-pasuser))                                                                               | Updates a user                                                   |
 | [`Unblock-PASUser`][Unblock-PASUser]                                                       | **9.7** ([Notes](#unblock-pasuser))                                                                           | Activates a suspended user                                       |
 | [`Get-PASDirectory`][Get-PASDirectory]                                                     | **10.4** ([Notes](#get-pasdirectory))                                                                         | Get configured LDAP directories                                  |
+| [`Get-PASDirectoryID`][Get-PASDirectoryID]                                                 | **---**                                                                                                       | Get directory IDs for use as the Add-PASSafeMember SearchIn value |
 | [`Add-PASDirectory`][Add-PASDirectory]                                                     | **10.4** ([Notes](#add-pasdirectory))                                                                         | Add a new LDAP directory                                         |
 | [`New-PASDirectoryMapping`][New-PASDirectoryMapping]                                       | **10.4** ([Notes](#new-pasdirectorymapping))                                                                  | Create a new LDAP directory mapping                              |
 | [`Add-PASPTARule`][Add-PASPTARule]                                                         | **10.4**                                                                                                      | Add a new Risky Commandrule to PTA                               |
@@ -456,6 +457,7 @@ If version requirement criteria are not met, operations may be prevented.
 [Set-PASUser]: /commands/Set-PASUser
 [Unblock-PASUser]: /commands/Unblock-PASUser
 [Get-PASDirectory]: /commands/Get-PASDirectory
+[Get-PASDirectoryID]: /commands/Get-PASDirectoryID
 [Add-PASDirectory]: /commands/Add-PASDirectory
 [New-PASDirectoryMapping]: /commands/New-PASDirectoryMapping
 [Add-PASPTARule]: /commands/Add-PASPTARule

--- a/psPAS/Functions/Authentication/New-PASSession.ps1
+++ b/psPAS/Functions/Authentication/New-PASSession.ps1
@@ -495,6 +495,12 @@ function New-PASSession {
 				$IdentityTenantURL = $SharedServicesURLs | Select-Object -ExpandProperty identity_user_portal | Select-Object -ExpandProperty api
 				$PrivilegeCloudURL = $SharedServicesURLs | Select-Object -ExpandProperty pcloud | Select-Object -ExpandProperty api
 
+				#Ensure URLs are in expected format
+				#Remove trailing space and PasswordVault (if provided in PrivilegeCloudURL)
+				$IdentityTenantURL = $IdentityTenantURL -replace '/$', ''
+				$PrivilegeCloudURL = $PrivilegeCloudURL -replace '/$', ''
+				$PrivilegeCloudURL = $PrivilegeCloudURL -replace '/PasswordVault$', ''
+
 			}
 
 			( { $PSItem -match '^ISPSS-.*-.*User$' } ) {

--- a/psPAS/Functions/LDAPDirectories/Get-PASDirectoryID.ps1
+++ b/psPAS/Functions/LDAPDirectories/Get-PASDirectoryID.ps1
@@ -1,0 +1,68 @@
+# .ExternalHelp psPAS-help.xml
+function Get-PASDirectoryID {
+	[CmdletBinding()]
+	param(
+		[parameter(
+			Mandatory = $false,
+			ValueFromPipelinebyPropertyName = $true
+		)]
+		[Alias('DomainName')]
+		[ArgumentCompleter({
+				#Standard ArgumentCompleter parameters.
+				param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+
+				#Avoid PSScriptAnalyzer PSReviewUnusedParameter rule on standard ArgumentCompleter parameters.
+				$null = $parameterName, $commandAst, $fakeBoundParameters
+
+				#strip any quote the user has already started typing
+				$wordToComplete = $wordToComplete.Trim("'`"")
+
+				#ask the API for the available directories
+				try {
+
+					$Module = (Get-Command $commandName -ErrorAction Stop).Module
+					$Directories = & $Module { Get-PASDirectoryID -ErrorAction Stop }
+
+				} catch { return }
+
+				$Directories.Name |
+					Where-Object { $_ -and ($_ -like "$wordToComplete*") } |
+					ForEach-Object {
+
+						#directory names can contain spaces/colons, quote the completion text so it remains a single argument
+						[System.Management.Automation.CompletionResult]::new("'$($_ -replace "'", "''")'", $_, 'ParameterValue', $_)
+
+					}
+
+			})]
+		[string]$Name
+	)
+
+	process {
+
+		#Create URL for request
+		$URI = "$($psPASSession.BaseURI)/api/settings/AddSafeMember"
+
+		#send request to web service
+		$result = Invoke-PASRestMethod -Uri $URI -Method GET
+
+		if ($null -ne $result) {
+
+			$Directories = $result.Directories
+
+			if ($PSBoundParameters.ContainsKey('Name')) {
+
+				#filter returned directories by name
+				$Directories = $Directories | Where-Object { $PSItem.Name -like $Name }
+
+			}
+
+			$Directories | Add-ObjectDetail -typename psPAS.CyberArk.Vault.Safe.Member.Directory
+
+		}
+
+	}#process
+
+	end { }#end
+
+}

--- a/psPAS/Functions/SafeMembers/Add-PASSafeMember.ps1
+++ b/psPAS/Functions/SafeMembers/Add-PASSafeMember.ps1
@@ -115,6 +115,35 @@ function Add-PASSafeMember {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'Full'
 		)]
+		[ArgumentCompleter({
+				#Standard ArgumentCompleter parameters.
+				param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+
+				#Avoid PSScriptAnalyzer PSReviewUnusedParameter rule on standard ArgumentCompleter parameters.
+				$null = $parameterName, $commandAst, $fakeBoundParameters
+
+				#strip any quote the user has already started typing
+				$wordToComplete = $wordToComplete.Trim("'`"")
+
+				#ask the API for the available directories
+				try {
+
+					$Module = (Get-Command $commandName -ErrorAction Stop).Module
+					$Directories = & $Module { Get-PASDirectoryID -ErrorAction Stop }
+
+				} catch { return }
+
+				$Directories |
+					Where-Object { ($_.Name -like "$wordToComplete*") -or ($_.ID -like "$wordToComplete*") } |
+					ForEach-Object {
+
+						#SearchIn requires the directory ID, but the directory Name is what's recognisable - insert
+						#the ID while displaying the Name in the completion list, so the right value ends up on the command line
+						[System.Management.Automation.CompletionResult]::new("'$($_.ID -replace "'", "''")'", $_.Name, 'ParameterValue', "$($_.Name) ($($_.ID))")
+
+					}
+
+			})]
 		[string]$SearchIn,
 
 		[parameter(

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -11136,6 +11136,7 @@ Add-PASPublicSSHKey -UserName Bob -PublicSSHKey $Key</dev:code>
             <maml:para>in which to search for the member to add to the safe.</maml:para>
             <maml:para>On Privilege Cloud, this must be the ID of the directory as known to the underlying CyberArk Identity platform, rather than a directory name - see Get-PASDirectoryID.</maml:para>
             <maml:para>Supports tab completion: queries Get-PASDirectoryID and offers directory names in the completion list, while inserting the required ID value onto the command line.</maml:para>
+            <maml:para>A plain Tab press cycles straight through the ID values with no names shown, since PSReadLine's default Tab behaviour only ever inserts the completion value. Press Ctrl+Space (PSReadLine's list/menu completion) instead to see the directory names alongside the values as you choose one - much easier to work with than the GUIDs.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -11513,6 +11514,7 @@ Add-PASPublicSSHKey -UserName Bob -PublicSSHKey $Key</dev:code>
             <maml:para>in which to search for the member to add to the safe.</maml:para>
             <maml:para>On Privilege Cloud, this must be the ID of the directory as known to the underlying CyberArk Identity platform, rather than a directory name - see Get-PASDirectoryID.</maml:para>
             <maml:para>Supports tab completion: queries Get-PASDirectoryID and offers directory names in the completion list, while inserting the required ID value onto the command line.</maml:para>
+            <maml:para>A plain Tab press cycles straight through the ID values with no names shown, since PSReadLine's default Tab behaviour only ever inserts the completion value. Press Ctrl+Space (PSReadLine's list/menu completion) instead to see the directory names alongside the values as you choose one - much easier to work with than the GUIDs.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -11878,6 +11880,7 @@ Add-PASPublicSSHKey -UserName Bob -PublicSSHKey $Key</dev:code>
             <maml:para>in which to search for the member to add to the safe.</maml:para>
             <maml:para>On Privilege Cloud, this must be the ID of the directory as known to the underlying CyberArk Identity platform, rather than a directory name - see Get-PASDirectoryID.</maml:para>
             <maml:para>Supports tab completion: queries Get-PASDirectoryID and offers directory names in the completion list, while inserting the required ID value onto the command line.</maml:para>
+            <maml:para>A plain Tab press cycles straight through the ID values with no names shown, since PSReadLine's default Tab behaviour only ever inserts the completion value. Press Ctrl+Space (PSReadLine's list/menu completion) instead to see the directory names alongside the values as you choose one - much easier to work with than the GUIDs.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -11980,6 +11983,7 @@ Add-PASPublicSSHKey -UserName Bob -PublicSSHKey $Key</dev:code>
             <maml:para>in which to search for the member to add to the safe.</maml:para>
             <maml:para>On Privilege Cloud, this must be the ID of the directory as known to the underlying CyberArk Identity platform, rather than a directory name - see Get-PASDirectoryID.</maml:para>
             <maml:para>Supports tab completion: queries Get-PASDirectoryID and offers directory names in the completion list, while inserting the required ID value onto the command line.</maml:para>
+            <maml:para>A plain Tab press cycles straight through the ID values with no names shown, since PSReadLine's default Tab behaviour only ever inserts the completion value. Press Ctrl+Space (PSReadLine's list/menu completion) instead to see the directory names alongside the values as you choose one - much easier to work with than the GUIDs.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -12082,6 +12086,7 @@ Add-PASPublicSSHKey -UserName Bob -PublicSSHKey $Key</dev:code>
             <maml:para>in which to search for the member to add to the safe.</maml:para>
             <maml:para>On Privilege Cloud, this must be the ID of the directory as known to the underlying CyberArk Identity platform, rather than a directory name - see Get-PASDirectoryID.</maml:para>
             <maml:para>Supports tab completion: queries Get-PASDirectoryID and offers directory names in the completion list, while inserting the required ID value onto the command line.</maml:para>
+            <maml:para>A plain Tab press cycles straight through the ID values with no names shown, since PSReadLine's default Tab behaviour only ever inserts the completion value. Press Ctrl+Space (PSReadLine's list/menu completion) instead to see the directory names alongside the values as you choose one - much easier to work with than the GUIDs.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -12184,6 +12189,7 @@ Add-PASPublicSSHKey -UserName Bob -PublicSSHKey $Key</dev:code>
             <maml:para>in which to search for the member to add to the safe.</maml:para>
             <maml:para>On Privilege Cloud, this must be the ID of the directory as known to the underlying CyberArk Identity platform, rather than a directory name - see Get-PASDirectoryID.</maml:para>
             <maml:para>Supports tab completion: queries Get-PASDirectoryID and offers directory names in the completion list, while inserting the required ID value onto the command line.</maml:para>
+            <maml:para>A plain Tab press cycles straight through the ID values with no names shown, since PSReadLine's default Tab behaviour only ever inserts the completion value. Press Ctrl+Space (PSReadLine's list/menu completion) instead to see the directory names alongside the values as you choose one - much easier to work with than the GUIDs.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -12286,6 +12292,7 @@ Add-PASPublicSSHKey -UserName Bob -PublicSSHKey $Key</dev:code>
             <maml:para>in which to search for the member to add to the safe.</maml:para>
             <maml:para>On Privilege Cloud, this must be the ID of the directory as known to the underlying CyberArk Identity platform, rather than a directory name - see Get-PASDirectoryID.</maml:para>
             <maml:para>Supports tab completion: queries Get-PASDirectoryID and offers directory names in the completion list, while inserting the required ID value onto the command line.</maml:para>
+            <maml:para>A plain Tab press cycles straight through the ID values with no names shown, since PSReadLine's default Tab behaviour only ever inserts the completion value. Press Ctrl+Space (PSReadLine's list/menu completion) instead to see the directory names alongside the values as you choose one - much easier to work with than the GUIDs.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -12388,6 +12395,7 @@ Add-PASPublicSSHKey -UserName Bob -PublicSSHKey $Key</dev:code>
           <maml:para>in which to search for the member to add to the safe.</maml:para>
           <maml:para>On Privilege Cloud, this must be the ID of the directory as known to the underlying CyberArk Identity platform, rather than a directory name - see Get-PASDirectoryID.</maml:para>
           <maml:para>Supports tab completion: queries Get-PASDirectoryID and offers directory names in the completion list, while inserting the required ID value onto the command line.</maml:para>
+          <maml:para>A plain Tab press cycles straight through the ID values with no names shown, since PSReadLine's default Tab behaviour only ever inserts the completion value. Press Ctrl+Space (PSReadLine's list/menu completion) instead to see the directory names alongside the values as you choose one - much easier to work with than the GUIDs.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -12914,6 +12922,18 @@ PS &gt; $Role | Add-PASSafeMember -SafeName NewSafe -MemberName User23 -SearchIn
         <dev:code>Add-PASSafeMember -SafeName NewSafe -MemberName User28 -SearchIn Vault -ConnectOnly</dev:code>
         <dev:remarks>
           <maml:para>Adds User28 to NewSafe with the predefined "Connect Only" role.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 10 --------------------------</maml:title>
+        <dev:code>$DirectoryID = Get-PASDirectoryID -Name "Active Directory: ad.SomeDomain.com" | Select-Object -ExpandProperty ID
+
+Add-PASSafeMember -SafeName Windows_Domain_Safe -MemberName anADGroup -SearchIn $DirectoryID -MemberType Group `
+-UseAccounts $true -RetrieveAccounts $true -ListAccounts $true</dev:code>
+        <dev:remarks>
+          <maml:para>Adds the AD Group anADGroup to Windows_Domain_Safe with Use, Retrieve &amp; List permissions.</maml:para>
+          <maml:para>On Privilege Cloud, SearchIn must be the directory ID rather than a directory name - Get-PASDirectoryID resolves this from the directory's friendly name. MemberType must always be specified alongside a Privilege Cloud SearchIn value.</maml:para>
+          <maml:para>Minimum required version 12.6</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -11134,6 +11134,8 @@ Add-PASPublicSSHKey -UserName Bob -PublicSSHKey $Key</dev:code>
           <maml:description>
             <maml:para>The Vault or Domain, defined in the vault,</maml:para>
             <maml:para>in which to search for the member to add to the safe.</maml:para>
+            <maml:para>On Privilege Cloud, this must be the ID of the directory as known to the underlying CyberArk Identity platform, rather than a directory name - see Get-PASDirectoryID.</maml:para>
+            <maml:para>Supports tab completion: queries Get-PASDirectoryID and offers directory names in the completion list, while inserting the required ID value onto the command line.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -11509,6 +11511,8 @@ Add-PASPublicSSHKey -UserName Bob -PublicSSHKey $Key</dev:code>
           <maml:description>
             <maml:para>The Vault or Domain, defined in the vault,</maml:para>
             <maml:para>in which to search for the member to add to the safe.</maml:para>
+            <maml:para>On Privilege Cloud, this must be the ID of the directory as known to the underlying CyberArk Identity platform, rather than a directory name - see Get-PASDirectoryID.</maml:para>
+            <maml:para>Supports tab completion: queries Get-PASDirectoryID and offers directory names in the completion list, while inserting the required ID value onto the command line.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -11872,6 +11876,8 @@ Add-PASPublicSSHKey -UserName Bob -PublicSSHKey $Key</dev:code>
           <maml:description>
             <maml:para>The Vault or Domain, defined in the vault,</maml:para>
             <maml:para>in which to search for the member to add to the safe.</maml:para>
+            <maml:para>On Privilege Cloud, this must be the ID of the directory as known to the underlying CyberArk Identity platform, rather than a directory name - see Get-PASDirectoryID.</maml:para>
+            <maml:para>Supports tab completion: queries Get-PASDirectoryID and offers directory names in the completion list, while inserting the required ID value onto the command line.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -11972,6 +11978,8 @@ Add-PASPublicSSHKey -UserName Bob -PublicSSHKey $Key</dev:code>
           <maml:description>
             <maml:para>The Vault or Domain, defined in the vault,</maml:para>
             <maml:para>in which to search for the member to add to the safe.</maml:para>
+            <maml:para>On Privilege Cloud, this must be the ID of the directory as known to the underlying CyberArk Identity platform, rather than a directory name - see Get-PASDirectoryID.</maml:para>
+            <maml:para>Supports tab completion: queries Get-PASDirectoryID and offers directory names in the completion list, while inserting the required ID value onto the command line.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -12072,6 +12080,8 @@ Add-PASPublicSSHKey -UserName Bob -PublicSSHKey $Key</dev:code>
           <maml:description>
             <maml:para>The Vault or Domain, defined in the vault,</maml:para>
             <maml:para>in which to search for the member to add to the safe.</maml:para>
+            <maml:para>On Privilege Cloud, this must be the ID of the directory as known to the underlying CyberArk Identity platform, rather than a directory name - see Get-PASDirectoryID.</maml:para>
+            <maml:para>Supports tab completion: queries Get-PASDirectoryID and offers directory names in the completion list, while inserting the required ID value onto the command line.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -12172,6 +12182,8 @@ Add-PASPublicSSHKey -UserName Bob -PublicSSHKey $Key</dev:code>
           <maml:description>
             <maml:para>The Vault or Domain, defined in the vault,</maml:para>
             <maml:para>in which to search for the member to add to the safe.</maml:para>
+            <maml:para>On Privilege Cloud, this must be the ID of the directory as known to the underlying CyberArk Identity platform, rather than a directory name - see Get-PASDirectoryID.</maml:para>
+            <maml:para>Supports tab completion: queries Get-PASDirectoryID and offers directory names in the completion list, while inserting the required ID value onto the command line.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -12272,6 +12284,8 @@ Add-PASPublicSSHKey -UserName Bob -PublicSSHKey $Key</dev:code>
           <maml:description>
             <maml:para>The Vault or Domain, defined in the vault,</maml:para>
             <maml:para>in which to search for the member to add to the safe.</maml:para>
+            <maml:para>On Privilege Cloud, this must be the ID of the directory as known to the underlying CyberArk Identity platform, rather than a directory name - see Get-PASDirectoryID.</maml:para>
+            <maml:para>Supports tab completion: queries Get-PASDirectoryID and offers directory names in the completion list, while inserting the required ID value onto the command line.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -12372,6 +12386,8 @@ Add-PASPublicSSHKey -UserName Bob -PublicSSHKey $Key</dev:code>
         <maml:description>
           <maml:para>The Vault or Domain, defined in the vault,</maml:para>
           <maml:para>in which to search for the member to add to the safe.</maml:para>
+          <maml:para>On Privilege Cloud, this must be the ID of the directory as known to the underlying CyberArk Identity platform, rather than a directory name - see Get-PASDirectoryID.</maml:para>
+          <maml:para>Supports tab completion: queries Get-PASDirectoryID and offers directory names in the completion list, while inserting the required ID value onto the command line.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -20632,6 +20648,90 @@ $Detail | Format-List *</dev:code>
       <maml:navigationLink>
         <maml:linkText>https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/LDAP_Get_directory_details.htm</maml:linkText>
         <maml:uri>https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/SDK/LDAP_Get_directory_details.htm</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Get-PASDirectoryID</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>PASDirectoryID</command:noun>
+      <maml:description>
+        <maml:para>Lists the directories available for use as the SearchIn value with Add-PASSafeMember</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>In Privilege Cloud, directories are not directly integrated with Privilege Cloud, they are integrated with the underlying CyberArk Identity Platform.</maml:para>
+      <maml:para>Because of this, the value required for the SearchIn parameter of Add-PASSafeMember is the GUID of the relevant directory as known to Identity, rather than a directory name, and this value is not otherwise exposed anywhere in the CyberArk UI.</maml:para>
+      <maml:para>This function returns the directories available for use as the SearchIn value, resolving the required GUID for a given directory name.</maml:para>
+      <maml:para>This also works against a self-hosted Vault - there, the same request instead returns the SearchIn value already expected by Add-PASSafeMember on self-hosted (the mapped directory's own name), rather than a GUID.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Get-PASDirectoryID</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="DomainName">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>The name of a directory to return the details of.</maml:para>
+            <maml:para>Accepts wildcards.</maml:para>
+            <maml:para>Supports tab completion, which will query the available directories and offer their names as suggestions.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="DomainName">
+        <maml:name>Name</maml:name>
+        <maml:description>
+          <maml:para>The name of a directory to return the details of.</maml:para>
+          <maml:para>Accepts wildcards.</maml:para>
+          <maml:para>Supports tab completion, which will query the available directories and offer their names as suggestions.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+        <dev:code>Get-PASDirectoryID</dev:code>
+        <dev:remarks>
+          <maml:para>Returns all directories available for use as the SearchIn value with Add-PASSafeMember</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
+        <dev:code>Get-PASDirectoryID -Name "Active Directory: SomeDomain.com"</dev:code>
+        <dev:remarks>
+          <maml:para>Returns the directory matching the specified name</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>https://pspas.pspete.dev/commands/Get-PASDirectoryID</maml:linkText>
+        <maml:uri>https://pspas.pspete.dev/commands/Get-PASDirectoryID</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>https://community.cyberark.com/s/article/PCloud-Adding-AD-Group-as-Safe-Member-via-Rest-API</maml:linkText>
+        <maml:uri>https://community.cyberark.com/s/article/PCloud-Adding-AD-Group-as-Safe-Member-via-Rest-API</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>

--- a/psPAS/psPAS.psd1
+++ b/psPAS/psPAS.psd1
@@ -158,6 +158,7 @@
 		'Export-PASPlatform',
 		'Get-PASUserLoginInfo',
 		'Get-PASDirectory',
+		'Get-PASDirectoryID',
 		'Add-PASDirectory',
 		'New-PASDirectoryMapping',
 		'Get-PASPTAEvent',


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
<!--
Please include a summary of the change and which issue is fixed & relevant motivation and context.
Put `Fixes #XXX` in your comment to link the issue that your PR fixes.
-->
### Added

- `Get-PASDirectoryID`
  - Resolves the directory ID value required by `Add-PASSafeMember -SearchIn` on Privilege Cloud, given a directory's friendly name - this value isn't otherwise exposed anywhere in the CyberArk UI
  - Also works against a self-hosted Vault, returning the directory name itself as its ID, matching what self-hosted `-SearchIn` already expects
  - `-Name` parameter supports tab completion

### Updated

- `Add-PASSafeMember`
  - `-SearchIn` now supports tab completion via `Get-PASDirectoryID`: displays directory names in the completion list while inserting the required ID value
  - Docs: added an example resolving `-SearchIn` via `Get-PASDirectoryID` for Privilege Cloud

### Fixed

- `New-PASSession`
  - Fixes a double-slash appearing in request URIs (e.g. `.../cyberark.cloud//PasswordVault/...`) when authenticating via `-TenantSubdomain` - the Privilege Cloud/Identity URLs returned by Shared Services discovery weren't having a trailing slash stripped before being combined with the PVWA application name
Fixes #

## Type of change
<!--
Please select all relevant options:
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [X] Documentation update (psPAS website or command help content)
- [ ] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [X] Pester test(s) updated
- [X] Pester test(s) passing

**Test Configuration**:
- PowerShell version:
- CyberArk PAS version:
- OS Version:

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [X] My code follows the style guidelines of this project
- [X] I have followed the contributing guidelines.
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new test failures or errors
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [ ] I have linked a related issue