### PR TITLE
🔒 Stop downgrading TLS in Invoke-PASRestMethod and Get-PASSAMLResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@
 - Continued development to encompass any new documented features of the CyberArk API.
 - psPAS v9.0...
 
+## [Unreleased]
+
+### Fixed
+
+- `Invoke-PASRestMethod` and `Get-PASSAMLResponse` no longer downgrade the TLS configuration of the
+  session.
+  - On PowerShell Core, `-SslProtocol TLS12` is no longer set. `WebSslProtocol` is a flags enum, so
+    it permitted TLS 1.2 and nothing else, excluding TLS 1.3. The connection now negotiates the
+    strongest protocol both ends support.
+  - On Windows PowerShell, a `SystemDefault` security protocol is left untouched rather than being
+    replaced with TLS 1.2 only. The previous guard tested `SystemDefault -match 'Tls12'`, which is
+    false, so a process on .NET Framework 4.7 or above - where `SystemDefault` is both the default
+    and the correct value - was pinned to TLS 1.2 on its first request, and a process with TLS 1.3
+    enabled had it stripped. TLS 1.2 is now added only where an explicit legacy protocol is set, and
+    is combined with the protocols already permitted.
+
 ## [8.0.20]
 
 ### Added

--- a/Tests/Invoke-PASRestMethod.Tests.ps1
+++ b/Tests/Invoke-PASRestMethod.Tests.ps1
@@ -107,15 +107,45 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			if ([Net.SecurityProtocolType].GetEnumNames() -contains 'Tls12') {
 
-				It 'enforces use of TLS 1.2' {
-					[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls11
-					Invoke-PASRestMethod @WebSession
-					[System.Net.ServicePointManager]::SecurityProtocol | Should -Be Tls12
+				It 'adds TLS 1.2 to an explicit legacy security protocol' {
+					Mock Test-IsCoreCLR -MockWith { return $false }
+					$Original = [System.Net.ServicePointManager]::SecurityProtocol
+					try {
+						[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls11
+						Invoke-PASRestMethod @WebSession
+						([System.Net.ServicePointManager]::SecurityProtocol).HasFlag([Net.SecurityProtocolType]::Tls12) | Should -BeTrue
+					} finally {
+						[System.Net.ServicePointManager]::SecurityProtocol = $Original
+					}
+				}
+
+				It 'preserves the security protocols already permitted' {
+					Mock Test-IsCoreCLR -MockWith { return $false }
+					$Original = [System.Net.ServicePointManager]::SecurityProtocol
+					try {
+						[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls11
+						Invoke-PASRestMethod @WebSession
+						([System.Net.ServicePointManager]::SecurityProtocol).HasFlag([Net.SecurityProtocolType]::Tls11) | Should -BeTrue
+					} finally {
+						[System.Net.ServicePointManager]::SecurityProtocol = $Original
+					}
+				}
+
+				It 'leaves a SystemDefault security protocol untouched' {
+					Mock Test-IsCoreCLR -MockWith { return $false }
+					$Original = [System.Net.ServicePointManager]::SecurityProtocol
+					try {
+						[System.Net.ServicePointManager]::SecurityProtocol = 0
+						Invoke-PASRestMethod @WebSession
+						[int][System.Net.ServicePointManager]::SecurityProtocol | Should -Be 0
+					} finally {
+						[System.Net.ServicePointManager]::SecurityProtocol = $Original
+					}
 				}
 
 			}
 
-			It 'specifies -SslProtocol TLS12' {
+			It 'does not pin a TLS protocol' {
 
 				If ($IsCoreCLR) {
 
@@ -123,7 +153,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 					Mock Invoke-WebRequest -MockWith { }
 					Invoke-PASRestMethod @WebSession
 					Assert-MockCalled 'Invoke-WebRequest' -Times 1 -Scope It -Exactly -ParameterFilter {
-						$SslProtocol -eq 'TLS12'
+						-not $PSBoundParameters.ContainsKey('SslProtocol')
 					}
 				} else { Set-ItResult -Inconclusive }
 			}

--- a/psPAS/Private/Get-PASSAMLResponse.ps1
+++ b/psPAS/Private/Get-PASSAMLResponse.ps1
@@ -34,24 +34,25 @@ https://gist.github.com/infamousjoeg/b44faa299ec3de65bdd1d3b8474b0649
 
 			if ($PSCmdlet.ShouldProcess($Uri, 'SAML Auth')) {
 
-				#If Tls12 Security Protocol is available
-				if (([Net.SecurityProtocolType].GetEnumNames() -contains 'Tls12') -and
+				#A SecurityProtocol of SystemDefault (0) lets Schannel negotiate the strongest
+				#protocol both ends support and is left untouched. Only a process pinned to explicit
+				#legacy protocols needs TLS 1.2 adding, combined with those already permitted.
+				if (-not (Test-IsCoreCLR)) {
 
-					#And Tls12 is not already in use
-					(-not ([System.Net.ServicePointManager]::SecurityProtocol -match 'Tls12'))) {
+					$SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol
 
-					[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+					if (([int]$SecurityProtocol -ne 0) -and
+						([Net.SecurityProtocolType].GetEnumNames() -contains 'Tls12') -and
+						(-not ($SecurityProtocol.HasFlag([Net.SecurityProtocolType]::Tls12)))) {
+
+						[Net.ServicePointManager]::SecurityProtocol = $SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
+					}
 
 				}
 
 				$Request = @{}
 
-				#Use TLS 1.2
-				if (Test-IsCoreCLR) {
-
-					$Request.Add('SslProtocol', 'TLS12')
-
-				}
 				$Request['Uri'] = $Uri
 				$Request['MaximumRedirection'] = 0
 				$Request['ErrorAction'] = 'SilentlyContinue'
@@ -61,12 +62,6 @@ https://gist.github.com/infamousjoeg/b44faa299ec3de65bdd1d3b8474b0649
 
 				$Request = @{}
 
-				#Use TLS 1.2
-				if (Test-IsCoreCLR) {
-
-					$Request.Add('SslProtocol', 'TLS12')
-
-				}
 				$Request['Uri'] = $($WebResponse.links.href)
 				$Request['MaximumRedirection'] = 1
 				$Request['UseDefaultCredentials'] = $true

--- a/psPAS/Private/Invoke-PASRestMethod.ps1
+++ b/psPAS/Private/Invoke-PASRestMethod.ps1
@@ -144,11 +144,13 @@
 		}
 
 		#Bypass strict RFC header parsing in PS Core
-		#Use TLS 1.2
 		if (Test-IsCoreCLR) {
 
 			$PSBoundParameters.Add('SkipHeaderValidation', $true)
-			$PSBoundParameters.Add('SslProtocol', 'TLS12')
+
+			#No TLS protocol is pinned. WebSslProtocol is a flags enum, so -SslProtocol TLS12 permits
+			#TLS 1.2 and nothing else, excluding TLS 1.3. Left unset, the connection negotiates the
+			#strongest protocol both ends support.
 
 		}
 
@@ -204,13 +206,21 @@
 
 		}
 
-		#If Tls12 Security Protocol is available
-		if (([Net.SecurityProtocolType].GetEnumNames() -contains 'Tls12') -and
+		#A SecurityProtocol of SystemDefault (0) lets Schannel negotiate the strongest protocol both
+		#ends support, which is the correct value on .NET Framework 4.7 and above, and is left
+		#untouched. Only a process pinned to explicit legacy protocols needs TLS 1.2 adding, and it is
+		#combined with the protocols already permitted rather than replacing them.
+		if (-not (Test-IsCoreCLR)) {
 
-			#And Tls12 is not already in use
-			(-not ([System.Net.ServicePointManager]::SecurityProtocol -match 'Tls12'))) {
+			$SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol
 
-			[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+			if (([int]$SecurityProtocol -ne 0) -and
+				([Net.SecurityProtocolType].GetEnumNames() -contains 'Tls12') -and
+				(-not ($SecurityProtocol.HasFlag([Net.SecurityProtocolType]::Tls12)))) {
+
+				[Net.ServicePointManager]::SecurityProtocol = $SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
+			}
 
 		}
 


### PR DESCRIPTION


<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
<!--
Please include a summary of the change and which issue is fixed & relevant motivation and context.
Put `Fixes #XXX` in your comment to link the issue that your PR fixes.
-->
WebSslProtocol is a flags enum, so -SslProtocol TLS12 permits TLS 1.2 and nothing else. Setting it on PowerShell Core excluded TLS 1.3 rather than raising a floor, so it is no longer set and the connection negotiates the strongest protocol both ends support. Get-PASSAMLResponse set it on both of its requests.

The Windows PowerShell branch had the same effect by another route. It assigned ServicePointManager.SecurityProtocol rather than combining with it, and its guard tested a SystemDefault value with -match 'Tls12', which is false. A process on .NET Framework 4.7+, where SystemDefault is both the default and the correct value, was therefore pinned to TLS 1.2 only on the first request, and a process with TLS 1.3 enabled had it stripped.

TLS 1.2 is now added only where an explicit legacy protocol is set, and is combined with the protocols already permitted. The ServicePointManager block is now reached only under Windows PowerShell, where it has any effect.

Replace the tests that asserted the previous behaviour: 'enforces use of TLS 1.2' passed only because the value was overwritten. Mocking Test-IsCoreCLR lets the Windows branch be covered on either host.

Fixes #

## Type of change
<!--
Please select all relevant options:
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [ ] Documentation update (psPAS website or command help content)
- [ ] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [X] Pester test(s) updated
- [X] Pester test(s) passing

**Test Configuration**:
- PowerShell version:
- CyberArk PAS version:
- OS Version:

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [X] My code follows the style guidelines of this project
- [X] I have followed the contributing guidelines.
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new test failures or errors
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [ ] I have linked a related issue