### PR TITLE
Add OAuth support to New-PASSession function

### DIFF
--- a/Tests/New-PASSession.Tests.ps1
+++ b/Tests/New-PASSession.Tests.ps1
@@ -1568,6 +1568,102 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 		}
 
+		Context 'OAuth' {
+
+			BeforeEach {
+
+				Mock Invoke-PASRestMethod -MockWith { }
+
+				Mock Get-PASServer -MockWith {
+					[PSCustomObject]@{
+						ExternalVersion = '15.2'
+					}
+				}
+
+				Mock Get-PASLoggedOnUser -MockWith {
+					@{'UserName' = 'SomeUser' }
+				}
+
+				Mock Get-PASSessionTimeout -MockWith {
+					[PSCustomObject]@{'Timeout' = '20' }
+				}
+
+				$AccessToken = ConvertTo-SecureString 'SomeAccessToken' -AsPlainText -Force
+
+				$psPASSession.ExternalVersion = '0.0'
+				$psPASSession.WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+			}
+
+			It 'does not send a logon request' {
+				New-PASSession -BaseURI 'https://P_URI' -AccessToken $AccessToken
+				Assert-MockCalled Invoke-PASRestMethod -Times 0 -Exactly -Scope It
+
+			}
+
+			It 'sets expected BaseURI' {
+
+				New-PASSession -BaseURI 'https://P_URI' -AccessToken $AccessToken
+				$Script:psPASSession.BaseURI | Should -Be 'https://P_URI/PasswordVault'
+
+			}
+
+			It 'sets expected authorization header' {
+
+				New-PASSession -BaseURI 'https://P_URI' -AccessToken $AccessToken
+				$psPASSession.WebSession.Headers['Authorization'] | Should -Be 'Bearer SomeAccessToken'
+
+			}
+
+			It 'sets expected X-CA-Authentication-Type header' {
+
+				New-PASSession -BaseURI 'https://P_URI' -AccessToken $AccessToken
+				$psPASSession.WebSession.Headers['X-CA-Authentication-Type'] | Should -Be 'OAuth'
+
+			}
+
+			It 'strips redundant Bearer prefix from provided token' {
+
+				$PrefixedToken = ConvertTo-SecureString 'Bearer SomeAccessToken' -AsPlainText -Force
+				New-PASSession -BaseURI 'https://P_URI' -AccessToken $PrefixedToken
+				$psPASSession.WebSession.Headers['Authorization'] | Should -Be 'Bearer SomeAccessToken'
+
+			}
+
+			It 'calls Get-PASServer' {
+
+				New-PASSession -BaseURI 'https://P_URI' -AccessToken $AccessToken
+				Assert-MockCalled Get-PASServer -Times 1 -Exactly -Scope It
+
+			}
+
+			It 'throws if version requirement is not met' {
+
+				Mock Get-PASServer -MockWith {
+					[PSCustomObject]@{
+						ExternalVersion = '15.0'
+					}
+				}
+
+				{ New-PASSession -BaseURI 'https://P_URI' -AccessToken $AccessToken } | Should -Throw
+
+			}
+
+			It 'skips version check' {
+
+				New-PASSession -BaseURI 'https://P_URI' -AccessToken $AccessToken -SkipVersionCheck
+				Assert-MockCalled Get-PASServer -Times 0 -Exactly -Scope It
+
+			}
+
+			It 'throws when used against Privilege Cloud' {
+
+				{ New-PASSession -BaseURI 'https://SomeSubDomain.privilegecloud.cyberark.cloud' -AccessToken $AccessToken } | Should -Throw
+
+			}
+
+		}
+
 	}
 
 }

--- a/docs/collections/_commands/New-PASSession.md
+++ b/docs/collections/_commands/New-PASSession.md
@@ -80,6 +80,13 @@ New-PASSession -TenantSubdomain <String> -SAMLResponse <String> [-PVWAAppName <S
  [-Confirm] [<CommonParameters>]
 ```
 
+### OAuth
+```
+New-PASSession -BaseURI <String> -AccessToken <SecureString> [-PVWAAppName <String>] [-SkipVersionCheck]
+ [-Certificate <X509Certificate>] [-CertificateThumbprint <String>] [-SkipCertificateCheck] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
+```
+
 ### integrated
 ```
 New-PASSession -BaseURI <String> [-UseDefaultCredentials] [-concurrentSession <Boolean>]
@@ -399,6 +406,15 @@ New-PASSession -SAMLResponse $SAMLToken -UseGen1API -BaseURI https://PVWA.domain
 
 Authenticates to a CyberArk Vault using SAML authentication & Gen1 API.
 
+### EXAMPLE 27
+
+```
+$Token = ConvertTo-SecureString 'eyJhbGciOiJSUzI1Ni...' -AsPlainText -Force
+New-PASSession -BaseURI https://pvwa.company.com -AccessToken $Token
+```
+
+Authenticates to CyberArk PAM REST API using an OAuth 2.0 / Entra ID Bearer access token.
+
 ## PARAMETERS
 
 ### -Credential
@@ -696,7 +712,7 @@ Do not include "/PasswordVault/"
 
 ```yaml
 Type: String
-Parameter Sets: Gen2, Gen1Radius, Gen1, Gen2Radius, integrated, shared, Gen2SAML, Gen1SAML
+Parameter Sets: Gen2, Gen1Radius, Gen1, Gen2Radius, OAuth, integrated, shared, Gen2SAML, Gen1SAML
 Aliases:
 
 Required: True
@@ -948,6 +964,23 @@ Required: True
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -AccessToken
+
+The OAuth 2.0 / Entra ID access token formatted as a SecureString.
+Used for bearer token authentication to CyberArk PAM REST API (v15.2+).
+
+```yaml
+Type: SecureString
+Parameter Sets: OAuth
+Aliases: OAuth
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/psPAS/Functions/Authentication/New-PASSession.ps1
+++ b/psPAS/Functions/Authentication/New-PASSession.ps1
@@ -119,6 +119,12 @@ function New-PASSession {
 			ValueFromPipelinebyPropertyName = $true,
 			ParameterSetName = 'integrated'
 		)]
