### PR TITLE
FIX RADIUS secondary auth body enumerated byte-by-byte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Fixed
 
 - `New-PASSession`
+  - Fixes RADIUS secondary/challenge authentication failing after the `8.0.x` change that sends logon request bodies as raw UTF8 bytes: `Send-RADIUSResponse` still treated the body as a JSON string, so the byte array was enumerated one byte at a time - producing a request body containing the `username`/OTP pair repeated once per body byte (with a null `username`). The body is now decoded back to a string before the OTP is applied.
   - Fixes a double-slash appearing in request URIs (e.g. `.../cyberark.cloud//PasswordVault/...`) when authenticating via `-TenantSubdomain` - the Privilege Cloud/Identity URLs returned by Shared Services discovery weren't having a trailing slash stripped before being combined with the PVWA application name
 
 ## [8.0.11]

--- a/Tests/Send-RADIUSResponse.Tests.ps1
+++ b/Tests/Send-RADIUSResponse.Tests.ps1
@@ -83,9 +83,13 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
                 $Response = @{
                     'LogonRequest' = @{
-                        'Body'   = [PSCustomObject]@{
-                            'Password' = 'SomePasswordValue'
-                        } | ConvertTo-Json
+                        #New-PASSession provides Body as raw UTF8 bytes
+                        'Body'   = [System.Text.Encoding]::UTF8.GetBytes(
+                            ([PSCustomObject]@{
+                                'username' = 'SomeUser'
+                                'password' = 'SomePasswordValue'
+                            } | ConvertTo-Json)
+                        )
                         'Method' = 'POST'
                         'URI'    = 'Value'
                     }
@@ -109,9 +113,25 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
                     Send-RADIUSResponse @Response
                     Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
 
-                        $Script:RequestBody = $Body | ConvertFrom-Json
+                        $Script:RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
 
                         $Script:RequestBody.password -eq '123456'
+
+                    } -Times 5 -Exactly -Scope It
+
+                } Else { Set-ItResult -Inconclusive }
+            }
+
+            It 'sends a single username/password pair (not one per body byte)' {
+                if ($IsCoreCLR) {
+                    Send-RADIUSResponse @Response
+                    Assert-MockCalled Invoke-PASRestMethod -ParameterFilter {
+
+                        $RequestBody = [System.Text.Encoding]::UTF8.GetString($Body) | ConvertFrom-Json
+
+                        (@($RequestBody).Count -eq 1) -and
+                        ($RequestBody.username -eq 'SomeUser') -and
+                        ($RequestBody.password -eq '123456')
 
                     } -Times 5 -Exactly -Scope It
 

--- a/psPAS/Private/Send-RADIUSResponse.ps1
+++ b/psPAS/Private/Send-RADIUSResponse.ps1
@@ -65,9 +65,20 @@ function Send-RADIUSResponse {
         }
 
         #Construct Request Body with $OTP value as RADIUS response
-        $Body = $LogonRequest['Body'] | ConvertFrom-Json | Select-Object username
+        #New-PASSession (and this function on recursion) provides Body as raw UTF8 bytes;
+        #decode back to a string before parsing so the JSON isn't enumerated byte-by-byte.
+        $RawBody = $LogonRequest['Body']
+        if ($RawBody -is [byte[]]) {
+
+            $RawBody = [System.Text.Encoding]::UTF8.GetString($RawBody)
+
+        }
+        $Body = $RawBody | ConvertFrom-Json | Select-Object username
         $Body | Add-Member -MemberType NoteProperty -Name 'Password' -Value $OTP -Force
-        $LogonRequest['Body'] = $Body | ConvertTo-Json
+
+        #Send as raw UTF8 bytes rather than a String so ParameterBinding/module logging of this
+        #call records a non-revealing type name instead of the literal request content.
+        $LogonRequest['Body'] = [System.Text.Encoding]::UTF8.GetBytes($($Body | ConvertTo-Json))
 
         try {
 


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
<!--
Please include a summary of the change and which issue is fixed & relevant motivation and context.
Put `Fixes #XXX` in your comment to link the issue that your PR fixes.
-->
Since 924bf1d New-PASSession sends the logon body as a byte[]. Send-RADIUSResponse still piped it straight to ConvertFrom-Json, which enumerates the array one byte at a time - the challenge-response body became the username/OTP pair repeated once per body byte, with a null username. Decode the byte[] back to a string before applying the OTP, and re-encode to UTF8 bytes on the way out.

Fixes #653 

## Type of change
<!--
Please select all relevant options:
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [ ] Documentation update (psPAS website or command help content)
- [ ] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [X] Pester test(s) updated
- [X] Pester test(s) passing

**Test Configuration**:
- PowerShell version:
- CyberArk PAS version:
- OS Version:

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [X] My code follows the style guidelines of this project
- [X] I have followed the contributing guidelines.
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new test failures or errors
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [X] I have linked a related issue