+		[parameter(
+			Mandatory = $true,
+			ValueFromPipeline = $false,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'OAuth'
+		)]
 		[string]$BaseURI,
 
 		[Parameter(
@@ -255,6 +261,16 @@ function New-PASSession {
 		)]
 		[Alias('SAMLToken')]
 		[String]$SAMLResponse,
+
+		[Parameter(
+			Mandatory = $true,
+			ValueFromPipeline = $true,
+			ValueFromPipelinebyPropertyName = $true,
+			ParameterSetName = 'OAuth'
+		)]
+		[Alias('OAuth')]
+		[ValidateNotNullOrEmpty()]
+		[SecureString]$AccessToken,
 
 		[Parameter(
 			Mandatory = $True,
@@ -586,6 +602,52 @@ function New-PASSession {
 
 			}
 
+			'OAuth' {
+
+				#BaseURI required in module scope for Assert-VersionRequirement
+				$psPASSession.BaseURI = $Uri
+				Assert-VersionRequirement -SelfHosted
+
+				if ($SkipCertificateCheck) {
+					if (-not (Test-IsCoreCLR)) {
+						Skip-CertificateCheck
+					} else {
+						$Script:SkipCertificateCheck = $true
+					}
+				}
+
+				# Create WebSession
+				$WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+				if ($Certificate) {
+					$WebSession.Certificates.Add($Certificate) | Out-Null
+				}
+
+				if ($CertificateThumbprint) {
+					#Resolve certificate from the store and add to WebSession
+					$ClientCertificate = Get-ChildItem -Path 'Cert:\CurrentUser\My', 'Cert:\LocalMachine\My' |
+						Where-Object { $PSItem.Thumbprint -eq $CertificateThumbprint } | Select-Object -First 1
+
+					if ($null -ne $ClientCertificate) {
+						$WebSession.Certificates.Add($ClientCertificate) | Out-Null
+					} else {
+						throw "No certificate with thumbprint $CertificateThumbprint found in Cert:\CurrentUser\My or Cert:\LocalMachine\My"
+					}
+				}
+
+				# Securely decode AccessToken and strip any redundant 'Bearer ' prefix
+				$TokenString = (ConvertTo-InsecureString -SecureString $AccessToken) -replace '^Bearer\s+', ''
+
+				# Set required CyberArk OAuth headers
+				$WebSession.Headers['Authorization'] = "Bearer $TokenString"
+				$WebSession.Headers['X-CA-Authentication-Type'] = 'OAuth'
+
+				$psPASSession.WebSession = $WebSession
+				$LogonRequest['Uri'] = $Uri
+				break
+
+			}
+
 			( { $PSItem -match '^Gen2' } ) {
 
 				$LogonRequest['Uri'] = "$Uri/api/Auth/$type/Logon"
@@ -702,6 +764,11 @@ function New-PASSession {
 					( { $PSItem -match '^ISPSS-.*-ServiceUser$' } ) {
 						#Perform Identity User Authentication using IdentityCommand module
 						$PASSession = New-IDPlatformToken -tenant_url $LogonRequest['Uri'] -Credential $LogonRequest['Credential']
+						break
+					}
+					'OAuth' {
+						#OAuth uses Bearer token directly with WebSession
+						$PASSession = $TokenString
 						break
 					}
 					default {
@@ -826,6 +893,13 @@ function New-PASSession {
 
 						}
 
+						( { $PSCmdlet.ParameterSetName -eq 'OAuth' } ) {
+
+							#OAuth 2.0 Bearer Token
+							$CyberArkLogonResult = "Bearer $TokenString"
+
+						}
+
 						default {
 
 							if ($PASSession.length -ge 180) {
@@ -868,6 +942,12 @@ function New-PASSession {
 
 					#Version information available in module scope.
 					$psPASSession.ExternalVersion = $Version
+
+					if ($PSCmdlet.ParameterSetName -eq 'OAuth' -and -not $SkipVersionCheck) {
+
+						Assert-VersionRequirement -RequiredVersion 15.2
+
+					}
 
 					try {
 

--- a/psPAS/en-US/psPAS-help.xml
+++ b/psPAS/en-US/psPAS-help.xml
@@ -39378,6 +39378,123 @@ New-PASRequest -BulkItems $Requests</dev:code>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
       </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>New-PASSession</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>BaseURI</maml:name>
+          <maml:description>
+            <maml:para>A string containing the base web address to send the request to.</maml:para>
+            <maml:para>Pass the PVWA HTTP address.</maml:para>
+            <maml:para>Do not include "/PasswordVault/"</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>PVWAAppName</maml:name>
+          <maml:description>
+            <maml:para>The name of the CyberArk PVWA Virtual Directory.</maml:para>
+            <maml:para>Defaults to PasswordVault</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>PasswordVault</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>SkipVersionCheck</maml:name>
+          <maml:description>
+            <maml:para>If the SkipVersionCheck switch is specified, Get-PASServer will not be called after successfully authenticating.</maml:para>
+            <maml:para>Get-PASServer is not supported before version 9.7.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Certificate</maml:name>
+          <maml:description>
+            <maml:para>See Invoke-WebRequest</maml:para>
+            <maml:para>Specifies the client certificate that is used for a secure web request.</maml:para>
+            <maml:para>Enter a variable that contains a certificate or a command or expression that gets the certificate.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">X509Certificate</command:parameterValue>
+          <dev:type>
+            <maml:name>X509Certificate</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>CertificateThumbprint</maml:name>
+          <maml:description>
+            <maml:para>See Invoke-WebRequest</maml:para>
+            <maml:para>The thumbprint of the certificate to use for client certificate authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>SkipCertificateCheck</maml:name>
+          <maml:description>
+            <maml:para>Skips certificate validation checks.</maml:para>
+            <maml:para>Using this parameter is not secure and is not recommended.</maml:para>
+            <maml:para>This switch is only intended to be used against known hosts using a self-signed certificate for testing purposes.</maml:para>
+            <maml:para>Use at your own risk.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="OAuth">
+          <maml:name>AccessToken</maml:name>
+          <maml:description>
+            <maml:para>The OAuth 2.0 / Entra ID access token formatted as a SecureString. Used for bearer token authentication to CyberArk PAM REST API (v15.2+).</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
+          <dev:type>
+            <maml:name>SecureString</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
     </command:syntax>
     <command:parameters>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
@@ -39752,6 +39869,18 @@ New-PASRequest -BulkItems $Requests</dev:code>
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="OAuth">
+        <maml:name>AccessToken</maml:name>
+        <maml:description>
+          <maml:para>The OAuth 2.0 / Entra ID access token formatted as a SecureString. Used for bearer token authentication to CyberArk PAM REST API (v15.2+).</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
+        <dev:type>
+          <maml:name>SecureString</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
     </command:parameters>
     <command:inputTypes />
     <command:returnValues />
@@ -39985,6 +40114,14 @@ New-PASSession -SAMLAuth -concurrentSession $true -BaseURI $baseURL -SAMLRespons
         <dev:code>New-PASSession -SAMLResponse $SAMLToken -UseGen1API -BaseURI https://PVWA.domain.com</dev:code>
         <dev:remarks>
           <maml:para>Authenticates to a CyberArk Vault using SAML authentication &amp; Gen1 API.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 27 --------------------------</maml:title>
+        <dev:code>$Token = ConvertTo-SecureString 'eyJhbGciOiJSUzI1Ni...' -AsPlainText -Force
+New-PASSession -BaseURI https://pvwa.company.com -AccessToken $Token</dev:code>
+        <dev:remarks>
+          <maml:para>Authenticates to CyberArk PAM REST API using an OAuth 2.0 / Entra ID Bearer access token.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
<!--
Please include a summary of the change and which issue is fixed & relevant motivation and context.
Put `Fixes #XXX` in your comment to link the issue that your PR fixes.
-->

* Added a new `OAuth` parameter set to `New-PASSession`, allowing authentication using a SecureString `AccessToken` instead of username/password or other methods. The function now sets the required HTTP headers for OAuth and handles certificate options. The certificate options are somewhat unneeded but can maybe needed when load balancer/proxy require mTLS or something...

CyberArks implementation of OAuth is not really like SAML or other auth methods. It is not the one triggering the login flow. It already expects that flow to be done. It just wants the token that you have. CyberArks job is just to validate it. 
So the New-PASSession is a little bit different then other auth methods. 

## Type of change
<!--
Please select all relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [x] Documentation update (psPAS website or command help content)
- [ ] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [x] Pester test(s) updated
- [ ] Pester test(s) passing

**Test Configuration**:
- PowerShell version: 7
- CyberArk PAS version: 15.2
- OS Version: Windows 11

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [x] My code follows the style guidelines of this project
- [x] I have followed the contributing guidelines.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new test failures or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [ ] I have linked a related issue